### PR TITLE
Add starter gallery for seeded workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Write agent workflows as TypeScript, run them for minutes or days, and keep the 
 
 ```bash
 bunx smithers-orchestrator@latest init
+bunx smithers-orchestrator@latest starters
 ```
 
-This scaffolds a `.smithers/` folder with canonical workflows for implementation, review, debugging, planning, audits, and long-horizon missions.
+This scaffolds a `.smithers/` folder with canonical workflows for implementation, review, debugging, planning, audits, and long-horizon missions. `starters` shows plain-English outcomes like product briefs, support incident fixes, launch checklists, quality audits, and larger milestone projects, then gives you the exact command to run.
 
 Use the `smithers` CLI or Gateway console to operate runs.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Write agent workflows as TypeScript, run them for minutes or days, and keep the 
 
 ```bash
 bunx smithers-orchestrator@latest init
-bunx smithers-orchestrator@latest starters
+bunx smithers-orchestrator@latest init --template idea-to-prd
 ```
 
-This scaffolds a `.smithers/` folder with canonical workflows for implementation, review, debugging, planning, audits, and long-horizon missions. `starters` shows plain-English outcomes like product briefs, support incident fixes, launch checklists, quality audits, and larger milestone projects, then gives you the exact command to run.
+This scaffolds a `.smithers/` folder with canonical workflows for implementation, review, debugging, planning, audits, and long-horizon missions. Add `--template <id>` with a canonical starter ID when you want guided next steps for plain-English outcomes like product briefs, support incident fixes, launch checklists, quality audits, and larger milestone projects. Run `bunx smithers-orchestrator@latest starters` to browse the template IDs.
 
 Use the `smithers` CLI or Gateway console to operate runs.
 

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2744,7 +2744,7 @@ const cli = Cli.create({
             commandExitOverride = 4;
             return c.error({
                 code: "STARTER_NOT_FOUND",
-                message: `Starter not found: ${c.args.id}. Run "smithers starters" to list available starters.`,
+                message: `Starter not found: ${c.args.id}. Run "bunx smithers-orchestrator starters" to list available starters.`,
                 details: {
                     availableStarters: buildStarterGallery().starters.map((starter) => starter.id),
                 },

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -40,7 +40,7 @@ import { detectAvailableAgents } from "./agent-detection.js";
 import { listAccounts, removeAccount } from "@smithers-orchestrator/accounts";
 import { runAgentAdd, pingAccount } from "./agent-commands/runAgentAdd.js";
 import { agentAddWizard } from "./agent-commands/agentAddWizard.js";
-import { initWorkflowPack, getWorkflowFollowUpCtas } from "./workflow-pack.js";
+import { getWorkflowFollowUpCtas } from "./workflow-pack.js";
 import { discoverWorkflows, resolveWorkflow, createWorkflowFile, renderWorkflowSkill, writeWorkflowSkillFiles } from "./workflows.js";
 import {
     assertEvalRunIdsAvailable,
@@ -53,7 +53,8 @@ import {
     renderEvalReport,
     writeEvalReport,
 } from "./eval-suite.js";
-import { STARTER_TEMPLATE_IDS, buildStarterGallery, findStarterRecipe, renderStarterGallery } from "./starter-gallery.js";
+import { initOptions, runInitCommand } from "./init-command.js";
+import { startersArgs, startersOptions, runStartersCommand } from "./starter-gallery-command.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1408,26 +1409,6 @@ const revertOptions = z.object({
     attempt: z.number().int().min(1).default(1).describe("Attempt number"),
     iteration: z.number().int().min(0).default(0).describe("Loop iteration number"),
 });
-const initTemplateOption = z
-    .union(STARTER_TEMPLATE_IDS.map((id) => z.literal(id)))
-    .optional()
-    .describe("Show next steps for a canonical starter template ID after init");
-const initOptions = z.object({
-    force: z.boolean().default(false).describe("Overwrite existing scaffold files"),
-    agentsOnly: z.boolean().default(false).describe("Only create .smithers/agents/ and leave the rest of the workflow pack untouched"),
-    install: z.boolean().default(true).describe("Run `bun install` inside .smithers/ after scaffolding (--no-install to skip)"),
-    addAgents: z.boolean().default(false).describe("After scaffolding, launch the interactive `agents add` wizard to register one or more accounts."),
-    template: initTemplateOption,
-});
-const startersArgs = z.object({
-    id: z.string().optional().describe("Starter ID or alias"),
-});
-const startersOptions = z.object({
-    audience: z.string().optional().describe("Filter by audience, such as product, support, or founder"),
-    goal: z.string().optional().describe("Filter by goal, such as plan, build, debug, or quality"),
-    workflow: z.string().optional().describe("Filter by seeded workflow ID"),
-    tag: z.string().optional().describe("Filter by starter tag"),
-});
 const workflowPathArgs = z.object({
     name: z.string().describe("Workflow ID"),
 });
@@ -2685,61 +2666,7 @@ const cli = Cli.create({
             commandExitOverride = opts.exitCode ?? 1;
             return c.error(opts);
         };
-        try {
-            const selectedTemplate = c.options.template ? findStarterRecipe(c.options.template) : undefined;
-            const result = initWorkflowPack({
-                force: c.options.force,
-                agentsOnly: c.options.agentsOnly,
-                skipInstall: c.options.agentsOnly || !c.options.install,
-            });
-            if (selectedTemplate) {
-                const gallery = buildStarterGallery({ id: selectedTemplate.id });
-                result.template = gallery.selected;
-            }
-            if (c.options.addAgents) {
-                const added = await agentAddWizard({ loop: true });
-                result.addedAccounts = added;
-                // Regenerate agents.ts now that accounts are in place — the
-                // initial generateAgentsTs() call ran before any accounts
-                // existed, so it produced the detection-based file.
-                if (added.length > 0) {
-                    const { regenerateAgentsTsIfPresent } = await import("./agent-commands/regenerateAgentsTsIfPresent.js");
-                    result.regen = regenerateAgentsTsIfPresent();
-                }
-            }
-            return c.ok(result, c.options.agentsOnly
-                ? undefined
-                : {
-                    cta: {
-                        description: "Next steps:",
-                        commands: selectedTemplate
-                            ? [
-                                { command: result.template.command.replace(/^bunx smithers-orchestrator\s+/, ""), description: `Run ${result.template.id}` },
-                                { command: "starters", description: "Browse the other templates" },
-                                { command: "workflow list", description: "View all available workflows" },
-                            ]
-                            : [
-                                { command: "init --template <id>", description: "Start from a guided template" },
-                                { command: "starters", description: "Browse templates by outcome" },
-                                { command: "workflow list", description: "View all available workflows" },
-                            ],
-                    },
-                });
-        }
-        catch (err) {
-            if (err instanceof SmithersError) {
-                return fail({
-                    code: err.code,
-                    message: err.message,
-                    exitCode: 4,
-                });
-            }
-            return fail({
-                code: "INIT_FAILED",
-                message: err?.message ?? String(err),
-                exitCode: 1,
-            });
-        }
+        return runInitCommand(c, fail);
     },
 })
     // =========================================================================
@@ -2750,30 +2677,11 @@ const cli = Cli.create({
     args: startersArgs,
     options: startersOptions,
     run(c) {
-        if (c.args.id && !findStarterRecipe(c.args.id)) {
-            commandExitOverride = 4;
-            return c.error({
-                code: "STARTER_NOT_FOUND",
-                message: `Starter not found: ${c.args.id}. Run "bunx smithers-orchestrator starters" to list available starters.`,
-                details: {
-                    availableStarters: buildStarterGallery().starters.map((starter) => starter.id),
-                },
-                exitCode: 4,
-            });
-        }
-        const gallery = buildStarterGallery({
-            id: c.args.id,
-            audience: c.options.audience,
-            goal: c.options.goal,
-            workflow: c.options.workflow,
-            tag: c.options.tag,
-        });
-        const explicitFormat = process.argv.some((arg) => arg === "--format" || arg.startsWith("--format="));
-        if (explicitFormat || c.format === "json" || c.format === "jsonl") {
-            return c.ok(gallery);
-        }
-        process.stdout.write(`${renderStarterGallery(gallery)}\n`);
-        return undefined;
+        const fail = (opts) => {
+            commandExitOverride = opts.exitCode ?? 1;
+            return c.error(opts);
+        };
+        return runStartersCommand(c, fail);
     },
 })
     // =========================================================================

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -53,6 +53,7 @@ import {
     renderEvalReport,
     writeEvalReport,
 } from "./eval-suite.js";
+import { buildStarterGallery, findStarterRecipe, renderStarterGallery } from "./starter-gallery.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1413,6 +1414,15 @@ const initOptions = z.object({
     install: z.boolean().default(true).describe("Run `bun install` inside .smithers/ after scaffolding (--no-install to skip)"),
     addAgents: z.boolean().default(false).describe("After scaffolding, launch the interactive `agents add` wizard to register one or more accounts."),
 });
+const startersArgs = z.object({
+    id: z.string().optional().describe("Starter ID or alias"),
+});
+const startersOptions = z.object({
+    audience: z.string().optional().describe("Filter by audience, such as product, support, or founder"),
+    goal: z.string().optional().describe("Filter by goal, such as plan, build, debug, or quality"),
+    workflow: z.string().optional().describe("Filter by seeded workflow ID"),
+    tag: z.string().optional().describe("Filter by starter tag"),
+});
 const workflowPathArgs = z.object({
     name: z.string().describe("Workflow ID"),
 });
@@ -2694,10 +2704,12 @@ const cli = Cli.create({
                         description: "Next steps:",
                         commands: c.agent
                             ? [
+                                { command: "starters", description: "Pick a starter by outcome" },
                                 { command: "workflow list", description: "View all available workflows" },
                                 { command: "workflow run implement", description: "Run the implementation workflow" },
                             ]
                             : [
+                                { command: "starters", description: "Pick a starter by outcome" },
                                 { command: "workflow list", description: "View all available workflows" },
                                 { command: "workflow run implement", description: "Run the implementation workflow" },
                             ],
@@ -2718,6 +2730,40 @@ const cli = Cli.create({
                 exitCode: 1,
             });
         }
+    },
+})
+    // =========================================================================
+    // smithers starters [id]
+    // =========================================================================
+    .command("starters", {
+    description: "Show plain-English starter workflows with copy-paste commands.",
+    args: startersArgs,
+    options: startersOptions,
+    run(c) {
+        if (c.args.id && !findStarterRecipe(c.args.id)) {
+            commandExitOverride = 4;
+            return c.error({
+                code: "STARTER_NOT_FOUND",
+                message: `Starter not found: ${c.args.id}. Run "smithers starters" to list available starters.`,
+                details: {
+                    availableStarters: buildStarterGallery().starters.map((starter) => starter.id),
+                },
+                exitCode: 4,
+            });
+        }
+        const gallery = buildStarterGallery({
+            id: c.args.id,
+            audience: c.options.audience,
+            goal: c.options.goal,
+            workflow: c.options.workflow,
+            tag: c.options.tag,
+        });
+        const explicitFormat = process.argv.some((arg) => arg === "--format" || arg.startsWith("--format="));
+        if (explicitFormat || c.format === "json" || c.format === "jsonl") {
+            return c.ok(gallery);
+        }
+        process.stdout.write(`${renderStarterGallery(gallery)}\n`);
+        return undefined;
     },
 })
     // =========================================================================

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -53,7 +53,7 @@ import {
     renderEvalReport,
     writeEvalReport,
 } from "./eval-suite.js";
-import { buildStarterGallery, findStarterRecipe, renderStarterGallery } from "./starter-gallery.js";
+import { STARTER_TEMPLATE_IDS, buildStarterGallery, findStarterRecipe, renderStarterGallery } from "./starter-gallery.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1408,11 +1408,16 @@ const revertOptions = z.object({
     attempt: z.number().int().min(1).default(1).describe("Attempt number"),
     iteration: z.number().int().min(0).default(0).describe("Loop iteration number"),
 });
+const initTemplateOption = z
+    .union(STARTER_TEMPLATE_IDS.map((id) => z.literal(id)))
+    .optional()
+    .describe("Show next steps for a canonical starter template ID after init");
 const initOptions = z.object({
     force: z.boolean().default(false).describe("Overwrite existing scaffold files"),
     agentsOnly: z.boolean().default(false).describe("Only create .smithers/agents/ and leave the rest of the workflow pack untouched"),
     install: z.boolean().default(true).describe("Run `bun install` inside .smithers/ after scaffolding (--no-install to skip)"),
     addAgents: z.boolean().default(false).describe("After scaffolding, launch the interactive `agents add` wizard to register one or more accounts."),
+    template: initTemplateOption,
 });
 const startersArgs = z.object({
     id: z.string().optional().describe("Starter ID or alias"),
@@ -2681,11 +2686,16 @@ const cli = Cli.create({
             return c.error(opts);
         };
         try {
+            const selectedTemplate = c.options.template ? findStarterRecipe(c.options.template) : undefined;
             const result = initWorkflowPack({
                 force: c.options.force,
                 agentsOnly: c.options.agentsOnly,
                 skipInstall: c.options.agentsOnly || !c.options.install,
             });
+            if (selectedTemplate) {
+                const gallery = buildStarterGallery({ id: selectedTemplate.id });
+                result.template = gallery.selected;
+            }
             if (c.options.addAgents) {
                 const added = await agentAddWizard({ loop: true });
                 result.addedAccounts = added;
@@ -2702,16 +2712,16 @@ const cli = Cli.create({
                 : {
                     cta: {
                         description: "Next steps:",
-                        commands: c.agent
+                        commands: selectedTemplate
                             ? [
-                                { command: "starters", description: "Pick a starter by outcome" },
+                                { command: result.template.command.replace(/^bunx smithers-orchestrator\s+/, ""), description: `Run ${result.template.id}` },
+                                { command: "starters", description: "Browse the other templates" },
                                 { command: "workflow list", description: "View all available workflows" },
-                                { command: "workflow run implement", description: "Run the implementation workflow" },
                             ]
                             : [
-                                { command: "starters", description: "Pick a starter by outcome" },
+                                { command: "init --template <id>", description: "Start from a guided template" },
+                                { command: "starters", description: "Browse templates by outcome" },
                                 { command: "workflow list", description: "View all available workflows" },
-                                { command: "workflow run implement", description: "Run the implementation workflow" },
                             ],
                     },
                 });

--- a/apps/cli/src/init-command.js
+++ b/apps/cli/src/init-command.js
@@ -1,0 +1,81 @@
+import { z } from "incur";
+import { SmithersError } from "@smithers-orchestrator/errors";
+import { agentAddWizard } from "./agent-commands/agentAddWizard.js";
+import { STARTER_TEMPLATE_IDS, buildStarterGallery, findStarterRecipe } from "./starter-gallery.js";
+import { initWorkflowPack } from "./workflow-pack.js";
+
+const initTemplateOption = z
+    .union(STARTER_TEMPLATE_IDS.map((id) => z.literal(id)))
+    .optional()
+    .describe("Show next steps for a canonical starter template ID after init");
+
+export const initOptions = z.object({
+    force: z.boolean().default(false).describe("Overwrite existing scaffold files"),
+    agentsOnly: z.boolean().default(false).describe("Only create .smithers/agents/ and leave the rest of the workflow pack untouched"),
+    install: z.boolean().default(true).describe("Run `bun install` inside .smithers/ after scaffolding (--no-install to skip)"),
+    addAgents: z.boolean().default(false).describe("After scaffolding, launch the interactive `agents add` wizard to register one or more accounts."),
+    template: initTemplateOption,
+});
+
+/**
+ * @param {{ options: any; ok: (...args: any[]) => any; error: (...args: any[]) => any }} c
+ * @param {(opts: { code: string; message: string; exitCode?: number; details?: Record<string, unknown> }) => any} fail
+ */
+export async function runInitCommand(c, fail) {
+    try {
+        const selectedTemplate = c.options.template ? findStarterRecipe(c.options.template) : undefined;
+        const result = initWorkflowPack({
+            force: c.options.force,
+            agentsOnly: c.options.agentsOnly,
+            skipInstall: c.options.agentsOnly || !c.options.install,
+        });
+        const templateResult = selectedTemplate
+            ? buildStarterGallery({ id: selectedTemplate.id }).selected
+            : undefined;
+        if (templateResult) {
+            result.template = templateResult;
+        }
+        if (c.options.addAgents) {
+            const added = await agentAddWizard({ loop: true });
+            result.addedAccounts = added;
+            // Regenerate agents.ts now that accounts are in place; the initial
+            // generateAgentsTs() call ran before any accounts were registered.
+            if (added.length > 0) {
+                const { regenerateAgentsTsIfPresent } = await import("./agent-commands/regenerateAgentsTsIfPresent.js");
+                result.regen = regenerateAgentsTsIfPresent();
+            }
+        }
+        return c.ok(result, c.options.agentsOnly
+            ? undefined
+            : {
+                cta: {
+                    description: "Next steps:",
+                    commands: templateResult
+                        ? [
+                            { command: templateResult.command.replace(/^bunx smithers-orchestrator\s+/, ""), description: `Run ${templateResult.id}` },
+                            { command: "starters", description: "Browse the other templates" },
+                            { command: "workflow list", description: "View all available workflows" },
+                        ]
+                        : [
+                            { command: "init --template <id>", description: "Start from a guided template" },
+                            { command: "starters", description: "Browse templates by outcome" },
+                            { command: "workflow list", description: "View all available workflows" },
+                        ],
+                },
+            });
+    }
+    catch (err) {
+        if (err instanceof SmithersError) {
+            return fail({
+                code: err.code,
+                message: err.message,
+                exitCode: 4,
+            });
+        }
+        return fail({
+            code: "INIT_FAILED",
+            message: err?.message ?? String(err),
+            exitCode: 1,
+        });
+    }
+}

--- a/apps/cli/src/starter-gallery-command.js
+++ b/apps/cli/src/starter-gallery-command.js
@@ -1,0 +1,43 @@
+import { z } from "incur";
+import { buildStarterGallery, findStarterRecipe, renderStarterGallery } from "./starter-gallery.js";
+
+export const startersArgs = z.object({
+    id: z.string().optional().describe("Starter ID or alias"),
+});
+
+export const startersOptions = z.object({
+    audience: z.string().optional().describe("Filter by audience, such as product, support, or founder"),
+    goal: z.string().optional().describe("Filter by goal, such as plan, build, debug, or quality"),
+    workflow: z.string().optional().describe("Filter by seeded workflow ID"),
+    tag: z.string().optional().describe("Filter by starter tag"),
+});
+
+/**
+ * @param {{ args: any; options: any; format?: string; ok: (...args: any[]) => any; error: (...args: any[]) => any }} c
+ * @param {(opts: { code: string; message: string; exitCode?: number; details?: Record<string, unknown> }) => any} fail
+ */
+export function runStartersCommand(c, fail) {
+    if (c.args.id && !findStarterRecipe(c.args.id)) {
+        return fail({
+            code: "STARTER_NOT_FOUND",
+            message: `Starter not found: ${c.args.id}. Run "bunx smithers-orchestrator starters" to list available starters.`,
+            details: {
+                availableStarters: buildStarterGallery().starters.map((starter) => starter.id),
+            },
+            exitCode: 4,
+        });
+    }
+    const gallery = buildStarterGallery({
+        id: c.args.id,
+        audience: c.options.audience,
+        goal: c.options.goal,
+        workflow: c.options.workflow,
+        tag: c.options.tag,
+    });
+    const explicitFormat = process.argv.some((arg) => arg === "--format" || arg.startsWith("--format="));
+    if (explicitFormat || c.format === "json" || c.format === "jsonl") {
+        return c.ok(gallery);
+    }
+    process.stdout.write(`${renderStarterGallery(gallery)}\n`);
+    return undefined;
+}

--- a/apps/cli/src/starter-gallery.js
+++ b/apps/cli/src/starter-gallery.js
@@ -1,0 +1,414 @@
+const INSTALL_COMMAND = "smithers init --add-agents";
+
+export const STARTER_AUDIENCES = [
+    "founder",
+    "product",
+    "operations",
+    "support",
+    "marketing",
+    "quality",
+    "engineering",
+];
+
+export const STARTER_GOALS = [
+    "plan",
+    "research",
+    "build",
+    "debug",
+    "review",
+    "quality",
+    "coordinate",
+];
+
+/**
+ * @typedef {{
+ *   id: string;
+ *   aliases: string[];
+ *   title: string;
+ *   audience: string[];
+ *   goals: string[];
+ *   workflow: string;
+ *   outcome: string;
+ *   setup: string[];
+ *   prompt: string;
+ *   followUps: string[];
+ *   goodFor: string[];
+ *   avoidWhen: string;
+ *   tags: string[];
+ * }} StarterRecipe
+ */
+
+/** @type {StarterRecipe[]} */
+export const STARTER_RECIPES = [
+    {
+        id: "idea-to-prd",
+        aliases: ["prd", "product-brief"],
+        title: "Turn a rough idea into a product brief",
+        audience: ["founder", "product", "marketing"],
+        goals: ["plan"],
+        workflow: "write-a-prd",
+        outcome: "A structured PRD with goals, users, scope, risks, launch notes, and open questions.",
+        setup: [
+            "Collect any notes, customer quotes, links, screenshots, or constraints in the prompt.",
+            "Name the user, business goal, and deadline if those are known.",
+        ],
+        prompt: "Draft a PRD for a self-serve onboarding flow that helps new customers finish setup in under ten minutes.",
+        followUps: [
+            "smithers workflow run tickets-create --prompt \"Break this PRD into implementation tickets\"",
+            "smithers workflow run grill-me --prompt \"Interview me until the unclear PRD requirements are actionable\"",
+        ],
+        goodFor: ["new feature ideas", "executive alignment", "scope decisions"],
+        avoidWhen: "You already have implementation-ready tickets.",
+        tags: ["product", "requirements", "launch"],
+    },
+    {
+        id: "idea-to-tickets",
+        aliases: ["tickets", "project-plan"],
+        title: "Break a project into implementation tickets",
+        audience: ["founder", "product", "operations", "engineering"],
+        goals: ["plan", "coordinate"],
+        workflow: "tickets-create",
+        outcome: "A batch of scoped tickets that can be assigned, reviewed, and tracked.",
+        setup: [
+            "Start from a PRD, customer request, incident summary, or internal project note.",
+            "Mention deadlines, dependencies, owners, and must-not-break constraints.",
+        ],
+        prompt: "Break our billing cleanup project into tickets. Include data migration, customer messaging, QA, rollback, and owner handoff work.",
+        followUps: [
+            "smithers workflow run kanban --prompt \"Implement the tickets in .smithers/tickets\"",
+            "smithers workflow run plan --prompt \"Sequence these tickets into milestones\"",
+        ],
+        goodFor: ["roadmap planning", "handoffs", "large changes"],
+        avoidWhen: "The request is still too vague to estimate.",
+        tags: ["tickets", "planning", "coordination"],
+    },
+    {
+        id: "launch-checklist",
+        aliases: ["launch", "release-plan"],
+        title: "Prepare a launch checklist",
+        audience: ["founder", "product", "marketing", "operations"],
+        goals: ["plan", "coordinate"],
+        workflow: "plan",
+        outcome: "A launch plan with phases, owners, validation gates, communications, and rollback checks.",
+        setup: [
+            "Provide the launch date, intended audience, channels, and known risk areas.",
+            "Include any docs, analytics, or support constraints that should be checked.",
+        ],
+        prompt: "Create a launch checklist for releasing team invitations to all customers next Friday.",
+        followUps: [
+            "smithers workflow run review --prompt \"Review this launch plan for missed risks\"",
+            "smithers workflow run ticket-create --prompt \"Create one ticket for the highest-risk launch gap\"",
+        ],
+        goodFor: ["go-to-market work", "internal rollouts", "customer-facing releases"],
+        avoidWhen: "The launch owner has not approved the scope.",
+        tags: ["launch", "operations", "planning"],
+    },
+    {
+        id: "customer-incident",
+        aliases: ["incident", "support-debug"],
+        title: "Turn a customer report into a fix path",
+        audience: ["support", "operations", "engineering"],
+        goals: ["debug", "coordinate"],
+        workflow: "debug",
+        outcome: "A reproduction plan, suspected root cause, fix, validation notes, and customer-safe summary.",
+        setup: [
+            "Paste the customer report, timestamps, account details that are safe to share, and expected behavior.",
+            "Include logs or screenshots when available.",
+        ],
+        prompt: "A customer says exports fail after selecting more than 500 rows. Reproduce the issue, fix it, and summarize customer impact.",
+        followUps: [
+            "smithers workflow run review --prompt \"Review the incident fix and customer summary\"",
+            "smithers workflow run audit --prompt \"Find similar export reliability risks\"",
+        ],
+        goodFor: ["support escalations", "bug reports", "urgent regressions"],
+        avoidWhen: "The report contains secrets that should not be sent to local tools.",
+        tags: ["support", "debugging", "incident"],
+    },
+    {
+        id: "nontechnical-research",
+        aliases: ["research-brief", "market-research"],
+        title: "Create a research brief before committing work",
+        audience: ["founder", "product", "marketing", "operations"],
+        goals: ["research", "plan"],
+        workflow: "research",
+        outcome: "A grounded brief with findings, assumptions, tradeoffs, and recommended next steps.",
+        setup: [
+            "Ask a specific question and list any sources, competitors, docs, or constraints to consider.",
+            "Say whether you want a decision, a summary, or a list of options.",
+        ],
+        prompt: "Research whether we should add a public template gallery. Compare user value, maintenance cost, and launch risk.",
+        followUps: [
+            "smithers workflow run write-a-prd --prompt \"Turn this research into a PRD\"",
+            "smithers workflow run plan --prompt \"Make a practical execution plan from this research\"",
+        ],
+        goodFor: ["strategy questions", "competitive scans", "before-build decisions"],
+        avoidWhen: "The answer depends on live private data that is not available in the repo.",
+        tags: ["research", "strategy", "brief"],
+    },
+    {
+        id: "requirements-interview",
+        aliases: ["clarify", "discovery"],
+        title: "Clarify a vague request",
+        audience: ["founder", "product", "support", "engineering"],
+        goals: ["plan"],
+        workflow: "grill-me",
+        outcome: "A tighter requirement set after the workflow asks targeted questions.",
+        setup: [
+            "Start with the messy request exactly as it came in.",
+            "Answer the questions directly; the point is to remove ambiguity before work starts.",
+        ],
+        prompt: "We need a better admin experience for enterprise customers, but the scope is unclear.",
+        followUps: [
+            "smithers workflow run write-a-prd --prompt \"Turn the clarified requirements into a PRD\"",
+            "smithers workflow run tickets-create --prompt \"Create tickets from the clarified requirements\"",
+        ],
+        goodFor: ["ambiguous stakeholder asks", "sales feedback", "pre-ticket discovery"],
+        avoidWhen: "You need implementation work immediately and already know the scope.",
+        tags: ["requirements", "discovery", "planning"],
+    },
+    {
+        id: "quality-audit",
+        aliases: ["audit", "risk-audit"],
+        title: "Audit a product area for quality gaps",
+        audience: ["quality", "product", "engineering", "operations"],
+        goals: ["quality", "review"],
+        workflow: "audit",
+        outcome: "A prioritized list of missing tests, docs, observability, reliability, and maintainability gaps.",
+        setup: [
+            "Name the feature area or workflow to inspect.",
+            "Mention the standard you care about: reliability, speed, safety, supportability, or docs.",
+        ],
+        prompt: "Audit the checkout flow for missing tests, unclear docs, weak observability, and support risks.",
+        followUps: [
+            "smithers workflow run improve-test-coverage --prompt \"Add the highest-impact missing tests from this audit\"",
+            "smithers workflow run ticket-create --prompt \"Create a ticket for the top audit finding\"",
+        ],
+        goodFor: ["release readiness", "technical debt triage", "risk reviews"],
+        avoidWhen: "You only need a single known bug fixed.",
+        tags: ["audit", "quality", "risk"],
+    },
+    {
+        id: "test-coverage",
+        aliases: ["coverage", "tests"],
+        title: "Add high-impact test coverage",
+        audience: ["quality", "engineering", "product"],
+        goals: ["quality", "build"],
+        workflow: "improve-test-coverage",
+        outcome: "Focused tests around behavior that matters, with validation that the suite still passes.",
+        setup: [
+            "Name the feature, package, or bug class where coverage is weak.",
+            "Call out user-visible behavior and risky edge cases.",
+        ],
+        prompt: "Improve test coverage for subscription downgrade behavior, especially invoices, entitlements, and rollback cases.",
+        followUps: [
+            "smithers workflow run review --prompt \"Review the new tests for meaningful assertions\"",
+            "smithers workflow run audit --prompt \"Find the next highest-value coverage gap\"",
+        ],
+        goodFor: ["pre-release hardening", "regression prevention", "quality drives"],
+        avoidWhen: "The feature is still changing too quickly for durable tests.",
+        tags: ["tests", "quality", "coverage"],
+    },
+    {
+        id: "ship-a-change",
+        aliases: ["build", "implement"],
+        title: "Ship a focused change",
+        audience: ["founder", "product", "engineering"],
+        goals: ["build"],
+        workflow: "research-plan-implement",
+        outcome: "Research, an implementation plan, code changes, validation, and review loops in one run.",
+        setup: [
+            "Give the exact user outcome and any files, APIs, screenshots, or acceptance criteria.",
+            "Keep the first request narrow enough to review in one pull request.",
+        ],
+        prompt: "Add a first-run checklist that helps a new workspace owner invite teammates and finish setup.",
+        followUps: [
+            "smithers workflow run review --prompt \"Review the completed change before opening a PR\"",
+            "smithers workflow run debug --prompt \"Fix the most important failure found during validation\"",
+        ],
+        goodFor: ["product polish", "small features", "workflow improvements"],
+        avoidWhen: "The change needs executive or legal approval before implementation.",
+        tags: ["implementation", "feature", "shipping"],
+    },
+    {
+        id: "mission-mode",
+        aliases: ["large-project", "milestones"],
+        title: "Run a larger project in approved milestones",
+        audience: ["founder", "product", "engineering", "operations"],
+        goals: ["build", "coordinate"],
+        workflow: "mission",
+        outcome: "A milestone plan, checkpoint approvals, focused workers, validation, and a final delivery summary.",
+        setup: [
+            "Write the desired end state and constraints.",
+            "Be ready to approve or revise milestones before execution continues.",
+        ],
+        prompt: "Modernize the onboarding funnel across copy, setup tasks, analytics, and support handoff without changing billing behavior.",
+        followUps: [
+            "smithers ps",
+            "smithers inspect <run-id>",
+        ],
+        goodFor: ["multi-step projects", "cross-functional work", "large refactors"],
+        avoidWhen: "The work should be a quick one-file change.",
+        tags: ["milestones", "coordination", "shipping"],
+    },
+];
+
+/**
+ * @param {string} value
+ */
+function normalize(value) {
+    return value.trim().toLowerCase();
+}
+
+/**
+ * @param {string} value
+ */
+function shellQuote(value) {
+    return `"${value.replace(/["\\$`]/g, "\\$&").replace(/\r?\n/g, "\\n")}"`;
+}
+
+/**
+ * @param {StarterRecipe} recipe
+ */
+export function starterCommand(recipe) {
+    return `smithers workflow run ${recipe.workflow} --prompt ${shellQuote(recipe.prompt)}`;
+}
+
+/**
+ * @param {StarterRecipe} recipe
+ */
+function starterSummary(recipe) {
+    return {
+        id: recipe.id,
+        title: recipe.title,
+        audience: recipe.audience,
+        goals: recipe.goals,
+        workflow: recipe.workflow,
+        outcome: recipe.outcome,
+        command: starterCommand(recipe),
+        tags: recipe.tags,
+    };
+}
+
+/**
+ * @param {string | undefined} id
+ */
+export function findStarterRecipe(id) {
+    if (!id)
+        return undefined;
+    const key = normalize(id);
+    return STARTER_RECIPES.find((recipe) => recipe.id === key || recipe.aliases.includes(key));
+}
+
+/**
+ * @param {{ audience?: string; goal?: string; workflow?: string; tag?: string }} [filters]
+ */
+export function listStarterRecipes(filters = {}) {
+    const audience = filters.audience ? normalize(filters.audience) : undefined;
+    const goal = filters.goal ? normalize(filters.goal) : undefined;
+    const workflow = filters.workflow ? normalize(filters.workflow) : undefined;
+    const tag = filters.tag ? normalize(filters.tag) : undefined;
+    return STARTER_RECIPES.filter((recipe) => {
+        if (audience && !recipe.audience.includes(audience))
+            return false;
+        if (goal && !recipe.goals.includes(goal))
+            return false;
+        if (workflow && recipe.workflow !== workflow)
+            return false;
+        if (tag && !recipe.tags.includes(tag))
+            return false;
+        return true;
+    });
+}
+
+/**
+ * @param {{ id?: string; audience?: string; goal?: string; workflow?: string; tag?: string }} [input]
+ */
+export function buildStarterGallery(input = {}) {
+    const selected = input.id ? findStarterRecipe(input.id) : undefined;
+    const filters = {
+        audience: input.audience ?? null,
+        goal: input.goal ?? null,
+        workflow: input.workflow ?? null,
+        tag: input.tag ?? null,
+    };
+    const recipes = selected ? [selected] : listStarterRecipes(input);
+    return {
+        installCommand: INSTALL_COMMAND,
+        filters,
+        count: recipes.length,
+        audiences: STARTER_AUDIENCES,
+        goals: STARTER_GOALS,
+        selected: selected
+            ? {
+                ...selected,
+                command: starterCommand(selected),
+            }
+            : null,
+        starters: recipes.map(starterSummary),
+    };
+}
+
+/**
+ * @param {string[]} values
+ */
+function renderInlineList(values) {
+    return values.length > 0 ? values.join(", ") : "none";
+}
+
+/**
+ * @param {ReturnType<typeof buildStarterGallery>} gallery
+ */
+export function renderStarterGallery(gallery) {
+    const lines = [];
+    if (gallery.selected) {
+        const recipe = gallery.selected;
+        lines.push(recipe.title);
+        lines.push("");
+        lines.push(`Starter ID: ${recipe.id}`);
+        lines.push(`Best for: ${renderInlineList(recipe.audience)}`);
+        lines.push(`Goals: ${renderInlineList(recipe.goals)}`);
+        lines.push(`Workflow: ${recipe.workflow}`);
+        lines.push("");
+        lines.push("Outcome:");
+        lines.push(recipe.outcome);
+        lines.push("");
+        lines.push("Before you run it:");
+        for (const step of recipe.setup) {
+            lines.push(`- ${step}`);
+        }
+        lines.push("");
+        lines.push("Run:");
+        lines.push(recipe.command);
+        lines.push("");
+        lines.push("Useful follow-ups:");
+        for (const command of recipe.followUps) {
+            lines.push(`- ${command}`);
+        }
+        lines.push("");
+        lines.push(`Good for: ${renderInlineList(recipe.goodFor)}`);
+        lines.push(`Avoid when: ${recipe.avoidWhen}`);
+        return lines.join("\n");
+    }
+    lines.push("Smithers starters");
+    lines.push("");
+    lines.push("Pick a plain-English outcome, run one command, and let the seeded workflow do the structured work.");
+    lines.push(`First-time setup: ${gallery.installCommand}`);
+    lines.push("");
+    if (gallery.count === 0) {
+        lines.push("No starters matched those filters.");
+        lines.push("Try: smithers starters --audience product");
+        lines.push("Try: smithers starters --goal quality");
+        return lines.join("\n");
+    }
+    for (const starter of gallery.starters) {
+        lines.push(`${starter.id}`);
+        lines.push(`  ${starter.title}`);
+        lines.push(`  For: ${renderInlineList(starter.audience)} | Goals: ${renderInlineList(starter.goals)} | Workflow: ${starter.workflow}`);
+        lines.push(`  Outcome: ${starter.outcome}`);
+        lines.push(`  Run: ${starter.command}`);
+        lines.push("");
+    }
+    lines.push("Use `smithers starters <id>` for setup notes and follow-ups.");
+    lines.push("Filter examples: `smithers starters --audience product`, `smithers starters --goal quality`, `smithers starters --workflow debug`.");
+    return lines.join("\n");
+}

--- a/apps/cli/src/starter-gallery.js
+++ b/apps/cli/src/starter-gallery.js
@@ -1,4 +1,28 @@
-const INSTALL_COMMAND = "smithers init --add-agents";
+const CLI_COMMAND = "bunx smithers-orchestrator";
+const INSTALL_COMMAND = `${CLI_COMMAND} init --add-agents`;
+
+/**
+ * @param {string} args
+ */
+function cliCommand(args) {
+    return `${CLI_COMMAND} ${args}`;
+}
+
+/**
+ * @param {string} workflow
+ * @param {string} prompt
+ */
+function workflowPromptCommand(workflow, prompt) {
+    return cliCommand(`workflow run ${workflow} --prompt ${shellQuote(prompt)}`);
+}
+
+/**
+ * @param {string} workflow
+ * @param {Record<string, unknown>} input
+ */
+function workflowInputCommand(workflow, input) {
+    return cliCommand(`workflow run ${workflow} --input ${shellQuote(JSON.stringify(input))}`);
+}
 
 export const STARTER_AUDIENCES = [
     "founder",
@@ -31,6 +55,7 @@ export const STARTER_GOALS = [
  *   outcome: string;
  *   setup: string[];
  *   prompt: string;
+ *   input?: Record<string, unknown>;
  *   followUps: string[];
  *   goodFor: string[];
  *   avoidWhen: string;
@@ -54,8 +79,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Draft a PRD for a self-serve onboarding flow that helps new customers finish setup in under ten minutes.",
         followUps: [
-            "smithers workflow run tickets-create --prompt \"Break this PRD into implementation tickets\"",
-            "smithers workflow run grill-me --prompt \"Interview me until the unclear PRD requirements are actionable\"",
+            workflowPromptCommand("tickets-create", "Break this PRD into implementation tickets"),
+            workflowPromptCommand("grill-me", "Interview me until the unclear PRD requirements are actionable"),
         ],
         goodFor: ["new feature ideas", "executive alignment", "scope decisions"],
         avoidWhen: "You already have implementation-ready tickets.",
@@ -75,8 +100,9 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Break our billing cleanup project into tickets. Include data migration, customer messaging, QA, rollback, and owner handoff work.",
         followUps: [
-            "smithers workflow run kanban --prompt \"Implement the tickets in .smithers/tickets\"",
-            "smithers workflow run plan --prompt \"Sequence these tickets into milestones\"",
+            "Save each generated ticket as a Markdown file under `.smithers/tickets/`.",
+            workflowInputCommand("kanban", { maxConcurrency: 3 }),
+            workflowPromptCommand("plan", "Sequence these tickets into milestones"),
         ],
         goodFor: ["roadmap planning", "handoffs", "large changes"],
         avoidWhen: "The request is still too vague to estimate.",
@@ -96,8 +122,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Create a launch checklist for releasing team invitations to all customers next Friday.",
         followUps: [
-            "smithers workflow run review --prompt \"Review this launch plan for missed risks\"",
-            "smithers workflow run ticket-create --prompt \"Create one ticket for the highest-risk launch gap\"",
+            workflowPromptCommand("review", "Review this launch plan for missed risks"),
+            workflowPromptCommand("ticket-create", "Create one ticket for the highest-risk launch gap"),
         ],
         goodFor: ["go-to-market work", "internal rollouts", "customer-facing releases"],
         avoidWhen: "The launch owner has not approved the scope.",
@@ -117,8 +143,12 @@ export const STARTER_RECIPES = [
         ],
         prompt: "A customer says exports fail after selecting more than 500 rows. Reproduce the issue, fix it, and summarize customer impact.",
         followUps: [
-            "smithers workflow run review --prompt \"Review the incident fix and customer summary\"",
-            "smithers workflow run audit --prompt \"Find similar export reliability risks\"",
+            workflowPromptCommand("review", "Review the incident fix and customer summary"),
+            workflowInputCommand("audit", {
+                features: { exports: ["bulk export reliability"] },
+                focus: "reliability",
+                additionalContext: "Find similar export reliability risks.",
+            }),
         ],
         goodFor: ["support escalations", "bug reports", "urgent regressions"],
         avoidWhen: "The report contains secrets that should not be sent to local tools.",
@@ -138,8 +168,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Research whether we should add a public template gallery. Compare user value, maintenance cost, and launch risk.",
         followUps: [
-            "smithers workflow run write-a-prd --prompt \"Turn this research into a PRD\"",
-            "smithers workflow run plan --prompt \"Make a practical execution plan from this research\"",
+            workflowPromptCommand("write-a-prd", "Turn this research into a PRD"),
+            workflowPromptCommand("plan", "Make a practical execution plan from this research"),
         ],
         goodFor: ["strategy questions", "competitive scans", "before-build decisions"],
         avoidWhen: "The answer depends on live private data that is not available in the repo.",
@@ -159,8 +189,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "We need a better admin experience for enterprise customers, but the scope is unclear.",
         followUps: [
-            "smithers workflow run write-a-prd --prompt \"Turn the clarified requirements into a PRD\"",
-            "smithers workflow run tickets-create --prompt \"Create tickets from the clarified requirements\"",
+            workflowPromptCommand("write-a-prd", "Turn the clarified requirements into a PRD"),
+            workflowPromptCommand("tickets-create", "Create tickets from the clarified requirements"),
         ],
         goodFor: ["ambiguous stakeholder asks", "sales feedback", "pre-ticket discovery"],
         avoidWhen: "You need implementation work immediately and already know the scope.",
@@ -179,9 +209,14 @@ export const STARTER_RECIPES = [
             "Mention the standard you care about: reliability, speed, safety, supportability, or docs.",
         ],
         prompt: "Audit the checkout flow for missing tests, unclear docs, weak observability, and support risks.",
+        input: {
+            features: { checkout: ["checkout flow"] },
+            focus: "release readiness",
+            additionalContext: "Audit the checkout flow for missing tests, unclear docs, weak observability, and support risks.",
+        },
         followUps: [
-            "smithers workflow run improve-test-coverage --prompt \"Add the highest-impact missing tests from this audit\"",
-            "smithers workflow run ticket-create --prompt \"Create a ticket for the top audit finding\"",
+            workflowPromptCommand("improve-test-coverage", "Add the highest-impact missing tests from this audit"),
+            workflowPromptCommand("ticket-create", "Create a ticket for the top audit finding"),
         ],
         goodFor: ["release readiness", "technical debt triage", "risk reviews"],
         avoidWhen: "You only need a single known bug fixed.",
@@ -201,8 +236,12 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Improve test coverage for subscription downgrade behavior, especially invoices, entitlements, and rollback cases.",
         followUps: [
-            "smithers workflow run review --prompt \"Review the new tests for meaningful assertions\"",
-            "smithers workflow run audit --prompt \"Find the next highest-value coverage gap\"",
+            workflowPromptCommand("review", "Review the new tests for meaningful assertions"),
+            workflowInputCommand("audit", {
+                features: { coverage: ["test coverage"] },
+                focus: "coverage",
+                additionalContext: "Find the next highest-value coverage gap.",
+            }),
         ],
         goodFor: ["pre-release hardening", "regression prevention", "quality drives"],
         avoidWhen: "The feature is still changing too quickly for durable tests.",
@@ -222,8 +261,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Add a first-run checklist that helps a new workspace owner invite teammates and finish setup.",
         followUps: [
-            "smithers workflow run review --prompt \"Review the completed change before opening a PR\"",
-            "smithers workflow run debug --prompt \"Fix the most important failure found during validation\"",
+            workflowPromptCommand("review", "Review the completed change before opening a PR"),
+            workflowPromptCommand("debug", "Fix the most important failure found during validation"),
         ],
         goodFor: ["product polish", "small features", "workflow improvements"],
         avoidWhen: "The change needs executive or legal approval before implementation.",
@@ -243,8 +282,8 @@ export const STARTER_RECIPES = [
         ],
         prompt: "Modernize the onboarding funnel across copy, setup tasks, analytics, and support handoff without changing billing behavior.",
         followUps: [
-            "smithers ps",
-            "smithers inspect <run-id>",
+            cliCommand("ps"),
+            cliCommand("inspect <run-id>"),
         ],
         goodFor: ["multi-step projects", "cross-functional work", "large refactors"],
         avoidWhen: "The work should be a quick one-file change.",
@@ -270,7 +309,9 @@ function shellQuote(value) {
  * @param {StarterRecipe} recipe
  */
 export function starterCommand(recipe) {
-    return `smithers workflow run ${recipe.workflow} --prompt ${shellQuote(recipe.prompt)}`;
+    return recipe.input
+        ? workflowInputCommand(recipe.workflow, recipe.input)
+        : workflowPromptCommand(recipe.workflow, recipe.prompt);
 }
 
 /**
@@ -396,8 +437,8 @@ export function renderStarterGallery(gallery) {
     lines.push("");
     if (gallery.count === 0) {
         lines.push("No starters matched those filters.");
-        lines.push("Try: smithers starters --audience product");
-        lines.push("Try: smithers starters --goal quality");
+        lines.push(`Try: ${cliCommand("starters --audience product")}`);
+        lines.push(`Try: ${cliCommand("starters --goal quality")}`);
         return lines.join("\n");
     }
     for (const starter of gallery.starters) {
@@ -408,7 +449,7 @@ export function renderStarterGallery(gallery) {
         lines.push(`  Run: ${starter.command}`);
         lines.push("");
     }
-    lines.push("Use `smithers starters <id>` for setup notes and follow-ups.");
-    lines.push("Filter examples: `smithers starters --audience product`, `smithers starters --goal quality`, `smithers starters --workflow debug`.");
+    lines.push(`Use \`${cliCommand("starters <id>")}\` for setup notes and follow-ups.`);
+    lines.push(`Filter examples: \`${cliCommand("starters --audience product")}\`, \`${cliCommand("starters --goal quality")}\`, \`${cliCommand("starters --workflow debug")}\`.`);
     return lines.join("\n");
 }

--- a/apps/cli/src/starter-gallery.js
+++ b/apps/cli/src/starter-gallery.js
@@ -291,6 +291,8 @@ export const STARTER_RECIPES = [
     },
 ];
 
+export const STARTER_TEMPLATE_IDS = STARTER_RECIPES.map((recipe) => recipe.id);
+
 /**
  * @param {string} value
  */
@@ -405,7 +407,7 @@ export function renderStarterGallery(gallery) {
         const recipe = gallery.selected;
         lines.push(recipe.title);
         lines.push("");
-        lines.push(`Starter ID: ${recipe.id}`);
+        lines.push(`Template ID: ${recipe.id}`);
         lines.push(`Best for: ${renderInlineList(recipe.audience)}`);
         lines.push(`Goals: ${renderInlineList(recipe.goals)}`);
         lines.push(`Workflow: ${recipe.workflow}`);
@@ -432,7 +434,7 @@ export function renderStarterGallery(gallery) {
     }
     lines.push("Smithers starters");
     lines.push("");
-    lines.push("Pick a plain-English outcome, run one command, and let the seeded workflow do the structured work.");
+    lines.push("Pick a plain-English outcome, initialize the workflow pack, and run the selected template command.");
     lines.push(`First-time setup: ${gallery.installCommand}`);
     lines.push("");
     if (gallery.count === 0) {
@@ -449,6 +451,7 @@ export function renderStarterGallery(gallery) {
         lines.push(`  Run: ${starter.command}`);
         lines.push("");
     }
+    lines.push(`Use \`${cliCommand("init --template <id>")}\` to initialize with a selected template.`);
     lines.push(`Use \`${cliCommand("starters <id>")}\` for setup notes and follow-ups.`);
     lines.push(`Filter examples: \`${cliCommand("starters --audience product")}\`, \`${cliCommand("starters --goal quality")}\`, \`${cliCommand("starters --workflow debug")}\`.`);
     return lines.join("\n");

--- a/apps/cli/tests/init.e2e.test.js
+++ b/apps/cli/tests/init.e2e.test.js
@@ -222,6 +222,54 @@ test("smithers init writes the expected workflow-pack layout and it typechecks",
     expect(repo.read(".smithers/workflows/kanban.tsx")).toContain('<Task id="tickets" output={outputs.tickets}>');
     runWorkflowPackTypecheck(repo);
 }, 20_000);
+test("smithers init --template preserves the default scaffold and returns the selected starter", () => {
+    const repo = createTempRepo();
+    const env = buildInitEnv(repo.dir);
+    const result = runSmithers(["init", "--template", "idea-to-prd", "--no-install"], {
+        cwd: repo.dir,
+        format: "json",
+        env,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(repo.exists(".smithers/workflows/write-a-prd.tsx")).toBe(true);
+    expect(repo.exists(".smithers/workflows/implement.tsx")).toBe(true);
+    expect(result.json.template.id).toBe("idea-to-prd");
+    expect(result.json.template.workflow).toBe("write-a-prd");
+    expect(result.json.template.command).toStartWith("bunx smithers-orchestrator workflow run write-a-prd --");
+    expect(result.json.install).toMatchObject({
+        reason: "skip-install",
+        status: "skipped",
+    });
+});
+test("smithers init rejects unknown templates in option validation before writing the scaffold", () => {
+    const repo = createTempRepo();
+    const result = runSmithers(["init", "--template", "does-not-exist", "--no-install"], {
+        cwd: repo.dir,
+        format: "json",
+    });
+    expect(result.exitCode).toBe(4);
+    expect(result.json.code).toBe("VALIDATION_ERROR");
+    expect(result.json.message).toContain("Invalid input");
+    expect(result.json.fieldErrors).toEqual([
+        {
+            path: "template",
+            expected: "",
+            received: "",
+            message: "Invalid input",
+        },
+    ]);
+    expect(repo.exists(".smithers")).toBe(false);
+});
+test("smithers init rejects starter aliases before writing the scaffold", () => {
+    const repo = createTempRepo();
+    const result = runSmithers(["init", "--template", "prd", "--no-install"], {
+        cwd: repo.dir,
+        format: "json",
+    });
+    expect(result.exitCode).toBe(4);
+    expect(result.json.code).toBe("VALIDATION_ERROR");
+    expect(repo.exists(".smithers")).toBe(false);
+});
 test("smithers init --agents-only creates only the user-owned agent scaffold", () => {
     const repo = createTempRepo();
     const result = runSmithers(["init", "--agents-only"], {

--- a/apps/cli/tests/starter-gallery.test.js
+++ b/apps/cli/tests/starter-gallery.test.js
@@ -9,6 +9,27 @@ import {
     starterCommand,
 } from "../src/starter-gallery.js";
 
+function extractQuotedFlag(command, flag) {
+    const prefix = `${flag} "`;
+    const start = command.indexOf(prefix);
+    expect(start).toBeGreaterThanOrEqual(0);
+    let value = "";
+    for (let i = start + prefix.length; i < command.length; i++) {
+        const char = command[i];
+        if (char === "\\") {
+            i += 1;
+            value += command[i] ?? "";
+        }
+        else if (char === "\"") {
+            return value;
+        }
+        else {
+            value += char;
+        }
+    }
+    throw new Error(`Missing closing quote for ${flag}`);
+}
+
 describe("starter gallery data", () => {
     test("every starter has stable IDs, commands, and required discovery fields", () => {
         const ids = new Set();
@@ -21,7 +42,39 @@ describe("starter gallery data", () => {
             expect(starter.goals.length).toBeGreaterThan(0);
             expect(starter.workflow).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
             expect(starter.outcome.length).toBeGreaterThan(20);
-            expect(starterCommand(starter)).toContain(`smithers workflow run ${starter.workflow} --prompt "`);
+            expect(starterCommand(starter)).toStartWith(`bunx smithers-orchestrator workflow run ${starter.workflow} --`);
+        }
+    });
+
+    test("renders commands that match seeded workflow inputs", () => {
+        const qualityAudit = findStarterRecipe("quality-audit");
+        expect(qualityAudit).toBeDefined();
+        const auditCommand = starterCommand(qualityAudit);
+        expect(auditCommand).toContain(" workflow run audit --input ");
+        expect(auditCommand).not.toContain(" --prompt ");
+        expect(JSON.parse(extractQuotedFlag(auditCommand, "--input"))).toEqual({
+            features: { checkout: ["checkout flow"] },
+            focus: "release readiness",
+            additionalContext: "Audit the checkout flow for missing tests, unclear docs, weak observability, and support risks.",
+        });
+
+        const tickets = findStarterRecipe("idea-to-tickets");
+        expect(tickets?.followUps).toContain("Save each generated ticket as a Markdown file under `.smithers/tickets/`.");
+        const kanbanCommand = tickets?.followUps.find((command) => command.includes(" workflow run kanban "));
+        expect(kanbanCommand).toBeDefined();
+        expect(kanbanCommand).toContain(" --input ");
+        expect(kanbanCommand).not.toContain(" --prompt ");
+        expect(JSON.parse(extractQuotedFlag(kanbanCommand, "--input"))).toEqual({ maxConcurrency: 3 });
+    });
+
+    test("does not emit bare smithers commands", () => {
+        const rendered = renderStarterGallery(buildStarterGallery());
+        expect(rendered).not.toMatch(/(^|[\s`])smithers(?:\s|$)/);
+        for (const recipe of STARTER_RECIPES) {
+            expect(starterCommand(recipe)).toStartWith("bunx smithers-orchestrator ");
+            for (const followUp of recipe.followUps) {
+                expect(followUp).not.toMatch(/^smithers(?:\s|$)/);
+            }
         }
     });
 
@@ -42,12 +95,12 @@ describe("starter gallery data", () => {
         const overview = renderStarterGallery(buildStarterGallery({ audience: "product" }));
         expect(overview).toContain("Smithers starters");
         expect(overview).toContain("idea-to-prd");
-        expect(overview).toContain("Use `smithers starters <id>`");
+        expect(overview).toContain("Use `bunx smithers-orchestrator starters <id>`");
 
         const detail = renderStarterGallery(buildStarterGallery({ id: "customer-incident" }));
         expect(detail).toContain("Turn a customer report into a fix path");
         expect(detail).toContain("Before you run it:");
-        expect(detail).toContain("smithers workflow run debug");
+        expect(detail).toContain("bunx smithers-orchestrator workflow run debug");
     });
 });
 
@@ -61,7 +114,7 @@ describe("smithers starters command", () => {
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("Smithers starters");
         expect(result.stdout).toContain("idea-to-prd");
-        expect(result.stdout).toContain("smithers workflow run write-a-prd");
+        expect(result.stdout).toContain("bunx smithers-orchestrator workflow run write-a-prd");
     });
 
     test("emits structured JSON for integrations", () => {
@@ -84,6 +137,6 @@ describe("smithers starters command", () => {
         });
         expect(result.exitCode).toBe(4);
         expect(result.json.code).toBe("STARTER_NOT_FOUND");
-        expect(result.json.message).toContain('Run "smithers starters"');
+        expect(result.json.message).toContain('Run "bunx smithers-orchestrator starters"');
     });
 });

--- a/apps/cli/tests/starter-gallery.test.js
+++ b/apps/cli/tests/starter-gallery.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
+import {
+    STARTER_RECIPES,
+    buildStarterGallery,
+    findStarterRecipe,
+    listStarterRecipes,
+    renderStarterGallery,
+    starterCommand,
+} from "../src/starter-gallery.js";
+
+describe("starter gallery data", () => {
+    test("every starter has stable IDs, commands, and required discovery fields", () => {
+        const ids = new Set();
+        for (const starter of STARTER_RECIPES) {
+            expect(starter.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+            expect(ids.has(starter.id)).toBe(false);
+            ids.add(starter.id);
+            expect(starter.title.length).toBeGreaterThan(8);
+            expect(starter.audience.length).toBeGreaterThan(0);
+            expect(starter.goals.length).toBeGreaterThan(0);
+            expect(starter.workflow).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+            expect(starter.outcome.length).toBeGreaterThan(20);
+            expect(starterCommand(starter)).toContain(`smithers workflow run ${starter.workflow} --prompt "`);
+        }
+    });
+
+    test("finds starters by ID and alias", () => {
+        expect(findStarterRecipe("idea-to-prd")?.id).toBe("idea-to-prd");
+        expect(findStarterRecipe("prd")?.id).toBe("idea-to-prd");
+        expect(findStarterRecipe("missing")).toBeUndefined();
+    });
+
+    test("filters by audience, goal, workflow, and tag", () => {
+        expect(listStarterRecipes({ audience: "support" }).map((starter) => starter.id)).toContain("customer-incident");
+        expect(listStarterRecipes({ goal: "quality" }).map((starter) => starter.id)).toContain("quality-audit");
+        expect(listStarterRecipes({ workflow: "debug" }).map((starter) => starter.id)).toEqual(["customer-incident"]);
+        expect(listStarterRecipes({ tag: "launch" }).map((starter) => starter.id)).toEqual(["idea-to-prd", "launch-checklist"]);
+    });
+
+    test("renders a browsable overview and a detailed starter", () => {
+        const overview = renderStarterGallery(buildStarterGallery({ audience: "product" }));
+        expect(overview).toContain("Smithers starters");
+        expect(overview).toContain("idea-to-prd");
+        expect(overview).toContain("Use `smithers starters <id>`");
+
+        const detail = renderStarterGallery(buildStarterGallery({ id: "customer-incident" }));
+        expect(detail).toContain("Turn a customer report into a fix path");
+        expect(detail).toContain("Before you run it:");
+        expect(detail).toContain("smithers workflow run debug");
+    });
+});
+
+describe("smithers starters command", () => {
+    test("prints the starter gallery for people choosing a workflow", () => {
+        const repo = createTempRepo();
+        const result = runSmithers(["starters", "--audience", "product"], {
+            cwd: repo.dir,
+            format: null,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("Smithers starters");
+        expect(result.stdout).toContain("idea-to-prd");
+        expect(result.stdout).toContain("smithers workflow run write-a-prd");
+    });
+
+    test("emits structured JSON for integrations", () => {
+        const repo = createTempRepo();
+        const result = runSmithers(["starters", "prd"], {
+            cwd: repo.dir,
+            format: "json",
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.json.selected.id).toBe("idea-to-prd");
+        expect(result.json.selected.workflow).toBe("write-a-prd");
+        expect(result.json.starters).toHaveLength(1);
+    });
+
+    test("returns a user-correctable error for unknown starter IDs", () => {
+        const repo = createTempRepo();
+        const result = runSmithers(["starters", "does-not-exist"], {
+            cwd: repo.dir,
+            format: "json",
+        });
+        expect(result.exitCode).toBe(4);
+        expect(result.json.code).toBe("STARTER_NOT_FOUND");
+        expect(result.json.message).toContain('Run "smithers starters"');
+    });
+});

--- a/apps/cli/tests/starter-gallery.test.js
+++ b/apps/cli/tests/starter-gallery.test.js
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
 import {
     STARTER_RECIPES,
+    STARTER_TEMPLATE_IDS,
     buildStarterGallery,
     findStarterRecipe,
     listStarterRecipes,
@@ -44,6 +45,7 @@ describe("starter gallery data", () => {
             expect(starter.outcome.length).toBeGreaterThan(20);
             expect(starterCommand(starter)).toStartWith(`bunx smithers-orchestrator workflow run ${starter.workflow} --`);
         }
+        expect(STARTER_TEMPLATE_IDS).toEqual(STARTER_RECIPES.map((starter) => starter.id));
     });
 
     test("renders commands that match seeded workflow inputs", () => {
@@ -95,10 +97,11 @@ describe("starter gallery data", () => {
         const overview = renderStarterGallery(buildStarterGallery({ audience: "product" }));
         expect(overview).toContain("Smithers starters");
         expect(overview).toContain("idea-to-prd");
-        expect(overview).toContain("Use `bunx smithers-orchestrator starters <id>`");
+        expect(overview).toContain("Use `bunx smithers-orchestrator init --template <id>`");
 
         const detail = renderStarterGallery(buildStarterGallery({ id: "customer-incident" }));
         expect(detail).toContain("Turn a customer report into a fix path");
+        expect(detail).toContain("Template ID: customer-incident");
         expect(detail).toContain("Before you run it:");
         expect(detail).toContain("bunx smithers-orchestrator workflow run debug");
     });

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -35,11 +35,12 @@ Commands listed by dotted name. `human` and `alerts` use an action positional in
 commands[63]:
   - name: init
     purpose: Install the local workflow pack into .smithers/
-    flags[4]{name,short,type,default,desc}:
+    flags[5]{name,short,type,default,desc}:
       force,,boolean,false,Overwrite existing scaffold files
       agents-only,,boolean,false,Only create .smithers/agents/ and leave workflow pack untouched
       install,,boolean,true,Run bun install inside .smithers/ after scaffolding
       add-agents,,boolean,false,Launch the account registration wizard after scaffolding
+      template,,string,,Show next steps for a canonical starter template ID after init
   - name: starters
     purpose: Show plain-English starter workflows with copy-paste commands
     args[1]{name,type,required,desc}:

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -32,7 +32,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[62]:
+commands[63]:
   - name: init
     purpose: Install the local workflow pack into .smithers/
     flags[4]{name,short,type,default,desc}:
@@ -40,6 +40,15 @@ commands[62]:
       agents-only,,boolean,false,Only create .smithers/agents/ and leave workflow pack untouched
       install,,boolean,true,Run bun install inside .smithers/ after scaffolding
       add-agents,,boolean,false,Launch the account registration wizard after scaffolding
+  - name: starters
+    purpose: Show plain-English starter workflows with copy-paste commands
+    args[1]{name,type,required,desc}:
+      id,string,false,Starter ID or alias
+    flags[4]{name,short,type,default,desc}:
+      audience,,string,,Filter by audience such as product, support, or founder
+      goal,,string,,Filter by goal such as plan, build, debug, or quality
+      workflow,,string,,Filter by seeded workflow ID
+      tag,,string,,Filter by starter tag
   - name: up
     purpose: Start or resume a workflow execution
     args[1]{name,type,required,desc}:

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -5,7 +5,8 @@ description: Short operational cheatsheet. The full catalog lives in CLI.
 
 ```bash
 bunx smithers-orchestrator init                                       # scaffold .smithers/
-bunx smithers-orchestrator starters                                   # choose by outcome
+bunx smithers-orchestrator init --template idea-to-prd                 # scaffold with guided template next steps
+bunx smithers-orchestrator starters                                   # browse template IDs
 bunx smithers-orchestrator workflow run implement --prompt "…"        # launch a seeded workflow
 bunx smithers-orchestrator ps                                         # list runs
 bunx smithers-orchestrator inspect <run-id>                           # structured run state

--- a/docs/cli/quickstart.mdx
+++ b/docs/cli/quickstart.mdx
@@ -5,6 +5,7 @@ description: Short operational cheatsheet. The full catalog lives in CLI.
 
 ```bash
 bunx smithers-orchestrator init                                       # scaffold .smithers/
+bunx smithers-orchestrator starters                                   # choose by outcome
 bunx smithers-orchestrator workflow run implement --prompt "…"        # launch a seeded workflow
 bunx smithers-orchestrator ps                                         # list runs
 bunx smithers-orchestrator inspect <run-id>                           # structured run state

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,6 +16,7 @@
           "introduction",
           "installation",
           "quickstart",
+          "starters",
           "tour"
         ]
       },

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,10 +5,11 @@ description: Scaffold and run a Smithers workflow in two commands.
 
 ```bash
 bunx smithers-orchestrator init
+bunx smithers-orchestrator starters
 bunx smithers-orchestrator workflow run implement --prompt "Add rate limiting"
 ```
 
-`init` scaffolds `.smithers/` (workflows, prompts, components, agent config). The `workflow run` command launches one of the seeded workflows.
+`init` scaffolds `.smithers/` (workflows, prompts, components, agent config). `starters` helps you choose a seeded workflow by outcome, then `workflow run` launches it.
 
 Inspect the run:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,11 +5,11 @@ description: Scaffold and run a Smithers workflow in two commands.
 
 ```bash
 bunx smithers-orchestrator init
-bunx smithers-orchestrator starters
+bunx smithers-orchestrator init --template idea-to-prd
 bunx smithers-orchestrator workflow run implement --prompt "Add rate limiting"
 ```
 
-`init` scaffolds `.smithers/` (workflows, prompts, components, agent config). `starters` helps you choose a seeded workflow by outcome, then `workflow run` launches it.
+`init` scaffolds `.smithers/` (workflows, prompts, components, agent config). Add `--template <id>` when you want the init result to include the selected starter command and follow-up notes. Run `bunx smithers-orchestrator starters` to browse template IDs.
 
 Inspect the run:
 

--- a/docs/recipes.mdx
+++ b/docs/recipes.mdx
@@ -5,6 +5,8 @@ description: Tight, reusable patterns. Copy, paste, adapt.
 
 Each recipe is a working snippet plus one line of context. They compose freely.
 
+If you want a ready-to-run outcome before writing workflow code, start with [Starters](/starters) or run `bunx smithers-orchestrator starters`.
+
 ## Implement → review loop
 
 Iterate until a reviewer signs off, with a hard cap.

--- a/docs/reference/package-configuration.mdx
+++ b/docs/reference/package-configuration.mdx
@@ -22,6 +22,7 @@ Use the subpath form to import only the surface you need.
 | `smithers-orchestrator/jsx-runtime` | `./src/jsx-runtime.js` | JSX runtime (auto-resolved by `jsxImportSource`) |
 | `smithers-orchestrator/jsx-dev-runtime` | `./src/jsx-runtime.js` | JSX dev runtime (auto-resolved in dev mode) |
 | `smithers-orchestrator/tools` | `./src/tools.js` | Tool sandbox: `defineTool`, `read`, `grep`, `bash`, `edit`, `write` |
+| `smithers-orchestrator/sandbox` | `./src/sandbox.js` | Sandbox provider registration and transport types for sandboxed workflow execution |
 | `smithers-orchestrator/server` | `./src/server.js` | HTTP server for run management and event streaming |
 | `smithers-orchestrator/observability` | `./src/observability.js` | OpenTelemetry traces, metrics, and Prometheus integration |
 | `smithers-orchestrator/mdx-plugin` | `./src/mdx-plugin.js` | Bun preload plugin for `.mdx` imports |

--- a/docs/starters.mdx
+++ b/docs/starters.mdx
@@ -3,7 +3,7 @@ title: Starters
 description: Choose a plain-English outcome and copy the Smithers command.
 ---
 
-Smithers ships with starter workflows for people who want a result before they want to write workflow code. Run the starter gallery from any repo:
+Smithers ships with starter workflows for people who want a result before they want to write workflow code. Browse the starter gallery from any repo:
 
 ```bash
 bunx smithers-orchestrator starters
@@ -15,20 +15,28 @@ First-time setup:
 bunx smithers-orchestrator init --add-agents
 ```
 
-Then pick a starter:
+Or initialize with guided next steps for one template:
+
+```bash
+bunx smithers-orchestrator init --template idea-to-prd
+```
+
+Template IDs:
+
+Use these canonical IDs with `init --template`. `starters <id>` also accepts aliases for lookup.
 
 | Starter | Best for | Workflow | Command |
 | --- | --- | --- | --- |
-| `idea-to-prd` | founders, product, marketing | `write-a-prd` | `bunx smithers-orchestrator starters idea-to-prd` |
-| `idea-to-tickets` | product, operations, engineering | `tickets-create` | `bunx smithers-orchestrator starters idea-to-tickets` |
-| `launch-checklist` | launch owners and operators | `plan` | `bunx smithers-orchestrator starters launch-checklist` |
-| `customer-incident` | support escalations | `debug` | `bunx smithers-orchestrator starters customer-incident` |
-| `nontechnical-research` | before-build decisions | `research` | `bunx smithers-orchestrator starters nontechnical-research` |
-| `requirements-interview` | vague stakeholder requests | `grill-me` | `bunx smithers-orchestrator starters requirements-interview` |
-| `quality-audit` | release readiness | `audit` | `bunx smithers-orchestrator starters quality-audit` |
-| `test-coverage` | regression prevention | `improve-test-coverage` | `bunx smithers-orchestrator starters test-coverage` |
-| `ship-a-change` | focused product improvements | `research-plan-implement` | `bunx smithers-orchestrator starters ship-a-change` |
-| `mission-mode` | larger approved milestones | `mission` | `bunx smithers-orchestrator starters mission-mode` |
+| `idea-to-prd` | founders, product, marketing | `write-a-prd` | `bunx smithers-orchestrator init --template idea-to-prd` |
+| `idea-to-tickets` | product, operations, engineering | `tickets-create` | `bunx smithers-orchestrator init --template idea-to-tickets` |
+| `launch-checklist` | launch owners and operators | `plan` | `bunx smithers-orchestrator init --template launch-checklist` |
+| `customer-incident` | support escalations | `debug` | `bunx smithers-orchestrator init --template customer-incident` |
+| `nontechnical-research` | before-build decisions | `research` | `bunx smithers-orchestrator init --template nontechnical-research` |
+| `requirements-interview` | vague stakeholder requests | `grill-me` | `bunx smithers-orchestrator init --template requirements-interview` |
+| `quality-audit` | release readiness | `audit` | `bunx smithers-orchestrator init --template quality-audit` |
+| `test-coverage` | regression prevention | `improve-test-coverage` | `bunx smithers-orchestrator init --template test-coverage` |
+| `ship-a-change` | focused product improvements | `research-plan-implement` | `bunx smithers-orchestrator init --template ship-a-change` |
+| `mission-mode` | larger approved milestones | `mission` | `bunx smithers-orchestrator init --template mission-mode` |
 
 Each detailed starter prints:
 

--- a/docs/starters.mdx
+++ b/docs/starters.mdx
@@ -19,22 +19,22 @@ Then pick a starter:
 
 | Starter | Best for | Workflow | Command |
 | --- | --- | --- | --- |
-| `idea-to-prd` | founders, product, marketing | `write-a-prd` | `smithers starters idea-to-prd` |
-| `idea-to-tickets` | product, operations, engineering | `tickets-create` | `smithers starters idea-to-tickets` |
-| `launch-checklist` | launch owners and operators | `plan` | `smithers starters launch-checklist` |
-| `customer-incident` | support escalations | `debug` | `smithers starters customer-incident` |
-| `nontechnical-research` | before-build decisions | `research` | `smithers starters nontechnical-research` |
-| `requirements-interview` | vague stakeholder requests | `grill-me` | `smithers starters requirements-interview` |
-| `quality-audit` | release readiness | `audit` | `smithers starters quality-audit` |
-| `test-coverage` | regression prevention | `improve-test-coverage` | `smithers starters test-coverage` |
-| `ship-a-change` | focused product improvements | `research-plan-implement` | `smithers starters ship-a-change` |
-| `mission-mode` | larger approved milestones | `mission` | `smithers starters mission-mode` |
+| `idea-to-prd` | founders, product, marketing | `write-a-prd` | `bunx smithers-orchestrator starters idea-to-prd` |
+| `idea-to-tickets` | product, operations, engineering | `tickets-create` | `bunx smithers-orchestrator starters idea-to-tickets` |
+| `launch-checklist` | launch owners and operators | `plan` | `bunx smithers-orchestrator starters launch-checklist` |
+| `customer-incident` | support escalations | `debug` | `bunx smithers-orchestrator starters customer-incident` |
+| `nontechnical-research` | before-build decisions | `research` | `bunx smithers-orchestrator starters nontechnical-research` |
+| `requirements-interview` | vague stakeholder requests | `grill-me` | `bunx smithers-orchestrator starters requirements-interview` |
+| `quality-audit` | release readiness | `audit` | `bunx smithers-orchestrator starters quality-audit` |
+| `test-coverage` | regression prevention | `improve-test-coverage` | `bunx smithers-orchestrator starters test-coverage` |
+| `ship-a-change` | focused product improvements | `research-plan-implement` | `bunx smithers-orchestrator starters ship-a-change` |
+| `mission-mode` | larger approved milestones | `mission` | `bunx smithers-orchestrator starters mission-mode` |
 
 Each detailed starter prints:
 
 - What outcome to expect
 - What context to gather before running
-- The exact `smithers workflow run ...` command
+- The exact `bunx smithers-orchestrator workflow run ...` command
 - Useful follow-up commands
 - When not to use that starter
 

--- a/docs/starters.mdx
+++ b/docs/starters.mdx
@@ -1,0 +1,53 @@
+---
+title: Starters
+description: Choose a plain-English outcome and copy the Smithers command.
+---
+
+Smithers ships with starter workflows for people who want a result before they want to write workflow code. Run the starter gallery from any repo:
+
+```bash
+bunx smithers-orchestrator starters
+```
+
+First-time setup:
+
+```bash
+bunx smithers-orchestrator init --add-agents
+```
+
+Then pick a starter:
+
+| Starter | Best for | Workflow | Command |
+| --- | --- | --- | --- |
+| `idea-to-prd` | founders, product, marketing | `write-a-prd` | `smithers starters idea-to-prd` |
+| `idea-to-tickets` | product, operations, engineering | `tickets-create` | `smithers starters idea-to-tickets` |
+| `launch-checklist` | launch owners and operators | `plan` | `smithers starters launch-checklist` |
+| `customer-incident` | support escalations | `debug` | `smithers starters customer-incident` |
+| `nontechnical-research` | before-build decisions | `research` | `smithers starters nontechnical-research` |
+| `requirements-interview` | vague stakeholder requests | `grill-me` | `smithers starters requirements-interview` |
+| `quality-audit` | release readiness | `audit` | `smithers starters quality-audit` |
+| `test-coverage` | regression prevention | `improve-test-coverage` | `smithers starters test-coverage` |
+| `ship-a-change` | focused product improvements | `research-plan-implement` | `smithers starters ship-a-change` |
+| `mission-mode` | larger approved milestones | `mission` | `smithers starters mission-mode` |
+
+Each detailed starter prints:
+
+- What outcome to expect
+- What context to gather before running
+- The exact `smithers workflow run ...` command
+- Useful follow-up commands
+- When not to use that starter
+
+Filter by audience or goal:
+
+```bash
+bunx smithers-orchestrator starters --audience product
+bunx smithers-orchestrator starters --goal quality
+bunx smithers-orchestrator starters --workflow debug
+```
+
+Use JSON when another tool needs the catalog:
+
+```bash
+bunx smithers-orchestrator starters --format json
+```

--- a/scripts/check-architecture-budget.mjs
+++ b/scripts/check-architecture-budget.mjs
@@ -7,7 +7,7 @@ const repoRoot = process.cwd();
 const budgets = [
   {
     path: "packages/engine/src/engine.js",
-    maxLines: 7340,
+    maxLines: 7402,
     reason: "engine orchestration core",
   },
   {


### PR DESCRIPTION
## Summary

- Add a top-level `smithers starters` command that helps people choose a seeded workflow by outcome, audience, goal, workflow, or tag.
- Add a curated starter catalog covering product briefs, tickets, launch planning, support incidents, research, requirements discovery, quality audits, test coverage, focused changes, and milestone projects.
- Add `smithers init --template <canonical-id>` so init can preserve the default scaffold while returning starter-specific next steps.
- Validate `init --template` with a literal union of canonical starter IDs. Aliases remain supported for `starters <id>` lookup, but init rejects aliases and unknown IDs before writing scaffold files.
- Add a public Starters docs page, quickstart links, README mention, CLI catalog coverage, and tests for catalog data, filtering, JSON output, workflow input compatibility, and init template validation.
- Rebase onto current `main`, clear conflicts, and keep the package export docs and architecture budget aligned with the current baseline.

## Validation

- `bun test apps/cli/tests/init.e2e.test.js apps/cli/tests/starter-gallery.test.js --timeout 30000`
- `bun test apps/cli/tests/docs-cli-overview-coverage.test.js --timeout 30000`
- `bun test apps/cli/tests/docs-public-surface-coverage.test.js --timeout 30000`
- `pnpm check:effect`
- `pnpm check:deps`
- `pnpm check:architecture`
- `pnpm -r typecheck`
- `pnpm lint` (0 errors; existing unrelated warnings remain)
- `pnpm test`
- GitHub checks: `faults`, `test`, `typecheck`
- `git diff --check`
