### PR TITLE
fix: restore JSX key/intrinsic typing for jsxImportSource runtime

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,2 +1,24 @@
+import type * as React from "react";
+
 export { jsx, jsxs, Fragment } from "react/jsx-runtime";
 export { jsxDEV } from "react/jsx-dev-runtime";
+
+// Re-export React's JSX namespace so `jsxImportSource: "smithers"` keeps
+// intrinsic attributes (`key`, `ref`) and intrinsic elements (e.g. `div`).
+export namespace JSX {
+  export type ElementType = React.JSX.ElementType;
+  export interface Element extends React.JSX.Element {}
+  export interface ElementClass extends React.JSX.ElementClass {}
+  export interface ElementAttributesProperty
+    extends React.JSX.ElementAttributesProperty {}
+  export interface ElementChildrenAttribute
+    extends React.JSX.ElementChildrenAttribute {}
+  export type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<
+    C,
+    P
+  >;
+  export interface IntrinsicAttributes extends React.JSX.IntrinsicAttributes {}
+  export interface IntrinsicClassAttributes<T>
+    extends React.JSX.IntrinsicClassAttributes<T> {}
+  export interface IntrinsicElements extends React.JSX.IntrinsicElements {}
+}

--- a/tests/jsx-runtime.typecheck.tsx
+++ b/tests/jsx-runtime.typecheck.tsx
@@ -1,0 +1,19 @@
+/**
+ * Compile-time guard for smithers/jsx-runtime types.
+ *
+ * Ensures `key` is accepted through JSX IntrinsicAttributes and intrinsic
+ * elements are available when using `jsxImportSource: "smithers"`.
+ */
+import { Sequence } from "../src/components";
+
+const items = [1, 2, 3];
+
+export const sequenceList = (
+  <>
+    {items.map((n) => (
+      <Sequence key={`s${n}`} skipIf={false}>
+        <div>{n}</div>
+      </Sequence>
+    ))}
+  </>
+);


### PR DESCRIPTION
## Problem (from library user perspective)
A library user configured TypeScript with:

```json
{
  "jsx": "react-jsx",
  "jsxImportSource": "smithers-orchestrator"
}
```

When rendering mapped Smithers components, React required a list key at runtime:

```tsx
items.map((item) => <Sequence key={item.id}>...</Sequence>)
```

But TypeScript rejected that same code with:

```
Property 'key' does not exist on type 'SequenceProps'
```

In the same setup, intrinsic JSX elements (like `<div>`) could also lose type information.

## Root cause
`smithers-orchestrator/jsx-runtime` only re-exported runtime functions (`jsx`, `jsxs`, `Fragment`, `jsxDEV`) and did not export the `JSX` namespace types that TypeScript expects from the `jsxImportSource` runtime module.

Without `JSX.IntrinsicAttributes` and related bridges, `key`/`ref` are not merged by TypeScript and are incorrectly checked against component props directly.

## Solution
- Added React-compatible `export namespace JSX` declarations in `src/jsx-runtime.ts`.
- This mirrors the type surface from React's own `jsx-runtime` declarations and restores:
  - `key` / `ref` handling via intrinsic attributes
  - intrinsic element typing (`JSX.IntrinsicElements`)
  - library-managed attribute behavior
- Added a compile-time regression guard at `tests/jsx-runtime.typecheck.tsx` covering:
  - mapped `<Sequence key={...}>...`
  - intrinsic `<div>` usage under the Smithers JSX runtime.

## Validation
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `bun test tests/type-inference.test.ts`
