### PR TITLE
fix: Ralph loops ignore approved reviews and always run all iterations

### DIFF
--- a/src/db/snapshot.ts
+++ b/src/db/snapshot.ts
@@ -6,6 +6,53 @@ import type { OutputSnapshot } from "../context";
 import { fromPromise } from "../effect/interop";
 import { runPromise } from "../effect/runtime";
 
+/**
+ * Detect columns declared with `{ mode: "boolean" }` in a Drizzle table.
+ * bun:sqlite returns raw INTEGER 0/1 for these columns instead of JS booleans,
+ * which breaks strict equality checks like `value === true`.
+ */
+function getBooleanColumnKeys(table: any): string[] {
+  try {
+    const cols = getTableColumns(table as any) as Record<string, any>;
+    const keys: string[] = [];
+    for (const [key, col] of Object.entries(cols)) {
+      // Check all known ways drizzle exposes boolean mode
+      const c = col as any;
+      if (
+        c?.columnType === "SQLiteBoolean" ||
+        c?.config?.mode === "boolean" ||
+        c?.mode === "boolean" ||
+        c?.mapFromDriverValue?.toString().includes("Boolean") ||
+        // Drizzle integer({ mode: "boolean" }) sets dataType to "integer"
+        // and stores mode in the config — check the column's JS name hints
+        (c?.dataType === "boolean")
+      ) {
+        keys.push(key);
+      }
+    }
+    return keys;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Coerce integer 0/1 values to proper JS booleans for boolean-mode columns.
+ */
+function coerceBooleanColumns(rows: any[], boolKeys: string[]): any[] {
+  if (boolKeys.length === 0) return rows;
+  return rows.map((row) => {
+    if (!row) return row;
+    const patched = { ...row };
+    for (const key of boolKeys) {
+      if (key in patched && typeof patched[key] !== "boolean") {
+        patched[key] = Boolean(patched[key]);
+      }
+    }
+    return patched;
+  });
+}
+
 export function loadInputEffect(
   db: any,
   inputTable: any,
@@ -57,12 +104,14 @@ export function loadOutputsEffect(
       } catch {
         continue;
       }
-      const rows = yield* fromPromise<any[]>(`load outputs ${tableName}`, () =>
+      const rawRows = yield* fromPromise<any[]>(`load outputs ${tableName}`, () =>
         db
           .select()
           .from(table as any)
           .where(eq(runIdCol, runId)),
       );
+      const boolKeys = getBooleanColumnKeys(table);
+      const rows = coerceBooleanColumns(rawRows, boolKeys);
       out[tableName] = rows;
       out[key] = rows;
     }


### PR DESCRIPTION
## Problem

When using Ralph loops with a review step, the loop keeps running all `maxIterations` even after the review approves. For example, if you have:

```tsx
<Ralph
  until={ctx.latest(reviewResult, "review1")?.approved === true}
  maxIterations={3}
>
  <Sequence>
    <Task id="fix1" ... />
    <Task id="review1" ... />
  </Sequence>
</Ralph>
```

The review task approves on iteration 0, but iterations 1 and 2 still run — wasting time and compute on redundant fix+review cycles that just confirm "everything is already fixed."

## Root cause

`bun:sqlite` returns raw INTEGER `0`/`1` for columns that drizzle declares with `{ mode: "boolean" }`. In JavaScript, `1 === true` is `false`. So `ctx.latest(reviewResult, "review1")?.approved === true` always evaluates to `false`, and the `until` condition is never satisfied.

## Fix

In `loadOutputs` (`src/db/snapshot.ts`), after reading rows from the database, detect boolean-mode columns and coerce `0`/`1` to proper JS `false`/`true`.

## Test plan

- [ ] Verify Ralph loop stops after first approved review instead of running all iterations
- [ ] Run existing test suite: `bun run test`