### PR TITLE
Add missing ./agents/cli subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "./server": "./src/server/index.ts",
     "./pi-plugin": "./src/pi-plugin/index.ts",
     "./mdx-plugin": "./src/mdx-plugin.ts",
-    "./dom/renderer": "./src/dom/renderer.ts"
+    "./dom/renderer": "./src/dom/renderer.ts",
+    "./agents/cli": "./src/agents/cli.ts"
   },
   "files": [
     "src/",


### PR DESCRIPTION
## Summary

- Adds `"./agents/cli": "./src/agents/cli.ts"` to the `exports` map in `package.json`

## Problem

The [CLI Agents docs](https://smithers.sh/integrations/cli-agents) instruct users to import via:

```ts
import { ClaudeCodeAgent, CodexAgent, GeminiAgent } from "smithers-orchestrator/agents/cli";
```

However, this import fails at resolution time because `./agents/cli` was not listed as a subpath export in `package.json`. The classes exist in `src/agents/cli.ts` and are re-exported from the root (`src/index.ts`), but the deep import path documented on the site was broken.

## Fix

Added the missing subpath export entry so the documented import path resolves correctly.

## Test plan

- [ ] `bun install` in a consumer project and verify `import { ClaudeCodeAgent } from "smithers-orchestrator/agents/cli"` resolves
- [ ] Verify root import `import { ClaudeCodeAgent } from "smithers-orchestrator"` still works