### PR TITLE
fix: resolve duplicate output refs, SDK structured output, and stale package docs

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -6,18 +6,19 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./src/index.js",
       "default": "./src/index.js"
     },
     "./*": {
-      "types": "./src/index.d.ts",
+      "types": "./dist/*.d.ts",
       "import": "./src/*.js",
       "default": "./src/*.js"
     }
   },
   "files": [
-    "src/"
+    "src/",
+    "dist/"
   ],
   "scripts": {
     "test": "bun test --timeout=60000 --max-concurrency=1 tests",

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -1,10 +1,29 @@
 import { defineConfig } from "tsup";
+import { readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+
+function collectEntries(dir: string): Record<string, string> {
+  const entries: Record<string, string> = {};
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      Object.assign(entries, collectEntries(fullPath));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".js")) {
+      continue;
+    }
+    const relativePath = relative("src", fullPath).replace(/\\/g, "/");
+    entries[relativePath.replace(/\.js$/, "")] = fullPath;
+  }
+  return entries;
+}
 
 export default defineConfig({
-  entry: { index: "src/index.js" },
+  entry: collectEntries("src"),
   dts: { only: true, resolve: false },
-  outDir: "src",
-  clean: false,
+  outDir: "dist",
+  clean: true,
   format: ["esm"],
   silent: true,
 });

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,9 @@
         "@smithers-orchestrator/driver": "workspace:*",
         "@smithers-orchestrator/engine": "workspace:*",
         "@smithers-orchestrator/errors": "workspace:*",
+        "@smithers-orchestrator/gateway": "workspace:*",
+        "@smithers-orchestrator/gateway-client": "workspace:*",
+        "@smithers-orchestrator/gateway-react": "workspace:*",
         "@smithers-orchestrator/graph": "workspace:*",
         "@smithers-orchestrator/memory": "workspace:*",
         "@smithers-orchestrator/observability": "workspace:*",
@@ -72,7 +75,7 @@
     },
     "apps/cli": {
       "name": "@smithers-orchestrator/cli",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@clack/prompts": "^0.10.1",
         "@effect/workflow": "^0.18.0",
@@ -110,7 +113,7 @@
     },
     "apps/observability": {
       "name": "@smithers-orchestrator/observability",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/opentelemetry": "^0.63.0",
         "@effect/platform": "^0.96.0",
@@ -130,7 +133,7 @@
     },
     "packages/accounts": {
       "name": "@smithers-orchestrator/accounts",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/errors": "workspace:*",
       },
@@ -141,7 +144,7 @@
     },
     "packages/agents": {
       "name": "@smithers-orchestrator/agents",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.71",
         "@ai-sdk/openai": "^3.0.53",
@@ -160,7 +163,7 @@
     },
     "packages/components": {
       "name": "@smithers-orchestrator/components",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/agents": "workspace:*",
         "@smithers-orchestrator/db": "workspace:*",
@@ -186,7 +189,7 @@
     },
     "packages/db": {
       "name": "@smithers-orchestrator/db",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/experimental": "^0.60.0",
         "@effect/sql": "^0.51.0",
@@ -208,7 +211,7 @@
     },
     "packages/devtools": {
       "name": "@smithers-orchestrator/devtools",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "~5.9.3",
@@ -216,7 +219,7 @@
     },
     "packages/driver": {
       "name": "@smithers-orchestrator/driver",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/db": "workspace:*",
         "@smithers-orchestrator/errors": "workspace:*",
@@ -233,7 +236,7 @@
     },
     "packages/engine": {
       "name": "@smithers-orchestrator/engine",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/cluster": "^0.58.0",
         "@effect/experimental": "^0.60.0",
@@ -270,7 +273,7 @@
     },
     "packages/errors": {
       "name": "@smithers-orchestrator/errors",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "effect": "^3.21.1",
       },
@@ -281,15 +284,47 @@
     },
     "packages/gateway": {
       "name": "@smithers-orchestrator/gateway",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "devDependencies": {
         "@types/bun": "latest",
         "typescript": "~5.9.3",
       },
     },
+    "packages/gateway-client": {
+      "name": "@smithers-orchestrator/gateway-client",
+      "version": "0.17.0",
+      "dependencies": {
+        "@smithers-orchestrator/gateway": "workspace:*",
+      },
+      "devDependencies": {
+        "@smithers-orchestrator/server": "workspace:*",
+        "@types/bun": "latest",
+        "typescript": "~5.9.3",
+      },
+    },
+    "packages/gateway-react": {
+      "name": "@smithers-orchestrator/gateway-react",
+      "version": "0.17.0",
+      "dependencies": {
+        "@smithers-orchestrator/gateway": "workspace:*",
+        "@smithers-orchestrator/gateway-client": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "typescript": "~5.9.3",
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+    },
     "packages/graph": {
       "name": "@smithers-orchestrator/graph",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/agents": "workspace:*",
         "@smithers-orchestrator/errors": "workspace:*",
@@ -303,7 +338,7 @@
     },
     "packages/memory": {
       "name": "@smithers-orchestrator/memory",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/db": "workspace:*",
         "@smithers-orchestrator/driver": "workspace:*",
@@ -322,7 +357,7 @@
     },
     "packages/openapi": {
       "name": "@smithers-orchestrator/openapi",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/driver": "workspace:*",
         "@smithers-orchestrator/errors": "workspace:*",
@@ -340,7 +375,7 @@
     },
     "packages/pi-plugin": {
       "name": "@smithers-orchestrator/pi-plugin",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.70.2",
         "@mariozechner/pi-tui": "^0.70.2",
@@ -361,7 +396,7 @@
     },
     "packages/protocol": {
       "name": "@smithers-orchestrator/protocol",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "effect": "^3.21.1",
         "zod": "^4.3.6",
@@ -373,7 +408,7 @@
     },
     "packages/react-reconciler": {
       "name": "@smithers-orchestrator/react-reconciler",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/devtools": "workspace:*",
         "@smithers-orchestrator/driver": "workspace:*",
@@ -392,7 +427,7 @@
     },
     "packages/sandbox": {
       "name": "@smithers-orchestrator/sandbox",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/cluster": "^0.58.0",
         "@effect/rpc": "^0.75.0",
@@ -413,7 +448,7 @@
     },
     "packages/scheduler": {
       "name": "@smithers-orchestrator/scheduler",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/errors": "workspace:*",
         "@smithers-orchestrator/graph": "workspace:*",
@@ -426,7 +461,7 @@
     },
     "packages/scorers": {
       "name": "@smithers-orchestrator/scorers",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@smithers-orchestrator/agents": "workspace:*",
         "@smithers-orchestrator/db": "workspace:*",
@@ -446,7 +481,7 @@
     },
     "packages/server": {
       "name": "@smithers-orchestrator/server",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/workflow": "^0.18.0",
         "@smithers-orchestrator/components": "workspace:*",
@@ -476,7 +511,7 @@
     },
     "packages/smithers": {
       "name": "smithers-orchestrator",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "bin": {
         "smithers": "./src/bin/smithers.js",
       },
@@ -492,6 +527,8 @@
         "@smithers-orchestrator/driver": "workspace:*",
         "@smithers-orchestrator/engine": "workspace:*",
         "@smithers-orchestrator/errors": "workspace:*",
+        "@smithers-orchestrator/gateway-client": "workspace:*",
+        "@smithers-orchestrator/gateway-react": "workspace:*",
         "@smithers-orchestrator/graph": "workspace:*",
         "@smithers-orchestrator/memory": "workspace:*",
         "@smithers-orchestrator/observability": "workspace:*",
@@ -518,7 +555,7 @@
     },
     "packages/time-travel": {
       "name": "@smithers-orchestrator/time-travel",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/platform": "^0.96.0",
         "@effect/platform-bun": "^0.89.0",
@@ -541,7 +578,7 @@
     },
     "packages/vcs": {
       "name": "@smithers-orchestrator/vcs",
-      "version": "0.16.9",
+      "version": "0.17.0",
       "dependencies": {
         "@effect/platform": "^0.96.0",
         "@smithers-orchestrator/observability": "workspace:*",
@@ -1052,6 +1089,10 @@
     "@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@workspace:packages/errors"],
 
     "@smithers-orchestrator/gateway": ["@smithers-orchestrator/gateway@workspace:packages/gateway"],
+
+    "@smithers-orchestrator/gateway-client": ["@smithers-orchestrator/gateway-client@workspace:packages/gateway-client"],
+
+    "@smithers-orchestrator/gateway-react": ["@smithers-orchestrator/gateway-react@workspace:packages/gateway-react"],
 
     "@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@workspace:packages/graph"],
 

--- a/docs/design-prompts/hmr-design.md
+++ b/docs/design-prompts/hmr-design.md
@@ -160,7 +160,7 @@ And the engine receives the workflow object, using `workflow.build` on every loo
 ```ts
 // src/cli/index.ts
 const workflow = await loadWorkflow(workflowPath);  // loaded once
-const result = await runWorkflow(workflow, { ... }); // passed into engine
+const result = await Effect.runPromise(runWorkflow(workflow, { ... })); // passed into engine
 ```
 
 ### Where state lives

--- a/docs/examples/claude-plugin-skill.mdx
+++ b/docs/examples/claude-plugin-skill.mdx
@@ -18,7 +18,7 @@ description: "Example from ~/.claude/plugins/smithers/ — A Claude Code plugin 
   "description": "Build AI agents with declarative JSX for Claude orchestration",
   "author": "William Cory",
   "license": "MIT",
-  "repository": "https://github.com/evmts/smithers",
+  "repository": "https://github.com/smithersai/smithers",
   "keywords": ["orchestration", "multi-agent", "workflow", "ai-agents", "claude", "jsx"],
   "skills": ["skills/smithers"]
 }

--- a/docs/integrations/tools.mdx
+++ b/docs/integrations/tools.mdx
@@ -338,13 +338,16 @@ const fullAgent = new Agent({
 | `toolTimeoutMs` | `60000` (60s) | Timeout for `bash` and `grep` |
 
 ```ts
-const result = await runWorkflow(workflow, {
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { file: "src/auth.ts" },
   rootDir: "/home/project",
   allowNetwork: false,
   maxOutputBytes: 500_000,
   toolTimeoutMs: 120_000,
-});
+}));
 ```
 
 ## See Also

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1,7 +1,7 @@
 # Smithers
 
 > Smithers — durable AI workflow orchestration as a JSX runtime.
-> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)
+> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This file contains the core Smithers documentation. Read top to bottom for a complete picture of the runtime, JSX surface, CLI, and components.
 
@@ -4147,8 +4147,11 @@ Use `KnownSmithersErrorCode` for an exhaustive switch over built-in Smithers cod
 | `SmithersError` | type | Public typed shape for serialized Smithers errors. |
 
 ```ts
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
 try {
-  await runWorkflow(workflow, { input: {} });
+  await Effect.runPromise(runWorkflow(workflow, { input: {} }));
 } catch (err) {
   if (isSmithersError(err) && isKnownSmithersErrorCode(err.code)) {
     switch (err.code) {
@@ -4672,10 +4675,11 @@ For workflow-level revert behavior, prefer the runtime and CLI docs:
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 
-const result = await runWorkflow(workflow, {
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
-});
+}));
 
 result.runId;     // string
 result.status;    // "finished" | "failed" | "cancelled" | "continued" | "waiting-approval" | "waiting-event" | "waiting-timer"
@@ -4689,7 +4693,7 @@ Signature:
 function runWorkflow<Schema>(
   workflow: SmithersWorkflow<Schema>,
   opts: RunOptions,                 // see Types
-): Promise<RunResult>;
+): Effect.Effect<RunResult, SmithersError>;
 ```
 
 Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
@@ -4699,7 +4703,7 @@ Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
 Pass the original `runId` plus `resume: true`. State loads from SQLite, completed tasks are skipped, in-progress attempts older than 15 minutes are abandoned and retried.
 
 ```ts
-await runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true });
+await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true }));
 ```
 
 The original input row is loaded from the DB; pass `{}` for `input`. The workflow file hash and VCS revision must match the original run.
@@ -4710,7 +4714,7 @@ The original input row is loaded from the DB; pass `{}` for `input`. The workflo
 const controller = new AbortController();
 setTimeout(() => controller.abort(), 5 * 60 * 1000);
 
-const result = await runWorkflow(workflow, { input: {...}, signal: controller.signal });
+const result = await Effect.runPromise(runWorkflow(workflow, { input: {...}, signal: controller.signal }));
 // result.status === "cancelled"
 ```
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -3629,6 +3629,7 @@ type CachePolicy<Ctx = any> = {
 type AgentLike = {
   id?: string;
   tools?: Record<string, any>;
+  supportsNativeStructuredOutput?: boolean;
   capabilities?: any;
   generate: (args: any) => Promise<any>;
 };

--- a/docs/llms-events.txt
+++ b/docs/llms-events.txt
@@ -14,16 +14,17 @@
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 import workflow from "./workflow";
 
-await runWorkflow(workflow, {
+await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
   onProgress: (event) => {
     if (event.type === "NodeStarted")  console.log(`▶ ${event.nodeId} (attempt ${event.attempt})`);
     if (event.type === "NodeFinished") console.log(`✓ ${event.nodeId}`);
     if (event.type === "NodeFailed")   console.error(`✗ ${event.nodeId}`, event.error);
   },
-});
+}));
 ```
 
 ## Read from the NDJSON log

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,7 +1,7 @@
 # Smithers — full documentation
 
 > Durable AI workflow orchestration as a JSX runtime.
-> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)
+> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This is the complete Smithers documentation in one file. It is the concatenation of every fragment listed in /llms.txt.
 
@@ -21,7 +21,7 @@ Changelogs are not included; see /docs/changelogs/ on the docs site.
 # Smithers
 
 > Smithers — durable AI workflow orchestration as a JSX runtime.
-> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)
+> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This file contains the core Smithers documentation. Read top to bottom for a complete picture of the runtime, JSX surface, CLI, and components.
 
@@ -4167,8 +4167,11 @@ Use `KnownSmithersErrorCode` for an exhaustive switch over built-in Smithers cod
 | `SmithersError` | type | Public typed shape for serialized Smithers errors. |
 
 ```ts
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
 try {
-  await runWorkflow(workflow, { input: {} });
+  await Effect.runPromise(runWorkflow(workflow, { input: {} }));
 } catch (err) {
   if (isSmithersError(err) && isKnownSmithersErrorCode(err.code)) {
     switch (err.code) {
@@ -4692,10 +4695,11 @@ For workflow-level revert behavior, prefer the runtime and CLI docs:
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 
-const result = await runWorkflow(workflow, {
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
-});
+}));
 
 result.runId;     // string
 result.status;    // "finished" | "failed" | "cancelled" | "continued" | "waiting-approval" | "waiting-event" | "waiting-timer"
@@ -4709,7 +4713,7 @@ Signature:
 function runWorkflow<Schema>(
   workflow: SmithersWorkflow<Schema>,
   opts: RunOptions,                 // see Types
-): Promise<RunResult>;
+): Effect.Effect<RunResult, SmithersError>;
 ```
 
 Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
@@ -4719,7 +4723,7 @@ Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
 Pass the original `runId` plus `resume: true`. State loads from SQLite, completed tasks are skipped, in-progress attempts older than 15 minutes are abandoned and retried.
 
 ```ts
-await runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true });
+await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true }));
 ```
 
 The original input row is loaded from the DB; pass `{}` for `input`. The workflow file hash and VCS revision must match the original run.
@@ -4730,7 +4734,7 @@ The original input row is loaded from the DB; pass `{}` for `input`. The workflo
 const controller = new AbortController();
 setTimeout(() => controller.abort(), 5 * 60 * 1000);
 
-const result = await runWorkflow(workflow, { input: {...}, signal: controller.signal });
+const result = await Effect.runPromise(runWorkflow(workflow, { input: {...}, signal: controller.signal }));
 // result.status === "cancelled"
 ```
 
@@ -7456,13 +7460,16 @@ const fullAgent = new Agent({
 | `toolTimeoutMs` | `60000` (60s) | Timeout for `bash` and `grep` |
 
 ```ts
-const result = await runWorkflow(workflow, {
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { file: "src/auth.ts" },
   rootDir: "/home/project",
   allowNetwork: false,
   maxOutputBytes: 500_000,
   toolTimeoutMs: 120_000,
-});
+}));
 ```
 
 ## See Also
@@ -7666,16 +7673,17 @@ Chat-provider integration lives in host applications, not this repo.
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 import workflow from "./workflow";
 
-await runWorkflow(workflow, {
+await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
   onProgress: (event) => {
     if (event.type === "NodeStarted")  console.log(`▶ ${event.nodeId} (attempt ${event.attempt})`);
     if (event.type === "NodeFinished") console.log(`✓ ${event.nodeId}`);
     if (event.type === "NodeFailed")   console.error(`✗ ${event.nodeId}`, event.error);
   },
-});
+}));
 ```
 
 ## Read from the NDJSON log

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3649,6 +3649,7 @@ type CachePolicy<Ctx = any> = {
 type AgentLike = {
   id?: string;
   tools?: Record<string, any>;
+  supportsNativeStructuredOutput?: boolean;
   capabilities?: any;
   generate: (args: any) => Promise<any>;
 };

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -687,13 +687,16 @@ const fullAgent = new Agent({
 | `toolTimeoutMs` | `60000` (60s) | Timeout for `bash` and `grep` |
 
 ```ts
-const result = await runWorkflow(workflow, {
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { file: "src/auth.ts" },
   rootDir: "/home/project",
   allowNetwork: false,
   maxOutputBytes: 500_000,
   toolTimeoutMs: 120_000,
-});
+}));
 ```
 
 ## See Also

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,5 +14,5 @@ Durable AI workflow orchestration as a JSX runtime.
 ## Pointers
 
 - npm: smithers-orchestrator
-- github: github.com/evmts/smithers
+- github: github.com/smithersai/smithers
 - changelogs: docs/changelogs/ on the site (not duplicated in llms files)

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -46,8 +46,11 @@ Use `KnownSmithersErrorCode` for an exhaustive switch over built-in Smithers cod
 | `SmithersError` | type | Public typed shape for serialized Smithers errors. |
 
 ```ts
+import { Effect } from "effect";
+import { runWorkflow } from "smithers-orchestrator";
+
 try {
-  await runWorkflow(workflow, { input: {} });
+  await Effect.runPromise(runWorkflow(workflow, { input: {} }));
 } catch (err) {
   if (isSmithersError(err) && isKnownSmithersErrorCode(err.code)) {
     switch (err.code) {

--- a/docs/reference/types.mdx
+++ b/docs/reference/types.mdx
@@ -231,6 +231,7 @@ type CachePolicy<Ctx = any> = {
 type AgentLike = {
   id?: string;
   tools?: Record<string, any>;
+  supportsNativeStructuredOutput?: boolean;
   capabilities?: any;
   generate: (args: any) => Promise<any>;
 };

--- a/docs/runtime/events.mdx
+++ b/docs/runtime/events.mdx
@@ -9,16 +9,17 @@ description: Subscribe to lifecycle events. Full event union lives in Types.
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 import workflow from "./workflow";
 
-await runWorkflow(workflow, {
+await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
   onProgress: (event) => {
     if (event.type === "NodeStarted")  console.log(`▶ ${event.nodeId} (attempt ${event.attempt})`);
     if (event.type === "NodeFinished") console.log(`✓ ${event.nodeId}`);
     if (event.type === "NodeFailed")   console.error(`✗ ${event.nodeId}`, event.error);
   },
-});
+}));
 ```
 
 ## Read from the NDJSON log

--- a/docs/runtime/run-workflow.mdx
+++ b/docs/runtime/run-workflow.mdx
@@ -5,10 +5,11 @@ description: Programmatic entry point. Equivalent to `bunx smithers-orchestrator
 
 ```ts
 import { runWorkflow } from "smithers-orchestrator";
+import { Effect } from "effect";
 
-const result = await runWorkflow(workflow, {
+const result = await Effect.runPromise(runWorkflow(workflow, {
   input: { task: "fix bug" },
-});
+}));
 
 result.runId;     // string
 result.status;    // "finished" | "failed" | "cancelled" | "continued" | "waiting-approval" | "waiting-event" | "waiting-timer"
@@ -22,7 +23,7 @@ Signature:
 function runWorkflow<Schema>(
   workflow: SmithersWorkflow<Schema>,
   opts: RunOptions,                 // see Types
-): Promise<RunResult>;
+): Effect.Effect<RunResult, SmithersError>;
 ```
 
 Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
@@ -32,7 +33,7 @@ Both `RunOptions` and `RunResult` are defined in [Types](/reference/types).
 Pass the original `runId` plus `resume: true`. State loads from SQLite, completed tasks are skipped, in-progress attempts older than 15 minutes are abandoned and retried.
 
 ```ts
-await runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true });
+await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "my-run-123", resume: true }));
 ```
 
 The original input row is loaded from the DB; pass `{}` for `input`. The workflow file hash and VCS revision must match the original run.
@@ -43,7 +44,7 @@ The original input row is loaded from the DB; pass `{}` for `input`. The workflo
 const controller = new AbortController();
 setTimeout(() => controller.abort(), 5 * 60 * 1000);
 
-const result = await runWorkflow(workflow, { input: {...}, signal: controller.signal });
+const result = await Effect.runPromise(runWorkflow(workflow, { input: {...}, signal: controller.signal }));
 // result.status === "cancelled"
 ```
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/evmts/smithers.git"
+    "url": "git+https://github.com/smithersai/smithers.git"
   },
-  "homepage": "https://github.com/evmts/smithers#readme",
+  "homepage": "https://github.com/smithersai/smithers#readme",
   "bugs": {
-    "url": "https://github.com/evmts/smithers/issues"
+    "url": "https://github.com/smithersai/smithers/issues"
   },
   "keywords": [
     "ai",

--- a/packages/agents/src/AgentLike.ts
+++ b/packages/agents/src/AgentLike.ts
@@ -12,6 +12,8 @@ export type AgentLike = {
   tools?: Record<string, unknown>;
   /** Optional structured capability registry for cache and diagnostics */
   capabilities?: AgentCapabilityRegistry;
+  /** True when the agent consumes outputSchema through a native structured-output API. */
+  supportsNativeStructuredOutput?: boolean;
   /**
    * Generates a response or action based on the provided arguments.
    *

--- a/packages/agents/src/AnthropicAgent.js
+++ b/packages/agents/src/AnthropicAgent.js
@@ -1,5 +1,5 @@
 import { anthropic } from "@ai-sdk/anthropic";
-import { ToolLoopAgent, } from "ai";
+import { Output, ToolLoopAgent, } from "ai";
 import { resolveSdkModel } from "./resolveSdkModel.js";
 import { streamResultToGenerateResult } from "./streamResultToGenerateResult.js";
 /** @typedef {import("ai").AgentCallParameters} AgentCallParameters */
@@ -17,6 +17,7 @@ import { streamResultToGenerateResult } from "./streamResultToGenerateResult.js"
 
 export class AnthropicAgent extends ToolLoopAgent {
     hijackEngine = "anthropic-sdk";
+    supportsNativeStructuredOutput = true;
     /**
    * @param {AnthropicAgentOptions<CALL_OPTIONS, TOOLS>} opts
    */
@@ -35,11 +36,15 @@ export class AnthropicAgent extends ToolLoopAgent {
         const promptArgs = "messages" in args
             ? { messages: args.messages }
             : { prompt: args.prompt };
+        const outputArgs = args.outputSchema
+            ? { output: Output.object({ schema: args.outputSchema }) }
+            : {};
         if (!args.onStdout) {
             return super.generate({
                 options: args.options,
                 abortSignal: args.abortSignal,
                 ...promptArgs,
+                ...outputArgs,
                 timeout: args.timeout,
                 onStepFinish: args.onStepFinish,
             });
@@ -48,6 +53,7 @@ export class AnthropicAgent extends ToolLoopAgent {
             options: args.options,
             abortSignal: args.abortSignal,
             ...promptArgs,
+            ...outputArgs,
             timeout: args.timeout,
             onStepFinish: args.onStepFinish,
         }).then((stream) => streamResultToGenerateResult(stream, args.onStdout));

--- a/packages/agents/src/OpenAIAgent.js
+++ b/packages/agents/src/OpenAIAgent.js
@@ -1,5 +1,5 @@
 import { openai } from "@ai-sdk/openai";
-import { ToolLoopAgent, } from "ai";
+import { Output, ToolLoopAgent, } from "ai";
 import { resolveSdkModel } from "./resolveSdkModel.js";
 import { streamResultToGenerateResult } from "./streamResultToGenerateResult.js";
 /** @typedef {import("ai").AgentCallParameters} AgentCallParameters */
@@ -17,6 +17,7 @@ import { streamResultToGenerateResult } from "./streamResultToGenerateResult.js"
 
 export class OpenAIAgent extends ToolLoopAgent {
     hijackEngine = "openai-sdk";
+    supportsNativeStructuredOutput = true;
     /**
    * @param {OpenAIAgentOptions<CALL_OPTIONS, TOOLS>} opts
    */
@@ -35,11 +36,15 @@ export class OpenAIAgent extends ToolLoopAgent {
         const promptArgs = "messages" in args
             ? { messages: args.messages }
             : { prompt: args.prompt };
+        const outputArgs = args.outputSchema
+            ? { output: Output.object({ schema: args.outputSchema }) }
+            : {};
         if (!args.onStdout) {
             return super.generate({
                 options: args.options,
                 abortSignal: args.abortSignal,
                 ...promptArgs,
+                ...outputArgs,
                 timeout: args.timeout,
                 onStepFinish: args.onStepFinish,
             });
@@ -48,6 +53,7 @@ export class OpenAIAgent extends ToolLoopAgent {
             options: args.options,
             abortSignal: args.abortSignal,
             ...promptArgs,
+            ...outputArgs,
             timeout: args.timeout,
             onStepFinish: args.onStepFinish,
         }).then((stream) => streamResultToGenerateResult(stream, args.onStdout));

--- a/packages/agents/src/__type-tests__/AgentLike.assignability.test-d.ts
+++ b/packages/agents/src/__type-tests__/AgentLike.assignability.test-d.ts
@@ -13,6 +13,11 @@ import type {
 
 type AssertAssignable<T extends AgentLike> = T;
 
+type _CustomNativeStructuredAgent = AssertAssignable<{
+  supportsNativeStructuredOutput: true;
+  generate: () => Promise<unknown>;
+}>;
+
 type _ConcreteAgentsAreAgentLike = [
   AssertAssignable<AmpAgent>,
   AssertAssignable<AnthropicAgent>,

--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -151,6 +151,8 @@ type AgentLike$1 = {
     tools?: Record<string, unknown>;
     /** Optional structured capability registry for cache and diagnostics */
     capabilities?: AgentCapabilityRegistry$1;
+    /** True when the agent consumes outputSchema through a native structured-output API. */
+    supportsNativeStructuredOutput?: boolean;
     /**
      * Generates a response or action based on the provided arguments.
      *

--- a/packages/agents/tests/sdk-agents.test.js
+++ b/packages/agents/tests/sdk-agents.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { simulateReadableStream } from "ai";
 import { MockLanguageModelV3 } from "ai/test";
 import { AnthropicAgent, OpenAIAgent } from "../src/index.js";
+import { z } from "zod";
 function createFakeModel() {
     let lastCall;
     return {
@@ -17,6 +18,14 @@ function createFakeModel() {
        */
             async doGenerate(options) {
                 lastCall = options;
+                if (options.responseFormat?.type === "json") {
+                    return {
+                        content: [{ type: "text", text: JSON.stringify({ value: 7 }) }],
+                        finishReason: "stop",
+                        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                        warnings: [],
+                    };
+                }
                 return {
                     content: [{ type: "text", text: "hello from sdk agent" }],
                     finishReason: "stop",
@@ -57,6 +66,36 @@ describe("SDK agents", () => {
         expect(result.text).toBe("hello from sdk agent");
         expect(fake.getLastCall()?.prompt?.[0]?.role).toBe("system");
         expect(fake.getLastCall()?.prompt?.[0]?.content).toBe("You are an implementer.");
+    });
+    test("OpenAIAgent forwards outputSchema through the SDK structured output channel", async () => {
+        const fake = createFakeModel();
+        const agent = new OpenAIAgent({
+            id: "openai-sdk-structured",
+            model: fake.model,
+        });
+        const result = await agent.generate({
+            prompt: "return a value",
+            outputSchema: z.object({ value: z.number() }),
+        });
+        expect(result.text).toBe(JSON.stringify({ value: 7 }));
+        expect(fake.getLastCall()?.responseFormat).toMatchObject({
+            type: "json",
+        });
+    });
+    test("AnthropicAgent forwards outputSchema through the SDK structured output channel", async () => {
+        const fake = createFakeModel();
+        const agent = new AnthropicAgent({
+            id: "anthropic-sdk-structured",
+            model: fake.model,
+        });
+        const result = await agent.generate({
+            prompt: "return a value",
+            outputSchema: z.object({ value: z.number() }),
+        });
+        expect(result.text).toBe(JSON.stringify({ value: 7 }));
+        expect(fake.getLastCall()?.responseFormat).toMatchObject({
+            type: "json",
+        });
     });
     test("OpenAIAgent streams assistant deltas through onStdout", async () => {
         const model = new MockLanguageModelV3({

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -1803,6 +1803,7 @@ function resolveTaskOutputs(tasks, workflow) {
         if (isTimerTask(task)) {
             continue;
         }
+        const hasAmbiguousOutputRef = Boolean(task.outputRef && workflow.ambiguousZodSchemas?.has(task.outputRef));
         // Already resolved (has a table)
         if (task.outputTable) {
             if (!task.outputSchema && task.outputTableName && workflow.schemaRegistry) {
@@ -1826,10 +1827,14 @@ function resolveTaskOutputs(tasks, workflow) {
                 }
             }
             if (!task.outputTable) {
+                if (hasAmbiguousOutputRef) {
+                    throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", `Task "${task.nodeId}" uses an output schema that is registered under multiple keys. Use createSmithers(...).outputs.<key> or a string output key instead of the shared raw Zod object.`);
+                }
                 throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", `Task "${task.nodeId}" uses an output ZodObject that is not registered in createSmithers()`);
             }
         }
         const raw = task.outputSchema;
+        const hasAmbiguousOutputSchema = Boolean(raw && typeof raw === "object" && workflow.ambiguousZodSchemas?.has(raw));
         // Resolve ZodObject via outputSchema when no outputRef resolved.
         if (!task.outputTable && raw && typeof raw === "object" && workflow.zodToKeyName) {
             const keyName = workflow.zodToKeyName.get(raw);
@@ -1843,6 +1848,9 @@ function resolveTaskOutputs(tasks, workflow) {
                 }
             }
             if (!task.outputTable) {
+                if (hasAmbiguousOutputSchema) {
+                    throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", `Task "${task.nodeId}" uses an output schema that is registered under multiple keys. Use createSmithers(...).outputs.<key> or a string output key instead of the shared raw Zod object.`);
+                }
                 throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", `Task "${task.nodeId}" uses an output ZodObject that is not registered in createSmithers()`);
             }
         }
@@ -2893,7 +2901,8 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                     maybeCompleteHijack();
                 };
                 let effectivePrompt = desc.prompt ?? "";
-                if (desc.outputTable) {
+                const supportsNativeStructuredOutput = effectiveAgent.supportsNativeStructuredOutput === true;
+                if (desc.outputTable && !supportsNativeStructuredOutput) {
                     const schemaDesc = describeSchemaShape(desc.outputTable, desc.outputSchema);
                     const jsonInstructions = [
                         "**REQUIRED OUTPUT** — You MUST end your response with a JSON object in a code fence matching this schema:",

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -2581,6 +2581,7 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
     let cacheJjBase = null;
     let responseText = null;
     let effectiveAgent = null;
+    let supportsNativeStructuredOutput = false;
     // Resolve effective root once so both caching and execution share it.
     const taskRoot = desc.worktreePath ?? toolConfig.rootDir;
     const stepCacheEnabled = cacheEnabled || Boolean(desc.cachePolicy);
@@ -2901,7 +2902,7 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                     maybeCompleteHijack();
                 };
                 let effectivePrompt = desc.prompt ?? "";
-                const supportsNativeStructuredOutput = effectiveAgent.supportsNativeStructuredOutput === true;
+                supportsNativeStructuredOutput = effectiveAgent.supportsNativeStructuredOutput === true;
                 if (desc.outputTable && !supportsNativeStructuredOutput) {
                     const schemaDesc = describeSchemaShape(desc.outputTable, desc.outputSchema);
                     const jsonInstructions = [
@@ -3514,17 +3515,25 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
             const zodIssues = validation.error?.issues
                 ?.map((iss) => `  - ${(iss.path ?? []).join(".")}: ${iss.message}`)
                 .join("\n") ?? "Unknown validation error";
-            const schemaRetryPrompt = [
-                `Your output didn't match the required schema. Validation errors:`,
-                zodIssues,
-                ``,
-                `Please return valid JSON matching the schema exactly.`,
-                ``,
-                `You MUST output ONLY a valid JSON object with exactly these fields and types:`,
-                schemaDesc,
-                ``,
-                `Output ONLY the JSON object, no other text.`,
-            ].join("\n");
+            const schemaRetryPrompt = supportsNativeStructuredOutput
+                ? [
+                    `Your structured output didn't match the required schema. Validation errors:`,
+                    zodIssues,
+                    ``,
+                    `Return corrected structured data matching this schema:`,
+                    schemaDesc,
+                ].join("\n")
+                : [
+                    `Your output didn't match the required schema. Validation errors:`,
+                    zodIssues,
+                    ``,
+                    `Please return valid JSON matching the schema exactly.`,
+                    ``,
+                    `You MUST output ONLY a valid JSON object with exactly these fields and types:`,
+                    schemaDesc,
+                    ``,
+                    `Output ONLY the JSON object, no other text.`,
+                ].join("\n");
             logInfo("schema validation retry", {
                 runId,
                 nodeId: desc.nodeId,
@@ -3554,6 +3563,9 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                     recordInternalHeartbeat();
                     emitOutput(text, "stderr");
                 },
+                ...(supportsNativeStructuredOutput
+                    ? { outputSchema: desc.outputSchema }
+                    : {}),
             });
             const retryText = (schemaRetryResult.text ?? "").trim();
             responseText = retryText || responseText;
@@ -3575,8 +3587,24 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                 cloneJsonValue(schemaRetryMessages) ?? schemaRetryMessages;
             // Try to parse the retry response
             let retryOutput;
+            if (supportsNativeStructuredOutput) {
+                try {
+                    if (schemaRetryResult._output !== undefined &&
+                        schemaRetryResult._output !== null) {
+                        retryOutput = schemaRetryResult._output;
+                    }
+                    else if (schemaRetryResult.output !== undefined &&
+                        schemaRetryResult.output !== null) {
+                        retryOutput = schemaRetryResult.output;
+                    }
+                }
+                catch {
+                    // Structured output access threw; fall back to text parsing.
+                }
+            }
             try {
-                if (retryText.startsWith("{") || retryText.startsWith("[")) {
+                if (retryOutput === undefined &&
+                    (retryText.startsWith("{") || retryText.startsWith("["))) {
                     retryOutput = JSON.parse(retryText);
                 }
             }

--- a/packages/engine/tests/duplicate-output-schemas.test.jsx
+++ b/packages/engine/tests/duplicate-output-schemas.test.jsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource smithers-orchestrator */
+import { expect, test } from "bun:test";
+import { Effect } from "effect";
+import { Task, Workflow, runWorkflow } from "smithers-orchestrator";
+import { z } from "zod";
+import { createTestSmithers } from "../../smithers/tests/helpers.js";
+
+test("duplicate output schemas route correctly through createSmithers outputs", async () => {
+    const shared = z.object({ value: z.string() });
+    const api = createTestSmithers({
+        accessibility: shared,
+        product: shared,
+    });
+    expect(api.outputs.accessibility).not.toBe(shared);
+    expect(api.outputs.product).not.toBe(shared);
+    expect(api.outputs.accessibility).not.toBe(api.outputs.product);
+    const workflow = api.smithers(() => (<Workflow name="duplicate-output-schemas">
+      <Task id="accessibility" output={api.outputs.accessibility}>
+        {{ value: "a11y" }}
+      </Task>
+      <Task id="product" output={api.outputs.product}>
+        {{ value: "product" }}
+      </Task>
+    </Workflow>));
+    const result = await Effect.runPromise(runWorkflow(workflow, {
+        input: {},
+        runId: "duplicate-output-schemas",
+    }));
+    expect(result.status).toBe("finished");
+    expect(api.db.select().from(api.tables.accessibility).all()).toEqual([
+        expect.objectContaining({
+            nodeId: "accessibility",
+            value: "a11y",
+        }),
+    ]);
+    expect(api.db.select().from(api.tables.product).all()).toEqual([
+        expect.objectContaining({
+            nodeId: "product",
+            value: "product",
+        }),
+    ]);
+    api.cleanup?.();
+});
+
+test("duplicate raw schema refs fail with a helpful error", async () => {
+    const shared = z.object({ value: z.string() });
+    const api = createTestSmithers({
+        accessibility: shared,
+        product: shared,
+    });
+    const workflow = api.smithers(() => (<Workflow name="duplicate-output-schema-error">
+      <Task id="accessibility" output={shared}>
+        {{ value: "a11y" }}
+      </Task>
+    </Workflow>));
+    const result = await Effect.runPromise(runWorkflow(workflow, {
+        input: {},
+        runId: "duplicate-output-schema-error",
+    }));
+    expect(result.status).toBe("failed");
+    expect(result.error?.message).toContain("outputs.<key>");
+    expect(api.db.select().from(api.tables.product).all()).toHaveLength(0);
+    api.cleanup?.();
+});

--- a/packages/engine/tests/sdk-structured-output.test.jsx
+++ b/packages/engine/tests/sdk-structured-output.test.jsx
@@ -1,0 +1,48 @@
+/** @jsxImportSource smithers-orchestrator */
+import { expect, test } from "bun:test";
+import { Effect } from "effect";
+import { Task, Workflow, runWorkflow } from "smithers-orchestrator";
+import { createTestSmithers } from "../../smithers/tests/helpers.js";
+import { outputSchemas } from "../../smithers/tests/schema.js";
+
+test("SDK agents with native structured output skip JSON code-fence prompt injection", async () => {
+    const { smithers, outputs, tables, db, cleanup } = createTestSmithers(outputSchemas);
+    const prompts = [];
+    const agent = {
+        id: "fake-sdk-agent",
+        hijackEngine: "openai-sdk",
+        supportsNativeStructuredOutput: true,
+        tools: {},
+        /**
+         * @param {any} args
+         */
+        async generate(args) {
+            prompts.push(args.prompt);
+            return {
+                text: "All set.",
+                output: { value: 42 },
+                response: {
+                    messages: [{ role: "assistant", content: "All set." }],
+                },
+            };
+        },
+    };
+    const workflow = smithers(() => (<Workflow name="sdk-structured-output">
+      <Task id="plan" output={outputs.outputA} agent={agent}>
+        produce a value
+      </Task>
+    </Workflow>));
+    const result = await Effect.runPromise(runWorkflow(workflow, {
+        input: {},
+        runId: "sdk-structured-output",
+    }));
+    expect(result.status).toBe("finished");
+    expect(prompts).toEqual(["produce a value"]);
+    expect(db.select().from(tables.outputA).all()).toEqual([
+        expect.objectContaining({
+            nodeId: "plan",
+            value: 42,
+        }),
+    ]);
+    cleanup();
+});

--- a/packages/engine/tests/sdk-structured-output.test.jsx
+++ b/packages/engine/tests/sdk-structured-output.test.jsx
@@ -46,3 +46,60 @@ test("SDK agents with native structured output skip JSON code-fence prompt injec
     ]);
     cleanup();
 });
+
+test("SDK agents with native structured output retry through outputSchema", async () => {
+    const { smithers, outputs, tables, db, cleanup } = createTestSmithers(outputSchemas);
+    const calls = [];
+    const agent = {
+        id: "fake-sdk-agent-retry",
+        hijackEngine: "openai-sdk",
+        supportsNativeStructuredOutput: true,
+        tools: {},
+        /**
+         * @param {any} args
+         */
+        async generate(args) {
+            calls.push(args);
+            if (calls.length === 1) {
+                return {
+                    text: "All set.",
+                    output: { value: "not-a-number" },
+                    response: {
+                        messages: [{ role: "assistant", content: "All set." }],
+                    },
+                };
+            }
+            return {
+                text: "",
+                output: { value: 42 },
+                response: {
+                    messages: [{ role: "assistant", content: "" }],
+                },
+            };
+        },
+    };
+    const workflow = smithers(() => (<Workflow name="sdk-structured-output-retry">
+      <Task id="plan" output={outputs.outputA} agent={agent}>
+        produce a value
+      </Task>
+    </Workflow>));
+    const result = await Effect.runPromise(runWorkflow(workflow, {
+        input: {},
+        runId: "sdk-structured-output-retry",
+    }));
+    expect(result.status).toBe("finished");
+    expect(calls).toHaveLength(2);
+    expect(calls[0].prompt).toBe("produce a value");
+    expect(calls[0].outputSchema).toBeDefined();
+    expect(calls[1].outputSchema).toBeDefined();
+    const retryPrompt = calls[1].messages.at(-1).content;
+    expect(retryPrompt).toContain("structured output");
+    expect(retryPrompt).not.toContain("```json");
+    expect(db.select().from(tables.outputA).all()).toEqual([
+        expect.objectContaining({
+            nodeId: "plan",
+            value: 42,
+        }),
+    ]);
+    cleanup();
+});

--- a/packages/graph/src/index.d.ts
+++ b/packages/graph/src/index.d.ts
@@ -41,6 +41,7 @@ type CachePolicy$1<Ctx = unknown> = {
 type AgentLike$1 = {
     id?: string;
     tools?: Record<string, unknown>;
+    supportsNativeStructuredOutput?: boolean;
     capabilities?: {
         version: 1;
         engine: string;

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -50,6 +50,7 @@ export type CachePolicy<Ctx = unknown> = {
 export type AgentLike = {
   id?: string;
   tools?: Record<string, unknown>;
+  supportsNativeStructuredOutput?: boolean;
   capabilities?: {
     version: 1;
     engine: string;

--- a/packages/smithers/src/create.js
+++ b/packages/smithers/src/create.js
@@ -50,6 +50,41 @@ function computeSchemaSig(schemas, dbPath) {
     return parts.join("\n");
 }
 /**
+ * Duplicate schema objects need distinct output refs so Task `output={outputs.foo}`
+ * can still resolve the intended table by identity.
+ * @param {Record<string, any>} schemas
+ */
+function prepareOutputSchemas(schemas) {
+    const counts = new Map();
+    for (const [name, zodSchema] of Object.entries(schemas)) {
+        if (name === "input")
+            continue;
+        counts.set(zodSchema, (counts.get(zodSchema) ?? 0) + 1);
+    }
+    const outputs = {
+        ...schemas,
+    };
+    const zodToKeyName = new Map();
+    const ambiguousZodSchemas = new Set();
+    for (const [name, zodSchema] of Object.entries(schemas)) {
+        if (name === "input")
+            continue;
+        if ((counts.get(zodSchema) ?? 0) > 1) {
+            ambiguousZodSchemas.add(zodSchema);
+            const aliasSchema = zodSchema.clone();
+            outputs[name] = aliasSchema;
+            zodToKeyName.set(aliasSchema, name);
+            continue;
+        }
+        zodToKeyName.set(zodSchema, name);
+    }
+    return {
+        outputs,
+        zodToKeyName,
+        ambiguousZodSchemas,
+    };
+}
+/**
  * @param {Record<string, string>} [base]
  * @param {Record<string, string>} [override]
  * @returns {Record<string, string> | undefined}
@@ -254,13 +289,8 @@ export function createSmithers(schemas, opts) {
             continue;
         schemaRegistry.set(name, { table: tables[name], zodSchema });
     }
-    // 6. Build reverse lookup: ZodObject reference → schema key name
-    const zodToKeyName = new Map();
-    for (const [name, zodSchema] of Object.entries(schemas)) {
-        if (name === "input")
-            continue;
-        zodToKeyName.set(zodSchema, name);
-    }
+    // 6. Build output refs and reverse lookup: ZodObject reference → schema key name
+    const { outputs, zodToKeyName, ambiguousZodSchemas } = prepareOutputSchemas(schemas);
     // 7. Context + hooks
     const { SmithersContext: RuntimeSmithersContext, useCtx, } = createSmithersContext();
     const ctxRef = { current: null };
@@ -302,6 +332,7 @@ export function createSmithers(schemas, opts) {
                 opts: {},
                 schemaRegistry,
                 zodToKeyName,
+                ambiguousZodSchemas,
             };
         return React.createElement(BaseSandbox, {
             ...props,
@@ -342,6 +373,7 @@ export function createSmithers(schemas, opts) {
             opts: workflowOpts,
             schemaRegistry,
             zodToKeyName,
+            ambiguousZodSchemas,
         };
     }
     /**
@@ -370,7 +402,7 @@ export function createSmithers(schemas, opts) {
         smithers: boundSmithers,
         db,
         tables: tables,
-        outputs: schemas,
+        outputs,
     };
     if (process.env.SMITHERS_HOT === "1") {
         const sig = computeSchemaSig(schemas, absDbPath);

--- a/packages/smithers/src/external/create-external-smithers.js
+++ b/packages/smithers/src/external/create-external-smithers.js
@@ -65,6 +65,33 @@ export function hostNodeToReact(node, agents) {
     return React.createElement(node.tag, rawProps, ...children);
 }
 /**
+ * @param {Record<string, any>} schemas
+ */
+function prepareOutputSchemas(schemas) {
+    const counts = new Map();
+    for (const [name, zodSchema] of Object.entries(schemas)) {
+        if (name === "input")
+            continue;
+        counts.set(zodSchema, (counts.get(zodSchema) ?? 0) + 1);
+    }
+    const zodToKeyName = new Map();
+    const ambiguousZodSchemas = new Set();
+    for (const [name, zodSchema] of Object.entries(schemas)) {
+        if (name === "input")
+            continue;
+        if ((counts.get(zodSchema) ?? 0) > 1) {
+            ambiguousZodSchemas.add(zodSchema);
+            zodToKeyName.set(zodSchema.clone(), name);
+            continue;
+        }
+        zodToKeyName.set(zodSchema, name);
+    }
+    return {
+        zodToKeyName,
+        ambiguousZodSchemas,
+    };
+}
+/**
  * Create a SmithersWorkflow from an external build function.
  *
  * Schemas and agents are defined in TS. The build function produces a HostNode JSON tree
@@ -126,12 +153,7 @@ export function createExternalSmithers(config) {
             continue;
         schemaRegistry.set(name, { table: tables[name], zodSchema });
     }
-    const zodToKeyName = new Map();
-    for (const [name, zodSchema] of Object.entries(schemas)) {
-        if (name === "input")
-            continue;
-        zodToKeyName.set(zodSchema, name);
-    }
+    const { zodToKeyName, ambiguousZodSchemas } = prepareOutputSchemas(schemas);
     return {
         db,
         build: (ctx) => {
@@ -142,6 +164,7 @@ export function createExternalSmithers(config) {
         opts: {},
         schemaRegistry,
         zodToKeyName,
+        ambiguousZodSchemas,
         tables,
         cleanup: closeDb,
     };

--- a/scripts/generate-llms.ts
+++ b/scripts/generate-llms.ts
@@ -184,7 +184,7 @@ function renderManifest(name: string, pages: string[], header: string): string {
 const HEADERS = {
   core: [
     "> Smithers — durable AI workflow orchestration as a JSX runtime.",
-    "> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)",
+    "> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)",
     "",
     "This file contains the core Smithers documentation. Read top to bottom for a complete picture of the runtime, JSX surface, CLI, and components.",
     "",
@@ -238,7 +238,7 @@ for (const b of builds) {
     "# Smithers — full documentation",
     "",
     "> Durable AI workflow orchestration as a JSX runtime.",
-    "> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)",
+    "> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)",
     "",
     "This is the complete Smithers documentation in one file. It is the concatenation of every fragment listed in /llms.txt.",
     "",
@@ -284,7 +284,7 @@ Durable AI workflow orchestration as a JSX runtime.
 ## Pointers
 
 - npm: smithers-orchestrator
-- github: github.com/evmts/smithers
+- github: github.com/smithersai/smithers
 - changelogs: docs/changelogs/ on the site (not duplicated in llms files)
 `;
 

--- a/scripts/optimize-llms-full.ts
+++ b/scripts/optimize-llms-full.ts
@@ -100,7 +100,7 @@ text = text.replace(/^>\s*Source:\s*https?:\/\/[^\s]+\s*\n/gm, "");
 // reference line.
 text = text.replace(
   /^>\s*GitHub:\s*[^\n]+\n>\s*Package:\s*[^\n]+\n/m,
-  "> Repo: github.com/evmts/smithers · Package: smithers-orchestrator (npm)\n",
+  "> Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)\n",
 );
 
 // --- 4. Collapse adjacent / doubled separators ------------------------------
@@ -322,7 +322,7 @@ text = text.replace(
             "After `bunx smithers-orchestrator init`, browse `.smithers/` for live copies.",
           );
           out.push(
-            "For repo-level files (`AGENTS.md`, `.github/workflows/ci.yml`, `~/.claude/plugins/smithers-orchestrator/`, etc.) see the source repository at github.com/evmts/smithers.",
+            "For repo-level files (`AGENTS.md`, `.github/workflows/ci.yml`, `~/.claude/plugins/smithers-orchestrator/`, etc.) see the source repository at github.com/smithersai/smithers.",
           );
           replacedOnce = true;
         }


### PR DESCRIPTION
## Summary
- make duplicate output schema registrations safe by giving `createSmithers(...).outputs.<key>` unique refs and surfacing a clear error for ambiguous raw shared schemas
- wire native structured output through the AI SDK agents and skip code-fence prompt injection when an agent can return structured output natively
- publish CLI subpath type declarations from `dist/` so `@smithers-orchestrator/cli/*` imports typecheck correctly after build/publish
- update docs and generated llms artifacts so `runWorkflow` is documented as an `Effect`, and refresh stale repo metadata/links

## Closes
- Closes #121
- Closes #127
- Closes #128
- Closes #129

## Validation
- `bun test packages/agents/tests/sdk-agents.test.js`
- `bun test packages/engine/tests/sdk-structured-output.test.jsx packages/engine/tests/duplicate-output-schemas.test.jsx`
- `bun test packages/components/tests/type-inference.test.js`
- `bun test packages/components/tests/context.test.js`
- `bun test packages/engine/tests/sdk-hijack-runtime.test.jsx`
- `bun run --cwd apps/cli build`
