### PR TITLE
Honor non-retryable agent failures

### DIFF
--- a/packages/components/src/components/WorktreeProps.ts
+++ b/packages/components/src/components/WorktreeProps.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 
 export type WorktreeProps = {
+	key?: string;
 	id?: string;
 	path: string;
 	branch?: string;

--- a/packages/components/src/index.d.ts
+++ b/packages/components/src/index.d.ts
@@ -29,6 +29,7 @@ import * as _smithers_errors from '@smithers-orchestrator/errors';
 import * as zod_v4_core from 'zod/v4/core';
 
 type WorktreeProps$2 = {
+    key?: string;
     id?: string;
     path: string;
     branch?: string;

--- a/packages/engine/src/effect/workflow-bridge.js
+++ b/packages/engine/src/effect/workflow-bridge.js
@@ -72,8 +72,12 @@ function isRetryableBridgeTaskFailure(attempt) {
     if (meta?.failureRetryable === false) {
         return false;
     }
+    const errorCode = parseAttemptErrorCode(attempt?.errorJson);
+    if (errorCode === "AGENT_CONFIG_INVALID") {
+        return false;
+    }
     const kind = typeof meta?.kind === "string" ? meta.kind : null;
-    return !(kind !== "agent" && parseAttemptErrorCode(attempt?.errorJson) === "INVALID_OUTPUT");
+    return !(kind !== "agent" && errorCode === "INVALID_OUTPUT");
 }
 /**
  * @param {SmithersDb} adapter

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -25,7 +25,7 @@ import { findVcsRoot } from "@smithers-orchestrator/vcs/find-root";
 import * as BunContext from "@effect/platform-bun/BunContext";
 import { eq, getTableName } from "drizzle-orm";
 import { getTableColumns } from "drizzle-orm/utils";
-import { Chunk, Duration, Effect, Fiber, Metric, Queue, Schedule } from "effect";
+import { Cause, Chunk, Duration, Effect, Exit, Fiber, Metric, Queue, Schedule } from "effect";
 import { attemptDuration, cacheHits, cacheMisses, nodeDuration, promptSizeBytes, responseSizeBytes, runDuration, runsResumedTotal, schedulerConcurrencyUtilization, schedulerQueueDepth, schedulerWaitDuration, trackEvent, } from "@smithers-orchestrator/observability/metrics";
 import { runScorersAsync } from "@smithers-orchestrator/scorers/run-scorers";
 import { dirname, resolve } from "node:path";
@@ -286,6 +286,25 @@ function isHeartbeatPayloadValidationError(err) {
     const code = err.code;
     return (code === "HEARTBEAT_PAYLOAD_NOT_JSON_SERIALIZABLE" ||
         code === "HEARTBEAT_PAYLOAD_TOO_LARGE");
+}
+/**
+ * Effect.runPromise rejects with a FiberFailure wrapper. For task execution we
+ * need the original failure so retry metadata can read SmithersError fields.
+ *
+ * @template A
+ * @param {Effect.Effect<A, unknown>} effect
+ * @returns {Promise<A>}
+ */
+async function runPromisePreservingFailure(effect) {
+    const exit = await Effect.runPromiseExit(effect);
+    if (Exit.isSuccess(exit)) {
+        return exit.value;
+    }
+    const failure = Cause.failureOption(exit.cause);
+    if (failure._tag === "Some") {
+        throw failure.value;
+    }
+    throw Cause.squash(exit.cause);
 }
 /**
  * @param {Record<string, unknown>} meta
@@ -3026,7 +3045,7 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                 // Use fallback agent on retry attempts when available
                 let result;
                 try {
-                    result = await Effect.runPromise(withSmithersSpan(smithersSpanNames.agent, Effect.tryPromise({
+                    result = await runPromisePreservingFailure(withSmithersSpan(smithersSpanNames.agent, Effect.tryPromise({
                         try: () => {
                             const agentCall = guidedResumeMessages?.length
                                 ? {
@@ -3743,9 +3762,9 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
         if (effectiveError &&
             typeof effectiveError === "object" &&
             // @ts-ignore — duck-type on SmithersError shape
-            effectiveError.details &&
-            // @ts-ignore
-            effectiveError.details.failureRetryable === false) {
+            (effectiveError.details?.failureRetryable === false ||
+                // @ts-ignore
+                effectiveError.code === "AGENT_CONFIG_INVALID")) {
             attemptMeta.failureRetryable = false;
         }
         // Honour `discardResumeSession: true` from agent-side errors (e.g. kimi

--- a/packages/engine/tests/failure-retryable-false.e2e.test.jsx
+++ b/packages/engine/tests/failure-retryable-false.e2e.test.jsx
@@ -8,28 +8,13 @@ import { outputSchemas } from "../../smithers/tests/schema.js";
 import { Effect } from "effect";
 
 /**
- * Regression coverage for commit b561fca0f. When an agent throws a SmithersError
- * with `details.failureRetryable === false` (or code === "AGENT_CONFIG_INVALID"),
- * the engine must NOT retry — even if `retries` would otherwise allow it. The
- * non-retryable signal short-circuits both regular retries and any backoff
- * delay: the run should fail immediately after attempt 1.
+ * When an agent throws a non-retryable SmithersError, the engine must stop after
+ * the first failed attempt even if `retries` would otherwise allow another try.
+ * This also bypasses retry backoff, so deterministic configuration failures
+ * surface immediately.
  */
 describe("failureRetryable=false short-circuits engine retries", () => {
-    // FIXME: bug — engine.js executeTask runs the agent via `Effect.promise(()
-    // => agent.generate(...))`. When the agent throws, Effect wraps the
-    // rejection into a `FiberFailureImpl` defect that does NOT preserve the
-    // SmithersError's `code` or `details` fields on the surface object. The
-    // catch block at engine.js line 3743 checks `effectiveError.details
-    // ?.failureRetryable === false`, but `effectiveError` is the FiberFailure
-    // wrapper — `details` is `undefined`. So Kimi-style AGENT_CONFIG_INVALID
-    // errors thrown from `agent.generate` still get retried up to `desc
-    // .retries` times. compute-task-bridge.js (commit b561fca0f) was patched
-    // to also check `effectiveError.code === "AGENT_CONFIG_INVALID"`, but
-    // engine.js was NOT patched the same way and the underlying FiberFailure
-    // unwrapping is missing on both. Fix should either swap to
-    // `Effect.tryPromise({ catch: (e) => e })` so the original error is
-    // re-thrown, or unwrap FiberFailure in the catch.
-    test.skip("Kimi-style AGENT_CONFIG_INVALID stops after a single attempt", async () => {
+    test("Kimi-style AGENT_CONFIG_INVALID stops after a single attempt", async () => {
         const { smithers, outputs, cleanup, db } = createTestSmithers(outputSchemas);
         const adapter = new SmithersDb(db);
         try {
@@ -79,11 +64,7 @@ describe("failureRetryable=false short-circuits engine retries", () => {
         }
     }, 15_000);
 
-    // FIXME: bug — same root cause as the test above. The engine.js executeTask
-    // catch block cannot read `details.failureRetryable` because the agent's
-    // SmithersError was wrapped into Effect's FiberFailure defect and never
-    // unwrapped. Generic non-retryable signals are therefore retried.
-    test.skip("generic SmithersError with details.failureRetryable=false stops retrying", async () => {
+    test("generic SmithersError with details.failureRetryable=false stops retrying", async () => {
         const { smithers, outputs, cleanup, db } = createTestSmithers(outputSchemas);
         const adapter = new SmithersDb(db);
         try {
@@ -120,6 +101,51 @@ describe("failureRetryable=false short-circuits engine retries", () => {
             expect(elapsedMs).toBeLessThan(900);
             const attempts = await adapter.listAttempts(result.runId, "bad", 0);
             expect(attempts).toHaveLength(1);
+            const meta = JSON.parse(attempts[0].metaJson ?? "{}");
+            expect(meta.failureRetryable).toBe(false);
+        } finally {
+            cleanup();
+        }
+    }, 15_000);
+
+    test("AGENT_CONFIG_INVALID without details flag stops retrying", async () => {
+        const { smithers, outputs, cleanup, db } = createTestSmithers(outputSchemas);
+        const adapter = new SmithersDb(db);
+        try {
+            let callCount = 0;
+            const agent = {
+                id: "config-invalid-no-details",
+                tools: {},
+                async generate() {
+                    callCount += 1;
+                    throw new SmithersError(
+                        "AGENT_CONFIG_INVALID",
+                        "LLM not set: configure model in agent.",
+                    );
+                },
+            };
+            const workflow = smithers(() => (
+                <Workflow name="config-invalid-no-details">
+                    <Task
+                        id="missing-config"
+                        output={outputs.outputA}
+                        agent={agent}
+                        retries={4}
+                    >
+                        Configuration errors should not retry.
+                    </Task>
+                </Workflow>
+            ));
+            const startMs = Date.now();
+            const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+            const elapsedMs = Date.now() - startMs;
+            expect(result.status).toBe("failed");
+            expect(callCount).toBe(1);
+            expect(elapsedMs).toBeLessThan(900);
+            const attempts = await adapter.listAttempts(result.runId, "missing-config", 0);
+            expect(attempts).toHaveLength(1);
+            const error = JSON.parse(attempts[0].errorJson ?? "{}");
+            expect(error.code).toBe("AGENT_CONFIG_INVALID");
             const meta = JSON.parse(attempts[0].metaJson ?? "{}");
             expect(meta.failureRetryable).toBe(false);
         } finally {

--- a/packages/gateway-react/src/createGatewayReactRoot.ts
+++ b/packages/gateway-react/src/createGatewayReactRoot.ts
@@ -12,6 +12,6 @@ export function createGatewayReactRoot(
     throw new Error(`Gateway React root element not found: ${options.rootId ?? "root"}`);
   }
   const client = new SmithersGatewayClient(options);
-  createRoot(root).render(createElement(SmithersGatewayProvider, { client }, element));
+  createRoot(root).render(createElement(SmithersGatewayProvider, { client, children: element }));
   return client;
 }

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -4,11 +4,11 @@ info:
   version: v1
   description: "Stable v1 Smithers Gateway RPC contract generated from packages/gateway/src/rpc."
 servers:
-  - 
+  -
     url: https://gateway.example.com
     description: "Reference Gateway deployment."
 security:
-  - 
+  -
     bearerAuth: []
 paths:
   /v1/rpc/launchRun:
@@ -19,7 +19,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:write
       x-smithers-api-version: v1
@@ -357,7 +357,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:write
       x-smithers-api-version: v1
@@ -740,7 +740,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:write
       x-smithers-api-version: v1
@@ -1173,7 +1173,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:admin
       x-smithers-api-version: v1
@@ -1558,7 +1558,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:admin
       x-smithers-api-version: v1
@@ -2140,7 +2140,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - approval:submit
       x-smithers-api-version: v1
@@ -2186,22 +2186,22 @@ paths:
                           description: "Any JSON value."
                           nullable: true
                           oneOf:
-                            - 
+                            -
                               type: object
                               additionalProperties: true
-                            - 
+                            -
                               type: array
                               items:
                                 nullable: true
-                            - 
+                            -
                               type: string
-                            - 
+                            -
                               type: number
-                            - 
+                            -
                               type: integer
-                            - 
+                            -
                               type: boolean
-                            - 
+                            -
                               type: "null"
                         note:
                           type: string
@@ -2573,7 +2573,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - signal:submit
       x-smithers-api-version: v1
@@ -2612,22 +2612,22 @@ paths:
                       description: "Any JSON value."
                       nullable: true
                       oneOf:
-                        - 
+                        -
                           type: object
                           additionalProperties: true
-                        - 
+                        -
                           type: array
                           items:
                             nullable: true
-                        - 
+                        -
                           type: string
-                        - 
+                        -
                           type: number
-                        - 
+                        -
                           type: integer
-                        - 
+                        -
                           type: boolean
-                        - 
+                        -
                           type: "null"
                   required:
                     - runId
@@ -2971,7 +2971,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:read
       x-smithers-api-version: v1
@@ -3336,7 +3336,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:read
       x-smithers-api-version: v1
@@ -3443,11 +3443,672 @@ paths:
                 ok: true
                 apiVersion: v1
                 payload:
-                  - 
+                  -
                     runId: run_01
                     workflowKey: deploy
                     status: finished
                     createdAtMs: 1710000000000
+        400:
+          description: "The request shape is invalid."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        401:
+          description: "Authentication failed or the token expired."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        403:
+          description: "The token is missing the required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        500:
+          description: "The Gateway encountered an internal error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+  /v1/rpc/listWorkflows:
+    post:
+      operationId: listWorkflows
+      summary: "List Workflows"
+      description: "List workflows registered with the Gateway."
+      tags:
+        - "Gateway RPC"
+      security:
+        -
+          bearerAuth:
+            - run:read
+      x-smithers-api-version: v1
+      x-smithers-maturity: stable
+      x-smithers-transport: "http+websocket"
+      x-smithers-required-scope: run:read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - method
+                - params
+              additionalProperties: false
+              properties:
+                id:
+                  type: string
+                  description: "Optional caller request id."
+                method:
+                  const: listWorkflows
+                params:
+                  type: object
+                  properties:
+                    filter:
+                      type: object
+                      properties:
+                        hasUi:
+                          type: boolean
+                          description: "Only return workflows with or without an attached UI."
+                      required: []
+                      additionalProperties: false
+                  required: []
+                  additionalProperties: false
+            example:
+              id: listWorkflows-1
+              method: listWorkflows
+              params:
+                filter:
+                  hasUi: true
+      responses:
+        200:
+          description: "List Workflows response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - payload
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: true
+                  apiVersion:
+                    const: v1
+                  payload:
+                    type: array
+                    description: "Registered workflow summaries."
+                    items:
+                      type: object
+                      properties:
+                        key:
+                          type: string
+                          description: "Registered Gateway workflow key."
+                        readableName:
+                          type: string
+                          description: "Human-readable workflow name."
+                        description:
+                          type: string
+                          description: "Workflow description."
+                        hasUi:
+                          type: boolean
+                          description: "Whether this workflow has a custom UI mounted."
+                        uiPath:
+                          type:
+                            - string
+                            - "null"
+                          description: "Mounted UI path when present."
+                      required:
+                        - key
+                        - hasUi
+                        - uiPath
+                      additionalProperties: false
+              example:
+                type: res
+                id: listWorkflows-1
+                ok: true
+                apiVersion: v1
+                payload:
+                  -
+                    key: deploy
+                    readableName: Deploy
+                    hasUi: true
+                    uiPath: /workflows/deploy
+        400:
+          description: "The request shape is invalid."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        401:
+          description: "Authentication failed or the token expired."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        403:
+          description: "The token is missing the required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+        500:
+          description: "The Gateway encountered an internal error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - observability:read
+                      refresh:
+                        type: string
+  /v1/rpc/listApprovals:
+    post:
+      operationId: listApprovals
+      summary: "List Approvals"
+      description: "List pending Gateway approval requests."
+      tags:
+        - "Gateway RPC"
+      security:
+        -
+          bearerAuth:
+            - run:read
+      x-smithers-api-version: v1
+      x-smithers-maturity: stable
+      x-smithers-transport: "http+websocket"
+      x-smithers-required-scope: run:read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - method
+                - params
+              additionalProperties: false
+              properties:
+                id:
+                  type: string
+                  description: "Optional caller request id."
+                method:
+                  const: listApprovals
+                params:
+                  type: object
+                  properties:
+                    filter:
+                      type: object
+                      properties:
+                        runId:
+                          type: string
+                          description: "Stable run identifier."
+                        workflow:
+                          type: string
+                          description: "Registered Gateway workflow key."
+                        limit:
+                          type: integer
+                          minimum: 1
+                          description: "Maximum number of approvals."
+                      required: []
+                      additionalProperties: false
+                  required: []
+                  additionalProperties: false
+            example:
+              id: listApprovals-1
+              method: listApprovals
+              params:
+                filter:
+                  workflow: deploy
+                  limit: 20
+      responses:
+        200:
+          description: "List Approvals response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - payload
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: true
+                  apiVersion:
+                    const: v1
+                  payload:
+                    type: array
+                    description: "Pending approvals."
+                    items:
+                      type: object
+                      description: "Pending approval summary."
+                      properties: {}
+                      required: []
+                      additionalProperties: true
+              example:
+                type: res
+                id: listApprovals-1
+                ok: true
+                apiVersion: v1
+                payload:
+                  -
+                    runId: run_01
+                    workflowKey: deploy
+                    nodeId: approve
+                    iteration: 0
+                    requestTitle: "Approve deploy"
+                    requestedAtMs: 1710000000000
         400:
           description: "The request shape is invalid."
           content:
@@ -3672,7 +4333,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:read
       x-smithers-api-version: v1
@@ -4065,7 +4726,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - observability:read
       x-smithers-api-version: v1
@@ -4513,7 +5174,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:read
       x-smithers-api-version: v1
@@ -4968,7 +5629,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - run:read
       x-smithers-api-version: v1
@@ -5422,7 +6083,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - cron:read
       x-smithers-api-version: v1
@@ -5509,7 +6170,7 @@ paths:
                 ok: true
                 apiVersion: v1
                 payload:
-                  - 
+                  -
                     cronId: cron_01
                     workflow: deploy
                     pattern: "0 8 * * 1-5"
@@ -5737,7 +6398,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - cron:write
       x-smithers-api-version: v1
@@ -6055,7 +6716,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - cron:write
       x-smithers-api-version: v1
@@ -6426,7 +7087,7 @@ paths:
       tags:
         - "Gateway RPC"
       security:
-        - 
+        -
           bearerAuth:
             - cron:write
       x-smithers-api-version: v1

--- a/packages/gateway/scripts/generate-openapi.ts
+++ b/packages/gateway/scripts/generate-openapi.ts
@@ -221,7 +221,10 @@ function toYaml(value: unknown, indent = 0): string {
       .map((entry) => {
         if (entry && typeof entry === "object") {
           const rendered = toYaml(entry, indent + 2);
-          return `${pad}- ${rendered.startsWith("\n") ? rendered.slice(1) : `\n${rendered}`}`;
+          if (rendered === "{}" || rendered === "[]") {
+            return `${pad}- ${rendered}`;
+          }
+          return `${pad}-\n${rendered}`;
         }
         return `${pad}- ${scalarToYaml(entry)}`;
       })

--- a/packages/scheduler/src/ScheduleResult.ts
+++ b/packages/scheduler/src/ScheduleResult.ts
@@ -12,4 +12,6 @@ export type ScheduleResult = {
   readonly continuation?: ContinuationRequest;
   readonly nextRetryAtMs?: number;
   readonly fatalError?: string;
+  readonly failureRecoveryActive?: boolean;
+  readonly failureRecoveryKeys?: readonly string[];
 };

--- a/packages/scheduler/src/index.d.ts
+++ b/packages/scheduler/src/index.d.ts
@@ -74,6 +74,8 @@ type ScheduleResult$3 = {
     readonly continuation?: ContinuationRequest$1;
     readonly nextRetryAtMs?: number;
     readonly fatalError?: string;
+    readonly failureRecoveryActive?: boolean;
+    readonly failureRecoveryKeys?: readonly string[];
 };
 
 type ScheduleSnapshot$1 = {

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -179,8 +179,15 @@ function isRetryableFailure(descriptor, error) {
     const payloadCode = error && typeof error === "object" && typeof error.code === "string"
         ? error.code
         : undefined;
+    const payloadDetails = error && typeof error === "object" && error.details && typeof error.details === "object"
+        ? error.details
+        : undefined;
     const normalized = toSmithersError(error);
     const code = payloadCode ?? normalized.code;
+    const failureRetryable = payloadDetails?.failureRetryable ?? normalized.details?.failureRetryable;
+    if (failureRetryable === false || code === "AGENT_CONFIG_INVALID") {
+        return false;
+    }
     const isAgentTask = Boolean(descriptor.agent);
     const nonRetryableComputeCodes = new Set([
         "INVALID_OUTPUT",
@@ -372,6 +379,25 @@ export function makeWorkflowSession(options = {}) {
         state.failures.set(key, error);
         return decide();
     }
+    /**
+   * @returns {EngineDecision | null}
+   */
+    function unhandledFailureDecision(recoveryKeys = new Set()) {
+        for (const [key, taskState] of state.states) {
+            const parsed = parseStateKey(key);
+            const descriptor = findDescriptor(state, parsed.nodeId, parsed.iteration);
+            if (taskState === "failed" && !descriptor?.continueOnFail) {
+                if (recoveryKeys.has(key)) {
+                    continue;
+                }
+                return {
+                    _tag: "Failed",
+                    error: new SmithersError("SESSION_ERROR", `Task failed: ${descriptor?.nodeId ?? key}`, { key }, state.failures.get(key)),
+                };
+            }
+        }
+        return null;
+    }
     function ralphStatePayload() {
         return {
             ralphState: Object.fromEntries([...state.ralphState.entries()].map(([id, value]) => [
@@ -393,16 +419,6 @@ export function makeWorkflowSession(options = {}) {
         if (!state.graph) {
             return { _tag: "Wait", reason: { _tag: "ExternalTrigger" } };
         }
-        for (const [key, taskState] of state.states) {
-            const parsed = parseStateKey(key);
-            const descriptor = findDescriptor(state, parsed.nodeId, parsed.iteration);
-            if (taskState === "failed" && !descriptor?.continueOnFail) {
-                return {
-                    _tag: "Failed",
-                    error: new SmithersError("SESSION_ERROR", `Task failed: ${descriptor?.nodeId ?? key}`, { key }, state.failures.get(key)),
-                };
-            }
-        }
         const schedule = computeSchedule();
         if (schedule.fatalError) {
             return {
@@ -418,6 +434,11 @@ export function makeWorkflowSession(options = {}) {
                     stateJson: schedule.continuation.stateJson,
                 },
             };
+        }
+        const recoveryKeys = new Set(schedule.failureRecoveryKeys ?? []);
+        let failure = unhandledFailureDecision(recoveryKeys);
+        if (failure) {
+            return failure;
         }
         const executable = [];
         let waitReason;
@@ -488,6 +509,10 @@ export function makeWorkflowSession(options = {}) {
         }
         if ([...state.states.values()].some((taskState) => taskState === "in-progress")) {
             return { _tag: "Wait", reason: { _tag: "ExternalTrigger" } };
+        }
+        failure = unhandledFailureDecision(recoveryKeys);
+        if (failure) {
+            return failure;
         }
         if (schedule.readyRalphs.length > 0) {
             for (const ralph of schedule.readyRalphs) {

--- a/packages/scheduler/src/scheduleTasks.js
+++ b/packages/scheduler/src/scheduleTasks.js
@@ -134,24 +134,79 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                 return { terminal, failed: terminal && failed };
             }
             case "saga": {
+                let completedActions = 0;
+                let failed = false;
                 for (const child of node.actionChildren) {
-                    const result = inspect(child, options);
+                    const result = inspect(child, {
+                        includeContinuedFailures: true,
+                    });
+                    if (!result.terminal)
+                        return { terminal: false, failed: false };
+                    if (result.failed) {
+                        failed = true;
+                        break;
+                    }
+                    completedActions += 1;
+                }
+                if (!failed)
+                    return { terminal: true, failed: false };
+                if (node.onFailure === "fail")
+                    return { terminal: true, failed: true };
+                let compensationFailed = false;
+                for (let index = completedActions - 1; index >= 0; index -= 1) {
+                    const compensation = node.compensationChildren[index];
+                    if (!compensation)
+                        continue;
+                    const result = inspect(compensation, options);
                     if (!result.terminal)
                         return { terminal: false, failed: false };
                     if (result.failed)
-                        return { terminal: true, failed: true };
+                        compensationFailed = true;
                 }
-                return { terminal: true, failed: false };
+                return {
+                    terminal: true,
+                    failed: compensationFailed || node.onFailure === "compensate-and-fail",
+                };
             }
             case "try-catch-finally": {
+                let tryFailed = false;
                 for (const child of node.tryChildren) {
-                    const result = inspect(child, options);
+                    const result = inspect(child, {
+                        includeContinuedFailures: true,
+                    });
                     if (!result.terminal)
                         return { terminal: false, failed: false };
-                    if (result.failed)
-                        return { terminal: true, failed: true };
+                    if (result.failed) {
+                        tryFailed = true;
+                        break;
+                    }
                 }
-                return { terminal: true, failed: false };
+                if (!tryFailed) {
+                    return inspect({
+                        kind: "sequence",
+                        children: node.finallyChildren,
+                    }, options);
+                }
+                let catchFailed = node.catchChildren.length === 0;
+                if (node.catchChildren.length > 0) {
+                    const catchStatus = inspect({
+                        kind: "sequence",
+                        children: node.catchChildren,
+                    }, options);
+                    if (!catchStatus.terminal)
+                        return { terminal: false, failed: false };
+                    catchFailed = catchStatus.failed;
+                }
+                const finallyStatus = inspect({
+                    kind: "sequence",
+                    children: node.finallyChildren,
+                }, options);
+                if (!finallyStatus.terminal)
+                    return { terminal: false, failed: false };
+                return {
+                    terminal: true,
+                    failed: catchFailed || finallyStatus.failed,
+                };
             }
             default:
                 return { terminal: true, failed: false };
@@ -189,6 +244,12 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                 return;
             case "try-catch-finally":
                 for (const child of node.tryChildren) {
+                    collectFailureKeys(child, options);
+                }
+                for (const child of node.catchChildren) {
+                    collectFailureKeys(child, options);
+                }
+                for (const child of node.finallyChildren) {
                     collectFailureKeys(child, options);
                 }
                 return;
@@ -359,24 +420,45 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                         break;
                     }
                 }
-                if (tryFailed) {
+                if (tryFailed && node.catchChildren.length > 0) {
                     const collectTryFailureKeys = () => collectChildFailureKeys(node.tryChildren, {
                         includeContinuedFailures: true,
                     });
-                    if (node.catchChildren.length > 0) {
-                        collectTryFailureKeys();
-                        const catchStatus = inspect({
-                            kind: "sequence",
-                            children: node.catchChildren,
-                        });
-                        if (catchStatus.failed) {
-                            return { terminal: false };
-                        }
-                        failureRecoveryActive = true;
+                    let catchFailed = false;
+                    collectTryFailureKeys();
+                    const catchStatus = inspect({
+                        kind: "sequence",
+                        children: node.catchChildren,
+                    });
+                    failureRecoveryActive = true;
+                    catchFailed = catchStatus.failed;
+                    if (!catchStatus.terminal) {
                         const catchResult = walkSequence(node.catchChildren);
                         if (!catchResult.terminal)
                             return catchResult;
                     }
+                    const finallyStatus = inspect({
+                        kind: "sequence",
+                        children: node.finallyChildren,
+                    });
+                    if (finallyStatus.failed) {
+                        collectTryFailureKeys();
+                        failureRecoveryActive = false;
+                        return { terminal: false };
+                    }
+                    const finallyResult = walkSequence(node.finallyChildren);
+                    if (!finallyResult.terminal) {
+                        collectTryFailureKeys();
+                        if (catchFailed) {
+                            collectChildFailureKeys(node.catchChildren);
+                        }
+                        failureRecoveryActive = true;
+                        return finallyResult;
+                    }
+                    if (catchFailed) {
+                        return { terminal: true };
+                    }
+                    return { terminal: true };
                 }
                 const finallyStatus = inspect({
                     kind: "sequence",

--- a/packages/scheduler/src/scheduleTasks.js
+++ b/packages/scheduler/src/scheduleTasks.js
@@ -70,6 +70,8 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
     let continuation;
     let nextRetryAtMs;
     let fatalError;
+    let failureRecoveryActive = false;
+    const failureRecoveryKeys = new Set();
     const groupUsage = new Map();
     for (const [stateKey, state] of states) {
         if (state !== "in-progress")
@@ -89,7 +91,7 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
    * @param {PlanNode} node
    * @returns {{ readonly terminal: boolean; readonly failed: boolean }}
    */
-    function inspect(node) {
+    function inspect(node, options = {}) {
         switch (node.kind) {
             case "task": {
                 const descriptor = descriptors.get(node.nodeId);
@@ -102,12 +104,16 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                     state === "failed" ||
                     Boolean(descriptor.waitAsync &&
                         (state === "waiting-approval" || state === "waiting-event"));
-                return { terminal, failed: state === "failed" && !descriptor.continueOnFail };
+                return {
+                    terminal,
+                    failed: state === "failed" &&
+                        (options.includeContinuedFailures || !descriptor.continueOnFail),
+                };
             }
             case "sequence":
             case "group": {
                 for (const child of node.children) {
-                    const result = inspect(child);
+                    const result = inspect(child, options);
                     if (!result.terminal)
                         return { terminal: false, failed: false };
                     if (result.failed)
@@ -119,7 +125,7 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                 let terminal = true;
                 let failed = false;
                 for (const child of node.children) {
-                    const result = inspect(child);
+                    const result = inspect(child, options);
                     if (!result.terminal)
                         terminal = false;
                     if (result.failed)
@@ -129,7 +135,7 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
             }
             case "saga": {
                 for (const child of node.actionChildren) {
-                    const result = inspect(child);
+                    const result = inspect(child, options);
                     if (!result.terminal)
                         return { terminal: false, failed: false };
                     if (result.failed)
@@ -139,7 +145,7 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
             }
             case "try-catch-finally": {
                 for (const child of node.tryChildren) {
-                    const result = inspect(child);
+                    const result = inspect(child, options);
                     if (!result.terminal)
                         return { terminal: false, failed: false };
                     if (result.failed)
@@ -149,6 +155,52 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
             }
             default:
                 return { terminal: true, failed: false };
+        }
+    }
+    /**
+   * @param {PlanNode} node
+   * @param {{ includeContinuedFailures?: boolean }} options
+   */
+    function collectFailureKeys(node, options = {}) {
+        switch (node.kind) {
+            case "task": {
+                const descriptor = descriptors.get(node.nodeId);
+                if (!descriptor)
+                    return;
+                const key = buildStateKey(descriptor.nodeId, descriptor.iteration);
+                const state = states.get(key) ?? "pending";
+                if (state === "failed" &&
+                    (options.includeContinuedFailures || !descriptor.continueOnFail)) {
+                    failureRecoveryKeys.add(key);
+                }
+                return;
+            }
+            case "sequence":
+            case "group":
+            case "parallel":
+                for (const child of node.children) {
+                    collectFailureKeys(child, options);
+                }
+                return;
+            case "saga":
+                for (const child of node.actionChildren) {
+                    collectFailureKeys(child, options);
+                }
+                return;
+            case "try-catch-finally":
+                for (const child of node.tryChildren) {
+                    collectFailureKeys(child, options);
+                }
+                return;
+        }
+    }
+    /**
+   * @param {readonly PlanNode[]} children
+   * @param {{ includeContinuedFailures?: boolean }} options
+   */
+    function collectChildFailureKeys(children, options = {}) {
+        for (const child of children) {
+            collectFailureKeys(child, options);
         }
     }
     /**
@@ -247,7 +299,9 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                 let completedActions = 0;
                 let failed = false;
                 for (const child of node.actionChildren) {
-                    const status = inspect(child);
+                    const status = inspect(child, {
+                        includeContinuedFailures: true,
+                    });
                     if (!status.terminal)
                         return walk(child);
                     if (status.failed) {
@@ -262,6 +316,23 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                     fatalError ??= `Saga ${node.id} failed`;
                     return { terminal: true };
                 }
+                collectChildFailureKeys(node.actionChildren, {
+                    includeContinuedFailures: true,
+                });
+                let compensationFailed = false;
+                for (let index = completedActions - 1; index >= 0; index -= 1) {
+                    const compensation = node.compensationChildren[index];
+                    if (!compensation)
+                        continue;
+                    if (inspect(compensation).failed) {
+                        compensationFailed = true;
+                        break;
+                    }
+                }
+                if (compensationFailed) {
+                    return { terminal: false };
+                }
+                failureRecoveryActive = true;
                 for (let index = completedActions - 1; index >= 0; index -= 1) {
                     const compensation = node.compensationChildren[index];
                     if (!compensation)
@@ -278,7 +349,9 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
             case "try-catch-finally": {
                 let tryFailed = false;
                 for (const child of node.tryChildren) {
-                    const status = inspect(child);
+                    const status = inspect(child, {
+                        includeContinuedFailures: true,
+                    });
                     if (!status.terminal)
                         return walk(child);
                     if (status.failed) {
@@ -287,18 +360,50 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
                     }
                 }
                 if (tryFailed) {
+                    const collectTryFailureKeys = () => collectChildFailureKeys(node.tryChildren, {
+                        includeContinuedFailures: true,
+                    });
                     if (node.catchChildren.length > 0) {
+                        collectTryFailureKeys();
+                        const catchStatus = inspect({
+                            kind: "sequence",
+                            children: node.catchChildren,
+                        });
+                        if (catchStatus.failed) {
+                            return { terminal: false };
+                        }
+                        failureRecoveryActive = true;
                         const catchResult = walkSequence(node.catchChildren);
                         if (!catchResult.terminal)
                             return catchResult;
                     }
-                    else {
-                        fatalError ??= `TryCatchFinally ${node.id} failed`;
+                }
+                const finallyStatus = inspect({
+                    kind: "sequence",
+                    children: node.finallyChildren,
+                });
+                if (finallyStatus.failed) {
+                    if (tryFailed) {
+                        collectChildFailureKeys(node.tryChildren, {
+                            includeContinuedFailures: true,
+                        });
                     }
+                    failureRecoveryActive = false;
+                    return { terminal: false };
                 }
                 const finallyResult = walkSequence(node.finallyChildren);
-                if (!finallyResult.terminal)
+                if (!finallyResult.terminal) {
+                    if (tryFailed && node.catchChildren.length === 0) {
+                        collectChildFailureKeys(node.tryChildren, {
+                            includeContinuedFailures: true,
+                        });
+                        failureRecoveryActive = true;
+                    }
                     return finallyResult;
+                }
+                if (tryFailed && node.catchChildren.length === 0) {
+                    fatalError ??= `TryCatchFinally ${node.id} failed`;
+                }
                 return { terminal: true };
             }
             case "group": {
@@ -326,5 +431,7 @@ export function scheduleTasks(plan, states, descriptors, ralphState, retryWait, 
         continuation,
         nextRetryAtMs,
         fatalError,
+        failureRecoveryActive,
+        failureRecoveryKeys: [...failureRecoveryKeys],
     };
 }

--- a/packages/scheduler/tests/scheduleTasks.test.js
+++ b/packages/scheduler/tests/scheduleTasks.test.js
@@ -372,7 +372,7 @@ describe("scheduleTasks rescheduling after failure (retry wait)", () => {
     expect(result.runnable.map((r) => r.nodeId)).toEqual(["b"]);
   });
 
-  test("failed task with continueOnFail does not trigger try catch", () => {
+  test("failed task with continueOnFail triggers try catch inside boundary", () => {
     const plan = {
       kind: "try-catch-finally",
       id: "safe-try",
@@ -398,7 +398,7 @@ describe("scheduleTasks rescheduling after failure (retry wait)", () => {
       makeDescriptor("catch"),
     );
     const result = scheduleTasks(plan, states, descs, new Map(), new Map(), 0);
-    expect(result.runnable.map((r) => r.nodeId)).toEqual([]);
+    expect(result.runnable.map((r) => r.nodeId)).toEqual(["catch"]);
     expect(result.fatalError).toBeUndefined();
   });
 });

--- a/packages/scheduler/tests/state-plan-boundaries.test.js
+++ b/packages/scheduler/tests/state-plan-boundaries.test.js
@@ -529,4 +529,24 @@ describe("scheduleTasks boundaries", () => {
     );
     expect(result.fatalError).toBe("TryCatchFinally tcf failed");
   });
+
+  test("try failure without catch schedules finally before fatal error", () => {
+    const result = scheduleTasks(
+      {
+        kind: "try-catch-finally",
+        id: "tcf",
+        tryChildren: [{ kind: "task", nodeId: "try" }],
+        catchChildren: [],
+        finallyChildren: [{ kind: "task", nodeId: "finally" }],
+      },
+      new Map([[buildStateKey("try", 0), "failed"]]),
+      descriptorMap(makeDescriptor("try"), makeDescriptor("finally")),
+      new Map(),
+      new Map(),
+      0,
+    );
+    expect(result.runnable.map((task) => task.nodeId)).toEqual(["finally"]);
+    expect(result.fatalError).toBeUndefined();
+    expect(result.failureRecoveryActive).toBe(true);
+  });
 });

--- a/packages/scheduler/tests/state-plan-boundaries.test.js
+++ b/packages/scheduler/tests/state-plan-boundaries.test.js
@@ -549,4 +549,93 @@ describe("scheduleTasks boundaries", () => {
     expect(result.fatalError).toBeUndefined();
     expect(result.failureRecoveryActive).toBe(true);
   });
+
+  test("try-catch-finally schedules finally before surfacing catch failure", () => {
+    const result = scheduleTasks(
+      {
+        kind: "try-catch-finally",
+        id: "tcf",
+        tryChildren: [{ kind: "task", nodeId: "try" }],
+        catchChildren: [{ kind: "task", nodeId: "catch" }],
+        finallyChildren: [{ kind: "task", nodeId: "finally" }],
+      },
+      new Map([
+        [buildStateKey("try", 0), "failed"],
+        [buildStateKey("catch", 0), "failed"],
+      ]),
+      descriptorMap(
+        makeDescriptor("try"),
+        makeDescriptor("catch"),
+        makeDescriptor("finally"),
+      ),
+      new Map(),
+      new Map(),
+      0,
+    );
+    expect(result.runnable.map((task) => task.nodeId)).toEqual(["finally"]);
+    expect(result.failureRecoveryKeys).toContain(buildStateKey("try", 0));
+    expect(result.failureRecoveryKeys).toContain(buildStateKey("catch", 0));
+  });
+
+  test("try-catch-finally surfaces catch failure after finally finishes", () => {
+    const result = scheduleTasks(
+      {
+        kind: "try-catch-finally",
+        id: "tcf",
+        tryChildren: [{ kind: "task", nodeId: "try" }],
+        catchChildren: [{ kind: "task", nodeId: "catch" }],
+        finallyChildren: [{ kind: "task", nodeId: "finally" }],
+      },
+      new Map([
+        [buildStateKey("try", 0), "failed"],
+        [buildStateKey("catch", 0), "failed"],
+        [buildStateKey("finally", 0), "finished"],
+      ]),
+      descriptorMap(
+        makeDescriptor("try"),
+        makeDescriptor("catch"),
+        makeDescriptor("finally"),
+      ),
+      new Map(),
+      new Map(),
+      0,
+    );
+    expect(result.runnable).toEqual([]);
+    expect(result.failureRecoveryKeys).toContain(buildStateKey("try", 0));
+    expect(result.failureRecoveryKeys).not.toContain(buildStateKey("catch", 0));
+  });
+
+  test("outer try-catch-finally does not catch an inner recovered failure", () => {
+    const result = scheduleTasks(
+      {
+        kind: "try-catch-finally",
+        id: "outer",
+        tryChildren: [
+          {
+            kind: "try-catch-finally",
+            id: "inner",
+            tryChildren: [{ kind: "task", nodeId: "inner-try" }],
+            catchChildren: [{ kind: "task", nodeId: "inner-catch" }],
+            finallyChildren: [],
+          },
+        ],
+        catchChildren: [{ kind: "task", nodeId: "outer-catch" }],
+        finallyChildren: [],
+      },
+      new Map([
+        [buildStateKey("inner-try", 0), "failed"],
+        [buildStateKey("inner-catch", 0), "finished"],
+      ]),
+      descriptorMap(
+        makeDescriptor("inner-try"),
+        makeDescriptor("inner-catch"),
+        makeDescriptor("outer-catch"),
+      ),
+      new Map(),
+      new Map(),
+      0,
+    );
+    expect(result.runnable).toEqual([]);
+    expect(result.failureRecoveryKeys).toEqual([]);
+  });
 });

--- a/packages/scheduler/tests/workflowSession-retry.test.js
+++ b/packages/scheduler/tests/workflowSession-retry.test.js
@@ -1,0 +1,281 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { makeWorkflowSession } from "../src/makeWorkflowSession.js";
+
+function el(tag, props = {}, children = []) {
+  return { kind: "element", tag, props, children };
+}
+
+function makeAgentDescriptor(overrides = {}) {
+  return {
+    nodeId: "agent-task",
+    iteration: 0,
+    ordinal: 0,
+    outputTable: null,
+    outputTableName: "",
+    continueOnFail: false,
+    retries: 3,
+    retryPolicy: { initialDelayMs: 1_000 },
+    agent: { id: "agent" },
+    ...overrides,
+  };
+}
+
+function makeGraph(descriptor = makeAgentDescriptor()) {
+  return {
+    xml: el("smithers:workflow", {}, [
+      el("smithers:task", { id: descriptor.nodeId }),
+    ]),
+    tasks: [descriptor],
+    mountedTaskIds: new Set([`${descriptor.nodeId}::${descriptor.iteration}`]),
+  };
+}
+
+describe("makeWorkflowSession retry classification", () => {
+  test("details.failureRetryable=false fails an agent task without backoff", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const descriptor = makeAgentDescriptor();
+    const initial = Effect.runSync(session.submitGraph(makeGraph(descriptor)));
+
+    expect(initial._tag).toBe("Execute");
+
+    const decision = Effect.runSync(session.taskFailed({
+      nodeId: descriptor.nodeId,
+      iteration: descriptor.iteration,
+      error: {
+        code: "AGENT_CLI_ERROR",
+        message: "operator action required",
+        details: { failureRetryable: false },
+      },
+    }));
+
+    expect(decision._tag).toBe("Failed");
+  });
+
+  test("AGENT_CONFIG_INVALID fails an agent task without backoff", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const descriptor = makeAgentDescriptor();
+    Effect.runSync(session.submitGraph(makeGraph(descriptor)));
+
+    const decision = Effect.runSync(session.taskFailed({
+      nodeId: descriptor.nodeId,
+      iteration: descriptor.iteration,
+      error: {
+        code: "AGENT_CONFIG_INVALID",
+        message: "missing model configuration",
+      },
+    }));
+
+    expect(decision._tag).toBe("Failed");
+  });
+
+  test("ordinary agent failures still use retry backoff", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const descriptor = makeAgentDescriptor();
+    Effect.runSync(session.submitGraph(makeGraph(descriptor)));
+
+    const decision = Effect.runSync(session.taskFailed({
+      nodeId: descriptor.nodeId,
+      iteration: descriptor.iteration,
+      error: {
+        code: "AGENT_CLI_ERROR",
+        message: "transient failure",
+      },
+    }));
+
+    expect(decision).toEqual({
+      _tag: "Wait",
+      reason: {
+        _tag: "RetryBackoff",
+        waitMs: 1_000,
+      },
+    });
+  });
+});
+
+describe("makeWorkflowSession failure control flow", () => {
+  test("try-catch-finally runs catch after try task failure", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const explode = makeAgentDescriptor({
+      nodeId: "explode",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const recover = makeAgentDescriptor({
+      nodeId: "recover",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const cleanup = makeAgentDescriptor({
+      nodeId: "cleanup",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const graph = {
+      xml: el("smithers:workflow", {}, [
+        el("smithers:try-catch-finally", { id: "tcf" }, [
+          el("smithers:tcf-try", {}, [el("smithers:task", { id: "explode" })]),
+          el("smithers:tcf-catch", {}, [el("smithers:task", { id: "recover" })]),
+          el("smithers:tcf-finally", {}, [el("smithers:task", { id: "cleanup" })]),
+        ]),
+      ]),
+      tasks: [explode, recover, cleanup],
+      mountedTaskIds: new Set(["explode::0", "recover::0", "cleanup::0"]),
+    };
+
+    expect(Effect.runSync(session.submitGraph(graph))._tag).toBe("Execute");
+
+    const afterFailure = Effect.runSync(session.taskFailed({
+      nodeId: "explode",
+      iteration: 0,
+      error: { message: "boom" },
+    }));
+
+    expect(afterFailure._tag).toBe("Execute");
+    expect(afterFailure.tasks.map((task) => task.nodeId)).toEqual(["recover"]);
+  });
+
+  test("saga failure runs compensation for completed actions", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const reserve = makeAgentDescriptor({
+      nodeId: "reserve",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const charge = makeAgentDescriptor({
+      nodeId: "charge",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const release = makeAgentDescriptor({
+      nodeId: "release",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const graph = {
+      xml: el("smithers:workflow", {}, [
+        el("smithers:saga", { id: "saga", onFailure: "compensate" }, [
+          el("smithers:saga-actions", {}, [
+            el("smithers:task", { id: "reserve" }),
+            el("smithers:task", { id: "charge" }),
+          ]),
+          el("smithers:saga-compensations", {}, [
+            el("smithers:task", { id: "release" }),
+          ]),
+        ]),
+      ]),
+      tasks: [reserve, charge, release],
+      mountedTaskIds: new Set(["reserve::0", "charge::0", "release::0"]),
+    };
+
+    expect(Effect.runSync(session.submitGraph(graph))._tag).toBe("Execute");
+    const afterReserve = Effect.runSync(session.taskCompleted({
+      nodeId: "reserve",
+      iteration: 0,
+      output: { ok: true },
+    }));
+    expect(afterReserve._tag).toBe("Execute");
+    expect(afterReserve.tasks.map((task) => task.nodeId)).toEqual(["charge"]);
+
+    const afterFailure = Effect.runSync(session.taskFailed({
+      nodeId: "charge",
+      iteration: 0,
+      error: { message: "payment failed" },
+    }));
+
+    expect(afterFailure._tag).toBe("Execute");
+    expect(afterFailure.tasks.map((task) => task.nodeId)).toEqual(["release"]);
+  });
+
+  test("unhandled hard failure does not start a pending parallel sibling", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const a = makeAgentDescriptor({
+      nodeId: "a",
+      retries: 0,
+      retryPolicy: undefined,
+      parallelGroupId: "group",
+      parallelMaxConcurrency: 1,
+    });
+    const b = makeAgentDescriptor({
+      nodeId: "b",
+      retries: 0,
+      retryPolicy: undefined,
+      parallelGroupId: "group",
+      parallelMaxConcurrency: 1,
+    });
+    const graph = {
+      xml: el("smithers:workflow", {}, [
+        el("smithers:parallel", {}, [
+          el("smithers:task", { id: "a" }),
+          el("smithers:task", { id: "b" }),
+        ]),
+      ]),
+      tasks: [a, b],
+      mountedTaskIds: new Set(["a::0", "b::0"]),
+    };
+
+    const initial = Effect.runSync(session.submitGraph(graph));
+    expect(initial._tag).toBe("Execute");
+    expect(initial.tasks.map((task) => task.nodeId)).toEqual(["a"]);
+
+    const afterFailure = Effect.runSync(session.taskFailed({
+      nodeId: "a",
+      iteration: 0,
+      error: { message: "boom" },
+    }));
+
+    expect(afterFailure._tag).toBe("Failed");
+  });
+
+  test("handled boundary failure does not mask an unrelated failure", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const explode = makeAgentDescriptor({
+      nodeId: "explode",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const recover = makeAgentDescriptor({
+      nodeId: "recover",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const unrelated = makeAgentDescriptor({
+      nodeId: "unrelated",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const graph = {
+      xml: el("smithers:workflow", {}, [
+        el("smithers:parallel", {}, [
+          el("smithers:try-catch-finally", { id: "tcf" }, [
+            el("smithers:tcf-try", {}, [el("smithers:task", { id: "explode" })]),
+            el("smithers:tcf-catch", {}, [el("smithers:task", { id: "recover" })]),
+            el("smithers:tcf-finally", {}, []),
+          ]),
+          el("smithers:task", { id: "unrelated" }),
+        ]),
+      ]),
+      tasks: [explode, recover, unrelated],
+      mountedTaskIds: new Set(["explode::0", "recover::0", "unrelated::0"]),
+    };
+
+    const initial = Effect.runSync(session.submitGraph(graph));
+    expect(initial._tag).toBe("Execute");
+    expect(initial.tasks.map((task) => task.nodeId)).toEqual(["explode", "unrelated"]);
+
+    const afterBoundaryFailure = Effect.runSync(session.taskFailed({
+      nodeId: "explode",
+      iteration: 0,
+      error: { message: "handled" },
+    }));
+    expect(afterBoundaryFailure._tag).toBe("Execute");
+    expect(afterBoundaryFailure.tasks.map((task) => task.nodeId)).toEqual(["recover"]);
+
+    const afterUnrelatedFailure = Effect.runSync(session.taskFailed({
+      nodeId: "unrelated",
+      iteration: 0,
+      error: { message: "unhandled" },
+    }));
+    expect(afterUnrelatedFailure._tag).toBe("Failed");
+  });
+});

--- a/packages/scheduler/tests/workflowSession-retry.test.js
+++ b/packages/scheduler/tests/workflowSession-retry.test.js
@@ -135,6 +135,62 @@ describe("makeWorkflowSession failure control flow", () => {
     expect(afterFailure.tasks.map((task) => task.nodeId)).toEqual(["recover"]);
   });
 
+  test("try-catch-finally runs finally before surfacing catch failure", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const explode = makeAgentDescriptor({
+      nodeId: "explode",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const recover = makeAgentDescriptor({
+      nodeId: "recover",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const cleanup = makeAgentDescriptor({
+      nodeId: "cleanup",
+      retries: 0,
+      retryPolicy: undefined,
+    });
+    const graph = {
+      xml: el("smithers:workflow", {}, [
+        el("smithers:try-catch-finally", { id: "tcf" }, [
+          el("smithers:tcf-try", {}, [el("smithers:task", { id: "explode" })]),
+          el("smithers:tcf-catch", {}, [el("smithers:task", { id: "recover" })]),
+          el("smithers:tcf-finally", {}, [el("smithers:task", { id: "cleanup" })]),
+        ]),
+      ]),
+      tasks: [explode, recover, cleanup],
+      mountedTaskIds: new Set(["explode::0", "recover::0", "cleanup::0"]),
+    };
+
+    expect(Effect.runSync(session.submitGraph(graph))._tag).toBe("Execute");
+
+    const afterTryFailure = Effect.runSync(session.taskFailed({
+      nodeId: "explode",
+      iteration: 0,
+      error: { message: "boom" },
+    }));
+    expect(afterTryFailure._tag).toBe("Execute");
+    expect(afterTryFailure.tasks.map((task) => task.nodeId)).toEqual(["recover"]);
+
+    const afterCatchFailure = Effect.runSync(session.taskFailed({
+      nodeId: "recover",
+      iteration: 0,
+      error: { message: "recovery failed" },
+    }));
+    expect(afterCatchFailure._tag).toBe("Execute");
+    expect(afterCatchFailure.tasks.map((task) => task.nodeId)).toEqual(["cleanup"]);
+
+    const afterCleanup = Effect.runSync(session.taskCompleted({
+      nodeId: "cleanup",
+      iteration: 0,
+      output: { ok: true },
+    }));
+    expect(afterCleanup._tag).toBe("Failed");
+    expect(afterCleanup.error.message).toContain("Task failed: recover");
+  });
+
   test("saga failure runs compensation for completed actions", () => {
     const session = makeWorkflowSession({ nowMs: () => 1_000 });
     const reserve = makeAgentDescriptor({


### PR DESCRIPTION
## Summary
- preserve original agent generation failures so SmithersError code/details survive retry classification
- stop retrying agent failures marked failureRetryable=false or AGENT_CONFIG_INVALID
- keep catch, saga, and finally recovery paths from being mistaken for unhandled task failures

## Validation
- `pnpm -r typecheck`
- `pnpm lint`
- `pnpm test`