### PR TITLE
Add eval suites for workflow regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,25 @@ Each task output is validated against its Zod schema and persisted to SQLite. If
 ```bash
 smithers up workflow.tsx --input '{"description": "Fix bug"}'
 smithers up workflow.tsx --run-id abc123 --resume true
+smithers eval workflow.tsx --cases evals/smoke.jsonl --suite smoke
 smithers ps
 smithers workflow list
 smithers approve abc123 --node review
 ```
+
+## Eval suites
+
+Run repeatable workflow regressions from JSON or JSONL cases:
+
+```jsonl
+{"id":"happy-path","input":{"description":"Fix bug"},"expected":{"status":"finished"}}
+```
+
+```bash
+smithers eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --force
+```
+
+Reports are written to `.smithers/evals/<suite>.json` and the command exits non-zero when any case fails.
 
 ## Hot Reload
 

--- a/apps/cli/src/eval-suite.js
+++ b/apps/cli/src/eval-suite.js
@@ -5,6 +5,7 @@ import { SmithersError } from "@smithers-orchestrator/errors";
 
 export const EVAL_CASE_STATUSES = [
     "finished",
+    "continued",
     "failed",
     "cancelled",
     "waiting-approval",
@@ -13,6 +14,7 @@ export const EVAL_CASE_STATUSES = [
 ];
 
 const RUN_ID_MAX_LENGTH = 64;
+const EVAL_EXPECTED_KEYS = new Set(["status", "output", "outputContains", "errorContains"]);
 
 /**
  * @param {unknown} value
@@ -89,6 +91,13 @@ function normalizeExpected(value, label) {
         return { status: "finished" };
     }
     const object = assertJsonObject(value, label);
+    const unknownKeys = Object.keys(object).filter((key) => !EVAL_EXPECTED_KEYS.has(key));
+    if (unknownKeys.length > 0) {
+        throw new SmithersError("INVALID_INPUT", `${label} contains unsupported assertion keys: ${unknownKeys.join(", ")}.`, {
+            keys: unknownKeys,
+            supportedKeys: [...EVAL_EXPECTED_KEYS],
+        });
+    }
     const status = object.status ?? "finished";
     if (typeof status !== "string" || !EVAL_CASE_STATUSES.includes(status)) {
         throw new SmithersError("INVALID_INPUT", `${label}.status must be one of ${EVAL_CASE_STATUSES.join(", ")}.`, { status });
@@ -144,6 +153,25 @@ function jsonContains(actual, expected) {
 }
 
 /**
+ * @param {unknown} error
+ */
+function formatEvalError(error) {
+    if (error === undefined || error === null) {
+        return "";
+    }
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (isPlainObject(error)) {
+        if (typeof error.message === "string") {
+            return error.message;
+        }
+        return stableJson(error);
+    }
+    return String(error);
+}
+
+/**
  * @param {unknown} raw
  * @param {number} index
  */
@@ -169,6 +197,26 @@ export function normalizeEvalCase(raw, index) {
         expected,
         metadata,
     };
+}
+
+/**
+ * @param {Array<ReturnType<typeof normalizeEvalCase>>} cases
+ */
+function assertUniqueEvalCaseIds(cases) {
+    /** @type {Map<string, number>} */
+    const seen = new Map();
+    for (let index = 0; index < cases.length; index += 1) {
+        const testCase = cases[index];
+        const firstIndex = seen.get(testCase.id);
+        if (firstIndex !== undefined) {
+            throw new SmithersError("INVALID_INPUT", `Duplicate eval case ID after normalization: ${testCase.id}`, {
+                id: testCase.id,
+                firstIndex,
+                duplicateIndex: index,
+            });
+        }
+        seen.set(testCase.id, index);
+    }
 }
 
 /**
@@ -223,9 +271,11 @@ export function loadEvalCases(root, path, options = {}) {
         throw new SmithersError("INVALID_INPUT", "Eval case file must contain at least one case.", { path });
     }
     const limit = options.maxCases ?? rawCases.length;
+    const cases = rawCases.slice(0, limit).map(normalizeEvalCase);
+    assertUniqueEvalCaseIds(cases);
     return {
         path: absolutePath,
-        cases: rawCases.slice(0, limit).map(normalizeEvalCase),
+        cases,
         totalCases: rawCases.length,
     };
 }
@@ -258,6 +308,11 @@ export function buildEvalPlan(input) {
     const suiteId = slugifyEvalToken(input.suiteId ?? defaultSuite, "suite", 32);
     const runLabel = input.runLabel ? slugifyEvalToken(input.runLabel, "run", 24) : null;
     const runSuiteId = runLabel ? `${suiteId}-${runLabel}` : suiteId;
+    const cases = input.loadedCases.cases.map((testCase) => ({
+        ...testCase,
+        runId: evalRunId(runSuiteId, testCase.id),
+    }));
+    assertUniqueEvalRunIds(cases);
     return {
         suiteId,
         runLabel,
@@ -265,11 +320,45 @@ export function buildEvalPlan(input) {
         casesPath: input.loadedCases.path,
         totalCases: input.loadedCases.totalCases,
         plannedCases: input.loadedCases.cases.length,
-        cases: input.loadedCases.cases.map((testCase) => ({
-            ...testCase,
-            runId: evalRunId(runSuiteId, testCase.id),
-        })),
+        cases,
     };
+}
+
+/**
+ * @param {Array<{ runId: string; id: string }>} cases
+ */
+function assertUniqueEvalRunIds(cases) {
+    /** @type {Map<string, string>} */
+    const seen = new Map();
+    for (const testCase of cases) {
+        const firstCaseId = seen.get(testCase.runId);
+        if (firstCaseId !== undefined) {
+            throw new SmithersError("INVALID_INPUT", `Duplicate eval run ID after normalization: ${testCase.runId}`, {
+                runId: testCase.runId,
+                firstCaseId,
+                duplicateCaseId: testCase.id,
+            });
+        }
+        seen.set(testCase.runId, testCase.id);
+    }
+}
+
+/**
+ * @param {{ getRun(runId: string): Promise<unknown> }} adapter
+ * @param {Array<{ runId: string }>} cases
+ */
+export async function assertEvalRunIdsAvailable(adapter, cases) {
+    const existing = [];
+    for (const testCase of cases) {
+        if (await adapter.getRun(testCase.runId)) {
+            existing.push(testCase.runId);
+        }
+    }
+    if (existing.length > 0) {
+        throw new SmithersError("EVAL_RUN_ID_EXISTS", `Eval run ID${existing.length === 1 ? "" : "s"} already ${existing.length === 1 ? "exists" : "exist"}: ${existing.join(", ")}. Use a unique --run-label.`, {
+            runIds: existing,
+        });
+    }
 }
 
 /**
@@ -322,9 +411,7 @@ export function evaluateEvalCaseResult(testCase, result) {
         });
     }
     if (Object.prototype.hasOwnProperty.call(testCase.expected, "errorContains")) {
-        const actualError = result.error === undefined || result.error === null
-            ? ""
-            : String(result.error);
+        const actualError = formatEvalError(result.error);
         assertions.push({
             name: "errorContains",
             passed: actualError.includes(String(testCase.expected.errorContains)),

--- a/apps/cli/src/eval-suite.js
+++ b/apps/cli/src/eval-suite.js
@@ -1,0 +1,463 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import crypto from "node:crypto";
+import { SmithersError } from "@smithers-orchestrator/errors";
+
+export const EVAL_CASE_STATUSES = [
+    "finished",
+    "failed",
+    "cancelled",
+    "waiting-approval",
+    "waiting-event",
+    "waiting-timer",
+];
+
+const RUN_ID_MAX_LENGTH = 64;
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isPlainObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {string} value
+ */
+function stableHash(value) {
+    return crypto.createHash("sha1").update(value).digest("hex").slice(0, 8);
+}
+
+/**
+ * @param {string} value
+ * @param {string} fallback
+ * @param {number} maxLength
+ */
+export function slugifyEvalToken(value, fallback = "case", maxLength = 32) {
+    const slug = value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .replace(/-{2,}/g, "-");
+    const normalized = slug || fallback;
+    if (normalized.length <= maxLength) {
+        return normalized;
+    }
+    return `${normalized.slice(0, Math.max(1, maxLength - 9)).replace(/-+$/g, "")}-${stableHash(normalized)}`;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ */
+function assertJsonObject(value, label) {
+    if (!isPlainObject(value)) {
+        throw new SmithersError("INVALID_INPUT", `${label} must be a JSON object.`, { label });
+    }
+    return value;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ * @returns {Record<string, string | number | boolean>}
+ */
+function normalizeAnnotations(value, label) {
+    if (value === undefined || value === null) {
+        return {};
+    }
+    const object = assertJsonObject(value, label);
+    /** @type {Record<string, string | number | boolean>} */
+    const normalized = {};
+    for (const [key, entry] of Object.entries(object)) {
+        if (typeof entry !== "string" && typeof entry !== "number" && typeof entry !== "boolean") {
+            throw new SmithersError("INVALID_INPUT", `${label}.${key} must be a string, number, or boolean.`, { key });
+        }
+        normalized[key] = entry;
+    }
+    return normalized;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} label
+ */
+function normalizeExpected(value, label) {
+    if (value === undefined || value === null) {
+        return { status: "finished" };
+    }
+    const object = assertJsonObject(value, label);
+    const status = object.status ?? "finished";
+    if (typeof status !== "string" || !EVAL_CASE_STATUSES.includes(status)) {
+        throw new SmithersError("INVALID_INPUT", `${label}.status must be one of ${EVAL_CASE_STATUSES.join(", ")}.`, { status });
+    }
+    return { ...object, status };
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function stableJson(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(stableJson).join(",")}]`;
+    }
+    if (isPlainObject(value)) {
+        return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+    }
+    return JSON.stringify(value);
+}
+
+/**
+ * @param {unknown} actual
+ * @param {unknown} expected
+ */
+function jsonEquals(actual, expected) {
+    return stableJson(actual) === stableJson(expected);
+}
+
+/**
+ * @param {unknown} actual
+ * @param {unknown} expected
+ */
+function jsonContains(actual, expected) {
+    if (isPlainObject(expected)) {
+        if (!isPlainObject(actual)) {
+            return false;
+        }
+        for (const [key, value] of Object.entries(expected)) {
+            if (!jsonContains(actual[key], value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    if (Array.isArray(expected)) {
+        if (!Array.isArray(actual) || actual.length < expected.length) {
+            return false;
+        }
+        return expected.every((entry, index) => jsonContains(actual[index], entry));
+    }
+    return jsonEquals(actual, expected);
+}
+
+/**
+ * @param {unknown} raw
+ * @param {number} index
+ */
+export function normalizeEvalCase(raw, index) {
+    const object = assertJsonObject(raw, `cases[${index}]`);
+    const rawId = typeof object.id === "string"
+        ? object.id
+        : typeof object.name === "string"
+            ? object.name
+            : `case-${String(index + 1).padStart(3, "0")}`;
+    const id = slugifyEvalToken(rawId, `case-${index + 1}`, 40);
+    const input = object.input === undefined ? {} : assertJsonObject(object.input, `cases[${index}].input`);
+    const annotations = normalizeAnnotations(object.annotations, `cases[${index}].annotations`);
+    const expected = normalizeExpected(object.expected, `cases[${index}].expected`);
+    const metadata = object.metadata === undefined || object.metadata === null
+        ? {}
+        : assertJsonObject(object.metadata, `cases[${index}].metadata`);
+    return {
+        id,
+        name: rawId,
+        input,
+        annotations,
+        expected,
+        metadata,
+    };
+}
+
+/**
+ * @param {string} text
+ * @param {string} path
+ */
+function parseCasesText(text, path) {
+    if (extname(path).toLowerCase() === ".jsonl") {
+        return text
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .map((line, index) => {
+                try {
+                    return JSON.parse(line);
+                }
+                catch (err) {
+                    throw new SmithersError("INVALID_JSON", `Invalid JSONL case at line ${index + 1}: ${err?.message ?? String(err)}`, { line: index + 1 });
+                }
+            });
+    }
+    try {
+        const parsed = JSON.parse(text);
+        if (Array.isArray(parsed)) {
+            return parsed;
+        }
+        if (isPlainObject(parsed) && Array.isArray(parsed.cases)) {
+            return parsed.cases;
+        }
+        throw new SmithersError("INVALID_INPUT", "Eval case file must be a JSON array, a { cases: [...] } object, or JSONL.", { path });
+    }
+    catch (err) {
+        if (err instanceof SmithersError) {
+            throw err;
+        }
+        throw new SmithersError("INVALID_JSON", `Invalid JSON case file: ${err?.message ?? String(err)}`, { path });
+    }
+}
+
+/**
+ * @param {string} root
+ * @param {string} path
+ * @param {{ maxCases?: number }} [options]
+ */
+export function loadEvalCases(root, path, options = {}) {
+    const absolutePath = isAbsolute(path) ? path : resolve(root, path);
+    if (!existsSync(absolutePath)) {
+        throw new SmithersError("INVALID_INPUT", `Eval case file not found: ${path}`, { path });
+    }
+    const rawCases = parseCasesText(readFileSync(absolutePath, "utf8"), absolutePath);
+    if (rawCases.length === 0) {
+        throw new SmithersError("INVALID_INPUT", "Eval case file must contain at least one case.", { path });
+    }
+    const limit = options.maxCases ?? rawCases.length;
+    return {
+        path: absolutePath,
+        cases: rawCases.slice(0, limit).map(normalizeEvalCase),
+        totalCases: rawCases.length,
+    };
+}
+
+/**
+ * @param {string} suiteId
+ * @param {string} caseId
+ */
+export function evalRunId(suiteId, caseId) {
+    const suite = slugifyEvalToken(suiteId, "suite", 24);
+    const testCase = slugifyEvalToken(caseId, "case", 24);
+    const base = `eval-${suite}-${testCase}`;
+    if (base.length <= RUN_ID_MAX_LENGTH) {
+        return base;
+    }
+    return `${base.slice(0, RUN_ID_MAX_LENGTH - 9).replace(/-+$/g, "")}-${stableHash(base)}`;
+}
+
+/**
+ * @param {{
+ *   suiteId?: string;
+ *   runLabel?: string;
+ *   workflowPath: string;
+ *   casesPath: string;
+ *   loadedCases: ReturnType<typeof loadEvalCases>;
+ * }} input
+ */
+export function buildEvalPlan(input) {
+    const defaultSuite = basename(input.casesPath, extname(input.casesPath));
+    const suiteId = slugifyEvalToken(input.suiteId ?? defaultSuite, "suite", 32);
+    const runLabel = input.runLabel ? slugifyEvalToken(input.runLabel, "run", 24) : null;
+    const runSuiteId = runLabel ? `${suiteId}-${runLabel}` : suiteId;
+    return {
+        suiteId,
+        runLabel,
+        workflowPath: input.workflowPath,
+        casesPath: input.loadedCases.path,
+        totalCases: input.loadedCases.totalCases,
+        plannedCases: input.loadedCases.cases.length,
+        cases: input.loadedCases.cases.map((testCase) => ({
+            ...testCase,
+            runId: evalRunId(runSuiteId, testCase.id),
+        })),
+    };
+}
+
+/**
+ * @param {Array<{ passed: boolean; status?: string; durationMs?: number }>} results
+ */
+export function summarizeEvalResults(results) {
+    const byStatus = {};
+    for (const result of results) {
+        const status = result.status ?? "error";
+        byStatus[status] = (byStatus[status] ?? 0) + 1;
+    }
+    const passed = results.filter((result) => result.passed).length;
+    const failed = results.length - passed;
+    return {
+        total: results.length,
+        passed,
+        failed,
+        byStatus,
+        durationMs: results.reduce((sum, result) => sum + (result.durationMs ?? 0), 0),
+    };
+}
+
+/**
+ * @param {ReturnType<typeof normalizeEvalCase>} testCase
+ * @param {{ status?: string; output?: unknown; error?: unknown }} result
+ */
+export function evaluateEvalCaseResult(testCase, result) {
+    const assertions = [];
+    const actualStatus = result.status ?? "error";
+    assertions.push({
+        name: "status",
+        passed: actualStatus === testCase.expected.status,
+        expected: testCase.expected.status,
+        actual: actualStatus,
+    });
+    if (Object.prototype.hasOwnProperty.call(testCase.expected, "output")) {
+        assertions.push({
+            name: "output",
+            passed: jsonEquals(result.output, testCase.expected.output),
+            expected: testCase.expected.output,
+            actual: result.output,
+        });
+    }
+    if (Object.prototype.hasOwnProperty.call(testCase.expected, "outputContains")) {
+        assertions.push({
+            name: "outputContains",
+            passed: jsonContains(result.output, testCase.expected.outputContains),
+            expected: testCase.expected.outputContains,
+            actual: result.output,
+        });
+    }
+    if (Object.prototype.hasOwnProperty.call(testCase.expected, "errorContains")) {
+        const actualError = result.error === undefined || result.error === null
+            ? ""
+            : String(result.error);
+        assertions.push({
+            name: "errorContains",
+            passed: actualError.includes(String(testCase.expected.errorContains)),
+            expected: String(testCase.expected.errorContains),
+            actual: actualError,
+        });
+    }
+    return {
+        passed: assertions.every((assertion) => assertion.passed),
+        assertions,
+    };
+}
+
+/**
+ * @param {{
+ *   plan: ReturnType<typeof buildEvalPlan>;
+ *   results: Array<Record<string, unknown> & { passed: boolean; status?: string; durationMs?: number }>;
+ *   startedAtMs: number;
+ *   finishedAtMs: number;
+ *   reportPath?: string | null;
+ * }} input
+ */
+export function buildEvalReport(input) {
+    return {
+        suiteId: input.plan.suiteId,
+        runLabel: input.plan.runLabel,
+        workflowPath: input.plan.workflowPath,
+        casesPath: input.plan.casesPath,
+        startedAtMs: input.startedAtMs,
+        finishedAtMs: input.finishedAtMs,
+        durationMs: input.finishedAtMs - input.startedAtMs,
+        reportPath: input.reportPath ?? null,
+        summary: summarizeEvalResults(input.results),
+        results: input.results,
+    };
+}
+
+/**
+ * @param {string} root
+ * @param {string} suiteId
+ */
+export function defaultEvalReportPath(root, suiteId) {
+    return join(root, ".smithers", "evals", `${suiteId}.json`);
+}
+
+/**
+ * @param {string} root
+ * @param {string | undefined} path
+ */
+function resolveOutputPath(root, path) {
+    if (!path) {
+        return null;
+    }
+    return isAbsolute(path) ? path : resolve(root, path);
+}
+
+/**
+ * @param {string} root
+ * @param {string} suiteId
+ * @param {string | undefined} path
+ */
+export function resolveEvalReportPath(root, suiteId, path) {
+    return resolveOutputPath(root, path) ?? defaultEvalReportPath(root, suiteId);
+}
+
+/**
+ * @param {string} root
+ * @param {string} suiteId
+ * @param {{ path?: string; force?: boolean }} [options]
+ */
+export function assertEvalReportWritable(root, suiteId, options = {}) {
+    const target = resolveEvalReportPath(root, suiteId, options.path);
+    if (existsSync(target) && !options.force) {
+        throw new SmithersError("INVALID_INPUT", `Eval report already exists: ${target}. Pass --force to overwrite.`, { path: target });
+    }
+    return target;
+}
+
+/**
+ * @param {string} root
+ * @param {Record<string, unknown>} report
+ * @param {{ path?: string; force?: boolean }} [options]
+ */
+export function writeEvalReport(root, report, options = {}) {
+    const suiteId = typeof report.suiteId === "string" ? report.suiteId : "suite";
+    const target = assertEvalReportWritable(root, suiteId, options);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, `${JSON.stringify({ ...report, reportPath: target }, null, 2)}\n`, "utf8");
+    return target;
+}
+
+/**
+ * @param {ReturnType<typeof buildEvalPlan>} plan
+ */
+export function renderEvalPlan(plan) {
+    const lines = [
+        `Eval suite: ${plan.suiteId}`,
+        ...(plan.runLabel ? [`Run label: ${plan.runLabel}`] : []),
+        `Workflow: ${plan.workflowPath}`,
+        `Cases: ${plan.plannedCases}${plan.totalCases !== plan.plannedCases ? ` of ${plan.totalCases}` : ""}`,
+        "",
+        "Planned runs:",
+    ];
+    for (const testCase of plan.cases) {
+        lines.push(`- ${testCase.id} -> ${testCase.runId} (expect ${testCase.expected.status})`);
+    }
+    lines.push("");
+    lines.push("Dry run only. Re-run without --dry-run to execute the suite.");
+    return lines.join("\n");
+}
+
+/**
+ * @param {ReturnType<typeof buildEvalReport>} report
+ */
+export function renderEvalReport(report) {
+    const lines = [
+        `Eval suite: ${report.suiteId}`,
+        ...(report.runLabel ? [`Run label: ${report.runLabel}`] : []),
+        `Workflow: ${report.workflowPath}`,
+        `Result: ${report.summary.passed}/${report.summary.total} passed`,
+        `Duration: ${report.durationMs}ms`,
+    ];
+    if (report.reportPath) {
+        lines.push(`Report: ${report.reportPath}`);
+    }
+    lines.push("");
+    lines.push("Cases:");
+    for (const result of report.results) {
+        const mark = result.passed ? "PASS" : "FAIL";
+        lines.push(`- ${mark} ${result.caseId} -> ${result.runId} (${result.status ?? "error"}, ${result.durationMs ?? 0}ms)`);
+        if (result.error) {
+            lines.push(`  ${result.error}`);
+        }
+    }
+    return lines.join("\n");
+}

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -41,6 +41,7 @@ import { agentAddWizard } from "./agent-commands/agentAddWizard.js";
 import { initWorkflowPack, getWorkflowFollowUpCtas } from "./workflow-pack.js";
 import { discoverWorkflows, resolveWorkflow, createWorkflowFile } from "./workflows.js";
 import {
+    assertEvalRunIdsAvailable,
     assertEvalReportWritable,
     buildEvalPlan,
     buildEvalReport,
@@ -1321,7 +1322,7 @@ const upOptions = z.object({
 const evalOptions = z.object({
     cases: z.string().describe("JSON or JSONL eval case file"),
     suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
-    runLabel: z.string().optional().describe("Run label appended to eval run IDs; defaults to current UTC timestamp"),
+    runLabel: z.string().optional().describe("Run label appended to eval run IDs; defaults to current UTC timestamp plus a nonce"),
     dryRun: z.boolean().default(false).describe("Plan the suite without launching runs"),
     concurrency: z.number().int().min(1).max(16).default(1).describe("Number of eval cases to run at once"),
     maxCases: z.number().int().min(1).optional().describe("Run only the first N cases"),
@@ -1497,7 +1498,8 @@ function formatRequestedJsonOutput() {
     return false;
 }
 function defaultEvalRunLabel() {
-    return new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
+    const timestamp = new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
+    return `${timestamp}-${crypto.randomUUID().slice(0, 8)}`;
 }
 /**
  * @param {string} workflowInput
@@ -2738,6 +2740,7 @@ const cli = Cli.create({
             });
             const workflow = await loadWorkflow(workflowPath);
             ensureSmithersTables(workflow.db);
+            await assertEvalRunIdsAvailable(new SmithersDb(workflow.db), plan.cases);
             setupSqliteCleanup(workflow);
             const schema = resolveSchema(workflow.db);
             const resolvedWorkflowPath = resolve(process.cwd(), workflowPath);
@@ -2766,9 +2769,7 @@ const cli = Cli.create({
                         },
                         signal: abort.signal,
                     }));
-                    const output = result.output === undefined
-                        ? await loadOutputs(workflow.db, schema, testCase.runId)
-                        : result.output;
+                    const output = await loadOutputs(workflow.db, schema, testCase.runId);
                     const durationMs = Date.now() - caseStartedAtMs;
                     const evaluation = evaluateEvalCaseResult(testCase, {
                         ...result,
@@ -2792,7 +2793,7 @@ const cli = Cli.create({
                     const durationMs = Date.now() - caseStartedAtMs;
                     const evaluation = evaluateEvalCaseResult(testCase, {
                         status: "error",
-                        error: errorMessage,
+                        error: err,
                     });
                     return {
                         caseId: testCase.id,

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -40,6 +40,16 @@ import { runAgentAdd, pingAccount } from "./agent-commands/runAgentAdd.js";
 import { agentAddWizard } from "./agent-commands/agentAddWizard.js";
 import { initWorkflowPack, getWorkflowFollowUpCtas } from "./workflow-pack.js";
 import { discoverWorkflows, resolveWorkflow, createWorkflowFile } from "./workflows.js";
+import {
+    assertEvalReportWritable,
+    buildEvalPlan,
+    buildEvalReport,
+    evaluateEvalCaseResult,
+    loadEvalCases,
+    renderEvalPlan,
+    renderEvalReport,
+    writeEvalReport,
+} from "./eval-suite.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1308,6 +1318,24 @@ const upOptions = z.object({
     authToken: z.string().optional().describe("Bearer token for HTTP auth (or set SMITHERS_API_KEY)"),
     metrics: z.boolean().default(true).describe("Expose /metrics endpoint (with --serve)"),
 });
+const evalOptions = z.object({
+    cases: z.string().describe("JSON or JSONL eval case file"),
+    suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
+    runLabel: z.string().optional().describe("Run label appended to eval run IDs; defaults to current UTC timestamp"),
+    dryRun: z.boolean().default(false).describe("Plan the suite without launching runs"),
+    concurrency: z.number().int().min(1).max(16).default(1).describe("Number of eval cases to run at once"),
+    maxCases: z.number().int().min(1).optional().describe("Run only the first N cases"),
+    report: z.string().optional().describe("Write report JSON to this path"),
+    force: z.boolean().default(false).describe("Overwrite an existing eval report"),
+    includeOutput: z.boolean().default(true).describe("Include workflow outputs in the report"),
+    maxConcurrency: z.number().int().min(1).optional().describe("Per-workflow max task concurrency"),
+    root: z.string().optional().describe("Tool sandbox root directory"),
+    log: z.boolean().default(true).describe("Enable NDJSON event log file output"),
+    logDir: z.string().optional().describe("NDJSON event logs directory"),
+    allowNetwork: z.boolean().default(false).describe("Allow bash tool network requests"),
+    maxOutputBytes: z.number().int().min(1).optional().describe("Max bytes a single tool call can return"),
+    toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
+});
 const superviseOptions = z.object({
     dryRun: z.boolean().default(false).describe("Show which stale runs would be resumed, without acting"),
     interval: z.string().default("10s").describe("Poll interval (e.g. 10s, 30s, 1m)"),
@@ -1454,6 +1482,53 @@ function normalizeWorkflowRunOptions(options) {
                 : undefined),
         root: options.root ?? ".",
     };
+}
+function formatRequestedJsonOutput() {
+    for (let index = 0; index < process.argv.length; index += 1) {
+        const arg = process.argv[index];
+        if (arg === "--format") {
+            const value = process.argv[index + 1];
+            return value === "json" || value === "jsonl";
+        }
+        if (arg === "--format=json" || arg === "--format=jsonl") {
+            return true;
+        }
+    }
+    return false;
+}
+function defaultEvalRunLabel() {
+    return new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
+}
+/**
+ * @param {string} workflowInput
+ */
+function resolveWorkflowPathForEval(workflowInput) {
+    const asPath = resolve(process.cwd(), workflowInput);
+    if (existsSync(asPath)) {
+        return workflowInput;
+    }
+    return resolveWorkflow(workflowInput, process.cwd()).entryFile;
+}
+/**
+ * @template T
+ * @template R
+ * @param {T[]} items
+ * @param {number} limit
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @returns {Promise<R[]>}
+ */
+async function runWithLimit(items, limit, worker) {
+    const results = new Array(items.length);
+    let cursor = 0;
+    const workerCount = Math.min(limit, items.length);
+    await Promise.all(Array.from({ length: workerCount }, async () => {
+        while (cursor < items.length) {
+            const index = cursor;
+            cursor += 1;
+            results[index] = await worker(items[index], index);
+        }
+    }));
+    return results;
 }
 /**
  * @param {string} intervalRaw
@@ -2622,6 +2697,142 @@ const cli = Cli.create({
             return c.error(opts);
         };
         return executeUpCommand(c, c.args.workflow, c.options, fail);
+    },
+})
+    // =========================================================================
+    // smithers eval <workflow>
+    // =========================================================================
+    .command("eval", {
+    description: "Run a workflow over a JSON/JSONL eval suite and write a regression report.",
+    args: workflowArgs,
+    options: evalOptions,
+    alias: { cases: "c", suite: "s", dryRun: "n", concurrency: "j", report: "r" },
+    async run(c) {
+        const fail = (opts) => {
+            commandExitOverride = opts.exitCode ?? 1;
+            return c.error(opts);
+        };
+        try {
+            const workflowPath = resolveWorkflowPathForEval(c.args.workflow);
+            const loadedCases = loadEvalCases(process.cwd(), c.options.cases, {
+                maxCases: c.options.maxCases,
+            });
+            const plan = buildEvalPlan({
+                suiteId: c.options.suite,
+                runLabel: c.options.runLabel ?? defaultEvalRunLabel(),
+                workflowPath,
+                casesPath: c.options.cases,
+                loadedCases,
+            });
+            const wantsStructured = c.format === "json" || c.format === "jsonl" || formatRequestedJsonOutput();
+            if (c.options.dryRun) {
+                if (wantsStructured) {
+                    return c.ok({ suite: plan });
+                }
+                process.stdout.write(`${renderEvalPlan(plan)}\n`);
+                return c.ok(undefined);
+            }
+            assertEvalReportWritable(process.cwd(), plan.suiteId, {
+                path: c.options.report,
+                force: c.options.force,
+            });
+            const workflow = await loadWorkflow(workflowPath);
+            ensureSmithersTables(workflow.db);
+            setupSqliteCleanup(workflow);
+            const schema = resolveSchema(workflow.db);
+            const resolvedWorkflowPath = resolve(process.cwd(), workflowPath);
+            const rootDir = c.options.root ? resolve(process.cwd(), c.options.root) : dirname(resolvedWorkflowPath);
+            const logDir = c.options.log ? c.options.logDir : null;
+            const abort = setupAbortSignal();
+            const startedAtMs = Date.now();
+            const results = await runWithLimit(plan.cases, c.options.concurrency, async (testCase) => {
+                const caseStartedAtMs = Date.now();
+                process.stderr.write(`[eval:${plan.suiteId}] ${testCase.id} -> ${testCase.runId}\n`);
+                try {
+                    const result = await Effect.runPromise(runWorkflow(workflow, {
+                        input: testCase.input,
+                        runId: testCase.runId,
+                        workflowPath: resolvedWorkflowPath,
+                        maxConcurrency: c.options.maxConcurrency,
+                        rootDir,
+                        logDir,
+                        allowNetwork: c.options.allowNetwork,
+                        maxOutputBytes: c.options.maxOutputBytes,
+                        toolTimeoutMs: c.options.toolTimeoutMs,
+                        annotations: {
+                            suiteId: plan.suiteId,
+                            caseId: testCase.id,
+                            ...testCase.annotations,
+                        },
+                        signal: abort.signal,
+                    }));
+                    const output = result.output === undefined
+                        ? await loadOutputs(workflow.db, schema, testCase.runId)
+                        : result.output;
+                    const durationMs = Date.now() - caseStartedAtMs;
+                    const evaluation = evaluateEvalCaseResult(testCase, {
+                        ...result,
+                        output,
+                    });
+                    return {
+                        caseId: testCase.id,
+                        runId: testCase.runId,
+                        expectedStatus: testCase.expected.status,
+                        status: result.status,
+                        passed: evaluation.passed,
+                        assertions: evaluation.assertions,
+                        durationMs,
+                        input: testCase.input,
+                        ...(c.options.includeOutput ? { output } : {}),
+                        metadata: testCase.metadata,
+                    };
+                }
+                catch (err) {
+                    const errorMessage = err?.message ?? String(err);
+                    const durationMs = Date.now() - caseStartedAtMs;
+                    const evaluation = evaluateEvalCaseResult(testCase, {
+                        status: "error",
+                        error: errorMessage,
+                    });
+                    return {
+                        caseId: testCase.id,
+                        runId: testCase.runId,
+                        expectedStatus: testCase.expected.status,
+                        status: "error",
+                        passed: evaluation.passed,
+                        assertions: evaluation.assertions,
+                        durationMs,
+                        input: testCase.input,
+                        error: errorMessage,
+                        metadata: testCase.metadata,
+                    };
+                }
+            });
+            const finishedAtMs = Date.now();
+            let report = buildEvalReport({
+                plan,
+                results,
+                startedAtMs,
+                finishedAtMs,
+            });
+            const reportPath = writeEvalReport(process.cwd(), report, {
+                path: c.options.report,
+                force: c.options.force,
+            });
+            report = { ...report, reportPath };
+            process.exitCode = report.summary.failed > 0 ? 1 : 0;
+            if (wantsStructured) {
+                return c.ok({ eval: report });
+            }
+            process.stdout.write(`${renderEvalReport(report)}\n`);
+            return c.ok(undefined);
+        }
+        catch (err) {
+            if (err instanceof SmithersError) {
+                return fail({ code: err.code, message: err.message, exitCode: 4 });
+            }
+            return fail({ code: "EVAL_FAILED", message: err?.message ?? String(err), exitCode: 1 });
+        }
     },
 })
     // =========================================================================
@@ -4990,7 +5201,7 @@ wrapCliCommandHandlersWithInputBounds(cliCommands);
 // Main
 // ---------------------------------------------------------------------------
 const KNOWN_COMMANDS = new Set([
-    "init", "up", "supervise", "down", "ps", "logs", "events", "chat", "inspect", "node", "why", "approve", "deny",
+    "init", "up", "eval", "supervise", "down", "ps", "logs", "events", "chat", "inspect", "node", "why", "approve", "deny",
     "cancel", "graph", "revert", "scores", "observability", "workflow", "ask", "cron", "chat-create",
     "replay", "diff", "fork", "timeline", "memory", "openapi", "token", "agents", "alerts",
     "tree", "output", "rewind", "gui",

--- a/apps/cli/tests/eval-suite.test.js
+++ b/apps/cli/tests/eval-suite.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildEvalPlan,
+    evaluateEvalCaseResult,
+    evalRunId,
+    loadEvalCases,
+    renderEvalPlan,
+} from "../src/eval-suite.js";
+import { createTempRepo, runSmithers, writeTestWorkflow } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+describe("eval suite helpers", () => {
+    test("loads JSONL cases and builds stable run IDs", () => {
+        const repo = createTempRepo();
+        repo.write("evals/smoke.jsonl", [
+            '{"id":"alpha","input":{"prompt":"A"},"expected":{"status":"finished"}}',
+            '{"name":"Beta Case","input":{"prompt":"B"},"annotations":{"area":"docs"}}',
+            "",
+        ].join("\n"));
+
+        const loaded = loadEvalCases(repo.dir, "evals/smoke.jsonl");
+        const plan = buildEvalPlan({
+            suiteId: "Release Smoke",
+            runLabel: "ci-123",
+            workflowPath: "workflow.tsx",
+            casesPath: "evals/smoke.jsonl",
+            loadedCases: loaded,
+        });
+
+        expect(plan.suiteId).toBe("release-smoke");
+        expect(plan.runLabel).toBe("ci-123");
+        expect(plan.plannedCases).toBe(2);
+        expect(plan.cases[0].runId).toBe("eval-release-smoke-ci-123-alpha");
+        expect(plan.cases[1].id).toBe("beta-case");
+        expect(renderEvalPlan(plan)).toContain("Dry run only");
+    });
+
+    test("caps long eval run IDs", () => {
+        const id = evalRunId("suite-with-a-very-long-name-that-keeps-going", "case-with-a-very-long-name-that-keeps-going");
+        expect(id.length).toBeLessThanOrEqual(64);
+        expect(id.startsWith("eval-")).toBe(true);
+    });
+
+    test("evaluates status, exact output, and partial output assertions", () => {
+        const testCase = {
+            id: "checks",
+            name: "checks",
+            input: {},
+            annotations: {},
+            expected: {
+                status: "finished",
+                output: [{ summary: "ok", nested: { score: 1 } }],
+                outputContains: [{ nested: { score: 1 } }],
+            },
+            metadata: {},
+        };
+        const result = evaluateEvalCaseResult(testCase, {
+            status: "finished",
+            output: [{ nested: { score: 1 }, summary: "ok" }],
+        });
+
+        expect(result.passed).toBe(true);
+        expect(result.assertions.map((assertion) => assertion.name)).toEqual([
+            "status",
+            "output",
+            "outputContains",
+        ]);
+    });
+});
+
+describe("smithers eval command", () => {
+    test("prints a dry-run plan", () => {
+        const repo = createTempRepo();
+        writeTestWorkflow(repo);
+        repo.write("evals/smoke.jsonl", '{"id":"alpha","input":{"prompt":"A"},"expected":{"status":"finished"}}\n');
+
+        const result = runSmithers([
+            "eval",
+            "workflow.tsx",
+            "--cases",
+            "evals/smoke.jsonl",
+            "--suite",
+            "smoke",
+            "--run-label",
+            "ci",
+            "--dry-run",
+        ], { cwd: repo.dir, format: null });
+
+        if (result.exitCode !== 0) {
+            throw new Error(`smithers eval exited ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        }
+        expect(result.stdout).toContain("Eval suite: smoke");
+        expect(result.stdout).toContain("eval-smoke-ci-alpha");
+        expect(result.stdout).toContain("Dry run only");
+    });
+
+    test("runs cases, checks outputs, and writes a report", () => {
+        const repo = createTempRepo();
+        writeTestWorkflow(repo);
+        repo.write("evals/smoke.jsonl", [
+            '{"id":"alpha","input":{"prompt":"A"},"expected":{"status":"finished","outputContains":{"result":[{"prompt":"A"}]}}}',
+            '{"id":"beta","input":{"prompt":"B"},"expected":{"status":"finished","outputContains":{"result":[{"summary":"fixture workflow ran"}]}}}',
+            "",
+        ].join("\n"));
+
+        const result = runSmithers([
+            "eval",
+            "workflow.tsx",
+            "--cases",
+            "evals/smoke.jsonl",
+            "--suite",
+            "smoke",
+            "--run-label",
+            "ci",
+            "--report",
+            "artifacts/smoke-report.json",
+            "--force",
+        ], { cwd: repo.dir, format: "json" });
+
+        if (result.exitCode !== 0) {
+            throw new Error(`smithers eval exited ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        }
+        expect(result.json?.eval.summary).toMatchObject({
+            total: 2,
+            passed: 2,
+            failed: 0,
+        });
+        expect(result.json?.eval.results[0]).toMatchObject({
+            caseId: "alpha",
+            runId: "eval-smoke-ci-alpha",
+            passed: true,
+        });
+        expect(repo.exists("artifacts/smoke-report.json")).toBe(true);
+        const report = JSON.parse(repo.read("artifacts/smoke-report.json"));
+        expect(report.summary.total).toBe(2);
+        expect(report.results[0].assertions.map((assertion) => assertion.name)).toContain("outputContains");
+    }, 20_000);
+});

--- a/apps/cli/tests/eval-suite.test.js
+++ b/apps/cli/tests/eval-suite.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+    assertEvalRunIdsAvailable,
     buildEvalPlan,
     evaluateEvalCaseResult,
     evalRunId,
@@ -40,6 +41,18 @@ describe("eval suite helpers", () => {
         expect(id.startsWith("eval-")).toBe(true);
     });
 
+    test("rejects ambiguous eval case files before planning", () => {
+        const repo = createTempRepo();
+        repo.write("evals/dupes.jsonl", [
+            '{"id":"Alpha Case","input":{}}',
+            '{"id":"alpha-case","input":{}}',
+        ].join("\n"));
+        expect(() => loadEvalCases(repo.dir, "evals/dupes.jsonl")).toThrow("Duplicate eval case ID after normalization: alpha-case");
+
+        repo.write("evals/unknown-expected.jsonl", '{"id":"alpha","expected":{"outputsContains":{}}}\n');
+        expect(() => loadEvalCases(repo.dir, "evals/unknown-expected.jsonl")).toThrow("unsupported assertion keys");
+    });
+
     test("evaluates status, exact output, and partial output assertions", () => {
         const testCase = {
             id: "checks",
@@ -64,6 +77,48 @@ describe("eval suite helpers", () => {
             "output",
             "outputContains",
         ]);
+    });
+
+    test("supports continued status and structured error matching", () => {
+        const testCase = {
+            id: "error",
+            name: "error",
+            input: {},
+            annotations: {},
+            expected: {
+                status: "continued",
+                errorContains: "durable handoff",
+            },
+            metadata: {},
+        };
+        const result = evaluateEvalCaseResult(testCase, {
+            status: "continued",
+            error: { message: "continued via durable handoff", code: "CONTINUED" },
+        });
+
+        expect(result.passed).toBe(true);
+        expect(result.assertions.map((assertion) => assertion.name)).toEqual([
+            "status",
+            "errorContains",
+        ]);
+    });
+
+    test("detects existing run IDs before execution", async () => {
+        let checked = 0;
+        await assertEvalRunIdsAvailable({
+            async getRun(runId) {
+                checked += 1;
+                return runId === "eval-smoke-alpha" ? { runId } : null;
+            },
+        }, [
+            { runId: "eval-smoke-alpha" },
+            { runId: "eval-smoke-beta" },
+        ]).then(() => {
+            throw new Error("expected duplicate run ID rejection");
+        }).catch((err) => {
+            expect(err.message).toContain("Eval run ID already exists");
+        });
+        expect(checked).toBe(2);
     });
 });
 
@@ -133,5 +188,23 @@ describe("smithers eval command", () => {
         const report = JSON.parse(repo.read("artifacts/smoke-report.json"));
         expect(report.summary.total).toBe(2);
         expect(report.results[0].assertions.map((assertion) => assertion.name)).toContain("outputContains");
+        expect(report.results[0].output.result[0].prompt).toBe("A");
+
+        const rerun = runSmithers([
+            "eval",
+            "workflow.tsx",
+            "--cases",
+            "evals/smoke.jsonl",
+            "--suite",
+            "smoke",
+            "--run-label",
+            "ci",
+            "--report",
+            "artifacts/smoke-report.json",
+            "--force",
+        ], { cwd: repo.dir, format: "json" });
+
+        expect(rerun.exitCode).toBe(4);
+        expect(rerun.json?.code).toBe("EVAL_RUN_ID_EXISTS");
     }, 20_000);
 });

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -11,7 +11,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 - Boolean flags accept either bare form (`--watch`) or explicit `--watch true|false`.
 - Global options: `--format toon|json|yaml|md|jsonl`, `--filter-output <key.path>`, `--full-output`, `--token-count`, `--token-limit N`, `--token-offset N`, `--schema`, `--llms`, `--llms-full`, `--mcp`, `--help`, `--version`.
 - MCP stdio mode: pass `--mcp` to start Smithers as an MCP server. Add `--surface semantic|raw|both` to choose the exposed tool surface.
-- Workflow resolution: `up`, `graph`, `revert`, `replay`, `fork`, `retry-task`, and `timetravel` take a workflow file path. `workflow run <name>` resolves IDs from `.smithers/workflows/<name>.tsx`.
+- Workflow resolution: `up`, `graph`, `revert`, `replay`, `fork`, `retry-task`, and `timetravel` take a workflow file path. `eval` accepts either a workflow path or a discovered workflow ID. `workflow run <name>` resolves IDs from `.smithers/workflows/<name>.tsx`.
 - Rewrites: `smithers workflow <id>` runs a discovered workflow when `<id>` resolves; `smithers workflow.tsx` behaves like `smithers up workflow.tsx`; `smithers chat create` behaves like `smithers chat-create`; `smithers .` opens the current directory in Smithers GUI.
 
 ## Exit codes
@@ -31,7 +31,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[59]:
+commands[60]:
   - name: init
     purpose: Install the local workflow pack into .smithers/
     flags[4]{name,short,type,default,desc}:
@@ -72,6 +72,27 @@ commands[59]:
       host,,string,127.0.0.1,HTTP bind address when --serve
       auth-token,,string,,Bearer token for HTTP auth or SMITHERS_API_KEY env
       metrics,,boolean,true,Expose /metrics Prometheus endpoint when --serve
+  - name: eval
+    purpose: Run a workflow over JSON/JSONL cases and write a regression report
+    args[1]{name,type,required,desc}:
+      workflow,string,true,Workflow file path or discovered workflow ID
+    flags[16]{name,short,type,default,desc}:
+      cases,c,string,,JSON array, { cases: [...] }, or JSONL case file
+      suite,s,string,,Stable suite ID used in run IDs and report paths
+      run-label,,string,current UTC timestamp,Label appended to eval run IDs
+      dry-run,n,boolean,false,Plan run IDs without launching workflows
+      concurrency,j,number,1,Number of eval cases to run at once
+      max-cases,,number,,Run only the first N cases
+      report,r,string,.smithers/evals/<suite>.json,Report path
+      force,,boolean,false,Overwrite an existing report
+      include-output,,boolean,true,Include workflow outputs in the report
+      max-concurrency,,number,,Per-workflow task concurrency
+      root,,string,,Tool sandbox root directory
+      log,,boolean,true,Enable NDJSON event log file output
+      log-dir,,string,,NDJSON event logs directory
+      allow-network,,boolean,false,Allow bash tool network requests
+      max-output-bytes,,number,,Max bytes a single tool call can return
+      tool-timeout-ms,,number,,Max wall-clock time per tool call in ms
   - name: supervise
     purpose: Watch for stale running runs and auto-resume them
     flags[4]{name,short,type,default,desc}:

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -79,7 +79,7 @@ commands[60]:
     flags[16]{name,short,type,default,desc}:
       cases,c,string,,JSON array, { cases: [...] }, or JSONL case file
       suite,s,string,,Stable suite ID used in run IDs and report paths
-      run-label,,string,current UTC timestamp,Label appended to eval run IDs
+      run-label,,string,current UTC timestamp + nonce,Label appended to eval run IDs
       dry-run,n,boolean,false,Plan run IDs without launching workflows
       concurrency,j,number,1,Number of eval cases to run at once
       max-cases,,number,,Run only the first N cases

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,6 +45,7 @@
         "pages": [
           "cli/quickstart",
           "cli/overview",
+          "guides/evals-quickstart",
           "guides/tui",
           "deployment/reference"
         ]
@@ -335,7 +336,6 @@
     { "source": "/guides/troubleshooting", "destination": "/cli/overview" },
     { "source": "/guides/tutorial-workflow", "destination": "/tour" },
     { "source": "/guides/time-travel-quickstart", "destination": "/recipes" },
-    { "source": "/guides/evals-quickstart", "destination": "/recipes" },
     { "source": "/guides/memory-quickstart", "destination": "/llms-memory.txt" },
     { "source": "/guides/openapi-tools-quickstart", "destination": "/llms-openapi.txt" },
     { "source": "/guides/project-structure", "destination": "/recipes" },

--- a/docs/guides/evals-quickstart.mdx
+++ b/docs/guides/evals-quickstart.mdx
@@ -1,6 +1,93 @@
 ---
-title: "Evals Quickstart"
-description: Folded into Recipes.
+title: "Eval Suites Quickstart"
+description: Run repeatable workflow regressions from JSON or JSONL cases.
 ---
 
-This material is now in [Recipes](/recipes#scoring-tasks).
+Use eval suites when a workflow is important enough to protect with repeatable cases. Each case gets a persisted run record, stable case metadata, and a JSON report that can be checked in CI.
+
+## 1. Create cases
+
+Create `evals/smoke.jsonl`:
+
+```jsonl
+{"id":"simple-request","input":{"prompt":"Summarize the repository"},"expected":{"status":"finished"}}
+{"id":"structured-output","input":{"prompt":"Return the key risks"},"expected":{"status":"finished","outputContains":{"analysis":[{"riskLevel":"low"}]}}}
+```
+
+Case files can be JSONL, a JSON array, or an object with a `cases` array:
+
+```json
+{
+  "cases": [
+    {
+      "id": "happy-path",
+      "input": { "prompt": "Draft a release note" },
+      "annotations": { "area": "release" },
+      "expected": {
+        "status": "finished",
+        "outputContains": { "analysis": [{ "riskLevel": "low" }] }
+      }
+    }
+  ]
+}
+```
+
+Supported `expected` checks:
+
+- `status`: one of `finished`, `failed`, `cancelled`, `waiting-approval`, `waiting-event`, or `waiting-timer`
+- `output`: exact JSON match against the workflow result output
+- `outputContains`: recursive partial JSON match
+- `errorContains`: substring match against thrown errors
+
+For standard workflows, output assertions match the persisted output snapshot, keyed by output name.
+
+## 2. Dry-run the plan
+
+```bash
+bunx smithers-orchestrator eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --dry-run
+```
+
+Dry-run mode prints the planned case IDs and run IDs without touching the database. Pass `--run-label <label>` when you want the dry-run and execution to use the same generated IDs.
+
+## 3. Execute the suite
+
+```bash
+bunx smithers-orchestrator eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --force
+```
+
+By default, the report is written to `.smithers/evals/smoke.json`. Use `--report path/to/report.json` to choose a different location.
+
+The command exits `0` when all cases pass and `1` when any case fails. Invalid case files exit with `4`.
+
+## 4. Use structured output in CI
+
+```bash
+bunx smithers-orchestrator eval workflow.tsx \
+  --cases evals/smoke.jsonl \
+  --suite smoke \
+  --report artifacts/smoke-eval.json \
+  --force \
+  --format json
+```
+
+The JSON payload includes the suite summary, per-case assertions, run IDs, inputs, outputs, errors, and report path.
+
+## Options that matter in production
+
+- `--concurrency N`: run multiple cases at once; keep this low for stateful or expensive workflows.
+- `--run-label LABEL`: append a stable label to run IDs, useful for CI build IDs or benchmark names.
+- `--max-concurrency N`: pass a per-workflow task concurrency cap to each case.
+- `--max-cases N`: shard or sample a large suite.
+- `--no-include-output`: omit workflow outputs from the report when outputs are too large or sensitive.
+- `--allow-network`: enable network access for bash tools in cases that need it.
+- `--root PATH`: set the sandbox root for tool execution.
+
+## Run a discovered workflow
+
+`eval` also accepts workflow IDs from `.smithers/workflows`:
+
+```bash
+bunx smithers-orchestrator eval implement --cases evals/implement.jsonl --suite implement-smoke
+```
+
+Use this for workflow packs so the same suite can run on every checkout without hard-coding entry file paths.

--- a/docs/recipes.mdx
+++ b/docs/recipes.mdx
@@ -292,7 +292,7 @@ Scorers run after the task and never block. Sample expensive scorers with `ratio
 bunx smithers-orchestrator eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --force
 ```
 
-Use eval suites when you need repeatable workflow-level checks. `output` asserts exact JSON; `outputContains` asserts a recursive partial match; reports are written to `.smithers/evals/<suite>.json` and exit non-zero on failed cases.
+Use eval suites when you need repeatable workflow-level checks. Expected assertions support `status`, `output`, `outputContains`, and `errorContains`; unknown assertion keys fail before launch. `output` asserts exact JSON against the normalized output snapshot, while `outputContains` asserts a recursive partial match. Reports are written to `.smithers/evals/<suite>.json` and exit non-zero on failed cases. Reuse `--run-label` only when you know the generated run IDs are new.
 
 ## Continue-as-new for very long runs
 

--- a/docs/recipes.mdx
+++ b/docs/recipes.mdx
@@ -281,6 +281,19 @@ import { schemaAdherenceScorer, latencyScorer, llmJudge } from "smithers-orchest
 
 Scorers run after the task and never block. Sample expensive scorers with `ratio`.
 
+## Eval suites for regressions
+
+```jsonl
+{"id":"happy-path","input":{"prompt":"Draft release notes"},"expected":{"status":"finished"}}
+{"id":"quality-gate","input":{"prompt":"Find risky changes"},"expected":{"status":"finished","outputContains":{"analysis":[{"riskLevel":"low"}]}}}
+```
+
+```bash
+bunx smithers-orchestrator eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --force
+```
+
+Use eval suites when you need repeatable workflow-level checks. `output` asserts exact JSON; `outputContains` asserts a recursive partial match; reports are written to `.smithers/evals/<suite>.json` and exit non-zero on failed cases.
+
 ## Continue-as-new for very long runs
 
 A run with too much accumulated state hands off to a fresh run with carried state.


### PR DESCRIPTION
Summary
- Add `smithers eval` for JSON and JSONL workflow regression suites.
- Support dry-run planning, run labels, bounded case concurrency, status checks, output assertions, error substring checks, and persisted JSON reports.
- Document eval suites in the CLI catalog, quickstart guide, recipes, and README.

Validation
- `pnpm --filter @smithers-orchestrator/cli typecheck`
- `pnpm --filter @smithers-orchestrator/cli test`
- `pnpm typecheck`
