### PR TITLE
Harden gateway client contracts

### DIFF
--- a/packages/gateway-client/src/SmithersGatewayClient.ts
+++ b/packages/gateway-client/src/SmithersGatewayClient.ts
@@ -15,6 +15,13 @@ type StreamRunEventPayload = {
   payload?: unknown;
 };
 
+type StreamDevToolsEventPayload = {
+  streamId?: string;
+  runId?: string;
+  event?: unknown;
+  error?: unknown;
+};
+
 declare global {
   var __SMITHERS_GATEWAY_UI__: GatewayUiBootConfig | undefined;
 }
@@ -36,21 +43,53 @@ function toWebSocketUrl(baseUrl: string, wsPath = "/") {
   return url.toString();
 }
 
-function randomId(method: string) {
-  const cryptoApi = globalThis.crypto;
-  const suffix = typeof cryptoApi?.randomUUID === "function"
-    ? cryptoApi.randomUUID()
-    : Math.random().toString(36).slice(2);
-  return `${method}-${suffix}`;
-}
+const unavailableFetch = (() => Promise.reject(new Error("fetch is not available in this environment."))) as unknown as typeof fetch;
 
-function headersFromOptions(options: SmithersGatewayClientOptions) {
+function headersFromOptions(options: Pick<SmithersGatewayClientOptions, "headers" | "token">) {
   const headers = new Headers(options.headers);
   headers.set("content-type", "application/json");
   if (options.token) {
     headers.set("authorization", `Bearer ${options.token}`);
   }
   return headers;
+}
+
+function gatewayHttpError(method: string, status: number, message = `Gateway HTTP ${status}`) {
+  return new GatewayRpcError({
+    method,
+    status,
+    code: "HTTP_ERROR",
+    message,
+  });
+}
+
+function invalidGatewayResponse(method: string, status: number | undefined, details?: unknown) {
+  return new GatewayRpcError({
+    method,
+    status,
+    code: "INVALID_GATEWAY_RESPONSE",
+    message: "Gateway returned an invalid RPC response frame.",
+    details,
+  });
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isGatewayResponseFrame(value: unknown): value is GatewayResponseFrame {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.type !== "res" || typeof value.id !== "string" || typeof value.ok !== "boolean") {
+    return false;
+  }
+  if (value.ok === true) {
+    return "payload" in value;
+  }
+  return isObject(value.error) &&
+    typeof value.error.code === "string" &&
+    typeof value.error.message === "string";
 }
 
 function rpcError(frame: Extract<GatewayResponseFrame, { ok: false }>, method: string, status?: number) {
@@ -69,7 +108,7 @@ export class SmithersGatewayClient {
   readonly baseUrl: string;
   readonly token?: string;
   readonly fetchImpl: typeof fetch;
-  readonly WebSocketImpl: typeof WebSocket;
+  readonly WebSocketImpl: typeof WebSocket | undefined;
   readonly headers: HeadersInit | undefined;
   readonly client: Required<NonNullable<SmithersGatewayClientOptions["client"]>>;
   readonly boot: GatewayUiBootConfig | undefined;
@@ -79,7 +118,11 @@ export class SmithersGatewayClient {
     this.baseUrl = normalizeBaseUrl(options.baseUrl ?? defaultBaseUrl());
     this.token = options.token;
     this.headers = options.headers;
-    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.fetchImpl = options.fetch ?? (
+      typeof globalThis.fetch === "function"
+        ? globalThis.fetch.bind(globalThis)
+        : unavailableFetch
+    );
     this.WebSocketImpl = options.WebSocket ?? globalThis.WebSocket;
     this.client = {
       id: options.client?.id ?? "smithers-gateway-client",
@@ -103,14 +146,20 @@ export class SmithersGatewayClient {
       body: JSON.stringify(params ?? {}),
       signal: options.signal,
     });
-    const frame = (await response.json()) as GatewayResponseFrame;
-    if (!response.ok && !("ok" in frame)) {
-      throw new GatewayRpcError({
-        method,
-        status: response.status,
-        code: "HTTP_ERROR",
-        message: `Gateway HTTP ${response.status}`,
-      });
+    let frame: unknown;
+    try {
+      frame = await response.json();
+    } catch {
+      if (response.ok) {
+        throw invalidGatewayResponse(method, response.status);
+      }
+      throw gatewayHttpError(method, response.status);
+    }
+    if (!isGatewayResponseFrame(frame)) {
+      if (!response.ok) {
+        throw gatewayHttpError(method, response.status);
+      }
+      throw invalidGatewayResponse(method, response.status, frame);
     }
     if (!frame.ok) {
       throw rpcError(frame, method, response.status);
@@ -122,6 +171,9 @@ export class SmithersGatewayClient {
     if (!this.WebSocketImpl) {
       throw new Error("WebSocket is not available in this environment.");
     }
+    if (options.signal?.aborted) {
+      throw new Error("Gateway WebSocket open aborted.");
+    }
     const ws = new this.WebSocketImpl(toWebSocketUrl(this.baseUrl, this.boot?.wsPath));
     await new Promise<void>((resolve, reject) => {
       const onOpen = () => {
@@ -132,26 +184,33 @@ export class SmithersGatewayClient {
         cleanup();
         reject(new Error("Gateway WebSocket failed to open."));
       };
-      const cleanup = () => {
-        ws.removeEventListener("open", onOpen);
-        ws.removeEventListener("error", onError);
-      };
-      ws.addEventListener("open", onOpen);
-      ws.addEventListener("error", onError);
-      options.signal?.addEventListener("abort", () => {
+      const onAbort = () => {
         cleanup();
         ws.close();
         reject(new Error("Gateway WebSocket open aborted."));
-      }, { once: true });
+      };
+      const cleanup = () => {
+        ws.removeEventListener("open", onOpen);
+        ws.removeEventListener("error", onError);
+        options.signal?.removeEventListener("abort", onAbort);
+      };
+      ws.addEventListener("open", onOpen);
+      ws.addEventListener("error", onError);
+      options.signal?.addEventListener("abort", onAbort, { once: true });
     });
     const connection = new SmithersGatewayConnection(ws);
-    await connection.requestRaw("connect", {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: this.client,
-      ...(this.token ? { auth: { token: this.token } } : {}),
-      ...(options.subscribe ? { subscribe: options.subscribe } : {}),
-    });
+    try {
+      await connection.requestRaw("connect", {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: this.client,
+        ...(this.token ? { auth: { token: this.token } } : {}),
+        ...(options.subscribe ? { subscribe: options.subscribe } : {}),
+      });
+    } catch (error) {
+      connection.close();
+      throw error;
+    }
     return connection;
   }
 
@@ -181,6 +240,32 @@ export class SmithersGatewayClient {
     }
   }
 
+  async *streamDevTools(
+    params: GatewayRpcParams<"streamDevTools">,
+    options: { signal?: AbortSignal } = {},
+  ): AsyncGenerator<GatewayEventFrame<StreamDevToolsEventPayload>> {
+    const connection = await this.connect({ subscribe: [params.runId], signal: options.signal });
+    try {
+      const subscribed = await connection.request("streamDevTools", params);
+      if (!isObject(subscribed) || typeof subscribed.streamId !== "string") {
+        throw invalidGatewayResponse("streamDevTools", undefined, subscribed);
+      }
+      for await (const frame of connection.events(options.signal)) {
+        if (
+          (frame.event === "devtools.event" || frame.event === "devtools.error") &&
+          typeof frame.payload === "object" &&
+          frame.payload !== null &&
+          "streamId" in frame.payload &&
+          frame.payload.streamId === subscribed.streamId
+        ) {
+          yield frame as GatewayEventFrame<StreamDevToolsEventPayload>;
+        }
+      }
+    } finally {
+      connection.close();
+    }
+  }
+
   launchRun(params: GatewayRpcParams<"launchRun">) {
     return this.rpc("launchRun", params);
   }
@@ -191,6 +276,14 @@ export class SmithersGatewayClient {
 
   cancelRun(params: GatewayRpcParams<"cancelRun">) {
     return this.rpc("cancelRun", params);
+  }
+
+  hijackRun(params: GatewayRpcParams<"hijackRun">) {
+    return this.rpc("hijackRun", params);
+  }
+
+  rewindRun(params: GatewayRpcParams<"rewindRun">) {
+    return this.rpc("rewindRun", params);
   }
 
   submitApproval(params: GatewayRpcParams<"submitApproval">) {
@@ -223,5 +316,21 @@ export class SmithersGatewayClient {
 
   getNodeDiff(params: GatewayRpcParams<"getNodeDiff">) {
     return this.rpc("getNodeDiff", params);
+  }
+
+  cronList(params: GatewayRpcParams<"cronList"> = {}) {
+    return this.rpc("cronList", params);
+  }
+
+  cronCreate(params: GatewayRpcParams<"cronCreate">) {
+    return this.rpc("cronCreate", params);
+  }
+
+  cronDelete(params: GatewayRpcParams<"cronDelete">) {
+    return this.rpc("cronDelete", params);
+  }
+
+  cronRun(params: GatewayRpcParams<"cronRun">) {
+    return this.rpc("cronRun", params);
   }
 }

--- a/packages/gateway-client/src/SmithersGatewayConnection.ts
+++ b/packages/gateway-client/src/SmithersGatewayConnection.ts
@@ -34,6 +34,42 @@ function frameError(frame: Extract<GatewayResponseFrame, { ok: false }>, method:
   });
 }
 
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalidFrameError(details?: unknown) {
+  return new GatewayRpcError({
+    method: "websocket",
+    code: "INVALID_GATEWAY_RESPONSE",
+    message: "Gateway returned an invalid WebSocket frame.",
+    details,
+  });
+}
+
+function isGatewayResponseFrame(value: unknown): value is GatewayResponseFrame {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.type !== "res" || typeof value.id !== "string" || typeof value.ok !== "boolean") {
+    return false;
+  }
+  if (value.ok === true) {
+    return "payload" in value;
+  }
+  return isObject(value.error) &&
+    typeof value.error.code === "string" &&
+    typeof value.error.message === "string";
+}
+
+function isGatewayEventFrame(value: unknown): value is GatewayEventFrame {
+  return isObject(value) &&
+    value.type === "event" &&
+    typeof value.event === "string" &&
+    typeof value.seq === "number" &&
+    typeof value.stateVersion === "number";
+}
+
 export class SmithersGatewayConnection {
   readonly ws: WebSocket;
   readonly pending = new Map<string, PendingRequest>();
@@ -50,12 +86,12 @@ export class SmithersGatewayConnection {
       this.push({ kind: "error", error: new Error("Gateway WebSocket error") });
     });
     ws.addEventListener("close", () => {
+      const alreadyClosed = this.closed;
       this.closed = true;
-      for (const pending of this.pending.values()) {
-        pending.reject(new Error("Gateway WebSocket closed"));
+      this.rejectPending(new Error("Gateway WebSocket closed"));
+      if (!alreadyClosed) {
+        this.push({ kind: "close" });
       }
-      this.pending.clear();
-      this.push({ kind: "close" });
     });
   }
 
@@ -63,6 +99,9 @@ export class SmithersGatewayConnection {
     method: Method,
     params: GatewayRpcParams<Method>,
   ): Promise<GatewayRpcPayload<Method>> {
+    if (this.closed) {
+      return Promise.reject(new Error("Gateway WebSocket is closed"));
+    }
     const id = randomId(method);
     const frame = { type: "req", id, method, params };
     return new Promise((resolve, reject) => {
@@ -71,21 +110,38 @@ export class SmithersGatewayConnection {
         resolve: (payload) => resolve(payload as GatewayRpcPayload<Method>),
         reject,
       });
-      this.ws.send(JSON.stringify(frame));
+      try {
+        this.ws.send(JSON.stringify(frame));
+      } catch (cause) {
+        this.pending.delete(id);
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
     });
   }
 
   requestRaw(method: string, params?: unknown): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(new Error("Gateway WebSocket is closed"));
+    }
     const id = randomId(method);
     const frame = { type: "req", id, method, params };
     return new Promise((resolve, reject) => {
       this.pending.set(id, { method, resolve, reject });
-      this.ws.send(JSON.stringify(frame));
+      try {
+        this.ws.send(JSON.stringify(frame));
+      } catch (cause) {
+        this.pending.delete(id);
+        reject(cause instanceof Error ? cause : new Error(String(cause)));
+      }
     });
   }
 
   async *events(signal?: AbortSignal): AsyncGenerator<GatewayEventFrame> {
     const abort = () => this.close();
+    if (signal?.aborted) {
+      this.close();
+      return;
+    }
     signal?.addEventListener("abort", abort, { once: true });
     try {
       while (!this.closed || this.queue.length > 0) {
@@ -108,13 +164,21 @@ export class SmithersGatewayConnection {
       return;
     }
     this.closed = true;
+    this.rejectPending(new Error("Gateway WebSocket closed"));
+    this.push({ kind: "close" });
     this.ws.close();
   }
 
   private handleMessage(raw: unknown) {
     const text = typeof raw === "string" ? raw : String(raw);
-    const frame = JSON.parse(text) as GatewayResponseFrame | GatewayEventFrame;
-    if (frame.type === "res") {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(text);
+    } catch {
+      this.push({ kind: "error", error: invalidFrameError(text) });
+      return;
+    }
+    if (isGatewayResponseFrame(frame)) {
       const pending = this.pending.get(frame.id);
       if (!pending) {
         return;
@@ -127,9 +191,19 @@ export class SmithersGatewayConnection {
       pending.reject(frameError(frame, pending.method));
       return;
     }
-    if (frame.type === "event") {
-      this.push({ kind: "event", frame });
+    if (isObject(frame) && frame.type === "res" && typeof frame.id === "string") {
+      const pending = this.pending.get(frame.id);
+      if (pending) {
+        this.pending.delete(frame.id);
+        pending.reject(invalidFrameError(frame));
+      }
+      return;
     }
+    if (isGatewayEventFrame(frame)) {
+      this.push({ kind: "event", frame });
+      return;
+    }
+    this.push({ kind: "error", error: invalidFrameError(frame) });
   }
 
   private push(event: QueuedEvent) {
@@ -150,5 +224,12 @@ export class SmithersGatewayConnection {
       });
     }
     return this.queue.shift();
+  }
+
+  private rejectPending(error: Error) {
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
   }
 }

--- a/packages/gateway-client/tests/gateway-client.test.ts
+++ b/packages/gateway-client/tests/gateway-client.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, test } from "bun:test";
+import { GatewayRpcError, SmithersGatewayClient, SmithersGatewayConnection } from "../src/index.ts";
+
+type SentRequest = {
+  type: "req";
+  id: string;
+  method: string;
+  params?: unknown;
+};
+
+class FakeWebSocket extends EventTarget {
+  static instances: FakeWebSocket[] = [];
+
+  readonly OPEN = 1;
+  readonly CLOSED = 3;
+  readonly url: string;
+  readyState = this.OPEN;
+  sent: string[] = [];
+  closeCalls = 0;
+  sendError: Error | undefined;
+
+  constructor(url: string) {
+    super();
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string) {
+    if (this.sendError) {
+      throw this.sendError;
+    }
+    this.sent.push(String(data));
+  }
+
+  close() {
+    if (this.readyState === this.CLOSED) {
+      return;
+    }
+    this.readyState = this.CLOSED;
+    this.closeCalls += 1;
+    this.dispatchEvent(new Event("close"));
+  }
+
+  open() {
+    this.readyState = this.OPEN;
+    this.dispatchEvent(new Event("open"));
+  }
+
+  receive(frame: unknown) {
+    const data = typeof frame === "string" ? frame : JSON.stringify(frame);
+    this.dispatchEvent(new MessageEvent("message", { data }));
+  }
+
+  lastRequest(): SentRequest {
+    const raw = this.sent.at(-1);
+    if (!raw) {
+      throw new Error("FakeWebSocket has no sent request.");
+    }
+    return JSON.parse(raw) as SentRequest;
+  }
+}
+
+function fakeWebSocketCtor() {
+  FakeWebSocket.instances = [];
+  return FakeWebSocket as unknown as typeof WebSocket;
+}
+
+function okResponse(payload: unknown, status = 200) {
+  return Response.json({ type: "res", id: "http", ok: true, payload }, { status });
+}
+
+function errorResponse(error: Record<string, unknown>, status = 500) {
+  return Response.json({ type: "res", id: "http", ok: false, error }, { status });
+}
+
+async function waitForSent(ws: FakeWebSocket, count: number) {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (ws.sent.length >= count) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`Timed out waiting for ${count} sent WebSocket frame(s).`);
+}
+
+describe("SmithersGatewayClient HTTP RPC", () => {
+  test("normalizes base URLs and sends typed JSON RPC requests with auth headers", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (url, init) => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return okResponse({ runId: "run-1", workflow: "deploy" });
+    };
+    const client = new SmithersGatewayClient({
+      baseUrl: "http://gateway.local///",
+      token: "secret-token",
+      headers: { "x-client": "test" },
+      fetch: fetchImpl,
+    });
+
+    const result = await client.launchRun({ workflow: "deploy", input: { sha: "abc123" } });
+
+    expect(result).toEqual({ runId: "run-1", workflow: "deploy" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("http://gateway.local/v1/rpc/launchRun");
+    expect(calls[0].init.method).toBe("POST");
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+      workflow: "deploy",
+      input: { sha: "abc123" },
+    });
+    const headers = calls[0].init.headers as Headers;
+    expect(headers.get("content-type")).toBe("application/json");
+    expect(headers.get("authorization")).toBe("Bearer secret-token");
+    expect(headers.get("x-client")).toBe("test");
+  });
+
+  test("preserves gateway error details on failed RPC frames", async () => {
+    const client = new SmithersGatewayClient({
+      fetch: async () => errorResponse({
+        code: "Forbidden",
+        message: "Missing scope.",
+        requiredScope: "run:write",
+        refresh: "reauth",
+        details: { scope: "run:write" },
+      }, 403),
+    });
+
+    const failure = client.resumeRun({ runId: "run-1" }).catch((error) => error);
+
+    await expect(failure).resolves.toBeInstanceOf(GatewayRpcError);
+    await expect(failure).resolves.toMatchObject({
+      name: "GatewayRpcError",
+      method: "resumeRun",
+      status: 403,
+      code: "Forbidden",
+      message: "Missing scope.",
+      requiredScope: "run:write",
+      refresh: "reauth",
+      details: { scope: "run:write" },
+    });
+  });
+
+  test("rejects malformed successful responses as invalid gateway frames", async () => {
+    const client = new SmithersGatewayClient({
+      fetch: async () => Response.json({ ok: true, payload: { runId: "run-1" } }),
+    });
+
+    await expect(client.getRun({ runId: "run-1" })).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      method: "getRun",
+      code: "INVALID_GATEWAY_RESPONSE",
+      status: 200,
+    });
+  });
+
+  test("rejects non-JSON successful responses as invalid gateway frames", async () => {
+    const client = new SmithersGatewayClient({
+      fetch: async () => new Response("not json", { status: 200 }),
+    });
+
+    await expect(client.getRun({ runId: "run-1" })).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      method: "getRun",
+      code: "INVALID_GATEWAY_RESPONSE",
+      status: 200,
+    });
+  });
+
+  test("maps non-frame HTTP failures to HTTP_ERROR", async () => {
+    const client = new SmithersGatewayClient({
+      fetch: async () => Response.json({ error: "bad gateway" }, { status: 502 }),
+    });
+
+    await expect(client.getRun({ runId: "run-1" })).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      method: "getRun",
+      code: "HTTP_ERROR",
+      status: 502,
+    });
+  });
+
+  test("covers all stable convenience RPC methods added around the gateway contract", async () => {
+    const methods: string[] = [];
+    const client = new SmithersGatewayClient({
+      fetch: async (url) => {
+        methods.push(String(url).split("/").at(-1) ?? "");
+        return okResponse({});
+      },
+    });
+
+    await client.hijackRun({ runId: "run-1" });
+    await client.rewindRun({ runId: "run-1", frameNo: 1, confirm: true });
+    await client.cronList();
+    await client.cronCreate({ workflow: "deploy", pattern: "* * * * *" });
+    await client.cronDelete({ cronId: "cron-1" });
+    await client.cronRun({ workflow: "deploy", input: { manual: true } });
+
+    expect(methods).toEqual(["hijackRun", "rewindRun", "cronList", "cronCreate", "cronDelete", "cronRun"]);
+  });
+});
+
+describe("SmithersGatewayConnection WebSocket RPC", () => {
+  test("sends request frames and resolves matching response frames", async () => {
+    const ws = new FakeWebSocket("ws://gateway.local");
+    const connection = new SmithersGatewayConnection(ws as unknown as WebSocket);
+
+    const pending = connection.requestRaw("connect", { minProtocol: 1 });
+    const request = ws.lastRequest();
+
+    expect(request).toMatchObject({
+      type: "req",
+      method: "connect",
+      params: { minProtocol: 1 },
+    });
+
+    ws.receive({ type: "res", id: request.id, ok: true, payload: { sessionToken: "session-1" } });
+
+    await expect(pending).resolves.toEqual({ sessionToken: "session-1" });
+  });
+
+  test("rejects matching response errors with GatewayRpcError", async () => {
+    const ws = new FakeWebSocket("ws://gateway.local");
+    const connection = new SmithersGatewayConnection(ws as unknown as WebSocket);
+
+    const pending = connection.requestRaw("streamRunEvents", { runId: "run-1" });
+    const request = ws.lastRequest();
+    ws.receive({
+      type: "res",
+      id: request.id,
+      ok: false,
+      error: { code: "RunNotFound", message: "Run not found." },
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      method: "streamRunEvents",
+      code: "RunNotFound",
+      message: "Run not found.",
+    });
+  });
+
+  test("removes failed sends from the pending map", async () => {
+    const ws = new FakeWebSocket("ws://gateway.local");
+    ws.sendError = new Error("socket buffer full");
+    const connection = new SmithersGatewayConnection(ws as unknown as WebSocket);
+
+    await expect(connection.requestRaw("connect", {})).rejects.toThrow("socket buffer full");
+    expect(connection.pending.size).toBe(0);
+  });
+
+  test("rejects malformed WebSocket frames through the event stream", async () => {
+    const ws = new FakeWebSocket("ws://gateway.local");
+    const connection = new SmithersGatewayConnection(ws as unknown as WebSocket);
+    const iterator = connection.events();
+
+    const next = iterator.next();
+    ws.receive("{not json");
+
+    await expect(next).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      code: "INVALID_GATEWAY_RESPONSE",
+    });
+    connection.close();
+  });
+
+  test("rejects pending requests when the connection closes", async () => {
+    const ws = new FakeWebSocket("ws://gateway.local");
+    const connection = new SmithersGatewayConnection(ws as unknown as WebSocket);
+
+    const pending = connection.requestRaw("getRun", { runId: "run-1" });
+    connection.close();
+
+    await expect(pending).rejects.toThrow("Gateway WebSocket closed");
+    expect(connection.pending.size).toBe(0);
+    expect(ws.closeCalls).toBe(1);
+  });
+});
+
+describe("SmithersGatewayClient WebSocket helpers", () => {
+  test("performs the connect handshake with auth, client metadata, and subscribed runs", async () => {
+    const WebSocket = fakeWebSocketCtor();
+    const client = new SmithersGatewayClient({
+      baseUrl: "https://gateway.local",
+      token: "secret-token",
+      WebSocket,
+      client: { id: "client-1", version: "1.2.3", platform: "test" },
+    });
+
+    const pending = client.connect({ subscribe: ["run-1"] });
+    const ws = FakeWebSocket.instances[0];
+    expect(ws.url).toBe("wss://gateway.local/");
+    ws.open();
+    await waitForSent(ws, 1);
+
+    const request = ws.lastRequest();
+    expect(request).toMatchObject({
+      type: "req",
+      method: "connect",
+      params: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "client-1", version: "1.2.3", platform: "test" },
+        auth: { token: "secret-token" },
+        subscribe: ["run-1"],
+      },
+    });
+    ws.receive({ type: "res", id: request.id, ok: true, payload: { sessionToken: "session-1" } });
+
+    const connection = await pending;
+    expect(connection).toBeInstanceOf(SmithersGatewayConnection);
+    connection.close();
+  });
+
+  test("closes the socket when the connect handshake is rejected", async () => {
+    const WebSocket = fakeWebSocketCtor();
+    const client = new SmithersGatewayClient({ WebSocket });
+
+    const pending = client.connect();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    await waitForSent(ws, 1);
+    const request = ws.lastRequest();
+    ws.receive({
+      type: "res",
+      id: request.id,
+      ok: false,
+      error: { code: "Unauthorized", message: "Bad token." },
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      name: "GatewayRpcError",
+      method: "connect",
+      code: "Unauthorized",
+    });
+    expect(ws.closeCalls).toBe(1);
+  });
+
+  test("filters run stream events by stream id and closes after iterator return", async () => {
+    const WebSocket = fakeWebSocketCtor();
+    const client = new SmithersGatewayClient({ WebSocket });
+
+    const iterator = client.streamRunEvents({ runId: "run-1" });
+    const next = iterator.next();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    await waitForSent(ws, 1);
+    ws.receive({ type: "res", id: ws.lastRequest().id, ok: true, payload: {} });
+    await waitForSent(ws, 2);
+    ws.receive({
+      type: "res",
+      id: ws.lastRequest().id,
+      ok: true,
+      payload: { streamId: "stream-1", runId: "run-1", afterSeq: null, currentSeq: 0 },
+    });
+
+    ws.receive({
+      type: "event",
+      event: "run.event",
+      seq: 1,
+      stateVersion: 1,
+      payload: { streamId: "other", runId: "run-1" },
+    });
+    ws.receive({
+      type: "event",
+      event: "run.event",
+      seq: 2,
+      stateVersion: 1,
+      payload: { streamId: "stream-1", runId: "run-1", event: "task.completed" },
+    });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        event: "run.event",
+        seq: 2,
+        payload: { streamId: "stream-1", runId: "run-1", event: "task.completed" },
+      },
+    });
+
+    await iterator.return(undefined);
+    expect(ws.closeCalls).toBe(1);
+  });
+
+  test("streams DevTools frames through the same typed helper pattern as run events", async () => {
+    const WebSocket = fakeWebSocketCtor();
+    const client = new SmithersGatewayClient({ WebSocket });
+
+    const iterator = client.streamDevTools({ runId: "run-1", afterSeq: 2 });
+    const next = iterator.next();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    await waitForSent(ws, 1);
+    ws.receive({ type: "res", id: ws.lastRequest().id, ok: true, payload: {} });
+    await waitForSent(ws, 2);
+    ws.receive({
+      type: "res",
+      id: ws.lastRequest().id,
+      ok: true,
+      payload: { streamId: "devtools-1", runId: "run-1", afterSeq: 2 },
+    });
+
+    ws.receive({
+      type: "event",
+      event: "devtools.event",
+      seq: 1,
+      stateVersion: 1,
+      payload: { streamId: "other", runId: "run-1", event: { kind: "snapshot" } },
+    });
+    ws.receive({
+      type: "event",
+      event: "devtools.event",
+      seq: 2,
+      stateVersion: 1,
+      payload: { streamId: "devtools-1", runId: "run-1", event: { kind: "delta" } },
+    });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: {
+        event: "devtools.event",
+        seq: 2,
+        payload: { streamId: "devtools-1", runId: "run-1", event: { kind: "delta" } },
+      },
+    });
+
+    await iterator.return(undefined);
+    expect(ws.closeCalls).toBe(1);
+  });
+});

--- a/packages/gateway-react/src/useGatewayActions.ts
+++ b/packages/gateway-react/src/useGatewayActions.ts
@@ -8,8 +8,13 @@ export function useGatewayActions() {
       launchRun: client.launchRun.bind(client),
       resumeRun: client.resumeRun.bind(client),
       cancelRun: client.cancelRun.bind(client),
+      hijackRun: client.hijackRun.bind(client),
+      rewindRun: client.rewindRun.bind(client),
       submitApproval: client.submitApproval.bind(client),
       submitSignal: client.submitSignal.bind(client),
+      cronCreate: client.cronCreate.bind(client),
+      cronDelete: client.cronDelete.bind(client),
+      cronRun: client.cronRun.bind(client),
     }),
     [client],
   );

--- a/packages/gateway-react/src/useGatewayRpc.ts
+++ b/packages/gateway-react/src/useGatewayRpc.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GatewayRpcMethod } from "@smithers-orchestrator/gateway/rpc";
 import type { GatewayRpcParams, GatewayRpcPayload } from "@smithers-orchestrator/gateway-client";
 import { useSmithersGateway } from "./useSmithersGateway.ts";
@@ -13,6 +13,14 @@ export function useGatewayRpc<Method extends GatewayRpcMethod>(
   const enabled = options.enabled ?? true;
   const paramsKey = useMemo(() => JSON.stringify(params ?? {}), [params]);
   const deps = options.deps ?? [paramsKey];
+  const paramsRef = useRef(params);
+  const previousEffectRef = useRef<{
+    client: typeof client;
+    enabled: boolean;
+    method: Method;
+    deps: readonly unknown[];
+  } | undefined>(undefined);
+  paramsRef.current = params;
   const [data, setData] = useState<GatewayRpcPayload<Method>>();
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState(enabled);
@@ -24,17 +32,27 @@ export function useGatewayRpc<Method extends GatewayRpcMethod>(
     setLoading(true);
     setError(undefined);
     try {
-      setData(await client.rpc(method, params));
+      setData(await client.rpc(method, paramsRef.current));
     } catch (cause) {
       setError(cause instanceof Error ? cause : new Error(String(cause)));
     } finally {
       setLoading(false);
     }
-  }, [client, enabled, method, paramsKey]);
+  }, [client, enabled, method]);
 
   useEffect(() => {
-    void refetch();
-  }, [refetch, ...deps]);
+    const previous = previousEffectRef.current;
+    const changed = !previous ||
+      previous.client !== client ||
+      previous.enabled !== enabled ||
+      previous.method !== method ||
+      previous.deps.length !== deps.length ||
+      deps.some((dep, index) => !Object.is(dep, previous.deps[index]));
+    previousEffectRef.current = { client, enabled, method, deps: [...deps] };
+    if (changed) {
+      void refetch();
+    }
+  });
 
   return { data, error, loading, refetch };
 }

--- a/packages/gateway-react/tests/gateway-react.test.ts
+++ b/packages/gateway-react/tests/gateway-react.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import {
+  SmithersGatewayContext,
+  SmithersGatewayProvider,
+  useGatewayActions,
+  useSmithersGateway,
+} from "../src/index.ts";
+import type { SmithersGatewayClient } from "@smithers-orchestrator/gateway-client";
+
+function createSpyClient() {
+  const calls: string[] = [];
+  const client = {
+    launchRun: () => calls.push("launchRun"),
+    resumeRun: () => calls.push("resumeRun"),
+    cancelRun: () => calls.push("cancelRun"),
+    hijackRun: () => calls.push("hijackRun"),
+    rewindRun: () => calls.push("rewindRun"),
+    submitApproval: () => calls.push("submitApproval"),
+    submitSignal: () => calls.push("submitSignal"),
+    cronCreate: () => calls.push("cronCreate"),
+    cronDelete: () => calls.push("cronDelete"),
+    cronRun: () => calls.push("cronRun"),
+  } as unknown as SmithersGatewayClient;
+  return { client, calls };
+}
+
+describe("SmithersGatewayProvider", () => {
+  test("provides an explicit client through context", () => {
+    const { client } = createSpyClient();
+    let observed: SmithersGatewayClient | null = null;
+
+    renderToString(createElement(
+      SmithersGatewayProvider,
+      { client },
+      createElement(SmithersGatewayContext.Consumer, {
+        children: (value: SmithersGatewayClient | null) => {
+          observed = value;
+          return null;
+        },
+      }),
+    ));
+
+    expect(observed).toBe(client);
+  });
+});
+
+describe("useSmithersGateway", () => {
+  test("throws a clear error outside the provider", () => {
+    function Probe() {
+      useSmithersGateway();
+      return null;
+    }
+
+    expect(() => renderToString(createElement(Probe))).toThrow(
+      "useSmithersGateway() must be used inside <SmithersGatewayProvider>.",
+    );
+  });
+});
+
+describe("useGatewayActions", () => {
+  test("exposes write helpers for the full stable gateway action surface", () => {
+    const { client, calls } = createSpyClient();
+    let actions: ReturnType<typeof useGatewayActions> | undefined;
+
+    function Probe() {
+      actions = useGatewayActions();
+      return null;
+    }
+
+    renderToString(createElement(SmithersGatewayProvider, { client }, createElement(Probe)));
+
+    expect(actions).toBeDefined();
+    actions?.launchRun({ workflow: "deploy" });
+    actions?.resumeRun({ runId: "run-1" });
+    actions?.cancelRun({ runId: "run-1" });
+    actions?.hijackRun({ runId: "run-1" });
+    actions?.rewindRun({ runId: "run-1", frameNo: 1, confirm: true });
+    actions?.submitApproval({
+      runId: "run-1",
+      nodeId: "approve",
+      decision: { approved: true },
+    });
+    actions?.submitSignal({ runId: "run-1", correlationKey: "signal-1" });
+    actions?.cronCreate({ workflow: "deploy", pattern: "* * * * *" });
+    actions?.cronDelete({ cronId: "cron-1" });
+    actions?.cronRun({ workflow: "deploy" });
+
+    expect(calls).toEqual([
+      "launchRun",
+      "resumeRun",
+      "cancelRun",
+      "hijackRun",
+      "rewindRun",
+      "submitApproval",
+      "submitSignal",
+      "cronCreate",
+      "cronDelete",
+      "cronRun",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add contract tests for gateway-client HTTP RPC, WebSocket RPC, handshake, stream filtering, and malformed-frame paths
- harden gateway-client error handling for invalid HTTP/WebSocket frames, failed sends, closed sockets, aborted opens, and rejected handshakes
- add typed helpers for hijack, rewind, cron RPCs, and DevTools streams, then expose the expanded write surface through gateway-react actions
- make useGatewayRpc dependency handling lint-clean while preserving explicit dependency control

## Validation
- pnpm --filter @smithers-orchestrator/gateway-client test
- pnpm --filter @smithers-orchestrator/gateway-client typecheck
- pnpm --filter @smithers-orchestrator/gateway-react test
- pnpm --filter @smithers-orchestrator/gateway-react typecheck
- pnpm lint
- pnpm typecheck
- pnpm test