### PR TITLE
fix: tolerate codex rollout recorder stderr

### DIFF
--- a/src/agents/cli.ts
+++ b/src/agents/cli.ts
@@ -886,6 +886,9 @@ abstract class BaseCliAgent implements Agent<any, any, any> {
       const benignPatterns = [
         /^.*state db missing rollout path.*$/gm,
         /^.*codex_core::rollout::list.*$/gm,
+        /^.*failed to record rollout items: failed to queue rollout items: channel closed.*$/gim,
+        /^.*Failed to shutdown rollout recorder.*$/gm,
+        /^.*failed to renew cache TTL: Operation not permitted.*$/gim,
       ];
       let filtered = stderr;
       for (const pattern of benignPatterns) {
@@ -897,11 +900,13 @@ abstract class BaseCliAgent implements Agent<any, any, any> {
 
     if (result.exitCode && result.exitCode !== 0) {
       const filteredStderr = filterBenignStderr(result.stderr);
-      const errorText =
-        filteredStderr ||
-        result.stdout.trim() ||
-        `CLI exited with code ${result.exitCode}`;
-      throw new Error(errorText);
+      if (!(commandSpec.command === "codex" && filteredStderr.length === 0)) {
+        const errorText =
+          filteredStderr ||
+          result.stdout.trim() ||
+          `CLI exited with code ${result.exitCode}`;
+        throw new Error(errorText);
+      }
     }
 
     const rawText = stdout.trim();


### PR DESCRIPTION
this is something that just came up today for me, so not sure if others have the same issues. this local fix worked for me.

Problem: Codex can exit non-zero with only rollout recorder shutdown noise, which Smithers treated as fatal.

Fix: filter known rollout-recorder and cache TTL stderr lines; treat Codex non-zero as success when stderr is empty after filtering.

Assumptions: rollout-recorder and cache TTL errors are non-fatal if output schema is still produced.