### PR TITLE
test(cli): reproduce waiting-timer supervisor double resume

### DIFF
--- a/apps/cli/tests/supervisor-e2e.test.js
+++ b/apps/cli/tests/supervisor-e2e.test.js
@@ -366,6 +366,50 @@ describe("supervisor e2e", () => {
             workflows.cleanup();
         }
     });
+    test("consecutive polls dont double-resume due waiting-timer runs", async () => {
+        const { adapter, sqlite } = createTestDb();
+        const workflows = createWorkflowDir();
+        const resumed = [];
+        try {
+            await insertDueTimerRun(adapter, "run-timer-idempotent", workflows.workflowPath("run-timer-idempotent"), now - 10);
+            const options = {
+                adapter,
+                staleThresholdMs: 30_000,
+                supervisorId: "timer-idempotent-e2e",
+                deps: {
+                    now: () => now,
+                    isPidAlive: () => false,
+                    spawnResumeDetached: (_workflowPath, runId) => {
+                        resumed.push(runId);
+                        return 7_000 + resumed.length;
+                    },
+                },
+            };
+            const first = await Effect.runPromise(supervisorPollEffect(options));
+            const second = await Effect.runPromise(supervisorPollEffect(options));
+            expect(first).toEqual({
+                staleCount: 0,
+                resumedCount: 1,
+                skippedCount: 0,
+                durationMs: 0,
+            });
+            expect(second).toEqual({
+                staleCount: 0,
+                resumedCount: 0,
+                skippedCount: 0,
+                durationMs: 0,
+            });
+            expect(resumed).toEqual(["run-timer-idempotent"]);
+            const run = await adapter.getRun("run-timer-idempotent");
+            expect(run?.runtimeOwnerId).toBe("supervisor:timer-idempotent-e2e");
+            expect(run?.heartbeatAtMs).toBe(now);
+            expect(await eventPayloads(adapter, "run-timer-idempotent", "RunAutoResumed")).toHaveLength(1);
+        }
+        finally {
+            sqlite.close();
+            workflows.cleanup();
+        }
+    });
     test("supervisor emits accurate summary metrics", async () => {
         const { adapter, sqlite } = createTestDb();
         const workflows = createWorkflowDir();


### PR DESCRIPTION
## What

Add a minimal regression test showing that consecutive supervisor polls can double-resume a due `waiting-timer` run.

## Why

The current documented supervisor behavior says timer-due candidates should go through claim acquisition before resume, just like stale `running` runs. In the shipped `0.15.1` implementation, the `waiting-timer` path does not claim the run before spawning detached resume.

That mismatch shows up in real usage as:

- overdue `waiting-timer` runs staying stuck
- repeated supervisor logs like `Resuming timer-blocked run ...`
- persisted run logs showing `RUN_NOT_FOUND`
- and in one earlier reproduction, `database is locked`

## How

- add a focused e2e regression in `apps/cli/tests/supervisor-e2e.test.js`
- assert that a due `waiting-timer` run is only resumed once across consecutive polls
- assert that the run is claimed by the supervisor after the first poll

## Minimal reproduction context

Observed locally on:

- date: 2026-04-14
- package version: `smithers-orchestrator@0.15.1`
- entry mode: `smithers up --serve --supervise`
- local exploration model: `Codex GPT-5.4 medium`

Real workflow shape used to reproduce:

- `Loop`
- `Timer`
- `Task inspect`
- timer becomes due
- supervisor logs repeated timer resumes
- run remains `waiting-timer` until manually resumed with `smithers up --run-id <id> --resume`

## Observed local logs

From the integrated `smithers up --serve --supervise` reproduction:

```text
timestamp=2026-04-14T10:43:26.254Z ... Resuming timer-blocked run run-1776163356203 with pid 68236
timestamp=2026-04-14T10:43:36.263Z ... Resuming timer-blocked run run-1776163356203 with pid 68621
timestamp=2026-04-14T10:43:46.270Z ... Resuming timer-blocked run run-1776163356203 with pid 69057
```

But `smithers inspect run-1776163356203 --format json` still reported:

```json
{
  "run": {
    "id": "run-1776163356203",
    "status": "waiting-timer"
  },
  "timers": [
    {
      "timerId": "backoff",
      "iteration": 1,
      "remaining": "due now"
    }
  ]
}
```

Persisted run log excerpt:

```text
code: RUN_NOT_FOUND
message: "Run not found: run-1776163356203"
```

Earlier local reproduction also produced:

```text
code: RUN_FAILED
message: "cli load workflow: database is locked See https://smithers.sh/reference/errors"
```

Manual resume advanced the run immediately:

```bash
smithers up .smithers/workflows/ci-watch-babysit.tsx --run-id run-1776160617725 --resume
```

## Notes

I could not run this focused test file to completion locally because the fresh upstream clone currently errors before test execution on an unrelated missing module:

- `Cannot find module '@mdx-js/esbuild' from '/packages/smithers/src/mdx-plugin.js'`

That appears unrelated to the timer-resume bug, so this PR is intentionally limited to the smallest regression expression of the observed behavior.
