### PR TITLE
fix: tolerate codex rollout recorder stderr

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9447,9 +9447,29 @@ export default smithers(db, (ctx) => (
 
 Internally, `<Loop>` renders as a `<smithers:ralph>` host element (or `null` when skipped). The runtime manages iteration state and re-renders the workflow tree on each iteration, re-evaluating the `until` condition with the latest context.
 
+## Nested loops
+
+Direct nesting — placing a `<Ralph>` as an immediate child of another `<Ralph>` — is not supported and throws `"Nested <Ralph> is not supported."` at render time. However, you can nest loops by wrapping the inner `<Ralph>` in a `<Sequence>`:
+
+```tsx
+<Workflow name="nested-loops">
+  <Ralph id="outer" until={outerDone} maxIterations={5}>
+    <Sequence>
+      <Ralph id="inner" until={innerDone} maxIterations={3}>
+        <Task id="innerTask" output="innerOutput" agent={agent}>
+          Run the inner loop body.
+        </Task>
+      </Ralph>
+    </Sequence>
+  </Ralph>
+</Workflow>
+```
+
+A common pattern is an outer loop driving the overall pipeline with an inner loop handling a review-until-LGTM cycle on each iteration.
+
 ## Restrictions
 
-- **Nesting is not supported.** Placing a `<Loop>` inside another `<Loop>` throws an error at render time.
+- **Direct nesting throws.** Placing a `<Loop>` as an immediate child of another `<Loop>` throws an error. Wrap the inner loop in a `<Sequence>` to nest loops (see [Nested loops](#nested-loops) above).
 - **Duplicate ids throw.** If two `<Loop>` loops share the same `id` (explicit or auto-generated), an error is thrown.
 
 ## Notes

--- a/src/agents/BaseCliAgent.ts
+++ b/src/agents/BaseCliAgent.ts
@@ -816,6 +816,9 @@ export abstract class BaseCliAgent implements Agent<any, any, any> {
         const benignPatterns = [
           /^.*state db missing rollout path.*$/gm,
           /^.*codex_core::rollout::list.*$/gm,
+          /^.*failed to record rollout items: failed to queue rollout items: channel closed.*$/gim,
+          /^.*Failed to shutdown rollout recorder.*$/gm,
+          /^.*failed to renew cache TTL: Operation not permitted.*$/gim,
         ];
         let filtered = stderr;
         for (const pattern of benignPatterns) {
@@ -827,11 +830,13 @@ export abstract class BaseCliAgent implements Agent<any, any, any> {
 
       if (result.exitCode && result.exitCode !== 0) {
         const filteredStderr = filterBenignStderr(result.stderr);
-        const errorText =
-          filteredStderr ||
-          result.stdout.trim() ||
-          `CLI exited with code ${result.exitCode}`;
-        throw new Error(errorText);
+        if (!(commandSpec.command === "codex" && filteredStderr.length === 0)) {
+          const errorText =
+            filteredStderr ||
+            result.stdout.trim() ||
+            `CLI exited with code ${result.exitCode}`;
+          throw new Error(errorText);
+        }
       }
 
       // Some CLIs may print extra banners to stdout. Allow individual agents


### PR DESCRIPTION
## Summary

- Rebased #86 by @SamuelLHuber onto current main (original `src/agents/cli.ts` was split into individual files in the agents refactor)
- Adds 3 new benign stderr patterns for codex rollout recorder shutdown noise and cache TTL errors
- When codex exits non-zero but stderr is empty after filtering benign patterns, treat it as success
- Regenerates `docs/llms-full.txt` to fix docs sync test after PR #94 merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)