### PR TITLE
feat: add idle timeout for CLI agents

### DIFF
--- a/docs/integrations/cli-agents.mdx
+++ b/docs/integrations/cli-agents.mdx
@@ -69,7 +69,8 @@ type BaseCliAgentOptions = {
   cwd?: string;              // Working directory for the CLI process
   env?: Record<string, string>;  // Additional environment variables
   yolo?: boolean;            // Skip permission prompts (default: true)
-  timeoutMs?: number;        // Process timeout in milliseconds
+  timeoutMs?: number;        // Hard wall-clock timeout in milliseconds
+  idleTimeoutMs?: number;    // Inactivity timeout (no stdout/stderr) in milliseconds
   maxOutputBytes?: number;   // Max output capture size
   extraArgs?: string[];      // Additional CLI arguments appended to the command
 };
@@ -84,9 +85,28 @@ type BaseCliAgentOptions = {
 | `cwd` | Tool context rootDir or `process.cwd()` | Working directory for the spawned process |
 | `env` | `{}` | Extra environment variables merged with `process.env` |
 | `yolo` | `true` | When true, configures the CLI to skip all interactive permission prompts |
-| `timeoutMs` | `undefined` | Kill the process after this many milliseconds |
+| `timeoutMs` | `undefined` | Hard wall-clock timeout; kill the process after this many milliseconds |
+| `idleTimeoutMs` | `undefined` | Inactivity timeout; kill the process after this many milliseconds with no stdout/stderr |
 | `maxOutputBytes` | `undefined` | Truncate captured output to this size |
 | `extraArgs` | `[]` | Arbitrary additional CLI flags |
+
+---
+### Timeouts
+
+You can use either or both timeouts:
+
+- `timeoutMs`: hard wall‑clock cap (backwards compatible).
+- `idleTimeoutMs`: inactivity cap that resets on any stdout/stderr output.
+
+When invoking an agent directly, you can also override per-call timeouts via
+`options.timeout`:
+
+```ts
+await agent.generate({
+  prompt: "do the thing",
+  timeout: { totalMs: 15 * 60 * 1000, idleMs: 2 * 60 * 1000 },
+});
+```
 
 ---
 
@@ -98,7 +118,8 @@ Wraps the `claude` CLI with `--print` mode.
 const claude = new ClaudeCodeAgent({
   model: "claude-sonnet-4-20250514",
   systemPrompt: "You are a careful code reviewer.",
-  timeoutMs: 300_000,
+  timeoutMs: 30 * 60 * 1000,
+  idleTimeoutMs: 2 * 60 * 1000,
 });
 ```
 

--- a/src/agents/BaseCliAgent.ts
+++ b/src/agents/BaseCliAgent.ts
@@ -10,7 +10,7 @@ import type {
 } from "ai";
 import { getToolContext } from "../tools/context";
 
-type TimeoutInput = number | { totalMs?: number } | undefined;
+type TimeoutInput = number | { totalMs?: number; idleMs?: number } | undefined;
 
 export type BaseCliAgentOptions = {
   id?: string;
@@ -21,6 +21,7 @@ export type BaseCliAgentOptions = {
   env?: Record<string, string>;
   yolo?: boolean;
   timeoutMs?: number;
+  idleTimeoutMs?: number;
   maxOutputBytes?: number;
   extraArgs?: string[];
 };
@@ -49,6 +50,7 @@ type RunRpcCommandOptions = {
   env: Record<string, string>;
   prompt: string;
   timeoutMs?: number;
+  idleTimeoutMs?: number;
   signal?: AbortSignal;
   maxOutputBytes?: number;
   onStderr?: (chunk: string) => void;
@@ -68,6 +70,7 @@ type RunCommandOptions = {
   env: Record<string, string>;
   input?: string;
   timeoutMs?: number;
+  idleTimeoutMs?: number;
   signal?: AbortSignal;
   maxOutputBytes?: number;
   onStdout?: (chunk: string) => void;
@@ -93,18 +96,23 @@ type CliCommandSpec = {
   errorOnBannerOnly?: boolean;
 };
 
-export function resolveTimeoutMs(
+export function resolveTimeouts(
   timeout: TimeoutInput,
-  fallback?: number,
-): number | undefined {
-  if (typeof timeout === "number") return timeout;
-  if (
-    timeout &&
-    typeof timeout === "object" &&
-    typeof timeout.totalMs === "number"
-  )
-    return timeout.totalMs;
-  return fallback;
+  fallback?: { totalMs?: number; idleMs?: number },
+): { totalMs?: number; idleMs?: number } {
+  if (typeof timeout === "number") {
+    return { totalMs: timeout };
+  }
+  if (timeout && typeof timeout === "object") {
+    return {
+      totalMs: typeof timeout.totalMs === "number" ? timeout.totalMs : fallback?.totalMs,
+      idleMs: typeof timeout.idleMs === "number" ? timeout.idleMs : fallback?.idleMs,
+    };
+  }
+  return {
+    totalMs: fallback?.totalMs,
+    idleMs: fallback?.idleMs,
+  };
 }
 
 export function combineNonEmpty(parts: Array<string | undefined>): string | undefined {
@@ -279,6 +287,39 @@ export function truncateToBytes(text: string, maxBytes?: number): string {
   return buf.subarray(0, maxBytes).toString("utf8");
 }
 
+function createOneShotTimer(timeoutMs: number | undefined, onTimeout: () => void) {
+  if (!timeoutMs || !Number.isFinite(timeoutMs)) {
+    return { clear: () => {} };
+  }
+  const timer = setTimeout(onTimeout, timeoutMs);
+  return {
+    clear: () => clearTimeout(timer),
+  };
+}
+
+function createInactivityTimer(timeoutMs: number | undefined, onTimeout: () => void) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (!timeoutMs || !Number.isFinite(timeoutMs)) {
+    return {
+      reset: () => {},
+      clear: () => {},
+    };
+  }
+
+  const reset = () => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(onTimeout, timeoutMs);
+  };
+
+  const clear = () => {
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+  };
+
+  reset();
+  return { reset, clear };
+}
+
 function emptyUsage() {
   return {
     inputTokens: undefined,
@@ -424,6 +465,7 @@ export async function runCommand(
     env,
     input,
     timeoutMs,
+    idleTimeoutMs,
     signal,
     maxOutputBytes,
     onStdout,
@@ -440,6 +482,7 @@ export async function runCommand(
     });
 
     const onData = (chunk: Buffer, target: "stdout" | "stderr") => {
+      inactivity.reset();
       const text = chunk.toString("utf8");
       const next = truncateToBytes(
         target === "stdout" ? stdout + text : stderr + text,
@@ -476,13 +519,12 @@ export async function runCommand(
       finalize(new Error(reason));
     };
 
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    if (timeoutMs && Number.isFinite(timeoutMs)) {
-      timer = setTimeout(
-        () => kill(`CLI timed out after ${timeoutMs}ms`),
-        timeoutMs,
-      );
-    }
+    const totalTimeout = createOneShotTimer(timeoutMs, () =>
+      kill(`CLI timed out after ${timeoutMs}ms`),
+    );
+    const inactivity = createInactivityTimer(idleTimeoutMs, () =>
+      kill(`CLI idle timed out after ${idleTimeoutMs}ms`),
+    );
 
     if (signal) {
       if (signal.aborted) {
@@ -495,11 +537,13 @@ export async function runCommand(
     }
 
     child.on("error", (err) => {
-      if (timer) clearTimeout(timer);
+      inactivity.clear();
+      totalTimeout.clear();
       finalize(err);
     });
     child.on("close", () => {
-      if (timer) clearTimeout(timer);
+      inactivity.clear();
+      totalTimeout.clear();
       finalize();
     });
 
@@ -516,7 +560,7 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
    stderr: string;
    exitCode: number | null;
  }> {
-   const { cwd, env, prompt, timeoutMs, signal, maxOutputBytes, onStderr, onExtensionUiRequest } = options;
+   const { cwd, env, prompt, timeoutMs, idleTimeoutMs, signal, maxOutputBytes, onStderr, onExtensionUiRequest } = options;
    return await new Promise((resolve, reject) => {
      let stderr = "";
      let settled = false;
@@ -543,7 +587,7 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
        }
        reject(err);
      };
- 
+
      const finalize = (text: string, output: unknown) => {
        if (settled) return;
        settled = true;
@@ -554,7 +598,7 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
        }
        resolve({ text, output, stderr, exitCode: child.exitCode });
      };
- 
+
      const terminateChild = () => {
        try {
          child.kill("SIGTERM");
@@ -575,12 +619,14 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
        terminateChild();
        handleError(new Error(reason));
      };
- 
-     let timer: ReturnType<typeof setTimeout> | undefined;
-     if (timeoutMs && Number.isFinite(timeoutMs)) {
-       timer = setTimeout(() => kill(`CLI timed out after ${timeoutMs}ms`), timeoutMs);
-     }
- 
+
+     const totalTimeout = createOneShotTimer(timeoutMs, () =>
+       kill(`CLI timed out after ${timeoutMs}ms`),
+     );
+     const inactivity = createInactivityTimer(idleTimeoutMs, () =>
+       kill(`CLI idle timed out after ${idleTimeoutMs}ms`),
+     );
+
      if (signal) {
        if (signal.aborted) {
          kill("CLI aborted");
@@ -608,6 +654,7 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
      };
  
      const handleLine = async (line: string) => {
+       inactivity.reset();
        let parsed: unknown;
        try {
          parsed = JSON.parse(line);
@@ -647,7 +694,8 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
            }
            const extracted = finalMessage ? extractTextFromJsonValue(finalMessage) : undefined;
            const text = extracted ?? textDeltas;
-           if (timer) clearTimeout(timer);
+           inactivity.clear();
+           totalTimeout.clear();
            if (promptResponseError) {
              handleError(new Error(promptResponseError));
              return;
@@ -668,21 +716,28 @@ export async function runRpcCommand(command: string, args: string[], options: Ru
          handleError(err instanceof Error ? err : new Error(String(err)));
        });
      });
- 
+
+     child.stdout?.on("data", () => {
+       inactivity.reset();
+     });
+
      child.stderr?.on("data", (chunk) => {
+       inactivity.reset();
        const text = chunk.toString("utf8");
        stderr = truncateToBytes(stderr + text, maxOutputBytes);
        onStderr?.(text);
      });
- 
+
      child.on("error", (err) => {
-       if (timer) clearTimeout(timer);
+       inactivity.clear();
+       totalTimeout.clear();
        handleError(err);
      });
- 
+
      child.on("close", (code) => {
        exitCode = code ?? null;
-       if (timer) clearTimeout(timer);
+       inactivity.clear();
+       totalTimeout.clear();
        if (settled) return;
        if (promptResponseError) {
          handleError(new Error(promptResponseError));
@@ -715,6 +770,7 @@ export abstract class BaseCliAgent implements Agent<any, any, any> {
   protected readonly env?: Record<string, string>;
   protected readonly yolo: boolean;
   protected readonly timeoutMs?: number;
+  protected readonly idleTimeoutMs?: number;
   protected readonly maxOutputBytes?: number;
   protected readonly extraArgs?: string[];
 
@@ -726,13 +782,17 @@ export abstract class BaseCliAgent implements Agent<any, any, any> {
     this.env = opts.env;
     this.yolo = opts.yolo ?? true;
     this.timeoutMs = opts.timeoutMs;
+    this.idleTimeoutMs = opts.idleTimeoutMs;
     this.maxOutputBytes = opts.maxOutputBytes;
     this.extraArgs = opts.extraArgs;
   }
 
   async generate(options: any): Promise<GenerateTextResult<any, any>> {
     const { prompt, systemFromMessages } = extractPrompt(options);
-    const callTimeout = resolveTimeoutMs(options?.timeout, this.timeoutMs);
+    const callTimeouts = resolveTimeouts(options?.timeout, {
+      totalMs: this.timeoutMs,
+      idleMs: this.idleTimeoutMs,
+    });
     const cwd = this.cwd ?? getToolContext()?.rootDir ?? process.cwd();
     const env = { ...process.env, ...(this.env ?? {}) } as Record<
       string,
@@ -756,7 +816,8 @@ export abstract class BaseCliAgent implements Agent<any, any, any> {
         cwd,
         env: commandEnv,
         input: commandSpec.stdin,
-        timeoutMs: callTimeout,
+        timeoutMs: callTimeouts.totalMs,
+        idleTimeoutMs: callTimeouts.idleMs,
         signal: options?.abortSignal,
         maxOutputBytes: this.maxOutputBytes ?? getToolContext()?.maxOutputBytes,
         onStdout: options?.onStdout,

--- a/src/agents/PiAgent.ts
+++ b/src/agents/PiAgent.ts
@@ -5,7 +5,7 @@ import {
   combineNonEmpty,
   extractPrompt,
   extractTextFromPiNdjson,
-  resolveTimeoutMs,
+  resolveTimeouts,
   runCommand,
   runRpcCommand,
   tryParseJson,
@@ -61,7 +61,10 @@ export class PiAgent extends BaseCliAgent {
 
   async generate(options: any): Promise<GenerateTextResult<any, any>> {
     const { prompt, systemFromMessages } = extractPrompt(options);
-    const callTimeout = resolveTimeoutMs(options?.timeout, this.timeoutMs);
+    const callTimeouts = resolveTimeouts(options?.timeout, {
+      totalMs: this.timeoutMs,
+      idleMs: this.idleTimeoutMs,
+    });
     const cwd = this.cwd ?? getToolContext()?.rootDir ?? process.cwd();
     const env = { ...process.env, ...(this.env ?? {}) } as Record<string, string>;
     const combinedSystem = combineNonEmpty([this.systemPrompt, systemFromMessages]);
@@ -164,7 +167,8 @@ export class PiAgent extends BaseCliAgent {
       const result = await runCommand("pi", args, {
         cwd,
         env,
-        timeoutMs: callTimeout,
+        timeoutMs: callTimeouts.totalMs,
+        idleTimeoutMs: callTimeouts.idleMs,
         signal: options?.abortSignal,
         maxOutputBytes: this.maxOutputBytes ?? getToolContext()?.maxOutputBytes,
         onStdout: options?.onStdout,
@@ -190,7 +194,8 @@ export class PiAgent extends BaseCliAgent {
       cwd,
       env,
       prompt,
-      timeoutMs: callTimeout,
+      timeoutMs: callTimeouts.totalMs,
+      idleTimeoutMs: callTimeouts.idleMs,
       signal: options?.abortSignal,
       maxOutputBytes: this.maxOutputBytes ?? getToolContext()?.maxOutputBytes,
       onStderr: options?.onStderr,

--- a/tests/base-cli-agent-timeouts.test.ts
+++ b/tests/base-cli-agent-timeouts.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { BaseCliAgent } from "../src/agents/BaseCliAgent";
+import type { BaseCliAgentOptions } from "../src/agents/BaseCliAgent";
+
+class TimedAgent extends BaseCliAgent {
+  constructor(
+    private readonly script: string,
+    opts: BaseCliAgentOptions = {},
+  ) {
+    super({ id: "timeout-test-agent", ...opts });
+  }
+
+  protected async buildCommand(_params: {
+    prompt: string;
+    systemPrompt?: string;
+    cwd: string;
+    options: any;
+  }) {
+    return {
+      command: "bash",
+      args: ["-lc", this.script],
+    };
+  }
+}
+
+describe("BaseCliAgent timeouts", () => {
+  test("idle timeout resets on stdout activity", async () => {
+    const agent = new TimedAgent(
+      "for i in 1 2 3 4 5; do echo tick; sleep 0.05; done",
+      { idleTimeoutMs: 80 },
+    );
+
+    const result = await agent.generate({ prompt: "run" });
+    expect(result.text).toContain("tick");
+  });
+
+  test("idle timeout fails after inactivity", async () => {
+    const agent = new TimedAgent("echo start; sleep 0.2; echo end", {
+      idleTimeoutMs: 80,
+    });
+
+    await expect(agent.generate({ prompt: "run" })).rejects.toThrow(
+      "CLI idle timed out after 80ms",
+    );
+  });
+
+  test("hard timeout still applies", async () => {
+    const agent = new TimedAgent("sleep 0.2; echo done", {
+      timeoutMs: 50,
+      idleTimeoutMs: 1000,
+    });
+
+    await expect(agent.generate({ prompt: "run" })).rejects.toThrow(
+      "CLI timed out after 50ms",
+    );
+  });
+});


### PR DESCRIPTION
Adding an idle timeout so that if there is no agent response, the agent gets cancelled and can retry.

Issue being that the task timeout should be large so agents can fully run, do tests and verify their work. We want to trust the models.

But when they don't respond the long task timeout means it stalls the pipeline. therefore the idle timeout allows retrying that agent when it doesn't respond due to e.g. upstream api hang ups