### PR TITLE
feat: add Pi CLI adapter for multi-provider LLM support

### DIFF
--- a/src/components/Pi.tsx
+++ b/src/components/Pi.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react'
+import { useAgentRunner } from '../hooks/useAgentRunner.js'
+import { PiAdapter } from '../hooks/adapters/pi.js'
+import { AgentRenderer } from './AgentRenderer.js'
+import type { PiProps } from './agents/types/pi.js'
+import type { AgentResult } from './agents/types/execution.js'
+
+export function Pi(props: PiProps): ReactNode {
+  const { status, agentId, executionId, result, error, tailLog } = useAgentRunner(props, PiAdapter)
+  const label = props.model ?? 'pi'
+
+  return (
+    <AgentRenderer
+      tag="pi"
+      status={status}
+      agentId={agentId}
+      executionId={executionId}
+      modelOrMode={label}
+      modelAttrName="model"
+      result={result}
+      error={error}
+      tailLog={tailLog}
+      tailLogCount={props.tailLogCount}
+      tailLogLines={props.tailLogLines}
+    >
+      {props.children}
+    </AgentRenderer>
+  )
+}
+
+export type { PiProps, AgentResult }
+export { executePiCLI } from './agents/pi-cli/executor.js'

--- a/src/components/agents/pi-cli/arg-builder.test.ts
+++ b/src/components/agents/pi-cli/arg-builder.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for arg-builder - pi CLI argument construction
+ */
+import { describe, test, expect } from 'bun:test'
+import { buildPiArgs } from './arg-builder.js'
+import type { PiCLIExecutionOptions } from '../types/pi.js'
+
+describe('buildPiArgs', () => {
+  test('always includes base flags: --mode json, -p, --no-session', () => {
+    const args = buildPiArgs({ prompt: 'test' })
+    
+    expect(args).toContain('--mode')
+    expect(args).toContain('json')
+    expect(args).toContain('-p')
+    expect(args).toContain('--no-session')
+  })
+
+  test('prompt is always last argument', () => {
+    const args = buildPiArgs({ prompt: 'hello world' })
+    
+    expect(args[args.length - 1]).toBe('hello world')
+  })
+
+  describe('provider handling', () => {
+    test('adds --provider flag when specified', () => {
+      const args = buildPiArgs({ prompt: 'test', provider: 'openai' })
+      
+      expect(args).toContain('--provider')
+      expect(args).toContain('openai')
+    })
+
+    test('omits --provider flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--provider')
+    })
+  })
+
+  describe('model handling', () => {
+    test('adds --model flag when specified', () => {
+      const args = buildPiArgs({ prompt: 'test', model: 'gpt-4o' })
+      
+      expect(args).toContain('--model')
+      expect(args).toContain('gpt-4o')
+    })
+
+    test('omits --model flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--model')
+    })
+  })
+
+  describe('thinking handling', () => {
+    test('adds --thinking flag for each level', () => {
+      const levels = ['off', 'minimal', 'low', 'medium', 'high'] as const
+      
+      for (const level of levels) {
+        const args = buildPiArgs({ prompt: 'test', thinking: level })
+        expect(args).toContain('--thinking')
+        expect(args).toContain(level)
+      }
+    })
+
+    test('omits --thinking flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--thinking')
+    })
+  })
+
+  describe('system prompt handling', () => {
+    test('adds --system-prompt flag when specified', () => {
+      const args = buildPiArgs({ prompt: 'test', systemPrompt: 'You are helpful' })
+      
+      expect(args).toContain('--system-prompt')
+      expect(args).toContain('You are helpful')
+    })
+
+    test('omits --system-prompt flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--system-prompt')
+    })
+  })
+
+  describe('append system prompt handling', () => {
+    test('adds --append-system-prompt flag when specified', () => {
+      const args = buildPiArgs({ prompt: 'test', appendSystemPrompt: 'Extra instructions' })
+      
+      expect(args).toContain('--append-system-prompt')
+      expect(args).toContain('Extra instructions')
+    })
+
+    test('omits --append-system-prompt flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--append-system-prompt')
+    })
+  })
+
+  describe('tools handling', () => {
+    test('adds --tools flag with comma-separated list', () => {
+      const args = buildPiArgs({ prompt: 'test', tools: ['read', 'bash', 'edit'] })
+      
+      expect(args).toContain('--tools')
+      expect(args).toContain('read,bash,edit')
+    })
+
+    test('single tool', () => {
+      const args = buildPiArgs({ prompt: 'test', tools: ['bash'] })
+      
+      expect(args).toContain('--tools')
+      expect(args).toContain('bash')
+    })
+
+    test('omits --tools flag when empty array', () => {
+      const args = buildPiArgs({ prompt: 'test', tools: [] })
+      
+      expect(args).not.toContain('--tools')
+    })
+
+    test('omits --tools flag when undefined', () => {
+      const args = buildPiArgs({ prompt: 'test' })
+      
+      expect(args).not.toContain('--tools')
+    })
+  })
+
+  describe('combined options', () => {
+    test('builds correct args with all options', () => {
+      const args = buildPiArgs({
+        prompt: 'write tests',
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+        thinking: 'medium',
+        systemPrompt: 'Be concise',
+        appendSystemPrompt: 'Use TypeScript',
+        tools: ['read', 'write'],
+      })
+
+      expect(args).toContain('--mode')
+      expect(args).toContain('json')
+      expect(args).toContain('-p')
+      expect(args).toContain('--no-session')
+      expect(args).toContain('--provider')
+      expect(args).toContain('anthropic')
+      expect(args).toContain('--model')
+      expect(args).toContain('claude-sonnet-4-20250514')
+      expect(args).toContain('--thinking')
+      expect(args).toContain('medium')
+      expect(args).toContain('--system-prompt')
+      expect(args).toContain('Be concise')
+      expect(args).toContain('--append-system-prompt')
+      expect(args).toContain('Use TypeScript')
+      expect(args).toContain('--tools')
+      expect(args).toContain('read,write')
+      expect(args[args.length - 1]).toBe('write tests')
+    })
+
+    test('minimal options includes base flags and prompt', () => {
+      const args = buildPiArgs({ prompt: 'hello' })
+
+      expect(args).toEqual(['--mode', 'json', '-p', '--no-session', 'hello'])
+    })
+  })
+})

--- a/src/components/agents/pi-cli/arg-builder.ts
+++ b/src/components/agents/pi-cli/arg-builder.ts
@@ -1,0 +1,15 @@
+import type { PiCLIExecutionOptions } from '../types/pi.js'
+
+export function buildPiArgs(options: PiCLIExecutionOptions): string[] {
+  const args: string[] = ['--mode', 'json', '-p', '--no-session']
+  
+  if (options.provider) args.push('--provider', options.provider)
+  if (options.model) args.push('--model', options.model)
+  if (options.thinking) args.push('--thinking', options.thinking)
+  if (options.systemPrompt) args.push('--system-prompt', options.systemPrompt)
+  if (options.appendSystemPrompt) args.push('--append-system-prompt', options.appendSystemPrompt)
+  if (options.tools?.length) args.push('--tools', options.tools.join(','))
+  
+  args.push(options.prompt)
+  return args
+}

--- a/src/components/agents/pi-cli/errors.test.ts
+++ b/src/components/agents/pi-cli/errors.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for errors - pi CLI error detection
+ */
+import { describe, test, expect } from 'bun:test'
+import { PiNotInstalledError, PiAuthError, detectPiError } from './errors.js'
+
+describe('PiNotInstalledError', () => {
+  test('has correct code', () => {
+    const err = new PiNotInstalledError()
+    expect(err.code).toBe('PI_NOT_INSTALLED')
+  })
+
+  test('has descriptive message with install command', () => {
+    const err = new PiNotInstalledError()
+    expect(err.message).toContain('pi CLI not found')
+    expect(err.message).toContain('npm i -g')
+  })
+
+  test('is instance of Error', () => {
+    const err = new PiNotInstalledError()
+    expect(err).toBeInstanceOf(Error)
+  })
+})
+
+describe('PiAuthError', () => {
+  test('has correct code', () => {
+    const err = new PiAuthError('anthropic', 'Missing key')
+    expect(err.code).toBe('PI_AUTH_ERROR')
+  })
+
+  test('stores provider', () => {
+    const err = new PiAuthError('openai', 'Invalid key')
+    expect(err.provider).toBe('openai')
+  })
+
+  test('includes provider in message', () => {
+    const err = new PiAuthError('google', 'Token expired')
+    expect(err.message).toContain('google')
+    expect(err.message).toContain('Token expired')
+  })
+})
+
+describe('detectPiError', () => {
+  describe('not installed (exit 127)', () => {
+    test('returns PiNotInstalledError for exit code 127', () => {
+      const result = detectPiError('', 127)
+      
+      expect(result).toBeInstanceOf(PiNotInstalledError)
+    })
+
+    test('exit 127 takes precedence over stderr content', () => {
+      const result = detectPiError('API key error', 127)
+      
+      expect(result).toBeInstanceOf(PiNotInstalledError)
+    })
+  })
+
+  describe('auth errors', () => {
+    test('detects missing API key', () => {
+      const result = detectPiError('Error: ANTHROPIC_API_KEY not set', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('anthropic')
+    })
+
+    test('detects generic API key error', () => {
+      const result = detectPiError('Invalid API key provided', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+    })
+
+    test('detects openai provider from stderr', () => {
+      const result = detectPiError('openai API key invalid', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('openai')
+    })
+
+    test('detects google provider from stderr', () => {
+      const result = detectPiError('google API key required', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('google')
+    })
+
+    test('detects github-copilot provider from stderr', () => {
+      const result = detectPiError('github-copilot API key missing', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('github-copilot')
+    })
+
+    test('defaults to unknown provider', () => {
+      const result = detectPiError('API key not found', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('unknown')
+    })
+  })
+
+  describe('OAuth errors', () => {
+    test('detects token expired', () => {
+      const result = detectPiError('Error: token expired', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect(result?.message).toContain('/login')
+    })
+
+    test('detects refresh failed', () => {
+      const result = detectPiError('OAuth refresh failed', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+    })
+  })
+
+  describe('rate limiting', () => {
+    test('detects 429 error', () => {
+      const result = detectPiError('HTTP 429: Too Many Requests', 1)
+      
+      expect(result).toBeInstanceOf(Error)
+      expect(result?.message).toContain('Rate limited')
+    })
+
+    test('detects rate limit message', () => {
+      const result = detectPiError('You have exceeded the rate limit', 1)
+      
+      expect(result).toBeInstanceOf(Error)
+      expect(result?.message).toContain('Rate limited')
+    })
+  })
+
+  describe('no error detected', () => {
+    test('returns null for successful exit', () => {
+      const result = detectPiError('', 0)
+      
+      expect(result).toBeNull()
+    })
+
+    test('returns null for unknown error patterns', () => {
+      const result = detectPiError('Some random error occurred', 1)
+      
+      expect(result).toBeNull()
+    })
+
+    test('returns null for empty stderr with non-zero exit', () => {
+      const result = detectPiError('', 1)
+      
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('case sensitivity', () => {
+    test('matches ANTHROPIC (uppercase)', () => {
+      const result = detectPiError('ANTHROPIC_API_KEY missing', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('anthropic')
+    })
+
+    test('matches Anthropic (mixed case)', () => {
+      const result = detectPiError('Anthropic API key invalid', 1)
+      
+      expect(result).toBeInstanceOf(PiAuthError)
+      expect((result as PiAuthError).provider).toBe('anthropic')
+    })
+  })
+})

--- a/src/components/agents/pi-cli/errors.ts
+++ b/src/components/agents/pi-cli/errors.ts
@@ -1,0 +1,47 @@
+export class PiNotInstalledError extends Error {
+  readonly code = 'PI_NOT_INSTALLED'
+  constructor() {
+    super('pi CLI not found. Install with: npm i -g @mariozechner/pi-coding-agent')
+  }
+}
+
+export class PiAuthError extends Error {
+  readonly code = 'PI_AUTH_ERROR'
+  readonly provider: string
+  constructor(provider: string, message: string) {
+    super(`${provider} auth failed: ${message}`)
+    this.provider = provider
+  }
+}
+
+export function detectPiError(stderr: string, exitCode: number): Error | null {
+  // Not installed
+  if (exitCode === 127) return new PiNotInstalledError()
+  
+  // Auth errors
+  if (stderr.includes('API key') || stderr.includes('ANTHROPIC_API_KEY')) {
+    const provider = extractProvider(stderr)
+    return new PiAuthError(provider, 'Missing or invalid API key')
+  }
+  
+  // OAuth expired
+  if (stderr.includes('token expired') || stderr.includes('refresh failed')) {
+    const provider = extractProvider(stderr)
+    return new PiAuthError(provider, 'OAuth token expired, run /login')
+  }
+  
+  // Rate limiting
+  if (stderr.includes('429') || stderr.includes('rate limit')) {
+    return new Error('Rate limited - retry after cooldown')
+  }
+  
+  return null
+}
+
+function extractProvider(text: string): string {
+  const providers = ['anthropic', 'openai', 'google', 'github-copilot']
+  for (const p of providers) {
+    if (text.toLowerCase().includes(p)) return p
+  }
+  return 'unknown'
+}

--- a/src/components/agents/pi-cli/executor.ts
+++ b/src/components/agents/pi-cli/executor.ts
@@ -1,0 +1,47 @@
+import type { PiCLIExecutionOptions } from '../types/pi.js'
+import type { AgentResult } from '../types/execution.js'
+import { executeCLI, DEFAULT_CLI_TIMEOUT_MS } from '../shared/cli-executor.js'
+import { buildPiArgs } from './arg-builder.js'
+import { parsePiOutput } from './output-parser.js'
+import { detectPiError } from './errors.js'
+
+export async function executePiCLI(
+  options: PiCLIExecutionOptions & { onProgress?: (chunk: string) => void }
+): Promise<AgentResult> {
+  const args = buildPiArgs(options)
+  let turnsUsed = 0
+
+  const { result } = await executeCLI({
+    cliName: 'pi',
+    args,
+    command: ['pi', ...args],
+    cwd: options.cwd ?? process.cwd(),
+    timeout: options.timeout ?? DEFAULT_CLI_TIMEOUT_MS,
+    ...(options.stopConditions ? { stopConditions: options.stopConditions } : {}),
+    ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+    
+    onStdoutChunk: (chunk) => {
+      // Count turns from JSON events
+      for (const line of chunk.split('\n')) {
+        if (!line.trim()) continue
+        try {
+          const event = JSON.parse(line)
+          if (event.type === 'turn_end') turnsUsed++
+        } catch {
+          // Non-JSON line, ignore
+        }
+      }
+      return { turnsUsed }
+    },
+    
+    parseOutput: (stdout) => parsePiOutput(stdout),
+    
+    formatError: (_parsed, spawnResult) => {
+      const piError = detectPiError(spawnResult.stderr, spawnResult.exitCode)
+      if (piError) return piError.message
+      return `pi CLI failed (exit ${spawnResult.exitCode})\n\nSTDERR:\n${spawnResult.stderr}`
+    },
+  })
+
+  return result
+}

--- a/src/components/agents/pi-cli/index.ts
+++ b/src/components/agents/pi-cli/index.ts
@@ -1,0 +1,4 @@
+export { buildPiArgs } from './arg-builder.js'
+export { parsePiOutput } from './output-parser.js'
+export { executePiCLI } from './executor.js'
+export { PiNotInstalledError, PiAuthError, detectPiError } from './errors.js'

--- a/src/components/agents/pi-cli/output-parser.ts
+++ b/src/components/agents/pi-cli/output-parser.ts
@@ -1,0 +1,42 @@
+import type { ParsedCLIOutput } from '../shared/cli-executor.js'
+
+interface PiEvent {
+  type: string
+  message?: {
+    role: string
+    content: Array<{ type: string; text?: string }>
+    usage?: { input: number; output: number }
+  }
+}
+
+export function parsePiOutput(stdout: string): ParsedCLIOutput {
+  const lines = stdout.split('\n').filter(Boolean)
+  let output = ''
+  const tokensUsed = { input: 0, output: 0 }
+  let turnsUsed = 0
+  
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line) as PiEvent
+      
+      if (event.type === 'message_end' && event.message?.role === 'assistant') {
+        // Extract text from message content
+        for (const block of event.message.content ?? []) {
+          if (block.type === 'text' && block.text) {
+            output += block.text
+          }
+        }
+        // Accumulate usage
+        if (event.message.usage) {
+          tokensUsed.input += event.message.usage.input
+          tokensUsed.output += event.message.usage.output
+        }
+        turnsUsed++
+      }
+    } catch {
+      // Non-JSON line, ignore
+    }
+  }
+  
+  return { output, tokensUsed, turnsUsed }
+}

--- a/src/components/agents/types/pi.ts
+++ b/src/components/agents/types/pi.ts
@@ -1,0 +1,42 @@
+import type { BaseAgentProps, StopCondition } from './agents.js'
+
+export type PiThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high'
+
+export interface PiProps extends BaseAgentProps {
+  /** Provider (anthropic, openai, google, etc.) */
+  provider?: string
+  /** Model ID */
+  model?: string
+  /** Thinking level */
+  thinking?: PiThinkingLevel
+  /** System prompt override */
+  systemPrompt?: string
+  /** Append to system prompt */
+  appendSystemPrompt?: string
+  /** Tool list (pi builtins only: read,bash,edit,write,grep,find,ls) */
+  tools?: string[]
+  /** Timeout in ms */
+  timeout?: number
+  /** Stop conditions */
+  stopConditions?: StopCondition[]
+  /** Working directory */
+  cwd?: string
+  /** Number of tail log entries to display during execution. */
+  tailLogCount?: number
+  /** Number of lines to show per tail log entry. */
+  tailLogLines?: number
+}
+
+export interface PiCLIExecutionOptions {
+  prompt: string
+  provider?: string
+  model?: string
+  thinking?: PiThinkingLevel
+  systemPrompt?: string
+  appendSystemPrompt?: string
+  tools?: string[]
+  timeout?: number
+  cwd?: string
+  stopConditions?: StopCondition[]
+  onProgress?: (chunk: string) => void
+}

--- a/src/hooks/adapters/pi.ts
+++ b/src/hooks/adapters/pi.ts
@@ -1,0 +1,71 @@
+import type { AgentAdapter, MessageParserInterface, ExtractPromptResult } from './types.js'
+import type { PiProps, PiCLIExecutionOptions } from '../../components/agents/types/pi.js'
+import type { AgentResult } from '../../components/agents/types/execution.js'
+import { executePiCLI } from '../../components/agents/pi-cli/executor.js'
+import { PiStreamParser } from '../../streaming/pi-parser.js'
+import { MessageParser } from '../../components/agents/claude-cli/message-parser.js'
+
+const PI_BUILTIN_TOOLS = ['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls']
+
+class PiMessageParserWrapper implements MessageParserInterface {
+  private parser: MessageParser
+  constructor(maxEntries: number) { this.parser = new MessageParser(maxEntries) }
+  parseChunk(chunk: string): void { this.parser.parseChunk(chunk) }
+  flush(): void { this.parser.flush() }
+  getLatestEntries(n: number) { return this.parser.getLatestEntries(n) }
+}
+
+export const PiAdapter: AgentAdapter<PiProps, PiCLIExecutionOptions> = {
+  name: 'pi',
+  
+  getAgentLabel(options) { return options.model ?? 'pi' },
+  getLoggerName() { return 'Pi' },
+  getLoggerContext(props) { return { model: props.model ?? 'default', provider: props.provider ?? '' } },
+
+  extractPrompt(childrenString, _props): ExtractPromptResult {
+    // Pi doesn't use MCP configs in prompt - just pass through
+    return { prompt: childrenString, mcpConfigPath: undefined }
+  },
+
+  buildOptions(props, ctx) {
+    // Filter tools to pi builtins only
+    const tools = ctx.builtinTools?.filter(t => PI_BUILTIN_TOOLS.includes(t))
+    
+    return {
+      prompt: ctx.prompt,
+      ...(props.provider ? { provider: props.provider } : {}),
+      ...(props.model ? { model: props.model } : {}),
+      ...(props.thinking ? { thinking: props.thinking } : {}),
+      ...(props.systemPrompt ? { systemPrompt: props.systemPrompt } : {}),
+      ...(props.appendSystemPrompt ? { appendSystemPrompt: props.appendSystemPrompt } : {}),
+      ...(tools && tools.length > 0 ? { tools } : {}),
+      ...(props.timeout !== undefined ? { timeout: props.timeout } : {}),
+      ...(ctx.cwd ? { cwd: ctx.cwd } : {}),
+      ...(props.stopConditions ? { stopConditions: props.stopConditions } : {}),
+    }
+  },
+
+  async execute(options): Promise<AgentResult> {
+    const result = await executePiCLI(options)
+    if (result.stopReason === 'error') {
+      throw new Error(result.output || 'Pi CLI execution failed')
+    }
+    return result
+  },
+
+  createMessageParser(maxEntries) {
+    return new PiMessageParserWrapper(maxEntries)
+  },
+
+  createStreamParser() {
+    return new PiStreamParser()
+  },
+
+  supportsTypedStreaming(_props) {
+    return true  // Pi always outputs JSON in --mode json
+  },
+
+  getDefaultOutputFormat(_props) {
+    return undefined  // Not applicable - pi manages its own format
+  },
+}

--- a/src/streaming/pi-parser.test.ts
+++ b/src/streaming/pi-parser.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for PiStreamParser - pi JSON event stream parsing
+ */
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { PiStreamParser } from './pi-parser.js'
+import type { SmithersStreamPart } from './types.js'
+
+describe('PiStreamParser', () => {
+  let parser: PiStreamParser
+
+  beforeEach(() => {
+    parser = new PiStreamParser()
+  })
+
+  describe('basic parsing', () => {
+    test('parses single JSON line', () => {
+      const parts = parser.parse('{"type":"agent_start"}\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('stream-start')
+    })
+
+    test('handles multiple lines in one chunk', () => {
+      const parts = parser.parse('{"type":"agent_start"}\n{"type":"agent_end","messages":[]}\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('stream-start')
+      expect(parts[1].type).toBe('finish')
+    })
+
+    test('buffers incomplete lines', () => {
+      const parts1 = parser.parse('{"type":"agent')
+      expect(parts1).toHaveLength(0)
+      
+      const parts2 = parser.parse('_start"}\n')
+      expect(parts2).toHaveLength(1)
+      expect(parts2[0].type).toBe('stream-start')
+    })
+
+    test('handles empty lines', () => {
+      const parts = parser.parse('\n\n{"type":"agent_start"}\n\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('stream-start')
+    })
+
+    test('emits cli-output for non-JSON lines', () => {
+      const parts = parser.parse('Some debug output\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('cli-output')
+      expect((parts[0] as any).raw).toBe('Some debug output')
+    })
+  })
+
+  describe('event mapping', () => {
+    test('agent_start -> stream-start', () => {
+      const parts = parser.parse('{"type":"agent_start"}\n')
+      
+      expect(parts[0]).toEqual({ type: 'stream-start', warnings: [] })
+    })
+
+    test('turn_start/turn_end ignored', () => {
+      const parts1 = parser.parse('{"type":"turn_start"}\n')
+      const parts2 = parser.parse('{"type":"turn_end"}\n')
+      
+      expect(parts1).toHaveLength(0)
+      expect(parts2).toHaveLength(0)
+    })
+
+    test('agent_end -> finish with usage', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'agent_end',
+        messages: [
+          { usage: { input: 100, output: 50 } },
+          { usage: { input: 200, output: 150 } },
+        ]
+      }) + '\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('finish')
+      const finish = parts[0] as Extract<SmithersStreamPart, { type: 'finish' }>
+      expect(finish.usage.inputTokens.total).toBe(300)
+      expect(finish.usage.outputTokens.total).toBe(200)
+    })
+
+    test('agent_end with no messages', () => {
+      const parts = parser.parse('{"type":"agent_end"}\n')
+      
+      expect(parts).toHaveLength(1)
+      const finish = parts[0] as Extract<SmithersStreamPart, { type: 'finish' }>
+      expect(finish.usage.inputTokens.total).toBe(0)
+      expect(finish.usage.outputTokens.total).toBe(0)
+    })
+  })
+
+  describe('text blocks', () => {
+    test('text_delta starts block on first delta', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('text-start')
+      expect((parts[0] as any).id).toBe('pi-text-0')
+      expect(parts[1].type).toBe('text-delta')
+      expect((parts[1] as any).delta).toBe('Hello')
+    })
+
+    test('subsequent text_delta does not restart block', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: ' world', contentIndex: 0 }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('text-delta')
+      expect((parts[0] as any).delta).toBe(' world')
+    })
+
+    test('different contentIndex creates new block', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'First', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Second', contentIndex: 1 }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('text-start')
+      expect((parts[0] as any).id).toBe('pi-text-1')
+    })
+  })
+
+  describe('thinking/reasoning blocks', () => {
+    test('thinking_delta starts reasoning block', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Let me think...', contentIndex: 0 }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('reasoning-start')
+      expect((parts[0] as any).id).toBe('pi-reasoning-0')
+      expect(parts[1].type).toBe('reasoning-delta')
+    })
+
+    test('subsequent thinking_delta does not restart block', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'First', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Second', contentIndex: 0 }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('reasoning-delta')
+    })
+  })
+
+  describe('tool execution', () => {
+    test('tool_execution_start emits tool-input-start', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_123',
+        toolName: 'Read'
+      }) + '\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('tool-input-start')
+      expect((parts[0] as any).id).toBe('call_123')
+      expect((parts[0] as any).toolName).toBe('Read')
+    })
+
+    test('tool_execution_end emits tool-input-end and tool-result', () => {
+      // Start first to register tool name
+      parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_123',
+        toolName: 'Read'
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_end',
+        toolCallId: 'call_123',
+        result: { content: 'file contents' }
+      }) + '\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('tool-input-end')
+      expect(parts[1].type).toBe('tool-result')
+      expect((parts[1] as any).toolName).toBe('Read')
+      expect((parts[1] as any).result).toEqual({ content: 'file contents' })
+    })
+
+    test('tool_execution_end without start uses unknown tool name', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_end',
+        toolCallId: 'call_orphan',
+        result: 'done'
+      }) + '\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('tool-result')
+      expect((parts[0] as any).toolName).toBe('unknown')
+    })
+
+    test('tool error emits error part', () => {
+      parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_err',
+        toolName: 'Bash'
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_end',
+        toolCallId: 'call_err',
+        result: 'Command failed',
+        isError: true
+      }) + '\n')
+      
+      expect(parts).toHaveLength(2)
+      expect(parts[0].type).toBe('tool-input-end')
+      expect(parts[1].type).toBe('error')
+      expect((parts[1] as any).error.type).toBe('tool_execution_error')
+      expect((parts[1] as any).error.toolName).toBe('Bash')
+    })
+
+    test('missing toolCallId in start is ignored', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolName: 'Read'
+      }) + '\n')
+      
+      expect(parts).toHaveLength(0)
+    })
+
+    test('missing toolCallId in end is ignored', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_end',
+        result: 'done'
+      }) + '\n')
+      
+      expect(parts).toHaveLength(0)
+    })
+  })
+
+  describe('message boundaries', () => {
+    test('message_start closes open blocks', () => {
+      // Open a text block
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.parse('{"type":"message_start"}\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('text-end')
+      expect((parts[0] as any).id).toBe('pi-text-0')
+    })
+
+    test('message_end closes open blocks', () => {
+      // Open text and reasoning blocks
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Hmm', contentIndex: 1 }
+      }) + '\n')
+      
+      const parts = parser.parse('{"type":"message_end"}\n')
+      
+      expect(parts.filter(p => p.type === 'text-end')).toHaveLength(1)
+      expect(parts.filter(p => p.type === 'reasoning-end')).toHaveLength(1)
+    })
+
+    test('message_start closes tool inputs', () => {
+      parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_123',
+        toolName: 'Read'
+      }) + '\n')
+      
+      const parts = parser.parse('{"type":"message_start"}\n')
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('tool-input-end')
+    })
+  })
+
+  describe('flush', () => {
+    test('flush parses remaining buffer', () => {
+      parser.parse('{"type":"agent_start"}')
+      
+      const parts = parser.flush()
+      
+      expect(parts.some(p => p.type === 'stream-start')).toBe(true)
+    })
+
+    test('flush closes open text blocks', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.flush()
+      
+      expect(parts.some(p => p.type === 'text-end')).toBe(true)
+    })
+
+    test('flush closes open reasoning blocks', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'thinking_delta', delta: 'Thinking', contentIndex: 0 }
+      }) + '\n')
+      
+      const parts = parser.flush()
+      
+      expect(parts.some(p => p.type === 'reasoning-end')).toBe(true)
+    })
+
+    test('flush closes open tool inputs', () => {
+      parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_123',
+        toolName: 'Read'
+      }) + '\n')
+      
+      const parts = parser.flush()
+      
+      expect(parts.some(p => p.type === 'tool-input-end')).toBe(true)
+    })
+
+    test('flush emits cli-output for unparseable buffer', () => {
+      parser.parse('partial garbage')
+      
+      const parts = parser.flush()
+      
+      expect(parts).toHaveLength(1)
+      expect(parts[0].type).toBe('cli-output')
+    })
+
+    test('flush clears state', () => {
+      parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'Hello', contentIndex: 0 }
+      }) + '\n')
+      
+      parser.flush()
+      const parts = parser.flush()
+      
+      // Second flush should return nothing
+      expect(parts).toHaveLength(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('handles missing assistantMessageEvent', () => {
+      const parts = parser.parse('{"type":"message_update"}\n')
+      
+      expect(parts).toHaveLength(0)
+    })
+
+    test('handles undefined delta', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', contentIndex: 0 }
+      }) + '\n')
+      
+      // No delta = no output
+      expect(parts).toHaveLength(0)
+    })
+
+    test('handles contentIndex defaulting to 0', () => {
+      const parts = parser.parse(JSON.stringify({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', delta: 'test' }
+      }) + '\n')
+      
+      expect((parts[0] as any).id).toBe('pi-text-0')
+    })
+
+    test('unknown event types return empty', () => {
+      const parts = parser.parse('{"type":"unknown_event","data":"foo"}\n')
+      
+      expect(parts).toHaveLength(0)
+    })
+
+    test('handles null result in tool_execution_end', () => {
+      parser.parse(JSON.stringify({
+        type: 'tool_execution_start',
+        toolCallId: 'call_123',
+        toolName: 'Read'
+      }) + '\n')
+      
+      const parts = parser.parse(JSON.stringify({
+        type: 'tool_execution_end',
+        toolCallId: 'call_123'
+      }) + '\n')
+      
+      expect(parts[1].type).toBe('tool-result')
+      expect((parts[1] as any).result).toBeNull()
+    })
+  })
+})

--- a/src/streaming/pi-parser.ts
+++ b/src/streaming/pi-parser.ts
@@ -1,0 +1,152 @@
+import { BaseStreamParser } from './base-parser.js'
+import type { SmithersStreamPart } from './types.js'
+import type { JSONValue } from './v3-compat.js'
+
+interface PiEvent {
+  type: string
+  messages?: Array<{ usage?: { input: number; output: number } }>
+  assistantMessageEvent?: { type: string; delta?: string; contentIndex?: number }
+  toolCallId?: string
+  toolName?: string
+  args?: unknown
+  result?: unknown
+  isError?: boolean
+}
+
+export class PiStreamParser extends BaseStreamParser {
+  private activeTextBlocks = new Set<number>()
+  private activeReasoningBlocks = new Set<number>()
+  // toolCallId -> toolName (tool_execution_end may omit toolName)
+  private activeToolInputs = new Map<string, string>()
+
+  protected handleNonJsonLine(line: string): SmithersStreamPart[] {
+    return [{ type: 'cli-output', stream: 'stdout', raw: line }]
+  }
+
+  protected mapEvent(event: Record<string, unknown>): SmithersStreamPart[] {
+    const e = event as unknown as PiEvent
+    switch (e.type) {
+      case 'agent_start':
+        return [{ type: 'stream-start', warnings: [] }]
+
+      case 'turn_start':
+      case 'turn_end':
+        return []
+
+      case 'message_start':
+      case 'message_end':
+        return this.closeOpenBlocks()
+
+      case 'message_update':
+        return this.mapMessageUpdate(e)
+
+      case 'tool_execution_start':
+        if (!e.toolCallId || !e.toolName) return []
+        this.activeToolInputs.set(e.toolCallId, e.toolName)
+        return [{ type: 'tool-input-start', id: e.toolCallId, toolName: e.toolName }]
+
+      case 'tool_execution_end':
+        return this.handleToolExecutionEnd(e)
+
+      case 'agent_end': {
+        let input = 0, output = 0
+        for (const m of e.messages ?? []) {
+          input += m.usage?.input ?? 0
+          output += m.usage?.output ?? 0
+        }
+        return [{
+          type: 'finish',
+          usage: { inputTokens: { total: input }, outputTokens: { total: output } },
+          finishReason: { unified: 'stop' },
+        }]
+      }
+
+      default:
+        return []
+    }
+  }
+
+  private handleToolExecutionEnd(e: PiEvent): SmithersStreamPart[] {
+    if (!e.toolCallId) return []
+
+    const parts: SmithersStreamPart[] = []
+    const toolName = this.activeToolInputs.get(e.toolCallId) ?? e.toolName ?? 'unknown'
+
+    if (this.activeToolInputs.has(e.toolCallId)) {
+      parts.push({ type: 'tool-input-end', id: e.toolCallId })
+      this.activeToolInputs.delete(e.toolCallId)
+    }
+
+    if (e.isError) {
+      parts.push({
+        type: 'error',
+        error: {
+          type: 'tool_execution_error',
+          toolCallId: e.toolCallId,
+          toolName,
+          result: e.result ?? null,
+        },
+      })
+      return parts
+    }
+
+    parts.push({
+      type: 'tool-result',
+      toolCallId: e.toolCallId,
+      toolName,
+      result: (e.result ?? null) as JSONValue,
+    })
+    return parts
+  }
+
+  private mapMessageUpdate(e: PiEvent): SmithersStreamPart[] {
+    const ae = e.assistantMessageEvent
+    if (!ae) return []
+    
+    const parts: SmithersStreamPart[] = []
+    const contentIndex = ae.contentIndex ?? 0
+
+    if (ae.type === 'text_delta' && ae.delta !== undefined) {
+      const blockId = `pi-text-${contentIndex}`
+      if (!this.activeTextBlocks.has(contentIndex)) {
+        parts.push({ type: 'text-start', id: blockId })
+        this.activeTextBlocks.add(contentIndex)
+      }
+      parts.push({ type: 'text-delta', id: blockId, delta: ae.delta })
+    }
+
+    if (ae.type === 'thinking_delta' && ae.delta !== undefined) {
+      const blockId = `pi-reasoning-${contentIndex}`
+      if (!this.activeReasoningBlocks.has(contentIndex)) {
+        parts.push({ type: 'reasoning-start', id: blockId })
+        this.activeReasoningBlocks.add(contentIndex)
+      }
+      parts.push({ type: 'reasoning-delta', id: blockId, delta: ae.delta })
+    }
+
+    return parts
+  }
+
+  private closeOpenBlocks(): SmithersStreamPart[] {
+    const parts: SmithersStreamPart[] = []
+    for (const contentIndex of this.activeTextBlocks) {
+      parts.push({ type: 'text-end', id: `pi-text-${contentIndex}` })
+    }
+    for (const contentIndex of this.activeReasoningBlocks) {
+      parts.push({ type: 'reasoning-end', id: `pi-reasoning-${contentIndex}` })
+    }
+    for (const toolCallId of this.activeToolInputs.keys()) {
+      parts.push({ type: 'tool-input-end', id: toolCallId })
+    }
+    this.activeTextBlocks.clear()
+    this.activeReasoningBlocks.clear()
+    this.activeToolInputs.clear()
+    return parts
+  }
+
+  override flush(): SmithersStreamPart[] {
+    const parts = super.flush()
+    parts.push(...this.closeOpenBlocks())
+    return parts
+  }
+}


### PR DESCRIPTION
## Summary

Adds `<Pi>` component that spawns `pi --mode json` to execute agents, giving Smithers multi-provider LLM support via the pi CLI.

## Changes

- **New component**: `<Pi provider="anthropic" model="sonnet">prompt</Pi>`
- **Stream parser**: Handles pi's JSON event stream with proper block lifecycle
- **Error handling**: Auth failures, missing CLI, rate limits
- **Unit tests**: 63 test cases for arg-builder, errors, stream parser

## Usage

```tsx
<Pi provider="anthropic" model="claude-sonnet-4-5" thinking="medium">
  Fix the failing tests
</Pi>

<Pi provider="openai" model="gpt-4o">
  Review this code
</Pi>
```

## Design

- CLI spawn (not direct API) for loose coupling and process isolation
- Reuses existing `executeCLI` infrastructure
- Extends `BaseStreamParser` for consistent patterns

## Testing

- `bun test src/components/agents/pi-cli/ src/streaming/pi-parser.test.ts`

---

## PROMPT

# PR #58: Pi CLI Adapter - Session Transcript

## Overview

This document captures the user prompts, design discussions, and decisions that led to the Pi CLI adapter implementation.

---

## User Prompts (Chronological)

### 1. Initial Request
> **User:** explore this codebase and figure out how to adapt it to pi sdk (~/pi-mono)

### 2. Understanding Current Architecture
> **User:** how do agent backends work in smithers rn

### 3. Challenging the Proposed Approach
> **User:** you are suggesting using direct api calls via pi sdk instead of spawning pi cli? explain why this might be a good idea

### 4. Critical Design Constraint
> **User:** like you should also consider how this is going to fit into smithers, given that it's owned by a 3rd party

### 5. Validation Request
> **User:** is the startup overhead the only difference? validate these assumptions with a trio of review subagents

### 6. Implementation Kickoff
> **User:** spawn another trio of subagents to design the code, then (combined with your own idea about how the code should look) write a task file. then, spawn an opus subagent to implement it. lastly, spawn a review trio to check adherence with the plan, then report back to me.

### 7. Iteration Style
> **User:** yes, next time don't ask, just spawn review agents / fix agent until it's done.

### 8. Specific Agent Assignment
> **User:** have chatgpt pro fix the bugs (give it read and edit tool only), then have an opus subagent clean up any syntax errors after. then spawn the review trio again

### 9. Final Tasks
> **User:** do both in subagents. for the unit tests, follow the same patterns as in the codebase.

---

## Design Discussion

### Initial Proposal (Model-Generated)
Two integration options were proposed:
1. **Direct API** - Import `@mariozechner/pi-agent` and make direct LLM calls
2. **CLI Spawn** - Spawn `pi --mode json` as subprocess

Initial model recommendation leaned toward Direct API for:
- No spawn overhead (~50-100ms per agent)
- Native streaming events
- In-process tool execution
- Type safety

### User Challenge
The user questioned whether startup overhead was the only meaningful difference, prompting a deeper analysis via three review subagents (Opus, Gemini, GPT).

### Review Findings (Model-Generated via Subagents)

**Opus identified:**
- Process isolation (crash containment)
- Resource cleanup handled by OS
- Session/context management differs
- MCP server lifecycle management
- Tool sandboxing differences
- Stop conditions: `proc.kill()` vs cooperative `abort()`

**Gemini identified:**
- Direct API would duplicate ~300 LOC that pi-agent already provides
- But CLI approach maintains independence

**GPT identified:**
- Security implications of shared vs isolated memory
- Tool execution context exposure
- Cancellation semantics differ materially

### Pivotal User Insight
> **User:** like you should also consider how this is going to fit into smithers, given that it's owned by a 3rd party

This reframed the decision from purely technical to architectural/ownership:

| CLI Spawn | Direct API |
|-----------|------------|
| Loose coupling via process boundary | Tight coupling to pi SDK internals |
| Can swap pi for any CLI | TypeScript types must match |
| Upgrade independently | Version conflicts possible |
| No dependency in package.json | pi becomes core dependency |

---

## Final Decision

**CLI spawning is the right answer** for a third-party integration:
- Smithers stays independent of pi's release cycle
- Process isolation is a feature, not overhead
- The "startup overhead" concern is noise (50ms vs 10s+ LLM calls)
- Can always switch to direct API later if same team owns both

---

## Implementation Approach

### Architecture
```
<Pi model="sonnet">prompt</Pi>
       │
       ▼
PiAdapter.execute()
       │
       ▼
Bun.spawn(['pi', '--mode', 'json', '-p', '--no-session', ...])
       │
       ▼
PiStreamParser (JSON events → SmithersStreamPart)
```

### Key Design Decisions

1. **Reuse existing infrastructure**
   - `executeCLI` from shared/cli-executor.ts
   - `BaseStreamParser` for consistent patterns
   - Adapter interface matches Claude/Amp/Codex adapters

2. **Event mapping**
   - Pi JSON events → SmithersStreamPart types
   - Block lifecycle tracking (text, reasoning, tools)
   - Message boundaries handled correctly

3. **Error handling**
   - `PiNotInstalledError` with install instructions
   - `PiAuthError` with provider context
   - Rate limit detection

4. **Limitations accepted for v1**
   - No custom tools (pi uses extensions, not MCP)
   - No session resume
   - Token usage returns zeros (pi doesn't stream this yet)

---

## Review Iterations

The implementation went through 6 review rounds with fix iterations:

| Round | Issues Found | Fixed |
|-------|--------------|-------|
| 1 | 4 critical (empty delta, static IDs, guards, contentIndex) | ✓ |
| 2 | Event type mismatch (messages vs message) | ✓ |
| 3 | isError handling, usage summing | ✓ |
| 4 | Message boundaries, tool lifecycle | ✓ |
| 5 | toolName lookup (pi omits from end event) | ✓ |
| 6 | flush() buffer parsing, message_end cleanup | ✓ |

---

## Final Deliverable

- 12 files, +1206 lines
- 63 unit test cases
- Production-ready stream parser with proper block lifecycle
- Commit: `a44827c`
