### PR TITLE
smithers: resume --force and SIGINT cancellation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -96,7 +96,7 @@ async function main() {
 
 Commands:
   run <workflow.tsx> [--input JSON] [--run-id ID] [--max-concurrency N]
-  resume <workflow.tsx> --run-id ID
+  resume <workflow.tsx> --run-id ID [--force]
   approve <workflow.tsx> --run-id ID --node-id ID [--iteration N] [--note TEXT] [--decided-by TEXT]
   deny <workflow.tsx> --run-id ID --node-id ID [--iteration N] [--note TEXT] [--decided-by TEXT]
   status <workflow.tsx> --run-id ID
@@ -161,6 +161,12 @@ Run options:
       const existing = await adapter.getRun(runId);
       if (resume && !existing) {
         console.error(`Run not found: ${runId}`);
+        process.exit(4);
+      }
+      if (resume && existing?.status === "running" && !args.force) {
+        console.error(
+          `Run is still marked running: ${runId}. Use --force to resume anyway.`,
+        );
         process.exit(4);
       }
       if (!resume && existing) {
@@ -229,6 +235,19 @@ Run options:
           break;
       }
     };
+    const abort = new AbortController();
+    let signalHandled = false;
+    const handleSignal = (signal: string) => {
+      if (signalHandled) return;
+      signalHandled = true;
+      process.stderr.write(`
+[smithers] received ${signal}, cancelling run...
+`);
+      abort.abort();
+    };
+    process.once("SIGINT", () => handleSignal("SIGINT"));
+    process.once("SIGTERM", () => handleSignal("SIGTERM"));
+
     const result = await runWorkflow(workflow, {
       input,
       runId,
@@ -241,6 +260,7 @@ Run options:
       maxOutputBytes,
       toolTimeoutMs,
       onProgress,
+      signal: abort.signal,
     });
     console.log(JSON.stringify(result, null, 2));
     process.exit(


### PR DESCRIPTION
## Problem
When a smithers run process crashes or is interrupted, the run can remain stuck as `running` and cannot be resumed.

### Reproduction
1. Start a smithers run.
2. Kill the process (e.g. Ctrl+C).
3. Run `smithers list`.

### Observed Behavior
- After interrupting the process with Ctrl-C, `smithers list` still shows the run as status: `running`.
- `smithers resume` won’t attach because the run is not in a resumable state (it’s still marked `running`).

### Expected Behavior
- When the process exits, it is caught and the run is marked as failed/cancelled (not `running`).
- Either the run transitions to a resumable state after the process is stopped, or `resume` can attach to a run that is still marked `running`.

### Current Workaround
1. `smithers cancel ... --run-id <id>`
2. `smithers run ...` (starts a new run)

## Fix
- Handle SIGINT/SIGTERM in the CLI and pass an abort signal so interrupted runs are marked `cancelled`.
- Add `resume --force` to allow resuming a run still marked `running` (manual recovery path).

## Notes
- This keeps surface area minimal and avoids schema changes.
