### PR TITLE
fix: use Zod 4 built-in toJSONSchema() for Codex output schema

### DIFF
--- a/src/agents/cli.ts
+++ b/src/agents/cli.ts
@@ -1089,8 +1089,7 @@ export class CodexAgent extends BaseCliAgent {
     let schemaCleanupFile: string | null = null;
     if (!this.opts.outputSchema && params.options?.outputSchema) {
       try {
-        const { zodToJsonSchema } = await import("zod-to-json-schema");
-        const jsonSchema = zodToJsonSchema(params.options.outputSchema);
+        const jsonSchema = params.options.outputSchema.toJSONSchema();
         const schemaFile = join(
           tmpdir(),
           `smithers-schema-${randomUUID()}.json`,
@@ -1099,7 +1098,7 @@ export class CodexAgent extends BaseCliAgent {
         pushFlag(args, "--output-schema", schemaFile);
         schemaCleanupFile = schemaFile;
       } catch {
-        // zod-to-json-schema not available or conversion failed, skip auto-wiring
+        // Schema conversion failed (e.g. unrepresentable types), skip auto-wiring
       }
     }
 

--- a/src/types/zod-to-json-schema.d.ts
+++ b/src/types/zod-to-json-schema.d.ts
@@ -1,3 +1,0 @@
-declare module "zod-to-json-schema" {
-  export function zodToJsonSchema(schema: any, options?: any): any;
-}


### PR DESCRIPTION
## Summary

- Replace `zod-to-json-schema` (v3) dynamic import with Zod 4's native `.toJSONSchema()` instance method in `CodexAgent.buildCommand`
- Remove the dead `src/types/zod-to-json-schema.d.ts` ambient declaration

## Problem

`zod-to-json-schema` v3 silently produces empty JSON schemas (`{"$schema":"..."}` — no `type`, no `properties`) when given Zod 4 objects. This gets written to a temp file and passed to `codex exec --output-schema`, which sends it to OpenAI, which rejects it:

```
"Invalid schema for response_format 'codex_output_schema':
 schema must be a JSON Schema of 'type: "object"', got 'type: "None"'."
```

The library isn't even a direct dependency — it was pulled transitively by `@ai-sdk/ui-utils` and could disappear at any time. When it's not found, the import silently fails and the schema is never auto-wired at all.

## Fix

Zod 4 ships first-party JSON Schema conversion via `.toJSONSchema()`. The `zod-to-json-schema` package is [officially deprecated](https://www.npmjs.com/package/zod-to-json-schema) in favor of it. Since `params.options.outputSchema` is typed as `ZodObject<any>`, the instance method is always available — no new imports needed.

**Before** (broken):
```ts
const { zodToJsonSchema } = await import("zod-to-json-schema");
const jsonSchema = zodToJsonSchema(params.options.outputSchema);
```

**After** (correct):
```ts
const jsonSchema = params.options.outputSchema.toJSONSchema();
```

Produces:
```json
{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}
```

## Test plan

- [x] `bun test` — 142 tests pass, 0 failures
- [x] `tsc --noEmit` — clean
- [x] Verified `.toJSONSchema()` produces `type: "object"` with correct `properties` and `required` fields
- [x] No remaining references to `zod-to-json-schema` in `src/`