### PR TITLE
Fix URL for "Background agents are here. Your orchestration isn't ready."

### DIFF
--- a/docs/why/background-agents.mdx
+++ b/docs/why/background-agents.mdx
@@ -3,7 +3,7 @@ title: Background agents are here. Smithers is ready.
 description: Reacting line by line to a forward-looking essay on agent orchestration. Our extensions, our additions, and the one place we push back.
 ---
 
-This post is a reaction to [Background agents are here. Your orchestration isn't ready.](https://TODO-replace-with-original-essay-url) That essay is the sharpest, most forward-looking writing we've seen on the problem Smithers exists to solve, and it inspired this response. Below: specific lines from it, and what we'd add to each.
+This post is a reaction to [Background agents are here. Your orchestration isn't ready.](https://www.inngest.com/blog/background-agents-are-here-your-orchestration-isnt-ready) That essay is the sharpest, most forward-looking writing we've seen on the problem Smithers exists to solve, and it inspired this response. Below: specific lines from it, and what we'd add to each.
 
 ---
 


### PR DESCRIPTION
Updated the URL in the background agents post to the correct blog link.