### PR TITLE
fix: move zod to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ If the process crashes, Smithers resumes from the last completed node.
 Requires Bun ≥ 1.3.
 
 ```bash
-bun add smithers-orchestrator ai @ai-sdk/anthropic zod
+bun add smithers-orchestrator ai @ai-sdk/anthropic zod@^4
 ```
+
+> **Note:** Smithers requires Zod v4. Zod v3 is not compatible.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -61,17 +61,18 @@
     "drizzle-zod": "^0.8.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-reconciler": "^0.31.0",
-    "zod": "^4.3.6"
+    "react-reconciler": "^0.31.0"
   },
   "peerDependencies": {
-    "typescript": "^5"
+    "typescript": "^5",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/diff": "^5.2.0",
     "@types/react": "^19.2.10",
     "@types/react-reconciler": "^0.28.9",
-    "@playwright/test": "^1.52.0"
+    "@playwright/test": "^1.52.0",
+    "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
## Summary

- Moves `zod` from `dependencies` to `peerDependencies` with `^4.0.0` range
- Adds `zod@^4.3.6` to `devDependencies` so the repo itself can still typecheck/test
- Updates README install command to `zod@^4` with a compatibility note

## Problem

Smithers bundles `zod@^4.3.6` as a direct dependency, but consumers naturally install `zod@^3.23` (the current mainstream version). This creates two incompatible Zod instances. The `z.ZodObject<any>` from Zod 3 doesn't satisfy the Zod 4-based overload signature in `createSmithers()`, so TypeScript picks the wrong overload (DB instead of schema). This cascades: `ctx.outputMaybe()` returns `never`, and the entire type system collapses.

Making `zod` a peer dependency with `^4.0.0`:
1. Forces consumers to install the correct version upfront
2. Gives a clear install-time error if they have the wrong version
3. Ensures a single Zod instance (consumer's and Smithers' types unify)
4. Fixes the downstream TS2742 portability error when consumers use `declaration: true`

## Test plan

- [ ] `bun install` succeeds in the repo (zod resolved from devDependencies)
- [ ] `bun run typecheck` passes
- [ ] `bun test` passes
- [ ] Consumer project with `zod@^4` correctly resolves `createSmithers()` schema overload
- [ ] Consumer project without `zod` or with `zod@3` gets a clear peer dependency warning