### PR TITLE
fix: throw on invalid prompt element type instead of degrading to [object Object]

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -44,6 +44,18 @@ function renderChildrenToText(children: any): string {
       .replace(/\n{3,}/g, "\n\n")
       .trim();
   } catch {
+    // When children is a React element whose type is not a valid component
+    // (string tag or function), fail loudly instead of degrading to
+    // "[object Object]". Common cause: uncompiled MDX import.
+    if (
+      React.isValidElement(children) &&
+      typeof (children as any).type !== "string" &&
+      typeof (children as any).type !== "function"
+    ) {
+      throw new Error(
+        `Task prompt could not be rendered: element type is "${typeof (children as any).type}", expected a string or component function`,
+      );
+    }
     return String(children ?? "");
   }
 }

--- a/src/dom/renderer.ts
+++ b/src/dom/renderer.ts
@@ -189,9 +189,11 @@ const reconciler = Reconciler(hostConfig);
 export class SmithersRenderer {
   private container: HostContainer;
   private root: any;
+  private _renderError: unknown = null;
 
   constructor() {
     this.container = { root: null };
+
     this.root = (reconciler as any).createContainer(
       this.container,
       0,
@@ -199,16 +201,20 @@ export class SmithersRenderer {
       false,
       null,
       "",
-      (reconciler as any).defaultOnUncaughtError,
-      (reconciler as any).defaultOnCaughtError,
-      (reconciler as any).defaultOnRecoverableError,
+      (error: unknown) => { this._renderError ??= error; }, // onUncaughtError — propagate
+      () => {}, // onCaughtError — handled by error boundary
+      () => {}, // onRecoverableError — React auto-recovered
       null,
     );
   }
 
   async render(element: React.ReactElement, opts?: ExtractOptions) {
+    this._renderError = null;
     (reconciler as any).updateContainerSync(element, this.root, null, () => {});
     (reconciler as any).flushSyncWork();
+    if (this._renderError) {
+      throw this._renderError;
+    }
     return extractFromHost(this.container.root, opts);
   }
 

--- a/tests/renderer.test.tsx
+++ b/tests/renderer.test.tsx
@@ -1,8 +1,36 @@
 /** @jsxImportSource smithers */
+import React from "react";
 import { describe, expect, test } from "bun:test";
 import { SmithersRenderer } from "../src/dom/renderer";
 import { Task, Workflow } from "../src/components";
 import { outputA } from "./schema";
+
+const fakeAgent: any = {
+  id: "fake",
+  tools: {},
+  generate: async () => ({ output: { value: 1 } }),
+};
+
+describe("MDX prompt error handling", () => {
+  test("throws when agent task prompt element has invalid type", async () => {
+    const renderer = new SmithersRenderer();
+    // Simulate an unloaded MDX import: a React element whose type is a module
+    // object instead of a component function, e.g. { default: "/path/to.mdx" }
+    const brokenMdx = React.createElement(
+      { default: "/path/to/Prompt.mdx" } as any,
+      {},
+    );
+    await expect(
+      renderer.render(
+        <Workflow name="w">
+          <Task id="t" output={outputA} agent={fakeAgent}>
+            {brokenMdx}
+          </Task>
+        </Workflow>,
+      ),
+    ).rejects.toThrow("Task prompt could not be rendered");
+  });
+});
 
 describe("renderer updates", () => {
   test("commitUpdate applies new props", async () => {


### PR DESCRIPTION
## Summary

- Detect React elements with invalid types (not string or function) in `renderChildrenToText` and throw instead of silently returning `[object Object]`
- Propagate uncaught component errors through `SmithersRenderer` instead of swallowing them via React's default error handler

## Problem

When an MDX prompt import isn't compiled (e.g. missing preload plugin), the import resolves to a module object instead of a component function. `renderToStaticMarkup` throws, and the catch block falls back to `String(children)` → `[object Object]`. The agent then receives a useless prompt with no diagnostic.

## Changes

**`src/components.ts`** — In the `renderChildrenToText` catch path, check whether children is a React element whose `type` is neither a string nor a function. If so, throw with a descriptive error instead of returning `[object Object]`.

**`src/dom/renderer.ts`** — Replace React's default error handlers with: propagate `onUncaughtError` (fatal), no-op for `onCaughtError` and `onRecoverableError` (handled by React). This ensures component-level throws surface to callers of `renderer.render()`.

**`tests/renderer.test.tsx`** — Test that a React element with an object type (simulating an uncompiled MDX import) throws `"Task prompt could not be rendered"`.

## Test plan

- [x] `bun test` — 143 tests pass, 0 failures
- [x] `tsc --noEmit` — clean
- [x] Existing tests with object children on agent tasks (parallel-edges, merge-queue) continue to work — the check is scoped to React elements with invalid types, not plain objects

Closes #78