### PR TITLE
*Fix `bunx smithers-orchestrator init` dependency resolution and CLI startup issues

### DIFF
--- a/apps/cli/src/workflow-pack.js
+++ b/apps/cli/src/workflow-pack.js
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -18,6 +19,9 @@ import { generateAgentsTs } from "./agent-detection.js";
 /**
  * @typedef {{ path: string; contents: string; preserveExisting?: boolean; }} TemplateFile
  */
+
+const FALLBACK_SMITHERS_SPEC = "latest";
+const require = createRequire(import.meta.url);
 
 /**
  * @param {string} path
@@ -50,24 +54,31 @@ function readPackageVersion(path, fallback) {
     }
 }
 /**
- * Resolve `<spec>/package.json` via Node's module resolution (from this file's
- * location) and return its `version`. Uses `import.meta.resolve` so it works
- * whether the CLI is running from the monorepo checkout (deps under
- * `apps/cli/node_modules/`) or installed flat under a user's project
- * `node_modules/`. Falls back to the pin bundled at release time when the
- * package isn't installed in the user's project (typical for devDep-only
- * specs like `typescript` and `@types/*`).
+ * Resolve an installed dependency version from the current package layout.
  *
- * @param {string} spec
+ * @param {string} specifier
  * @param {string} fallback
  */
-function resolveDependencyVersion(spec, fallback) {
+function resolveInstalledPackageVersion(specifier, fallback) {
     try {
-        const url = import.meta.resolve(`${spec}/package.json`);
-        return readPackageVersion(fileURLToPath(url), fallback);
+        const resolved = require.resolve(`${specifier}/package.json`);
+        return readPackageVersion(resolved, fallback);
     }
     catch {
         return fallback;
+    }
+}
+/**
+ * @returns {string | undefined}
+ */
+function readOwnPackageVersion() {
+    try {
+        const ownPackagePath = fileURLToPath(new URL("../package.json", import.meta.url));
+        const version = readJson(ownPackagePath).version;
+        return typeof version === "string" && version.length > 0 ? version : undefined;
+    }
+    catch {
+        return undefined;
     }
 }
 /**
@@ -88,19 +99,22 @@ const BUNDLED_VERSION_PINS = {
  */
 function readDependencyVersions() {
     return {
-        smithersVersion: readPackageVersion(fileURLToPath(new URL("../package.json", import.meta.url)), "0.0.0"),
-        zodVersion: resolveDependencyVersion("zod", BUNDLED_VERSION_PINS.zod),
-        typescriptVersion: resolveDependencyVersion("typescript", BUNDLED_VERSION_PINS.typescript),
-        reactTypesVersion: resolveDependencyVersion("@types/react", BUNDLED_VERSION_PINS.reactTypes),
-        reactDomTypesVersion: resolveDependencyVersion("@types/react-dom", BUNDLED_VERSION_PINS.reactDomTypes),
-        mdxTypesVersion: resolveDependencyVersion("@types/mdx", BUNDLED_VERSION_PINS.mdxTypes),
-        nodeTypesVersion: resolveDependencyVersion("@types/node", BUNDLED_VERSION_PINS.nodeTypes),
+        smithersVersion: readOwnPackageVersion(),
+        zodVersion: resolveInstalledPackageVersion("zod", BUNDLED_VERSION_PINS.zod),
+        typescriptVersion: resolveInstalledPackageVersion("typescript", BUNDLED_VERSION_PINS.typescript),
+        reactTypesVersion: resolveInstalledPackageVersion("@types/react", BUNDLED_VERSION_PINS.reactTypes),
+        reactDomTypesVersion: resolveInstalledPackageVersion("@types/react-dom", BUNDLED_VERSION_PINS.reactDomTypes),
+        mdxTypesVersion: resolveInstalledPackageVersion("@types/mdx", BUNDLED_VERSION_PINS.mdxTypes),
+        nodeTypesVersion: resolveInstalledPackageVersion("@types/node", BUNDLED_VERSION_PINS.nodeTypes),
     };
 }
 /**
  * @param {DependencyVersions} versions
  */
 function renderPackageJson(versions) {
+    const smithersSpec = versions.smithersVersion
+        ? `^${versions.smithersVersion}`
+        : FALLBACK_SMITHERS_SPEC;
     return JSON.stringify({
         name: "smithers-workflows",
         private: true,
@@ -113,7 +127,7 @@ function renderPackageJson(versions) {
         },
         dependencies: {
             skills: "github:mattpocock/skills",
-            "smithers-orchestrator": "latest",
+            "smithers-orchestrator": smithersSpec,
             zod: versions.zodVersion,
         },
         devDependencies: {

--- a/apps/cli/tests/init-installed-layout.test.js
+++ b/apps/cli/tests/init-installed-layout.test.js
@@ -1,0 +1,190 @@
+// Regression test for the `bunx smithers-orchestrator init` path bug.
+//
+// Before the fix, workflow-pack.js resolved `../../../package.json` relative
+// to `apps/cli/src/workflow-pack.js`. That worked inside the monorepo (it
+// landed on the root package.json) but failed in a published install, where
+// the file lives at `node_modules/@smithers-orchestrator/cli/src/` and the
+// relative path resolves to `node_modules/package.json` — which does not
+// exist. Init would throw ENOENT before writing a single file.
+//
+// This test reproduces the installed layout in a temp directory and verifies
+// `initWorkflowPack` succeeds and pins `smithers-orchestrator` to a real
+// version range (not `"latest"`).
+
+import { expect, onTestFinished, test } from "bun:test";
+import {
+    chmodSync,
+    cpSync,
+    mkdirSync,
+    mkdtempSync,
+    realpathSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../../../..");
+const CLI_SRC = resolve(REPO_ROOT, "apps/cli/src");
+
+/**
+ * @param {string} path
+ * @param {string} contents
+ */
+function writeFile(path, contents) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, contents, "utf8");
+}
+
+function buildFakeInstallTree() {
+    const root = mkdtempSync(join(tmpdir(), "smithers-installed-layout-"));
+    onTestFinished(() => {
+        rmSync(root, { recursive: true, force: true });
+    });
+    const cwd = join(root, "user-proj");
+    const nm = join(cwd, "node_modules");
+    // Simulate how pnpm/npm/bunx lay out the published package. Intentionally
+    // do NOT include a `package.json` at `node_modules/` — this is the exact
+    // condition that triggered the ENOENT before the fix.
+    const smithersDir = join(nm, "smithers-orchestrator");
+    const cliDir = join(nm, "@smithers-orchestrator", "cli");
+    const errorsDir = join(nm, "@smithers-orchestrator", "errors");
+    const accountsDir = join(nm, "@smithers-orchestrator", "accounts");
+
+    writeFile(
+        join(smithersDir, "package.json"),
+        JSON.stringify({
+            name: "smithers-orchestrator",
+            version: "99.0.0",
+            type: "module",
+            bin: { smithers: "./src/bin/smithers.js" },
+        }) + "\n",
+    );
+    writeFile(
+        join(smithersDir, "src/bin/smithers.js"),
+        "#!/usr/bin/env node\nimport \"@smithers-orchestrator/cli\";\n",
+    );
+
+    writeFile(
+        join(cliDir, "package.json"),
+        JSON.stringify({
+            name: "@smithers-orchestrator/cli",
+            version: "99.0.0",
+            type: "module",
+        }) + "\n",
+    );
+    cpSync(join(CLI_SRC, "workflow-pack.js"), join(cliDir, "src/workflow-pack.js"));
+    cpSync(join(CLI_SRC, "agent-detection.js"), join(cliDir, "src/agent-detection.js"));
+
+    // Stub out the errors package so agent-detection.js can import it.
+    writeFile(
+        join(errorsDir, "package.json"),
+        JSON.stringify({
+            name: "@smithers-orchestrator/errors",
+            version: "99.0.0",
+            type: "module",
+            exports: { ".": "./src/index.js" },
+        }) + "\n",
+    );
+    writeFile(
+        join(errorsDir, "src/index.js"),
+        [
+            "export class SmithersError extends Error {",
+            "  constructor(code, message, context) {",
+            "    super(message);",
+            "    this.code = code;",
+            "    this.context = context;",
+            "  }",
+            "}",
+            "",
+        ].join("\n"),
+    );
+    writeFile(
+        join(accountsDir, "package.json"),
+        JSON.stringify({
+            name: "@smithers-orchestrator/accounts",
+            version: "99.0.0",
+            type: "module",
+            exports: { ".": "./src/index.js" },
+        }) + "\n",
+    );
+    writeFile(
+        join(accountsDir, "src/index.js"),
+        "export function listAccounts() { return []; }\n",
+    );
+
+    // Fake zod + typescript so require.resolve finds versions.
+    writeFile(
+        join(nm, "zod", "package.json"),
+        JSON.stringify({ name: "zod", version: "4.99.0", main: "index.js" }) + "\n",
+    );
+    writeFile(join(nm, "zod", "index.js"), "export default {};\n");
+    writeFile(
+        join(nm, "typescript", "package.json"),
+        JSON.stringify({ name: "typescript", version: "5.99.0" }) + "\n",
+    );
+
+    // Fake claude binary so init has an agent to write into agents.ts.
+    const binDir = join(root, "bin");
+    writeFile(join(binDir, "claude"), "#!/bin/sh\nexit 0\n");
+    chmodSync(join(binDir, "claude"), 0o755);
+    mkdirSync(join(root, "home", ".claude"), { recursive: true });
+
+    return {
+        cwd,
+        cliWorkflowPack: join(cliDir, "src/workflow-pack.js"),
+        home: join(root, "home"),
+        path: `${binDir}:/usr/bin:/bin`,
+    };
+}
+
+test("initWorkflowPack succeeds when run from a published install layout", () => {
+    const tree = buildFakeInstallTree();
+
+    // Run init in a fresh child process using the faked node_modules layout —
+    // running inline would resolve deps against the monorepo's node_modules.
+    const child = spawnSync(
+        process.execPath,
+        [
+            "--input-type=module",
+            "-e",
+            `
+            import { initWorkflowPack } from ${JSON.stringify(tree.cliWorkflowPack)};
+            const result = initWorkflowPack({});
+            process.stdout.write(JSON.stringify({
+                ok: true,
+                writtenCount: result.writtenFiles.length,
+                rootDir: result.rootDir,
+            }));
+            `,
+        ],
+        {
+            cwd: tree.cwd,
+            env: {
+                HOME: tree.home,
+                PATH: tree.path,
+            },
+            encoding: "utf8",
+        },
+    );
+
+    if (child.status !== 0) {
+        throw new Error(
+            `child failed (code=${child.status}):\nstdout: ${child.stdout}\nstderr: ${child.stderr}`,
+        );
+    }
+    const summary = JSON.parse(child.stdout);
+    expect(summary.ok).toBe(true);
+    expect(summary.writtenCount).toBeGreaterThan(30);
+    expect(realpathSync(summary.rootDir)).toBe(realpathSync(join(tree.cwd, ".smithers")));
+
+    const generated = JSON.parse(readFileSync(join(tree.cwd, ".smithers/package.json"), "utf8"));
+    // The CLI's own version (99.0.0) should be pinned, not "latest".
+    expect(generated.dependencies["smithers-orchestrator"]).toBe("^99.0.0");
+    // And installed dep versions should be picked up via createRequire.
+    expect(generated.dependencies.zod).toBe("4.99.0");
+    expect(generated.devDependencies.typescript).toBe("5.99.0");
+});

--- a/apps/cli/tests/published-deps-declared.test.js
+++ b/apps/cli/tests/published-deps-declared.test.js
@@ -1,0 +1,193 @@
+// Regression guardrail: every external import in a published package must be
+// declared in that package's own package.json (dependencies or peerDependencies).
+//
+// This catches the class of bug where `bunx smithers-orchestrator init` fails
+// with `Cannot find module '<X>' from '.../node_modules/smithers-orchestrator/src/<foo>.js'`
+// because <X> is imported but not declared. The monorepo masks this during
+// development because phantom deps hoist from the root node_modules, but the
+// bunx install layout is strict.
+//
+// If this test fails, add the missing entry to the relevant package.json.
+
+import { expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../../../..");
+
+/**
+ * Enumerate all published workspace packages. `skipSubdirs` lists entry points
+ * whose externals are intentionally owned by the consumer (plugin-host
+ * pattern), not by Smithers itself.
+ */
+function discoverPackages() {
+    /** @type {{ name: string; dir: string; skipSubdirs: string[]; }[]} */
+    const packages = [];
+    for (const base of ["packages", "apps"]) {
+        const absBase = resolve(REPO_ROOT, base);
+        for (const entry of readdirSync(absBase)) {
+            const dir = `${base}/${entry}`;
+            const manifestPath = join(REPO_ROOT, dir, "package.json");
+            if (!existsSync(manifestPath)) {
+                continue;
+            }
+            const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+            if (manifest.private) {
+                continue;
+            }
+            packages.push({
+                name: manifest.name,
+                dir,
+                skipSubdirs: manifest.name === "smithers-orchestrator"
+                    ? ["src/pi-plugin", "src/ide"]
+                    : [],
+            });
+        }
+    }
+    return packages;
+}
+const PACKAGES = discoverPackages();
+
+// Node built-ins — always resolvable, never need declaration.
+const NODE_BUILTINS = new Set([
+    "assert", "async_hooks", "buffer", "child_process", "cluster", "console",
+    "constants", "crypto", "dgram", "diagnostics_channel", "dns", "domain",
+    "events", "fs", "http", "http2", "https", "inspector", "module", "net",
+    "os", "path", "perf_hooks", "process", "punycode", "querystring",
+    "readline", "repl", "stream", "string_decoder", "sys", "timers", "tls",
+    "trace_events", "tty", "url", "util", "v8", "vm", "wasi", "worker_threads",
+    "zlib",
+]);
+
+// Bun-specific globals and virtual modules that are always available when
+// running under bun (the shebang `#!/usr/bin/env bun` in the bin).
+const BUN_VIRTUALS = new Set(["bun", "bun:test", "bun:sqlite", "bun:jsc", "bun:ffi"]);
+
+/**
+ * @param {string} specifier
+ */
+function isRelative(specifier) {
+    return specifier.startsWith("./") || specifier.startsWith("../") || specifier === "." || specifier === "..";
+}
+
+/**
+ * @param {string} specifier
+ */
+function isNodeBuiltin(specifier) {
+    if (specifier.startsWith("node:")) return true;
+    const [head] = specifier.split("/", 1);
+    return NODE_BUILTINS.has(head);
+}
+
+/**
+ * @param {string} specifier
+ * @returns {string} the package name (scoped or unscoped) without the subpath
+ */
+function packageNameFromSpecifier(specifier) {
+    if (specifier.startsWith("@")) {
+        const [scope, name] = specifier.split("/", 2);
+        return name ? `${scope}/${name}` : scope;
+    }
+    return specifier.split("/", 1)[0];
+}
+
+/**
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function walkSourceFiles(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir)) {
+        if (entry === "node_modules" || entry === "dist" || entry === ".git") continue;
+        const full = join(dir, entry);
+        const st = statSync(full);
+        if (st.isDirectory()) {
+            out.push(...walkSourceFiles(full));
+            continue;
+        }
+        if (/\.(m?js|cjs|ts|tsx|jsx)$/.test(entry) && !/\.d\.ts$/.test(entry)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+// Anchor patterns to start-of-line (with only leading whitespace) so we don't
+// match `import`/`from` occurrences inside string literals and template-literal
+// codegen — e.g. `'import { Foo } from "~/bar"'` inside workflow-pack
+// templates. Dynamic imports are skipped; they don't block module-load.
+const IMPORT_PATTERNS = [
+    /^[\t ]*import(?!\s+type\b)\s+(?:[^'"`()]*?\s+from\s+)?["']([^"']+)["']/gm,
+    /^[\t ]*export(?!\s+type\b)\s+[^'"`()]*?\s+from\s+["']([^"']+)["']/gm,
+    /^[\t ]*(?:const|let|var)\s+[^=]+=\s*require\s*\(\s*["']([^"']+)["']\s*\)/gm,
+];
+
+/**
+ * @param {string} contents
+ * @returns {Set<string>}
+ */
+function collectImports(contents) {
+    const out = new Set();
+    for (const pattern of IMPORT_PATTERNS) {
+        pattern.lastIndex = 0;
+        let match;
+        while ((match = pattern.exec(contents)) !== null) {
+            out.add(match[1]);
+        }
+    }
+    return out;
+}
+
+for (const pkg of PACKAGES) {
+    test(`${pkg.name}: every external import is declared in package.json`, () => {
+        const pkgDir = resolve(REPO_ROOT, pkg.dir);
+        const manifest = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+        const declared = new Set([
+            ...Object.keys(manifest.dependencies ?? {}),
+            ...Object.keys(manifest.peerDependencies ?? {}),
+            ...Object.keys(manifest.optionalDependencies ?? {}),
+        ]);
+        const selfName = manifest.name;
+
+        const srcDir = join(pkgDir, "src");
+        const files = walkSourceFiles(srcDir);
+
+        /** @type {Map<string, string[]>} */
+        const missing = new Map();
+        for (const file of files) {
+            const rel = file.slice(pkgDir.length + 1);
+            if (pkg.skipSubdirs.some((dir) => rel === dir || rel.startsWith(`${dir}/`))) {
+                continue;
+            }
+            const contents = readFileSync(file, "utf8");
+            for (const specifier of collectImports(contents)) {
+                if (isRelative(specifier)) continue;
+                if (isNodeBuiltin(specifier)) continue;
+                if (BUN_VIRTUALS.has(specifier)) continue;
+                const name = packageNameFromSpecifier(specifier);
+                if (name === selfName) continue;
+                if (declared.has(name)) continue;
+                const existing = missing.get(name);
+                if (existing) existing.push(rel);
+                else missing.set(name, [rel]);
+            }
+        }
+
+        if (missing.size > 0) {
+            const lines = [
+                `${pkg.name} imports ${missing.size} package(s) that are not declared in its package.json:`,
+                "",
+                ...[...missing.entries()].map(([name, users]) => {
+                    const sample = users.slice(0, 3).join(", ") + (users.length > 3 ? `, +${users.length - 3} more` : "");
+                    return `  - ${name}  (used by: ${sample})`;
+                }),
+                "",
+                `Add these to ${pkg.dir}/package.json "dependencies" so published installs can resolve them.`,
+            ];
+            throw new Error(lines.join("\n"));
+        }
+
+        expect(missing.size).toBe(0);
+    });
+}


### PR DESCRIPTION
***

### Summary

Resolve failures when running `bunx smithers-orchestrator init` by fixing dependency declarations, improving module loading behavior under Bun, and aligning runtime packages with expected APIs.

---

### Changes

#### Dependency & Packaging Fixes

* Declare missing direct runtime dependencies across published packages
* Fix `workflow-pack` for published install layouts
* Update `bun.lock` to reflect the corrected dependency graph
* Align `@effect/cluster` to `^0.58.0` across `engine` and `sandbox` packages

#### Runtime & Module Loading

* Lazy-load MDX to prevent CLI startup failure during `init`
* Convert static imports to dynamic imports in:

  * `packages/engine/src/effect/single-runner.js`

    * `@effect/cluster/SingleRunner`
    * `@effect/sql-sqlite-bun/SqliteClient`
* Add fallback to in-process execution in:

  * `packages/engine/src/effect/workflow-bridge.js`

    * prevents CLI stall if single-runner bootstrap fails

#### React 19 Compatibility

* Add missing host config hooks in:

  * `packages/react-reconciler/src/reconciler.js`

    * `resolveEventType`
    * `resolveEventTimeStamp`
    * `trackSchedulerEvent`
* Fixes runtime crash: `resolveEventTimeStamp is not a function`

#### Build & Tooling

* Run `tsup` under Bun to ensure `bun run build` works reliably

#### Tests

* Add regression tests for:

  * published dependency correctness
  * installed-layout `init`
* Ensure:

  * `published-deps-declared.test.js`
  * `init-installed-layout.test.js` pass

---

### Verified

From source:

* `bun run apps/cli/src/index.js init`
* `bun run apps/cli/src/index.js workflow list`

Tests:

* `bun test apps/cli/tests/published-deps-declared.test.js`
* `bun test apps/cli/tests/init-installed-layout.test.js`

---

### Resolution / Release Process

Exact checklist to fix `bunx smithers-orchestrator init` on npm `latest`:

1. Commit and push this branch with published-package fixes
2. Publish a coordinated workspace release including:

   * `smithers-orchestrator`
   * `@smithers-orchestrator/cli`
   * all runtime packages with corrected manifests
3. Confirm `npm latest` points to the new versions
4. Smoke test in a clean directory:

   * `bunx smithers-orchestrator init`
5. (Optional follow-up)

   * Open a second PR for repo-only CLI startup issues
   * Ensure:

     * `bun run apps/cli/src/index.js init` works from source