### PR TITLE
fix: add transitive @types deps for raw .ts consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.36",
     "@mdx-js/esbuild": "^3.1.1",
+    "@types/react-dom": "^19.2.0",
+    "@types/react-reconciler": "^0.28.9",
     "ai": "^6.0.69",
     "diff": "^5.2.0",
     "drizzle-orm": "^0.45.1",
@@ -71,7 +73,6 @@
     "@types/bun": "latest",
     "@types/diff": "^5.2.0",
     "@types/react": "^19.2.10",
-    "@types/react-reconciler": "^0.28.9",
     "@playwright/test": "^1.52.0"
   }
 }


### PR DESCRIPTION
## Summary

- Moves `@types/react-reconciler` from `devDependencies` to `dependencies`
- Adds `@types/react-dom` to `dependencies`
- Adds a README note about `skipLibCheck: true` for consumers

## Problem

Smithers ships raw TypeScript source (all exports point to `./src/*.ts` files). When consumers type-check their project, TypeScript processes Smithers' source and encounters missing type declarations:

```
node_modules/smithers-orchestrator/src/components.ts(2,38): error TS7016:
  Could not find a declaration file for module 'react-dom/server'.
node_modules/smithers-orchestrator/src/dom/renderer.ts(1,24): error TS7016:
  Could not find a declaration file for module 'react-reconciler'.
```

`skipLibCheck: true` only skips `.d.ts` files — it has no effect on `.ts` files in `node_modules`. Moving the `@types/*` packages to `dependencies` ensures they're installed transitively.

This is a minimal fix. A more complete solution would be to ship compiled `.js` + `.d.ts` output so `skipLibCheck` works as expected.

## Test plan

- [ ] `bun install` succeeds
- [ ] `bun run typecheck` passes
- [ ] Consumer project no longer sees TS7016 errors from Smithers' internals
- [ ] `@types/react-dom` and `@types/react-reconciler` are present in consumer's `node_modules` after installing Smithers