### PR TITLE
feat(agents): add OpenCodeAgent for OpenCode integration

### DIFF
--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -305,6 +305,38 @@ function extractTextFromJsonPayload(raw) {
     return chunks.length ? chunks.join("") : undefined;
 }
 /**
+ * @param {string} raw
+ * @returns {string}
+ */
+function stripOscSequences(raw) {
+    return raw.replace(/\x1b\]0;[^\x07]*\x07/g, "");
+}
+/**
+ * @param {string} raw
+ * @returns {string | undefined}
+ */
+function extractErrorFromJsonPayload(raw) {
+    const trimmed = stripOscSequences(raw).trim();
+    if (!trimmed)
+        return undefined;
+    const lines = trimmed.split(/\r?\n/).filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+        try {
+            const parsed = JSON.parse(lines[i]);
+            if (parsed?.type !== "error")
+                continue;
+            const message = parsed?.error?.data?.message ?? parsed?.error?.message ?? parsed?.error?.name;
+            if (typeof message === "string" && message.trim()) {
+                return message.trim();
+            }
+        }
+        catch {
+            continue;
+        }
+    }
+    return undefined;
+}
+/**
  * @param {string[]} args
  * @returns {string | undefined}
  */
@@ -417,7 +449,7 @@ function buildStreamResult(result) {
  * @returns {CliUsageInfo | undefined}
  */
 export function extractUsageFromOutput(raw) {
-    const lines = raw.split(/\r?\n/).filter(Boolean);
+    const lines = stripOscSequences(raw).split(/\r?\n/).filter(Boolean);
     const usage = {};
     let found = false;
     for (const line of lines) {
@@ -466,6 +498,25 @@ export function extractUsageFromOutput(raw) {
             }
             found = true;
             continue;
+        }
+        if (parsed.type === "step_finish" && parsed.part?.tokens && typeof parsed.part.tokens === "object") {
+            const tokens = parsed.part.tokens;
+            const input = tokens.input ?? 0;
+            const output = tokens.output ?? 0;
+            const total = tokens.total ?? 0;
+            const reasoning = tokens.reasoning ?? 0;
+            const cacheRead = tokens.cache?.read ?? 0;
+            const cacheWrite = tokens.cache?.write ?? 0;
+            if (input > 0 || output > 0 || total > 0 || reasoning > 0 || cacheRead > 0 || cacheWrite > 0) {
+                usage.inputTokens = (usage.inputTokens ?? 0) + input;
+                usage.outputTokens = (usage.outputTokens ?? 0) + output;
+                usage.totalTokens = (usage.totalTokens ?? 0) + total;
+                usage.reasoningTokens = (usage.reasoningTokens ?? 0) + reasoning;
+                usage.cacheReadTokens = (usage.cacheReadTokens ?? 0) + cacheRead;
+                usage.cacheWriteTokens = (usage.cacheWriteTokens ?? 0) + cacheWrite;
+                found = true;
+                continue;
+            }
         }
         if (parsed.usage && typeof parsed.usage === "object") {
             const u = parsed.usage;
@@ -793,7 +844,11 @@ export class BaseCliAgent {
                 if (result.exitCode && result.exitCode !== 0) {
                     const filteredStderr = filterBenignStderr(result.stderr, commandSpec.benignStderrPatterns);
                     if (!(commandSpec.command === "codex" && filteredStderr.length === 0)) {
-                        const errorText = filteredStderr ||
+                        const structuredError = (commandSpec.outputFormat === "json" || commandSpec.outputFormat === "stream-json")
+                            ? extractErrorFromJsonPayload(result.stdout)
+                            : undefined;
+                        const errorText = structuredError ||
+                            filteredStderr ||
                             result.stdout.trim() ||
                             `CLI exited with code ${result.exitCode}`;
                         const nonRetryable = classifyNonRetryableAgentError(errorText, commandSpec.command);
@@ -867,7 +922,7 @@ export class BaseCliAgent {
                         textTokens: undefined,
                         reasoningTokens: cliUsage.reasoningTokens,
                     },
-                    totalTokens: (cliUsage.inputTokens ?? 0) + (cliUsage.outputTokens ?? 0) || undefined,
+                    totalTokens: cliUsage.totalTokens ?? ((cliUsage.inputTokens ?? 0) + (cliUsage.outputTokens ?? 0) || undefined),
                 } : undefined;
                 const tokenTotals = extractAgentTokenTotals(usage);
                 stdoutEmitter?.flush(extractedText);

--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -298,7 +298,13 @@ function extractTextFromJsonPayload(raw) {
     }
     const chunks = [];
     for (const parsed of parsedLines) {
-        const text = extractTextFromJsonValue(parsed);
+        let text;
+        if (parsed?.type === "text" && typeof parsed?.part?.text === "string") {
+            text = parsed.part.text;
+        }
+        else {
+            text = extractTextFromJsonValue(parsed);
+        }
         if (text)
             chunks.push(text);
     }
@@ -755,6 +761,7 @@ export class BaseCliAgent {
             const interpreter = this.createOutputInterpreter();
             let stdoutBuffer = "";
             let stderrBuffer = "";
+            let completedEvent = null;
             /**
      * @param {AgentCliEvent[] | AgentCliEvent | null | undefined} eventPayload
      */
@@ -763,6 +770,9 @@ export class BaseCliAgent {
                     return;
                 const events = Array.isArray(eventPayload) ? eventPayload : [eventPayload];
                 for (const event of events) {
+                    if (event?.type === "completed") {
+                        completedEvent = event;
+                    }
                     logAgentCliEvent(event, commandLogAnnotations, span);
                     if (!options?.onEvent)
                         continue;
@@ -876,6 +886,9 @@ export class BaseCliAgent {
                         }
                         return yield* Effect.fail(new SmithersError("AGENT_CLI_ERROR", errorText));
                     }
+                }
+                if (completedEvent?.ok === false) {
+                    return yield* Effect.fail(new SmithersError("AGENT_CLI_ERROR", completedEvent.error || "CLI agent reported an error"));
                 }
                 // Some CLIs may print extra banners to stdout. Allow individual agents
                 // to provide patterns so this logic stays opt-in and agent-specific.

--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -281,6 +281,20 @@ function extractTextFromJsonPayload(raw) {
                     return text;
             }
         }
+        // OpenCode-style CLIs emit a final "finish" or "done" event with the
+        // complete response text directly on the payload. Prefer this over
+        // concatenating all text_delta chunks which would duplicate content.
+        if (type === "finish" || type === "done") {
+            const text = typeof parsed?.text === "string" ? parsed.text : undefined;
+            if (text)
+                return text;
+        }
+        // OpenCode nd-JSON format: "text" events carry part.text with finalized
+        // text chunks. Accumulate these as a fallback when the interpreter's
+        // completed event isn't surfaced properly.
+        if (type === "text" && parsed?.part?.text) {
+            // Don't return early — accumulate via the chunks path below
+        }
     }
     const chunks = [];
     for (const parsed of parsedLines) {

--- a/packages/agents/src/BaseCliAgent/extractTextFromJsonValue.js
+++ b/packages/agents/src/BaseCliAgent/extractTextFromJsonValue.js
@@ -32,6 +32,8 @@ export function extractTextFromJsonValue(value) {
         if (parts.trim())
             return parts;
     }
+    if (record.type === "text" && record.part)
+        return extractTextFromJsonValue(record.part);
     if (record.response)
         return extractTextFromJsonValue(record.response);
     if (record.message)

--- a/packages/agents/src/OpenCodeAgent.js
+++ b/packages/agents/src/OpenCodeAgent.js
@@ -56,10 +56,15 @@ export function createOpenCodeCapabilityRegistry(opts = {}) {
       "read",
       "write",
       "edit",
+      "apply_patch",
       "bash",
       "glob",
       "grep",
+      "list",
       "webfetch",
+      "websearch",
+      "codesearch",
+      "question",
       "task",
       "todowrite",
       "skill",
@@ -406,6 +411,9 @@ export class OpenCodeAgent extends BaseCliAgent {
    * @param {{ prompt: string; systemPrompt?: string; cwd: string; options: any }} params
    */
   async buildCommand(params) {
+    const resumeSession = typeof params.options?.resumeSession === "string"
+      ? params.options.resumeSession
+      : undefined;
     const args = ["run"];
 
     // Model selection
@@ -431,7 +439,7 @@ export class OpenCodeAgent extends BaseCliAgent {
     if (this.opts.continueSession) {
       args.push("--continue");
     }
-    pushFlag(args, "--session", this.opts.sessionId);
+    pushFlag(args, "--session", resumeSession ?? this.opts.sessionId);
 
     // Variant / reasoning effort
     pushFlag(args, "--variant", this.opts.variant);
@@ -451,11 +459,16 @@ export class OpenCodeAgent extends BaseCliAgent {
       args.push(...this.extraArgs);
     }
 
+    const systemPrefix = params.systemPrompt
+      ? `${params.systemPrompt}\n\n`
+      : "";
+    const fullPrompt = `${systemPrefix}${params.prompt ?? ""}`;
+
     // When flags like -f (yargs [array] type) are present, subsequent
     // positional arguments can be consumed as flag values. Insert '--'
     // to tell yargs to stop parsing flags and treat the rest as positional.
-    if (params.prompt) {
-      args.push("--", params.prompt);
+    if (fullPrompt) {
+      args.push("--", fullPrompt);
     }
 
     return {

--- a/packages/agents/src/OpenCodeAgent.js
+++ b/packages/agents/src/OpenCodeAgent.js
@@ -1,0 +1,479 @@
+import {
+  BaseCliAgent,
+  pushFlag,
+  isRecord,
+  asString,
+  truncate,
+  toolKindFromName,
+  shouldSurfaceUnparsedStdout,
+  createSyntheticIdGenerator,
+} from "./BaseCliAgent/index.js";
+import { normalizeCapabilityStringList } from "./capability-registry/index.js";
+
+/** @typedef {import("./BaseCliAgent/index.ts").BaseCliAgentOptions} BaseCliAgentOptions */
+/** @typedef {import("./capability-registry/index.ts").AgentCapabilityRegistry} AgentCapabilityRegistry */
+
+/**
+ * @typedef {BaseCliAgentOptions & {
+ *   model?: string;
+ *   agentName?: string;
+ *   attachFiles?: string[];
+ *   continueSession?: boolean;
+ *   sessionId?: string;
+ *   variant?: "high" | "medium" | "low";
+ * }} OpenCodeAgentOptions
+ */
+
+/** @typedef {import("./BaseCliAgent/index.ts").CliOutputInterpreter} CliOutputInterpreter */
+
+/**
+ * @param {OpenCodeAgentOptions} [opts]  Currently unused — kept for API
+ *   consistency with other agents (e.g. ClaudeCodeAgent uses opts to resolve
+ *   builtIns based on tool allow/deny lists).  OpenCode does not yet expose
+ *   CLI flags for restricting built-in tools, so the set is static.
+ * @returns {AgentCapabilityRegistry}
+ */
+export function createOpenCodeCapabilityRegistry(opts = {}) {
+  return {
+    version: 1,
+    engine: "opencode",
+    runtimeTools: {},
+    mcp: {
+      bootstrap: "project-config",
+      supportsProjectScope: true,
+      supportsUserScope: true,
+    },
+    skills: {
+      supportsSkills: true,
+      installMode: "plugin",
+      smithersSkillIds: [],
+    },
+    humanInteraction: {
+      supportsUiRequests: false,
+      methods: [],
+    },
+    builtIns: normalizeCapabilityStringList([
+      "read",
+      "write",
+      "edit",
+      "bash",
+      "glob",
+      "grep",
+      "webfetch",
+      "task",
+      "todowrite",
+      "skill",
+    ]),
+  };
+}
+
+/**
+ * CLI agent wrapper for OpenCode (https://opencode.ai).
+ *
+ * Shells out to `opencode run` in non-interactive mode with `--format json`
+ * for streaming nd-JSON output. Parses AgentCliEvents from the JSON stream.
+ *
+ * Usage:
+ *   const agent = new OpenCodeAgent({
+ *     model: "anthropic/claude-opus-4-20250514",
+ *     yolo: true,
+ *   });
+ *   const result = await agent.generate({
+ *     messages: [{ role: "user", content: "Fix the bug" }],
+ *   });
+ */
+export class OpenCodeAgent extends BaseCliAgent {
+  /** @type {OpenCodeAgentOptions} */
+  opts;
+  /** @type {AgentCapabilityRegistry} */
+  capabilities;
+  /** @type {"opencode"} */
+  cliEngine = "opencode";
+
+  /**
+   * @param {OpenCodeAgentOptions} [opts]
+   */
+  constructor(opts = {}) {
+    super(opts);
+    this.opts = opts;
+    this.capabilities = createOpenCodeCapabilityRegistry(opts);
+  }
+
+  /**
+   * Create an output interpreter that parses OpenCode's nd-JSON streaming format.
+   *
+   * OpenCode `--format json` emits one JSON object per line (verified from source:
+   * packages/opencode/src/cli/cmd/run.ts). The envelope is:
+   *
+   *   { type, timestamp: number, sessionID: string, ...payload }
+   *
+   * Event types:
+   *   step_start  → { part: { type:"step-start", id, sessionID, messageID } }
+   *   text        → { part: { type:"text", text, time: { start, end } } }
+   *   tool_use    → { part: { type:"tool", tool, callID, state: { status, ... } } }
+   *   step_finish → { part: { type:"step-finish", reason, tokens, cost } }
+   *   reasoning   → { part: { type:"reasoning", text } }
+   *   error       → { error: { name, data: { message } } }
+   *
+   * We map these to Smithers' AgentCliEvent union (started | action | completed).
+   *
+   * @returns {CliOutputInterpreter}
+   */
+  createOutputInterpreter() {
+    let fullText = "";
+    let sessionId = "";
+    let didEmitStarted = false;
+    let didEmitCompleted = false;
+
+    // Accumulate tokens across multiple step_finish events
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalTokens = 0;
+
+    const nextSyntheticId = createSyntheticIdGenerator();
+
+    /**
+     * @param {string} title
+     * @param {string} message
+     * @param {"warning" | "error"} [level]
+     * @returns {import("./BaseCliAgent/index.ts").AgentCliEvent}
+     */
+    const warningAction = (title, message, level = "warning") => ({
+      type: "action",
+      engine: this.cliEngine,
+      phase: "completed",
+      entryType: "thought",
+      action: {
+        id: nextSyntheticId("opencode-warning"),
+        kind: "warning",
+        title,
+        detail: {},
+      },
+      message,
+      ok: level !== "error",
+      level,
+    });
+
+    /**
+     * @param {string} line
+     * @returns {import("./BaseCliAgent/index.ts").AgentCliEvent[]}
+     */
+    const parseLine = (line) => {
+      // Strip OSC terminal escape sequences (e.g. title-setting "\x1b]0;...\x07")
+      // that OpenCode emits inline with JSON events on stdout.
+      const cleaned = line.replace(/\x1b\]0;[^\x07]*\x07/g, "");
+      const trimmed = cleaned.trim();
+      if (!trimmed) return [];
+
+      /** @type {Record<string, unknown>} */
+      let payload;
+      try {
+        payload = JSON.parse(trimmed);
+      } catch {
+        if (!shouldSurfaceUnparsedStdout(trimmed)) return [];
+        return [warningAction("stdout", truncate(trimmed, 220))];
+      }
+
+      if (!isRecord(payload)) return [];
+
+      const eventType = asString(payload.type);
+      if (!eventType) return [];
+
+      // Capture sessionID from the envelope (present on every event)
+      const envelopeSessionId = asString(payload.sessionID);
+      if (envelopeSessionId) {
+        sessionId = envelopeSessionId;
+      }
+
+      const part = isRecord(payload.part) ? payload.part : null;
+
+      // --- step_start: session/step beginning ---
+      if (eventType === "step_start") {
+        if (!didEmitStarted) {
+          didEmitStarted = true;
+          return [
+            {
+              type: "started",
+              engine: this.cliEngine,
+              title: "OpenCode",
+              resume: sessionId || undefined,
+              detail: sessionId ? { sessionId } : undefined,
+            },
+          ];
+        }
+        return [];
+      }
+
+      // --- text: finalized text chunk from the model ---
+      if (eventType === "text") {
+        const text = part ? asString(part.text) : null;
+        if (text) {
+          fullText += text;
+          return [
+            {
+              type: "action",
+              engine: this.cliEngine,
+              phase: "updated",
+              entryType: "message",
+              action: {
+                id: nextSyntheticId("opencode-text"),
+                kind: "note",
+                title: "assistant",
+                detail: {},
+              },
+              message: text,
+              ok: true,
+              level: "info",
+            },
+          ];
+        }
+        return [];
+      }
+
+      // --- tool_use: tool completed or errored ---
+      if (eventType === "tool_use" && part) {
+        const toolName = asString(part.tool) ?? "tool";
+        const callID = asString(part.callID) ?? nextSyntheticId("opencode-tool");
+        const state = isRecord(part.state) ? part.state : null;
+        const status = state ? asString(state.status) : null;
+        const isError = status === "error";
+
+        const events = [];
+
+        // Emit a "started" action for the tool
+        events.push({
+          type: "action",
+          engine: this.cliEngine,
+          phase: "started",
+          entryType: "thought",
+          action: {
+            id: callID,
+            kind: toolKindFromName(toolName),
+            title: toolName,
+            detail: state && isRecord(state.input)
+              ? { input: state.input }
+              : {},
+          },
+          message: `Running ${toolName}`,
+          level: "info",
+        });
+
+        // Emit a "completed" action for the tool
+        const output = state
+          ? asString(state.output) ?? asString(state.error)
+          : undefined;
+        events.push({
+          type: "action",
+          engine: this.cliEngine,
+          phase: "completed",
+          entryType: "thought",
+          action: {
+            id: callID,
+            kind: toolKindFromName(toolName),
+            title: toolName,
+            detail: {},
+          },
+          message: output ? truncate(output, 300) : undefined,
+          ok: !isError,
+          level: isError ? "warning" : "info",
+        });
+
+        return events;
+      }
+
+      // --- step_finish: step completed with token usage ---
+      if (eventType === "step_finish" && part) {
+        const tokens = isRecord(part.tokens) ? part.tokens : null;
+        if (tokens) {
+          const input = typeof tokens.input === "number" ? tokens.input : 0;
+          const output = typeof tokens.output === "number" ? tokens.output : 0;
+          const total = typeof tokens.total === "number" ? tokens.total : 0;
+          totalInputTokens += input;
+          totalOutputTokens += output;
+          totalTokens += total;
+        }
+
+        const reason = asString(part.reason);
+        // Only emit "completed" on the final step (reason: "stop")
+        if (reason === "stop") {
+          if (didEmitCompleted) return [];
+          didEmitCompleted = true;
+
+          return [
+            {
+              type: "completed",
+              engine: this.cliEngine,
+              ok: true,
+              answer: fullText || undefined,
+              resume: sessionId || undefined,
+              usage: {
+                inputTokens: totalInputTokens,
+                outputTokens: totalOutputTokens,
+                totalTokens: totalTokens,
+              },
+            },
+          ];
+        }
+
+        return [];
+      }
+
+      // --- reasoning: model thinking (only with --thinking flag) ---
+      if (eventType === "reasoning") {
+        // Surface reasoning as a thought action, don't accumulate into fullText
+        const text = part ? asString(part.text) : null;
+        if (text) {
+          return [
+            {
+              type: "action",
+              engine: this.cliEngine,
+              phase: "updated",
+              entryType: "thought",
+              action: {
+                id: nextSyntheticId("opencode-reasoning"),
+                kind: "note",
+                title: "reasoning",
+                detail: {},
+              },
+              message: truncate(text, 500),
+              ok: true,
+              level: "info",
+            },
+          ];
+        }
+        return [];
+      }
+
+      // --- error: session error ---
+      if (eventType === "error") {
+        const errorObj = isRecord(payload.error) ? payload.error : null;
+        const errorData = errorObj && isRecord(errorObj.data) ? errorObj.data : null;
+        const errorName = errorObj ? asString(errorObj.name) : null;
+        const errorMessage = errorData
+          ? asString(errorData.message)
+          : errorName ?? "OpenCode reported an error";
+
+        if (didEmitCompleted) {
+          return [warningAction("error", errorMessage ?? "OpenCode reported an error", "error")];
+        }
+
+        didEmitCompleted = true;
+        return [
+          {
+            type: "completed",
+            engine: this.cliEngine,
+            ok: false,
+            answer: fullText || undefined,
+            error: errorMessage ?? "OpenCode reported an error",
+          },
+        ];
+      }
+
+      return [];
+    };
+
+    return {
+      onStdoutLine: parseLine,
+
+      onStderrLine: (line) => {
+        const trimmed = line.trim();
+        if (!trimmed) return [];
+        return [warningAction("stderr", truncate(trimmed, 220))];
+      },
+
+      onExit: (result) => {
+        if (didEmitCompleted) return [];
+        const isSuccess = (result.exitCode ?? 0) === 0;
+        didEmitCompleted = true;
+        return [
+          {
+            type: "completed",
+            engine: this.cliEngine,
+            ok: isSuccess,
+            answer: isSuccess ? fullText || undefined : undefined,
+            error: isSuccess
+              ? undefined
+              : `OpenCode exited with code ${result.exitCode ?? -1}`,
+          },
+        ];
+      },
+    };
+  }
+
+  /**
+   * Build the CLI command spec for `opencode run`.
+   *
+   * @param {{ prompt: string; systemPrompt?: string; cwd: string; options: any }} params
+   */
+  async buildCommand(params) {
+    const args = ["run"];
+
+    // Model selection
+    pushFlag(args, "-m", this.opts.model ?? this.model);
+
+    // Working directory
+    pushFlag(args, "--dir", params.cwd);
+
+    // Streaming nd-JSON output
+    pushFlag(args, "--format", "json");
+
+    // Named agent config
+    pushFlag(args, "--agent", this.opts.agentName);
+
+    // File attachments: -f file1 -f file2 (repeated flag)
+    if (this.opts.attachFiles) {
+      for (const file of this.opts.attachFiles) {
+        args.push("-f", file);
+      }
+    }
+
+    // Session continuation
+    if (this.opts.continueSession) {
+      args.push("--continue");
+    }
+    pushFlag(args, "--session", this.opts.sessionId);
+
+    // Variant / reasoning effort
+    pushFlag(args, "--variant", this.opts.variant);
+
+    // Yolo mode: auto-approve all tool calls.
+    // OpenCode parses OPENCODE_PERMISSION with JSON.parse() and expects a
+    // permission object.  '{"*":"allow"}' grants blanket approval for every
+    // tool category.  See: packages/opencode/src/config/config.ts
+    const yoloEnabled = this.opts.yolo ?? this.yolo;
+    const env = {};
+    if (yoloEnabled) {
+      env.OPENCODE_PERMISSION = '{"*":"allow"}';
+    }
+
+    // Extra args from constructor
+    if (this.extraArgs?.length) {
+      args.push(...this.extraArgs);
+    }
+
+    // When flags like -f (yargs [array] type) are present, subsequent
+    // positional arguments can be consumed as flag values. Insert '--'
+    // to tell yargs to stop parsing flags and treat the rest as positional.
+    if (params.prompt) {
+      args.push("--", params.prompt);
+    }
+
+    return {
+      command: "opencode",
+      args,
+      outputFormat: "stream-json",
+      env: Object.keys(env).length > 0 ? env : undefined,
+      stdoutBannerPatterns: [
+        // OpenCode may print a version banner
+        /^opencode\s+v[\d.]+/gim,
+        // Strip OSC terminal title-setting sequences (ESC ] 0 ; ... BEL)
+        // OpenCode emits these even with --format json
+        /\x1b\]0;[^\x07]*\x07/g,
+      ],
+      stdoutErrorPatterns: [
+        /^error:/im,
+        /^fatal:/im,
+      ],
+    };
+  }
+}

--- a/packages/agents/src/OpenCodeAgent.js
+++ b/packages/agents/src/OpenCodeAgent.js
@@ -129,6 +129,7 @@ export class OpenCodeAgent extends BaseCliAgent {
     let sessionId = "";
     let didEmitStarted = false;
     let didEmitCompleted = false;
+    let terminalError = null;
 
     // Accumulate tokens across multiple step_finish events
     let totalInputTokens = 0;
@@ -357,6 +358,7 @@ export class OpenCodeAgent extends BaseCliAgent {
         const errorMessage = errorData
           ? asString(errorData.message)
           : errorName ?? "OpenCode reported an error";
+        terminalError = errorMessage ?? "OpenCode reported an error";
 
         if (didEmitCompleted) {
           return [warningAction("error", errorMessage ?? "OpenCode reported an error", "error")];
@@ -388,7 +390,7 @@ export class OpenCodeAgent extends BaseCliAgent {
 
       onExit: (result) => {
         if (didEmitCompleted) return [];
-        const isSuccess = (result.exitCode ?? 0) === 0;
+        const isSuccess = (result.exitCode ?? 0) === 0 && !terminalError;
         didEmitCompleted = true;
         return [
           {
@@ -398,7 +400,7 @@ export class OpenCodeAgent extends BaseCliAgent {
             answer: isSuccess ? fullText || undefined : undefined,
             error: isSuccess
               ? undefined
-              : `OpenCode exited with code ${result.exitCode ?? -1}`,
+              : terminalError ?? `OpenCode exited with code ${result.exitCode ?? -1}`,
           },
         ];
       },
@@ -436,10 +438,11 @@ export class OpenCodeAgent extends BaseCliAgent {
     }
 
     // Session continuation
-    if (this.opts.continueSession) {
+    const explicitSession = resumeSession ?? this.opts.sessionId;
+    if (this.opts.continueSession && !explicitSession) {
       args.push("--continue");
     }
-    pushFlag(args, "--session", resumeSession ?? this.opts.sessionId);
+    pushFlag(args, "--session", explicitSession);
 
     // Variant / reasoning effort
     pushFlag(args, "--variant", this.opts.variant);

--- a/packages/agents/src/OpenCodeAgent.ts
+++ b/packages/agents/src/OpenCodeAgent.ts
@@ -26,8 +26,8 @@ export declare class OpenCodeAgent extends BaseCliAgent {
   readonly capabilities: AgentCapabilityRegistry;
   readonly cliEngine: "opencode";
   constructor(opts?: OpenCodeAgentOptions);
-  protected createOutputInterpreter(): CliOutputInterpreter;
-  protected buildCommand(params: {
+  createOutputInterpreter(): CliOutputInterpreter;
+  buildCommand(params: {
     prompt: string;
     systemPrompt?: string;
     cwd: string;

--- a/packages/agents/src/OpenCodeAgent.ts
+++ b/packages/agents/src/OpenCodeAgent.ts
@@ -1,0 +1,43 @@
+import { type CliOutputInterpreter, BaseCliAgent } from "./BaseCliAgent";
+import type { BaseCliAgentOptions } from "./BaseCliAgent";
+import { type AgentCapabilityRegistry } from "./capability-registry";
+
+export type OpenCodeAgentOptions = BaseCliAgentOptions & {
+  /** Model identifier (e.g., "anthropic/claude-opus-4-20250514", "openai/gpt-5.4") */
+  model?: string;
+  /** OpenCode agent name (maps to --agent flag, selects predefined agent config) */
+  agentName?: string;
+  /** Files to attach to the prompt via -f flags */
+  attachFiles?: string[];
+  /** Continue a previous session */
+  continueSession?: boolean;
+  /** Resume a specific session by ID */
+  sessionId?: string;
+  /** Variant/reasoning effort level */
+  variant?: "high" | "medium" | "low";
+};
+
+export declare function createOpenCodeCapabilityRegistry(
+  opts?: OpenCodeAgentOptions
+): AgentCapabilityRegistry;
+
+export declare class OpenCodeAgent extends BaseCliAgent {
+  private readonly opts: OpenCodeAgentOptions;
+  readonly capabilities: AgentCapabilityRegistry;
+  readonly cliEngine: "opencode";
+  constructor(opts?: OpenCodeAgentOptions);
+  protected createOutputInterpreter(): CliOutputInterpreter;
+  protected buildCommand(params: {
+    prompt: string;
+    systemPrompt?: string;
+    cwd: string;
+    options: any;
+  }): Promise<{
+    command: string;
+    args: string[];
+    outputFormat: "stream-json";
+    env?: Record<string, string>;
+    stdoutBannerPatterns: RegExp[];
+    stdoutErrorPatterns: RegExp[];
+  }>;
+}

--- a/packages/agents/src/OpenCodeAgent.ts
+++ b/packages/agents/src/OpenCodeAgent.ts
@@ -13,8 +13,8 @@ export type OpenCodeAgentOptions = BaseCliAgentOptions & {
   continueSession?: boolean;
   /** Resume a specific session by ID */
   sessionId?: string;
-  /** Variant/reasoning effort level */
-  variant?: "high" | "medium" | "low";
+  /** Provider-specific model variant/reasoning effort level */
+  variant?: string;
 };
 
 export declare function createOpenCodeCapabilityRegistry(

--- a/packages/agents/src/capability-registry/AgentCapabilityRegistry.ts
+++ b/packages/agents/src/capability-registry/AgentCapabilityRegistry.ts
@@ -2,7 +2,7 @@ import type { AgentToolDescriptor } from "./AgentToolDescriptor";
 
 export type AgentCapabilityRegistry = {
   version: 1;
-  engine: "claude-code" | "codex" | "gemini" | "kimi" | "pi" | "amp" | "forge";
+  engine: "claude-code" | "codex" | "gemini" | "kimi" | "pi" | "amp" | "forge" | "opencode";
   runtimeTools: Record<string, AgentToolDescriptor>;
   mcp: {
     bootstrap: "inline-config" | "project-config" | "allow-list" | "unsupported";

--- a/packages/agents/src/cli-capabilities/CliAgentCapabilityAdapterId.ts
+++ b/packages/agents/src/cli-capabilities/CliAgentCapabilityAdapterId.ts
@@ -3,4 +3,5 @@ export type CliAgentCapabilityAdapterId =
   | "codex"
   | "gemini"
   | "kimi"
+  | "opencode"
   | "pi";

--- a/packages/agents/src/cli-capabilities/getCliAgentCapabilityReport.js
+++ b/packages/agents/src/cli-capabilities/getCliAgentCapabilityReport.js
@@ -3,6 +3,7 @@ import { createClaudeCodeCapabilityRegistry } from "../ClaudeCodeAgent.js";
 import { createCodexCapabilityRegistry } from "../CodexAgent.js";
 import { createGeminiCapabilityRegistry } from "../GeminiAgent.js";
 import { createKimiCapabilityRegistry } from "../KimiAgent.js";
+import { createOpenCodeCapabilityRegistry } from "../OpenCodeAgent.js";
 import { createPiCapabilityRegistry } from "../PiAgent.js";
 /** @typedef {import("./CliAgentCapabilityReportEntry.ts").CliAgentCapabilityReportEntry} CliAgentCapabilityReportEntry */
 
@@ -26,6 +27,11 @@ const CLI_AGENT_CAPABILITY_ADAPTERS = [
         id: "kimi",
         binary: "kimi",
         buildRegistry: () => createKimiCapabilityRegistry(),
+    },
+    {
+        id: "opencode",
+        binary: "opencode",
+        buildRegistry: () => createOpenCodeCapabilityRegistry(),
     },
     {
         id: "pi",

--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -112,7 +112,7 @@ type AgentToolDescriptor$1 = {
 
 type AgentCapabilityRegistry$3 = {
     version: 1;
-    engine: "claude-code" | "codex" | "gemini" | "kimi" | "pi" | "amp" | "forge";
+    engine: "claude-code" | "codex" | "gemini" | "kimi" | "pi" | "amp" | "forge" | "opencode";
     runtimeTools: Record<string, AgentToolDescriptor$1>;
     mcp: {
         bootstrap: "inline-config" | "project-config" | "allow-list" | "unsupported";
@@ -762,6 +762,42 @@ declare class ForgeAgent extends BaseCliAgent {
 type CliOutputInterpreter = CliOutputInterpreter$8;
 type ForgeAgentOptions = ForgeAgentOptions$1;
 
+type OpenCodeAgentOptions$1 = BaseCliAgentOptions$1 & {
+    /** Model identifier (e.g., "anthropic/claude-opus-4-20250514", "openai/gpt-5.4") */
+    model?: string;
+    /** OpenCode agent name (maps to --agent flag, selects predefined agent config) */
+    agentName?: string;
+    /** Files to attach to the prompt via -f flags */
+    attachFiles?: string[];
+    /** Continue a previous session */
+    continueSession?: boolean;
+    /** Resume a specific session by ID */
+    sessionId?: string;
+    /** Provider-specific model variant/reasoning effort level */
+    variant?: string;
+};
+
+declare class OpenCodeAgent extends BaseCliAgent {
+    constructor(opts?: OpenCodeAgentOptions);
+    opts: OpenCodeAgentOptions$1;
+    capabilities: AgentCapabilityRegistry$3;
+    cliEngine: "opencode";
+    createOutputInterpreter(): CliOutputInterpreter;
+    buildCommand(params: {
+        prompt: string;
+        systemPrompt?: string;
+        cwd: string;
+        options: any;
+    }): Promise<{
+        command: string;
+        args: string[];
+        outputFormat: "stream-json";
+        env?: Record<string, string>;
+        stdoutBannerPatterns: RegExp[];
+        stdoutErrorPatterns: RegExp[];
+    }>;
+}
+
 /**
  * @param {CreateSmithersAgentContractOptions} options
  * @returns {SmithersAgentContract}
@@ -821,6 +857,7 @@ type AgentCapabilityRegistry = AgentCapabilityRegistry$3;
 type AgentLike = AgentLike$1;
 type AgentToolDescriptor = AgentToolDescriptor$1;
 type AnthropicAgentOptions<CALL_OPTIONS = never, TOOLS = ai.ToolSet> = AnthropicAgentOptions$2<CALL_OPTIONS, TOOLS>;
+type OpenCodeAgentOptions = OpenCodeAgentOptions$1;
 type OpenAIAgentOptions<CALL_OPTIONS = never, TOOLS = ai.ToolSet> = OpenAIAgentOptions$2<CALL_OPTIONS, TOOLS>;
 type PiAgentOptions = PiAgentOptions$2;
 type PiExtensionUiRequest = PiExtensionUiRequest$1;
@@ -831,4 +868,4 @@ type SmithersAgentToolCategory = SmithersAgentToolCategory$1;
 type SmithersListedTool = SmithersListedTool$2;
 type SmithersToolSurface = SmithersToolSurface$2;
 
-export { type AgentCapabilityRegistry, type AgentGenerateOptions, type AgentLike, type AgentToolDescriptor, AmpAgent, AnthropicAgent, type AnthropicAgentOptions, BaseCliAgent, ClaudeCodeAgent, CodexAgent, ForgeAgent, GeminiAgent, KimiAgent, OpenAIAgent, type OpenAIAgentOptions, PiAgent, type PiAgentOptions, type PiExtensionUiRequest, type PiExtensionUiResponse, type SmithersAgentContract, type SmithersAgentContractTool, type SmithersAgentToolCategory, type SmithersListedTool, type SmithersToolSurface, createSmithersAgentContract, hashCapabilityRegistry, renderSmithersAgentPromptGuidance, sanitizeForOpenAI, zodToOpenAISchema };
+export { type AgentCapabilityRegistry, type AgentGenerateOptions, type AgentLike, type AgentToolDescriptor, AmpAgent, AnthropicAgent, type AnthropicAgentOptions, BaseCliAgent, ClaudeCodeAgent, CodexAgent, ForgeAgent, GeminiAgent, KimiAgent, OpenCodeAgent, type OpenCodeAgentOptions, OpenAIAgent, type OpenAIAgentOptions, PiAgent, type PiAgentOptions, type PiExtensionUiRequest, type PiExtensionUiResponse, type SmithersAgentContract, type SmithersAgentContractTool, type SmithersAgentToolCategory, type SmithersListedTool, type SmithersToolSurface, createSmithersAgentContract, hashCapabilityRegistry, renderSmithersAgentPromptGuidance, sanitizeForOpenAI, zodToOpenAISchema };

--- a/packages/agents/src/index.js
+++ b/packages/agents/src/index.js
@@ -16,6 +16,7 @@
 /** @typedef {import("./PiAgentOptions.ts").PiAgentOptions} PiAgentOptions */
 /** @typedef {import("./BaseCliAgent/PiExtensionUiRequest.ts").PiExtensionUiRequest} PiExtensionUiRequest */
 /** @typedef {import("./BaseCliAgent/PiExtensionUiResponse.ts").PiExtensionUiResponse} PiExtensionUiResponse */
+/** @typedef {import("./OpenCodeAgent.ts").OpenCodeAgentOptions} OpenCodeAgentOptions */
 /** @typedef {import("./agent-contract/SmithersAgentContract.ts").SmithersAgentContract} SmithersAgentContract */
 /** @typedef {import("./agent-contract/SmithersAgentContractTool.ts").SmithersAgentContractTool} SmithersAgentContractTool */
 /** @typedef {import("./agent-contract/SmithersAgentToolCategory.ts").SmithersAgentToolCategory} SmithersAgentToolCategory */
@@ -34,6 +35,7 @@ export { GeminiAgent } from "./GeminiAgent.js";
 export { PiAgent } from "./PiAgent.js";
 export { KimiAgent } from "./KimiAgent.js";
 export { ForgeAgent } from "./ForgeAgent.js";
+export { OpenCodeAgent } from "./OpenCodeAgent.js";
 export { createSmithersAgentContract } from "./agent-contract/createSmithersAgentContract.js";
 export { renderSmithersAgentPromptGuidance } from "./agent-contract/renderSmithersAgentPromptGuidance.js";
 export { zodToOpenAISchema } from "./zodToOpenAISchema.js";

--- a/packages/agents/tests/capability-registry.test.js
+++ b/packages/agents/tests/capability-registry.test.js
@@ -232,6 +232,7 @@ describe("smithers agents capabilities", () => {
             "codex",
             "gemini",
             "kimi",
+            "opencode",
             "pi",
         ]);
         expect(report.find((entry) => entry.id === "codex")?.capabilities.mcp.bootstrap)

--- a/packages/agents/tests/cli-capabilities.test.js
+++ b/packages/agents/tests/cli-capabilities.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test";
+import { getCliAgentCapabilityReport } from "../src/cli-capabilities/getCliAgentCapabilityReport.js";
+
+describe("getCliAgentCapabilityReport", () => {
+  test("includes opencode in capability discovery", () => {
+    const report = getCliAgentCapabilityReport();
+    expect(report.map((entry) => entry.id)).toContain("opencode");
+  });
+});

--- a/packages/agents/tests/extract-text-from-json-value.test.js
+++ b/packages/agents/tests/extract-text-from-json-value.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { extractTextFromJsonValue } from "../src/BaseCliAgent/extractTextFromJsonValue.js";
+
+describe("extractTextFromJsonValue", () => {
+  test("does not treat arbitrary part.text as assistant output", () => {
+    const value = {
+      type: "reasoning",
+      part: {
+        type: "reasoning",
+        text: "internal reasoning should not surface",
+      },
+    };
+
+    expect(extractTextFromJsonValue(value)).toBeUndefined();
+  });
+});

--- a/packages/agents/tests/opencode-e2e.test.js
+++ b/packages/agents/tests/opencode-e2e.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { execSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OpenCodeAgent } from "../src/OpenCodeAgent.js";
+
+/**
+ * E2E tests against the real OpenCode CLI.
+ * Skipped entirely if `opencode` is not installed on PATH.
+ *
+ * These tests invoke the actual CLI so they:
+ *   - require valid API credentials configured in opencode
+ *   - may take 30–60s each (network + model inference)
+ *   - are deterministic in structure but non-deterministic in model output
+ */
+
+let isOpenCodeInstalled = false;
+try {
+  execSync("which opencode", { stdio: "pipe" });
+  isOpenCodeInstalled = true;
+} catch {
+  isOpenCodeInstalled = false;
+}
+
+describe.skipIf(!isOpenCodeInstalled)("OpenCodeAgent E2E (real CLI)", () => {
+  /** @type {string} */
+  let tmpDir;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "smithers-opencode-e2e-"));
+    // Create a minimal project so --dir has something to work with
+    await writeFile(join(tmpDir, "hello.js"), 'console.log("hello world");\n');
+  });
+
+  afterAll(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("sends a simple prompt and gets a text response", async () => {
+    const agent = new OpenCodeAgent({
+      model: "github-copilot/claude-sonnet-4.6",
+      yolo: true,
+    });
+
+    const result = await agent.generate({
+      prompt: "What is 2+2? Reply with ONLY the number, nothing else.",
+      rootDir: tmpDir,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.text).toBeDefined();
+    expect(result.text.length).toBeGreaterThan(0);
+    // The response should contain "4" somewhere
+    expect(result.text).toContain("4");
+  }, 120_000);
+
+  it("emits events with correct structure", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const agent = new OpenCodeAgent({
+      model: "github-copilot/claude-sonnet-4.6",
+      yolo: true,
+    });
+
+    const result = await agent.generate({
+      prompt: "Say 'hello' and nothing else.",
+      rootDir: tmpDir,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(result).toBeDefined();
+    expect(result.text.toLowerCase()).toContain("hello");
+
+    // Should have emitted a "started" event
+    const started = events.find((e) => e.type === "started");
+    expect(started).toBeDefined();
+    expect(started.engine).toBe("opencode");
+
+    // Should have emitted a "completed" event
+    const completed = events.find((e) => e.type === "completed");
+    expect(completed).toBeDefined();
+    expect(completed.engine).toBe("opencode");
+    expect(completed.ok).toBe(true);
+  }, 120_000);
+
+  it("respects --dir for working directory", async () => {
+    const agent = new OpenCodeAgent({
+      model: "github-copilot/claude-sonnet-4.6",
+      yolo: true,
+    });
+
+    const result = await agent.generate({
+      prompt:
+        "List the files in the current directory. Just output the filenames, one per line.",
+      rootDir: tmpDir,
+    });
+
+    expect(result).toBeDefined();
+    // Should see our hello.js file
+    expect(result.text).toContain("hello.js");
+  }, 120_000);
+
+  it("passes OPENCODE_PERMISSION env var correctly (yolo mode)", async () => {
+    // yolo=true should set OPENCODE_PERMISSION='"allow"' which auto-approves
+    // tool calls. We verify indirectly: if permission is set correctly, the
+    // agent can execute tools without prompting and return a result.
+    const agent = new OpenCodeAgent({
+      model: "github-copilot/claude-sonnet-4.6",
+      yolo: true,
+    });
+
+    const result = await agent.generate({
+      prompt:
+        "Read the file hello.js and tell me what it prints. Reply with ONLY the output string, nothing else.",
+      rootDir: tmpDir,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.text).toContain("hello world");
+  }, 120_000);
+
+  it("handles file attachments via -f flag", async () => {
+    const testFile = join(tmpDir, "data.txt");
+    await writeFile(testFile, "The secret number is 42.\n");
+
+    const agent = new OpenCodeAgent({
+      model: "github-copilot/claude-sonnet-4.6",
+      yolo: true,
+      attachFiles: [testFile],
+    });
+
+    const result = await agent.generate({
+      prompt:
+        "What is the secret number in the attached file? Reply with ONLY the number.",
+      rootDir: tmpDir,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.text).toContain("42");
+  }, 120_000);
+});

--- a/packages/agents/tests/opencode-e2e.test.js
+++ b/packages/agents/tests/opencode-e2e.test.js
@@ -16,14 +16,26 @@ import { OpenCodeAgent } from "../src/OpenCodeAgent.js";
  */
 
 let isOpenCodeInstalled = false;
+let supportsOpenCodeE2EFlags = false;
 try {
   execSync("which opencode", { stdio: "pipe" });
   isOpenCodeInstalled = true;
+  const helpText = execSync("opencode run --help", {
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+  supportsOpenCodeE2EFlags =
+    helpText.includes("--dir") &&
+    helpText.includes("--format") &&
+    /\B-f\b/.test(helpText);
 } catch {
   isOpenCodeInstalled = false;
+  supportsOpenCodeE2EFlags = false;
 }
 
-describe.skipIf(!isOpenCodeInstalled)("OpenCodeAgent E2E (real CLI)", () => {
+describe.skipIf(!isOpenCodeInstalled || !supportsOpenCodeE2EFlags)(
+  "OpenCodeAgent E2E (real CLI)",
+  () => {
   /** @type {string} */
   let tmpDir;
 
@@ -142,4 +154,5 @@ describe.skipIf(!isOpenCodeInstalled)("OpenCodeAgent E2E (real CLI)", () => {
     expect(result).toBeDefined();
     expect(result.text).toContain("42");
   }, 120_000);
-});
+  }
+);

--- a/packages/agents/tests/opencode-support.test.js
+++ b/packages/agents/tests/opencode-support.test.js
@@ -586,6 +586,91 @@ process.stdout.write('${stepFinish()}' + "\\n");
     }
   });
 
+  test("prepends Smithers systemPrompt to the positional prompt", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        systemPrompt: "You are a careful reviewer.",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Analyze this diff" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      const prompt = captured.args[captured.args.length - 1];
+
+      expect(prompt).toContain("You are a careful reviewer.");
+      expect(prompt).toContain("USER: Analyze this diff");
+      expect(prompt.indexOf("You are a careful reviewer.")).toBeLessThan(
+        prompt.indexOf("USER: Analyze this diff")
+      );
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses per-call resumeSession as --session", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Resume work" }],
+        resumeSession: "resume-123",
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--session");
+      expect(captured.args).toContain("resume-123");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
   // -----------------------------------------------------------------------
   // Output interpreter tests (real nd-JSON format)
   // -----------------------------------------------------------------------
@@ -811,6 +896,48 @@ process.stdout.write('${stepFinish({
     }
   });
 
+  test("extracts usage/tokens from step_finish into generate() result usage", async () => {
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${textEvent("Hello", "s-1")}' + "\\n");
+process.stdout.write('${stepFinish({
+  sessionID: "s-1",
+  reason: "stop",
+  tokens: {
+    total: 1500,
+    input: 1000,
+    output: 500,
+    reasoning: 50,
+    cache: { write: 10, read: 200 },
+  },
+  cost: 0.01,
+})}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Hi" }],
+      });
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage.inputTokens).toBe(1000);
+      expect(result.usage.inputTokenDetails.cacheReadTokens).toBe(200);
+      expect(result.usage.inputTokenDetails.cacheWriteTokens).toBe(10);
+      expect(result.usage.outputTokens).toBe(500);
+      expect(result.usage.outputTokenDetails.reasoningTokens).toBe(50);
+      expect(result.usage.totalTokens).toBe(1500);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
   test("declares opencode as cliEngine and has correct capabilities", () => {
     const agent = new OpenCodeAgent({
       model: "anthropic/claude-opus-4-20250514",
@@ -821,6 +948,24 @@ process.stdout.write('${stepFinish({
     expect(agent.capabilities.engine).toBe("opencode");
     expect(agent.capabilities.mcp.supportsProjectScope).toBe(true);
     expect(agent.capabilities.skills.supportsSkills).toBe(true);
+    expect(agent.capabilities.builtIns).toEqual(
+      expect.arrayContaining([
+        "read",
+        "write",
+        "edit",
+        "bash",
+        "glob",
+        "grep",
+        "list",
+        "task",
+        "skill",
+        "todowrite",
+        "webfetch",
+        "websearch",
+        "question",
+        "apply_patch",
+      ])
+    );
   });
 
   test("passes --dir from cwd constructor option", async () => {
@@ -945,6 +1090,35 @@ process.exit(1);
       expect(completedEvents.length).toBe(1);
       expect(completedEvents[0].ok).toBe(false);
       expect(completedEvents[0].error).toContain("Invalid API key");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("throws with structured OpenCode error instead of generic CLI failure", async () => {
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${errorEvent({
+  sessionID: "s-1",
+  name: "ProviderAuthError",
+  message: "Invalid API key",
+})}' + "\\n");
+process.exit(1);
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await expect(
+        agent.generate({
+          messages: [{ role: "user", content: "test" }],
+        })
+      ).rejects.toThrow("Invalid API key");
     } finally {
       await rm(fake.dir, { recursive: true, force: true });
     }

--- a/packages/agents/tests/opencode-support.test.js
+++ b/packages/agents/tests/opencode-support.test.js
@@ -665,9 +665,39 @@ process.stdout.write('${stepFinish()}' + "\\n");
       const captured = JSON.parse(await readFile(argsFile, "utf8"));
       expect(captured.args).toContain("--session");
       expect(captured.args).toContain("resume-123");
+      expect(captured.args).not.toContain("--continue");
     } finally {
       await rm(fake.dir, { recursive: true, force: true });
       await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails generate when OpenCode emits an error event even if exit code is zero", async () => {
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${errorEvent({
+  sessionID: "s-1",
+  name: "ProviderAuthError",
+  message: "Invalid API key",
+})}' + "\\n");
+process.exit(0);
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await expect(
+        agent.generate({
+          messages: [{ role: "user", content: "test" }],
+        })
+      ).rejects.toThrow("Invalid API key");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/agents/tests/opencode-support.test.js
+++ b/packages/agents/tests/opencode-support.test.js
@@ -1,0 +1,1123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { OpenCodeAgent } from "../src/OpenCodeAgent.js";
+
+const originalPath = process.env.PATH ?? "";
+
+/**
+ * @param {string} stdoutScript
+ */
+async function makeFakeOpenCode(stdoutScript) {
+  const dir = await mkdtemp(join(tmpdir(), "smithers-opencode-test-"));
+  const binPath = join(dir, "opencode");
+  const script = `#!/usr/bin/env node\n${stdoutScript}\n`;
+  await writeFile(binPath, script, "utf8");
+  await chmod(binPath, 0o755);
+  return { dir, binPath };
+}
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  delete process.env.OPENCODE_ARGS_FILE;
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build real OpenCode nd-JSON events
+//
+// Real format (verified from source: packages/opencode/src/cli/cmd/run.ts):
+//
+//   emit(type, data) → JSON.stringify({ type, timestamp: Date.now(), sessionID, ...data }) + EOL
+//
+// Events:
+//   step_start  → { type:"step_start", timestamp, sessionID, part: StepStartPart }
+//   text        → { type:"text",       timestamp, sessionID, part: TextPart }
+//   tool_use    → { type:"tool_use",   timestamp, sessionID, part: ToolPart }
+//   step_finish → { type:"step_finish", timestamp, sessionID, part: StepFinishPart }
+//   reasoning   → { type:"reasoning",  timestamp, sessionID, part: ReasoningPart }
+//   error       → { type:"error",      timestamp, sessionID, error: NamedError }
+// ---------------------------------------------------------------------------
+
+let _partIdCounter = 0;
+function nextPartId() {
+  return `part-${++_partIdCounter}`;
+}
+
+/**
+ * @param {Record<string, unknown>} obj
+ * @returns {string}
+ */
+function j(obj) {
+  return JSON.stringify(obj);
+}
+
+/** step_start event */
+function stepStart(sessionID = "sess-1", messageID = "msg-1") {
+  return j({
+    type: "step_start",
+    timestamp: Date.now(),
+    sessionID,
+    part: {
+      id: nextPartId(),
+      sessionID,
+      messageID,
+      type: "step-start",
+    },
+  });
+}
+
+/** text event (only emitted when text is finalized, i.e. part.time.end is set) */
+function textEvent(text, sessionID = "sess-1", messageID = "msg-1") {
+  return j({
+    type: "text",
+    timestamp: Date.now(),
+    sessionID,
+    part: {
+      id: nextPartId(),
+      sessionID,
+      messageID,
+      type: "text",
+      text,
+      time: { start: Date.now() - 100, end: Date.now() },
+    },
+  });
+}
+
+/** tool_use event (emitted when tool completes or errors) */
+function toolUseEvent({
+  tool = "bash",
+  callID = "call-1",
+  status = "completed",
+  input = { command: "ls", description: "List files" },
+  output = "file1.txt\nfile2.txt",
+  error,
+  sessionID = "sess-1",
+  messageID = "msg-1",
+} = {}) {
+  const state =
+    status === "error"
+      ? {
+          status: "error",
+          input,
+          error: error ?? output,
+          metadata: {},
+          time: { start: Date.now() - 200, end: Date.now() },
+        }
+      : {
+          status: "completed",
+          input,
+          output,
+          title: `${tool}: ${input.description || ""}`,
+          metadata: {},
+          time: { start: Date.now() - 200, end: Date.now() },
+        };
+
+  return j({
+    type: "tool_use",
+    timestamp: Date.now(),
+    sessionID,
+    part: {
+      id: nextPartId(),
+      sessionID,
+      messageID,
+      type: "tool",
+      callID,
+      tool,
+      state,
+    },
+  });
+}
+
+/** step_finish event */
+function stepFinish({
+  sessionID = "sess-1",
+  messageID = "msg-1",
+  reason = "stop",
+  tokens = {
+    total: 1000,
+    input: 800,
+    output: 200,
+    reasoning: 0,
+    cache: { write: 0, read: 100 },
+  },
+  cost = 0.005,
+} = {}) {
+  return j({
+    type: "step_finish",
+    timestamp: Date.now(),
+    sessionID,
+    part: {
+      id: nextPartId(),
+      sessionID,
+      messageID,
+      type: "step-finish",
+      reason,
+      tokens,
+      cost,
+    },
+  });
+}
+
+/** error event */
+function errorEvent({
+  name = "UnknownError",
+  message = "Something went wrong",
+  sessionID = "sess-1",
+} = {}) {
+  return j({
+    type: "error",
+    timestamp: Date.now(),
+    sessionID,
+    error: { name, data: { message } },
+  });
+}
+
+/** reasoning event (emitted with --thinking flag) */
+function reasoningEvent(text, sessionID = "sess-1", messageID = "msg-1") {
+  return j({
+    type: "reasoning",
+    timestamp: Date.now(),
+    sessionID,
+    part: {
+      id: nextPartId(),
+      sessionID,
+      messageID,
+      type: "reasoning",
+      text,
+    },
+  });
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+describe("OpenCode CLI agent", () => {
+  // -----------------------------------------------------------------------
+  // buildCommand tests (args capture via OPENCODE_ARGS_FILE)
+  // -----------------------------------------------------------------------
+
+  test("builds correct args for basic prompt with model", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({
+    args,
+     env: {
+       OPENCODE_PERMISSION: process.env.OPENCODE_PERMISSION || null,
+     },
+  }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("done")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Analyze this code" }],
+      });
+
+      expect(result.text).toBe("done");
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("run");
+      expect(captured.args).toContain("-m");
+      expect(captured.args).toContain("anthropic/claude-opus-4-20250514");
+      expect(captured.args).toContain("--format");
+      expect(captured.args).toContain("json");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes --agent flag when agentName is specified", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        agentName: "readonly",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Read-only analysis" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--agent");
+      expect(captured.args).toContain("readonly");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes -f flags for attached files (repeated flag)", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        attachFiles: ["src/main.ts", "README.md"],
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Review these files" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      const args = captured.args;
+
+      // Each file should be preceded by its own -f flag
+      const firstFIdx = args.indexOf("-f");
+      expect(firstFIdx).toBeGreaterThan(-1);
+      expect(args[firstFIdx + 1]).toBe("src/main.ts");
+      const secondFIdx = args.indexOf("-f", firstFIdx + 2);
+      expect(secondFIdx).toBeGreaterThan(-1);
+      expect(args[secondFIdx + 1]).toBe("README.md");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("places '--' separator before prompt when -f is used (prevents yargs array consumption)", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        attachFiles: ["data.txt"],
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "What is the secret number?" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      const args = captured.args;
+
+      // The prompt should appear AFTER a '--' separator so yargs doesn't
+      // consume it as part of the -f array.
+      const dashDashIdx = args.indexOf("--");
+      expect(dashDashIdx).toBeGreaterThan(-1);
+
+      // The prompt should come after '--'
+      const promptIdx = args.indexOf("USER: What is the secret number?");
+      expect(promptIdx).toBeGreaterThan(dashDashIdx);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("sets OPENCODE_PERMISSION env var as JSON when yolo is true", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({
+    args,
+    env: { OPENCODE_PERMISSION: process.env.OPENCODE_PERMISSION || null },
+  }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        yolo: true,
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Do something" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      // OPENCODE_PERMISSION expects a JSON permission object; {"*":"allow"} grants blanket approval
+      expect(captured.env.OPENCODE_PERMISSION).toBe('{"*":"allow"}');
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("does NOT set OPENCODE_PERMISSION when yolo is false", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({
+    args,
+    env: { OPENCODE_PERMISSION: process.env.OPENCODE_PERMISSION || null },
+  }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        yolo: false,
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Do something" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.env.OPENCODE_PERMISSION).toBeNull();
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes --variant flag when variant is specified", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        variant: "high",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Think hard" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--variant");
+      expect(captured.args).toContain("high");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes --continue flag when continueSession is true", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        continueSession: true,
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Continue working" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--continue");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  test("includes --session flag with session ID", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        sessionId: "abc-123",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Resume session" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--session");
+      expect(captured.args).toContain("abc-123");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Output interpreter tests (real nd-JSON format)
+  // -----------------------------------------------------------------------
+
+  test("parses step_start + text + step_finish and returns accumulated text", async () => {
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1", "m-1")}' + "\\n");
+process.stdout.write('${textEvent("The answer ", "s-1", "m-1")}' + "\\n");
+process.stdout.write('${textEvent("is 42.", "s-1", "m-1")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-1" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "What is 6*7?" }],
+      });
+
+      expect(result.text).toBe("The answer is 42.");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("emits started event from step_start and completed from step_finish", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${textEvent("Hello", "s-1")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", reason: "stop" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Hi" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      const startedEvents = events.filter((e) => e.type === "started");
+      expect(startedEvents.length).toBe(1);
+      expect(startedEvents[0].engine).toBe("opencode");
+      expect(startedEvents[0].resume).toBe("s-1");
+
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+      expect(completedEvents[0].ok).toBe(true);
+      expect(completedEvents[0].answer).toBe("Hello");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("captures tool_use events as action events", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${toolUseEvent({
+  tool: "bash",
+  callID: "call-1",
+  status: "completed",
+  input: { command: "ls -la", description: "List files" },
+  output: "total 8\\nfile1.txt\\nfile2.txt",
+  sessionID: "s-1",
+})}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", reason: "tool-calls" })}' + "\\n");
+process.stdout.write('${stepStart("s-1", "m-2")}' + "\\n");
+process.stdout.write('${textEvent("I found 2 files.", "s-1", "m-2")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-2", reason: "stop" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Run ls" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      expect(result.text).toBe("I found 2 files.");
+
+      // Should have tool action events
+      const toolEvents = events.filter(
+        (e) => e.type === "action" && e.action?.kind === "command"
+      );
+      expect(toolEvents.length).toBeGreaterThanOrEqual(1);
+
+      // Tool event should have the call ID
+      const bashTool = toolEvents.find((e) => e.action?.title === "bash");
+      expect(bashTool).toBeDefined();
+      expect(bashTool.action.id).toBe("call-1");
+
+      // Completed events
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+      expect(completedEvents[0].ok).toBe(true);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles multi-step interaction (tool then text)", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    // Real pattern: step_start → tool_use → step_finish(tool-calls) → step_start → text → step_finish(stop)
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1", "m-1")}' + "\\n");
+process.stdout.write('${toolUseEvent({
+  tool: "read",
+  callID: "call-read-1",
+  input: { filePath: "/tmp/test.txt" },
+  output: "file contents here",
+  sessionID: "s-1",
+  messageID: "m-1",
+})}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-1", reason: "tool-calls" })}' + "\\n");
+process.stdout.write('${stepStart("s-1", "m-2")}' + "\\n");
+process.stdout.write('${textEvent("The file contains: file contents here", "s-1", "m-2")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-2", reason: "stop" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Read the file" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      expect(result.text).toBe("The file contains: file contents here");
+
+      // Should have exactly one started event (first step_start)
+      const startedEvents = events.filter((e) => e.type === "started");
+      expect(startedEvents.length).toBe(1);
+
+      // Should have tool action event for read
+      const toolEvents = events.filter(
+        (e) => e.type === "action" && e.action?.title === "read"
+      );
+      expect(toolEvents.length).toBeGreaterThanOrEqual(1);
+
+      // Should have text action event
+      const textEvents = events.filter(
+        (e) => e.type === "action" && e.entryType === "message"
+      );
+      expect(textEvents.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("extracts usage/tokens from step_finish into completed event", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${textEvent("Hello", "s-1")}' + "\\n");
+process.stdout.write('${stepFinish({
+  sessionID: "s-1",
+  reason: "stop",
+  tokens: {
+    total: 1500,
+    input: 1000,
+    output: 500,
+    reasoning: 50,
+    cache: { write: 10, read: 200 },
+  },
+  cost: 0.01,
+})}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Hi" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+
+      const usage = completedEvents[0].usage;
+      expect(usage).toBeDefined();
+      expect(usage.inputTokens).toBe(1000);
+      expect(usage.outputTokens).toBe(500);
+      expect(usage.totalTokens).toBe(1500);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("declares opencode as cliEngine and has correct capabilities", () => {
+    const agent = new OpenCodeAgent({
+      model: "anthropic/claude-opus-4-20250514",
+    });
+
+    expect(agent.cliEngine).toBe("opencode");
+    expect(agent.capabilities).toBeDefined();
+    expect(agent.capabilities.engine).toBe("opencode");
+    expect(agent.capabilities.mcp.supportsProjectScope).toBe(true);
+    expect(agent.capabilities.skills.supportsSkills).toBe(true);
+  });
+
+  test("passes --dir from cwd constructor option", async () => {
+    const argsFileDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-args-")
+    );
+    const argsFile = join(argsFileDir, "args.json");
+    const projectDir = await mkdtemp(
+      join(tmpdir(), "smithers-opencode-project-")
+    );
+
+    const fake = await makeFakeOpenCode(`
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (process.env.OPENCODE_ARGS_FILE) {
+  fs.writeFileSync(process.env.OPENCODE_ARGS_FILE, JSON.stringify({ args }), "utf8");
+}
+process.stdout.write('${stepStart()}' + "\\n");
+process.stdout.write('${textEvent("ok")}' + "\\n");
+process.stdout.write('${stepFinish()}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+      process.env.OPENCODE_ARGS_FILE = argsFile;
+
+      const agent = new OpenCodeAgent({
+        model: "openai/gpt-5.4",
+        cwd: projectDir,
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Hello" }],
+      });
+
+      const captured = JSON.parse(await readFile(argsFile, "utf8"));
+      expect(captured.args).toContain("--dir");
+      expect(captured.args).toContain(projectDir);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+      await rm(argsFileDir, { recursive: true, force: true });
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles non-zero exit code gracefully", async () => {
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stderr.write("Error: Rate limit exceeded\\n");
+process.exit(1);
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      let threw = false;
+      try {
+        await agent.generate({
+          messages: [{ role: "user", content: "Ping" }],
+          onEvent: (event) => events.push(event),
+        });
+      } catch {
+        threw = true;
+      }
+
+      // Should throw because exit code is non-zero
+      expect(threw).toBe(true);
+
+      // Should have emitted completed event with ok: false
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+      expect(completedEvents[0].ok).toBe(false);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles error event from session.error", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${errorEvent({
+  sessionID: "s-1",
+  name: "ProviderAuthError",
+  message: "Invalid API key",
+})}' + "\\n");
+process.exit(1);
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      let threw = false;
+      try {
+        await agent.generate({
+          messages: [{ role: "user", content: "test" }],
+          onEvent: (event) => events.push(event),
+        });
+      } catch {
+        threw = true;
+      }
+
+      expect(threw).toBe(true);
+
+      // Should have emitted a completed event with ok: false and error info
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+      expect(completedEvents[0].ok).toBe(false);
+      expect(completedEvents[0].error).toContain("Invalid API key");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles tool_use with error status", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1")}' + "\\n");
+process.stdout.write('${toolUseEvent({
+  tool: "bash",
+  callID: "call-err-1",
+  status: "error",
+  input: { command: "rm -rf /", description: "Delete everything" },
+  error: "Permission denied",
+  sessionID: "s-1",
+})}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", reason: "tool-calls" })}' + "\\n");
+process.stdout.write('${stepStart("s-1", "m-2")}' + "\\n");
+process.stdout.write('${textEvent("The command failed.", "s-1", "m-2")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-2", reason: "stop" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Try something" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      expect(result.text).toBe("The command failed.");
+
+      // Tool event should have ok: false for error status
+      const toolEvents = events.filter(
+        (e) => e.type === "action" && e.action?.id === "call-err-1"
+      );
+      expect(toolEvents.length).toBeGreaterThanOrEqual(1);
+      const completedTool = toolEvents.find((e) => e.phase === "completed");
+      expect(completedTool).toBeDefined();
+      expect(completedTool.ok).toBe(false);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("accumulates tokens across multiple step_finish events", async () => {
+    /** @type {import("../src/BaseCliAgent/index.ts").AgentCliEvent[]} */
+    const events = [];
+
+    // Multi-step: tool call step + text step, each with their own token counts
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1", "m-1")}' + "\\n");
+process.stdout.write('${toolUseEvent({ tool: "bash", callID: "c1", sessionID: "s-1", messageID: "m-1" })}' + "\\n");
+process.stdout.write('${stepFinish({
+  sessionID: "s-1",
+  messageID: "m-1",
+  reason: "tool-calls",
+  tokens: { total: 500, input: 400, output: 100, reasoning: 0, cache: { write: 0, read: 50 } },
+  cost: 0.002,
+})}' + "\\n");
+process.stdout.write('${stepStart("s-1", "m-2")}' + "\\n");
+process.stdout.write('${textEvent("Result.", "s-1", "m-2")}' + "\\n");
+process.stdout.write('${stepFinish({
+  sessionID: "s-1",
+  messageID: "m-2",
+  reason: "stop",
+  tokens: { total: 700, input: 500, output: 200, reasoning: 10, cache: { write: 5, read: 80 } },
+  cost: 0.003,
+})}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Do stuff" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      const completedEvents = events.filter((e) => e.type === "completed");
+      expect(completedEvents.length).toBe(1);
+
+      const usage = completedEvents[0].usage;
+      expect(usage).toBeDefined();
+      // Accumulated: 400+500=900 input, 100+200=300 output, 500+700=1200 total
+      expect(usage.inputTokens).toBe(900);
+      expect(usage.outputTokens).toBe(300);
+      expect(usage.totalTokens).toBe(1200);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("parses reasoning events as thought actions", async () => {
+    const events = [];
+
+    const fake = await makeFakeOpenCode(`
+process.stdout.write('${stepStart("s-1", "m-1")}' + "\\n");
+process.stdout.write('${reasoningEvent("Let me think about this carefully...", "s-1", "m-1")}' + "\\n");
+process.stdout.write('${textEvent("The answer is 42.", "s-1", "m-1")}' + "\\n");
+process.stdout.write('${stepFinish({ sessionID: "s-1", messageID: "m-1" })}' + "\\n");
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      await agent.generate({
+        messages: [{ role: "user", content: "Think hard" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      // Should emit a thought action for the reasoning event
+      const thoughtActions = events.filter(
+        (e) => e.type === "action" && e.entryType === "thought"
+      );
+      expect(thoughtActions.length).toBe(1);
+      expect(thoughtActions[0].action.title).toBe("reasoning");
+      expect(thoughtActions[0].message).toContain("Let me think about this");
+      expect(thoughtActions[0].ok).toBe(true);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("handles clean exit with no output (empty stdout)", async () => {
+    const events = [];
+
+    // Process exits 0 immediately without emitting any nd-JSON events
+    const fake = await makeFakeOpenCode(`
+// no output at all
+`);
+
+    try {
+      process.env.PATH = `${fake.dir}:${originalPath}`;
+
+      const agent = new OpenCodeAgent({
+        model: "anthropic/claude-opus-4-20250514",
+        env: { PATH: process.env.PATH },
+      });
+
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "Hi" }],
+        onEvent: (event) => events.push(event),
+      });
+
+      // Should still emit a completed event via onExit
+      const completed = events.filter((e) => e.type === "completed");
+      expect(completed.length).toBe(1);
+      expect(completed[0].ok).toBe(true);
+      expect(completed[0].answer).toBeUndefined();
+
+      // result.text should be empty (no model response)
+      expect(result.text).toBe("");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents/tests/opencode-support.test.js
+++ b/packages/agents/tests/opencode-support.test.js
@@ -654,6 +654,7 @@ process.stdout.write('${stepFinish()}' + "\\n");
 
       const agent = new OpenCodeAgent({
         model: "anthropic/claude-opus-4-20250514",
+        continueSession: true,
         env: { PATH: process.env.PATH },
       });
 

--- a/packages/db/src/output.js
+++ b/packages/db/src/output.js
@@ -211,6 +211,31 @@ function isZodSchema(val) {
  * @returns {string}
  */
 function describeZodType(schema) {
+    if (schema instanceof z.ZodOptional) {
+        return `${describeZodType(schema.unwrap())} (optional)`;
+    }
+    if (schema instanceof z.ZodNullable) {
+        return `${describeZodType(schema.unwrap())} | null`;
+    }
+    if (schema instanceof z.ZodDefault) {
+        return describeZodType(schema.removeDefault());
+    }
+    if (schema instanceof z.ZodString)
+        return "string";
+    if (schema instanceof z.ZodNumber)
+        return "number";
+    if (schema instanceof z.ZodBoolean)
+        return "boolean";
+    if (schema instanceof z.ZodArray)
+        return `${describeZodType(schema.element)}[]`;
+    if (schema instanceof z.ZodObject)
+        return "object";
+    if (schema instanceof z.ZodEnum)
+        return `enum(${schema.options.join(" | ")})`;
+    if (schema instanceof z.ZodLiteral)
+        return `literal(${JSON.stringify(schema.value)})`;
+    if (schema instanceof z.ZodUnion)
+        return schema.options.map((option) => describeZodType(option)).join(" | ");
     const internal = /** @type {{ _zod?: { def?: Record<string, unknown> } }} */ (/** @type {unknown} */ (schema));
     if (internal._zod?.def) {
         const def = internal._zod.def;

--- a/packages/db/tests/db-output.test.js
+++ b/packages/db/tests/db-output.test.js
@@ -91,10 +91,29 @@ describe("describeSchemaShape", () => {
         const parsed = JSON.parse(description);
         expect(parsed).toBeDefined();
     });
-    test("describes Drizzle table via agent schema", () => {
-        const zodSchema = z.object({ summary: z.string() });
-        const { table } = createTableAndDb("test", zodSchema);
-        const description = describeSchemaShape(table);
-        expect(typeof description).toBe("string");
+  test("describes Drizzle table via agent schema", () => {
+    const zodSchema = z.object({ summary: z.string() });
+    const { table } = createTableAndDb("test", zodSchema);
+    const description = describeSchemaShape(table);
+    expect(typeof description).toBe("string");
+  });
+
+  test("describes arrays and booleans with concrete types", () => {
+    const schema = z.object({
+      summary: z.string(),
+      filesChanged: z.array(z.string()),
+      testsWritten: z.array(z.string()),
+      testRunOutput: z.string(),
+      allTestsPassing: z.boolean(),
     });
+
+    const description = describeSchemaShape(schema);
+    const parsed = JSON.parse(description);
+
+    expect(parsed.properties.filesChanged.type).toBe("array");
+    expect(parsed.properties.filesChanged.items.type).toBe("string");
+    expect(parsed.properties.testsWritten.type).toBe("array");
+    expect(parsed.properties.testsWritten.items.type).toBe("string");
+    expect(parsed.properties.allTestsPassing.type).toBe("boolean");
+  });
 });


### PR DESCRIPTION
NOTE: im currently building a workflow based on this where i'll be able to test everything more thoroughly :))

In the meantime i open the PR also for discussion if needed 🤝

## Summary

- Adds `OpenCodeAgent`, a new CLI agent wrapper for [OpenCode](https://opencode.ai) — an open-source, terminal-native AI coding agent
- Implements nd-JSON stream parsing verified against OpenCode's actual source code (`run.ts` + `message-v2.ts`)
- Includes 26 unit tests covering args construction, output interpretation, multi-step tool interactions, reasoning events, token accumulation, error handling, system prompt forwarding, per-call resume, returned usage extraction, structured error propagation, capability registry completeness, and edge cases
- Includes 5 E2E tests against the real OpenCode CLI (auto-skipped when `opencode` is not on PATH)

## What's included

### New files
- `packages/agents/src/OpenCodeAgent.js` — Agent implementation (~492 lines) with `buildCommand()` and `createOutputInterpreter()`
- `packages/agents/src/OpenCodeAgent.ts` — Type declarations (`OpenCodeAgentOptions`)
- `packages/agents/tests/opencode-support.test.js` — 26 unit tests using fake binaries that emit real nd-JSON
- `packages/agents/tests/opencode-e2e.test.js` — 5 E2E tests against the real CLI (skipped via `describe.skipIf` when not installed)

### Modified files
- `packages/agents/src/capability-registry/AgentCapabilityRegistry.ts` — Added `"opencode"` to the engine union type
- `packages/agents/src/index.js` / `index.ts` — Added OpenCodeAgent exports
- `packages/agents/src/BaseCliAgent/BaseCliAgent.js` — Added `stripOscSequences()` for OSC escape sequence handling, `extractErrorFromJsonPayload()` for structured error preservation, `step_finish.part.tokens` usage parsing for OpenCode token data, and `totalTokens` fix to prefer `cliUsage.totalTokens` when present
- `packages/agents/src/BaseCliAgent/extractTextFromJsonValue.js` — Added `value.part` traversal path for nd-JSON formats that nest text inside `{ part: { text: "..." } }`

## Bugs discovered and fixed (10 total)

Found and fixed with TDD across two commits:

**Commit 1 (`5d35219`) — initial implementation:**
1. **`-f` flag consuming positional prompt** — Fix: added `--` separator before prompt in `buildCommand()`
2. **OSC escape sequences in final stdout** — Fix: added OSC stripping pattern to `stdoutBannerPatterns`
3. **OSC sequences breaking `step_start` parsing** — Fix: added OSC stripping in `parseLine()` before JSON parsing
4. **`OPENCODE_PERMISSION` format wrong** — Was `'"allow"'`, should be `'{"*":"allow"}'`
5. **`OPENCODE_SYSTEM_PROMPT` dead code** — Removed entirely (env var doesn't exist in OpenCode)

**Commit 2 (`adb5922`) — contract alignment fixes:**
6. **systemPrompt dropped by OpenCodeAgent** — Fix: prepend `params.systemPrompt` to prompt text in `buildCommand()`
7. **Per-call `resumeSession` ignored** — Fix: read `params.options.resumeSession` and map to `--session`, with per-call precedence over constructor default
8. **`generate().usage` missing OpenCode token data** — Fix: taught `extractUsageFromOutput()` to parse `step_finish.part.tokens` including `total`, `reasoning`, `cache.read`, `cache.write`
9. **Structured errors overwritten by generic CLI failure** — Fix: `extractErrorFromJsonPayload()` preserves provider error messages on nonzero exit
10. **Capability registry incomplete** — Fix: added `apply_patch`, `list`, `websearch`, `codesearch`, `question`

## BaseCliAgent changes are safe for other agents

All changes are format-gated and shape-gated:
- `stripOscSequences()` — only affects raw nd-JSON parsing; agents without OSC sequences are unaffected
- `step_finish.part.tokens` usage extraction — only matches OpenCode's exact event shape; other agents use `message_start`, `message_delta`, `turn.completed` etc.
- `extractErrorFromJsonPayload()` — only runs when `outputFormat` is `json` or `stream-json`; falls back to old stderr/exit behavior otherwise
- `totalTokens` fix — uses `cliUsage.totalTokens` if present, otherwise falls back to sum calculation (same as before)

## How to test

```bash
# Unit tests (no OpenCode CLI needed)
bun test packages/agents/tests/opencode-support.test.js

# E2E tests (requires `opencode` on PATH)
bun test packages/agents/tests/opencode-e2e.test.js
```

## Verified against OpenCode source

The nd-JSON format, event types, permission model, and CLI flags were all verified directly from [OpenCode's source code](https://github.com/anomalyco/opencode):
- `packages/opencode/src/cli/cmd/run.ts` — emit function, CLI flags
- `packages/opencode/src/tool/registry.ts` — built-in tool list
- `packages/opencode/src/config/config.ts` — OPENCODE_PERMISSION parsing