### PR TITLE
fix(cli): update .gitignore templates in smithers init

### DIFF
--- a/apps/cli/src/workflow-pack.js
+++ b/apps/cli/src/workflow-pack.js
@@ -3267,7 +3267,35 @@ function renderTemplateFiles(versions, env) {
     return [
         {
             path: ".smithers/.gitignore",
-            contents: ["node_modules/", "executions/", "runs/", "sandboxes/", "state/", "tmp/", "*.db", "*.sqlite", "dist/", ".DS_Store", ""].join("\n"),
+            contents: [
+                "# Ephemeral data (never commit)",
+                "node_modules/",
+                "executions/",
+                "runs/",
+                "sandboxes/",
+                "state/",
+                "tmp/",
+                "*.db",
+                "*.sqlite",
+                "*.db-shm",
+                "*.db-wal",
+                "dist/",
+                ".DS_Store",
+                "",
+                "# Log files",
+                "*.log",
+                "logs/",
+                ""
+            ].join("\n"),
+        },
+        {
+            path: ".smithers/workflows/.gitignore",
+            contents: [
+                "# Ignore log files in workflows",
+                "*.log",
+                "run-*.log",
+                ""
+            ].join("\n"),
         },
         {
             path: ".smithers/package.json",

--- a/apps/cli/tests/init.e2e.test.js
+++ b/apps/cli/tests/init.e2e.test.js
@@ -157,6 +157,7 @@ test("smithers init writes the expected workflow-pack layout and it typechecks",
     });
     expect(result.exitCode).toBe(0);
     expect(repo.exists(".smithers/.gitignore")).toBe(true);
+    expect(repo.exists(".smithers/workflows/.gitignore")).toBe(true);
     expect(repo.exists(".smithers/package.json")).toBe(true);
     expect(repo.exists(".smithers/tsconfig.json")).toBe(true);
     expect(repo.exists(".smithers/bunfig.toml")).toBe(true);


### PR DESCRIPTION
Updates the .gitignore files generated by smithers init to include additional ephemeral patterns.

- .smithers/.gitignore: Added SQLite WAL files (*.db-shm, *.db-wal) and log patterns (*.log, logs/)

- .smithers/workflows/.gitignore (new): Created workflow-specific ignore file for *.log and run-*.log files

- Updated E2E test to verify both .gitignore files are created