### PR TITLE
docs: clarify when RunResult.output is populated

### DIFF
--- a/docs/runtime/run-workflow.mdx
+++ b/docs/runtime/run-workflow.mdx
@@ -71,8 +71,41 @@ type RunResult = {
 |---|---|---|
 | `runId` | `string` | The run identifier (either provided or auto-generated). |
 | `status` | `string` | Terminal status of the run. |
-| `output` | `unknown` | Rows from the `output` table in the schema, if the workflow finished successfully and the schema includes an `output` table. |
+| `output` | `unknown` | Rows from the `output` table in the schema, if the workflow finished successfully and the schema includes an `output` table. See note below. |
 | `error` | `unknown` | Error information if the run failed. Contains a serialized error object with `code`, `message`, and optional `details`. |
+
+### Understanding `result.output`
+
+The `output` field on `RunResult` is **only** populated if your schema passed to `createSmithers()` includes a key literally named `output`. For example:
+
+```ts
+// ✅ result.output WILL be populated
+const { Workflow, smithers } = createSmithers({
+  output: z.object({ summary: z.string() }),
+});
+```
+
+```ts
+// ❌ result.output will be undefined
+const { Workflow, smithers } = createSmithers({
+  page: z.object({ title: z.string(), html: z.string() }),
+});
+```
+
+If your schema uses other key names (like `page`, `analysis`, `research`, etc.), all task outputs are still persisted to SQLite — they're just not returned on `result.output`. To access them programmatically, query the SQLite database directly:
+
+```ts
+import { Database } from "bun:sqlite";
+
+const result = await runWorkflow(workflow, { input: {} });
+const db = new Database("smithers.db", { readonly: true });
+const rows = db.query(
+  "SELECT * FROM page WHERE run_id = ? ORDER BY iteration DESC"
+).all(result.runId);
+db.close();
+```
+
+Alternatively, name your schema key `output` if you want the convenience of `result.output`.
 
 ### Status Values
 


### PR DESCRIPTION
## Problem

When using `createSmithers()` with schema keys other than `"output"` (e.g. `"page"`, `"analysis"`), `result.output` from `runWorkflow()` is always `undefined`. The current docs mention this in a single clause — "if the schema includes an `output` table" — but it's easy to miss.

I ran into this building a workflow that generates HTML pages:

```ts
const { Workflow, smithers } = createSmithers({
  page: z.object({ title: z.string(), html: z.string() }),
});
```

After `runWorkflow()` returned `{ runId: "...", status: "finished" }` with no `output`, I spent time debugging before realizing the data was in SQLite all along — just not on the result object.

## Fix

Added a dedicated "Understanding `result.output`" section to `docs/runtime/run-workflow.mdx` that:

- Shows ✅/❌ examples of when `result.output` is vs isn't populated
- Explains how to query SQLite directly for non-`"output"` schema keys
- Suggests naming the schema key `"output"` as an alternative

## Test plan

- [ ] Verify docs render correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)