### PR TITLE
Harden runtime durability, sandboxing, and operator console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,27 @@ jobs:
       - run: pnpm -r typecheck
 
       - run: pnpm --filter ./.smithers typecheck
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.10.0
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm test

--- a/apps/cli/src/agent-commands/regenerateAgentsTsIfPresent.js
+++ b/apps/cli/src/agent-commands/regenerateAgentsTsIfPresent.js
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { generateAgentsTs } from "../agent-detection.js";
+import { extractGeneratedDetectionProviderIds, generateAgentsTs } from "../agent-detection.js";
 
 /**
  * If the current working directory contains a `.smithers/agents.ts` that was
@@ -19,7 +19,10 @@ export function regenerateAgentsTsIfPresent(cwd = process.cwd()) {
     if (!existing.startsWith("// smithers-source: generated")) {
         return { rewritten: false, path, reason: "agents.ts has been edited by hand; not overwriting" };
     }
-    const next = generateAgentsTs(process.env);
+    const next = generateAgentsTs(process.env, {
+        cwd,
+        preserveProviderIds: extractGeneratedDetectionProviderIds(existing),
+    });
     if (next === existing) {
         return { rewritten: false, path, reason: "no changes" };
     }

--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -154,6 +154,39 @@ function baseAgentIdForProviderId(id) {
 }
 
 /**
+ * Extracts detection-derived provider ids from a generated `.smithers/agents.ts`.
+ * Account labels are deliberately ignored; the accounts registry remains the
+ * source of truth for account-backed providers.
+ *
+ * @param {string} source
+ * @returns {Set<string>}
+ */
+export function extractGeneratedDetectionProviderIds(source) {
+    const ids = new Set();
+    if (!source.startsWith("// smithers-source: generated")) {
+        return ids;
+    }
+    const providersMatch = source.match(/export const providers\s*=\s*{([\s\S]*?)}\s*as const;/);
+    if (!providersMatch) {
+        return ids;
+    }
+    const providerKeyPattern = /^\s*([A-Za-z_$][\w$]*)\s*:/gm;
+    let match;
+    while ((match = providerKeyPattern.exec(providersMatch[1])) !== null) {
+        const providerId = match[1];
+        if (detectorForId(providerId)) {
+            ids.add(providerId);
+            continue;
+        }
+        const variant = variantForId(providerId);
+        if (variant) {
+            ids.add(variant.derivedFrom);
+        }
+    }
+    return ids;
+}
+
+/**
  * @param {string} id
  */
 function displayNameForProviderId(id) {
@@ -564,12 +597,32 @@ function renderTierLine(tier, providerIds, comments) {
 
 /**
  * @param {NodeJS.ProcessEnv} [env]
- * @param {{ cwd?: string }} [options]
+ * @param {{ cwd?: string; preserveProviderIds?: Iterable<string> }} [options]
  */
 export function generateAgentsTs(env = process.env, options = {}) {
     const registeredAccounts = listAccounts(env);
     const detections = detectAvailableAgents(env, options);
-    const available = detections.filter((entry) => entry.usable);
+    const availableById = new Map(detections.filter((entry) => entry.usable).map((entry) => [entry.id, entry]));
+    for (const providerId of options.preserveProviderIds ?? []) {
+        const baseId = baseAgentIdForProviderId(providerId);
+        const detector = detectorForId(baseId);
+        if (!detector || availableById.has(baseId)) continue;
+        availableById.set(baseId, {
+            id: detector.id,
+            displayName: detector.displayName,
+            binary: detector.binary,
+            hasBinary: false,
+            hasAuthSignal: false,
+            hasApiKeySignal: false,
+            hasProjectTrustSignal: true,
+            status: "unavailable",
+            score: 0,
+            usable: true,
+            checks: [`preserved-from-generated-agents-ts:${detector.id}`],
+            unusableReasons: [],
+        });
+    }
+    const available = [...availableById.values()];
     if (available.length === 0 && registeredAccounts.length === 0) {
         throw new SmithersError("NO_USABLE_AGENTS", formatNoUsableAgentsMessage(detections));
     }
@@ -581,7 +634,7 @@ export function generateAgentsTs(env = process.env, options = {}) {
     }
     // Base providers in detection order
     const orderedProviders = DETECTORS
-        .map((detector) => available.find((entry) => entry.id === detector.id))
+        .map((detector) => availableById.get(detector.id))
         .filter((entry) => Boolean(entry));
     // Derive variants (e.g. claudeSonnet from claude)
     const availableIds = new Set(orderedProviders.map((p) => p.id));

--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -170,16 +170,20 @@ export function extractGeneratedDetectionProviderIds(source) {
     if (!providersMatch) {
         return ids;
     }
-    const providerKeyPattern = /^\s*([A-Za-z_$][\w$]*)\s*:/gm;
-    let match;
-    while ((match = providerKeyPattern.exec(providersMatch[1])) !== null) {
-        const providerId = match[1];
-        if (detectorForId(providerId)) {
+    for (const line of providersMatch[1].split("\n")) {
+        const match = line.match(/^\s*([A-Za-z_$][\w$]*)\s*:\s*(.*?)\s*,?\s*$/);
+        if (!match)
+            continue;
+        const [, providerId, initializer] = match;
+        const scaffoldedProvider = SCAFFOLDED_PROVIDERS[providerId];
+        const constructorProvider = CONSTRUCTORS[providerId];
+        if ((scaffoldedProvider && initializer === scaffoldedProvider) ||
+            (constructorProvider && initializer === constructorProvider.expr)) {
             ids.add(providerId);
             continue;
         }
         const variant = variantForId(providerId);
-        if (variant) {
+        if (variant && initializer === variant.constructor.expr) {
             ids.add(variant.derivedFrom);
         }
     }

--- a/apps/cli/tests/agents-ts-codegen.test.js
+++ b/apps/cli/tests/agents-ts-codegen.test.js
@@ -107,4 +107,20 @@ describe("generateAgentsTs (account-driven)", () => {
         expect(regenerated).toContain("claudeSonnet: new SmithersClaudeCodeAgent(");
         expect(regenerated).toContain("codexProd: new SmithersCodexAgent(");
     });
+
+    test("does not preserve account labels that collide with generated provider ids", () => {
+        const env = newSmithersHome();
+        addAccount({ label: "codex", provider: "codex", configDir: `${env.HOME}/.smithers/accounts/codex` }, { env });
+        addAccount({ label: "claude-sonnet", provider: "claude-code", configDir: `${env.HOME}/.smithers/accounts/claude-sonnet` }, { env });
+
+        const generated = generateAgentsTs(env);
+        const preserved = extractGeneratedDetectionProviderIds(generated);
+        expect([...preserved]).toEqual([]);
+
+        const regenerated = generateAgentsTs(env, { preserveProviderIds: preserved });
+        expect(regenerated).toContain("codex: new SmithersCodexAgent(");
+        expect(regenerated).toContain("claudeSonnet: new SmithersClaudeCodeAgent(");
+        expect(regenerated).not.toContain("codex: CodexAgent");
+        expect(regenerated).not.toContain("claude: ClaudeCodeAgent");
+    });
 });

--- a/apps/cli/tests/agents-ts-codegen.test.js
+++ b/apps/cli/tests/agents-ts-codegen.test.js
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { addAccount } from "@smithers-orchestrator/accounts";
-import { generateAgentsTs } from "../src/agent-detection.js";
+import { extractGeneratedDetectionProviderIds, generateAgentsTs } from "../src/agent-detection.js";
 import { createExecutableDir, writeFakeClaudeBinary } from "../../../packages/smithers/tests/e2e-helpers.js";
 
 /** @type {string[]} */
@@ -87,5 +87,24 @@ describe("generateAgentsTs (account-driven)", () => {
         expect(generated).toContain("// smithers-source: generated");
         // Detection-based output does NOT pull in the accounts.json header.
         expect(generated).not.toContain("~/.smithers/accounts.json");
+    });
+
+    test("preserves generated detection providers when adding accounts in a different shell", () => {
+        const env = newSmithersHome();
+        const binDir = createExecutableDir();
+        writeFakeClaudeBinary(binDir);
+        const initial = generateAgentsTs({
+            ...env,
+            PATH: `${binDir}:/usr/bin:/bin:/usr/sbin:/sbin`,
+            ANTHROPIC_API_KEY: "test",
+        });
+        expect(initial).toContain("claude: ClaudeCodeAgent");
+        addAccount({ label: "codex-prod", provider: "codex", configDir: `${env.HOME}/.smithers/accounts/codex-prod` }, { env });
+        const regenerated = generateAgentsTs(env, {
+            preserveProviderIds: extractGeneratedDetectionProviderIds(initial),
+        });
+        expect(regenerated).toContain("claude: ClaudeCodeAgent");
+        expect(regenerated).toContain("claudeSonnet: new SmithersClaudeCodeAgent(");
+        expect(regenerated).toContain("codexProd: new SmithersCodexAgent(");
     });
 });

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -52,9 +52,20 @@ ws.onopen = () => ws.send(JSON.stringify({
 }));
 ```
 
+## Operator Console
+
+Gateway serves a built-in operator console at `/console`. It gives non-coding operators a same-origin surface for health, workflow launch, active runs, and pending approvals. The console uses the Gateway RPC API and accepts the same bearer tokens as programmatic clients.
+
+Disable or move it when embedding Smithers behind another app:
+
+```ts
+new Gateway({ operatorUi: false });
+new Gateway({ operatorUi: { path: "/ops", title: "Ops Console" } });
+```
+
 ## Custom React UI
 
-Gateway can also serve a browser React app from the same origin as the RPC and WebSocket API. Use this when a workflow needs a custom operator surface instead of a generic client.
+Gateway can also serve a browser React app from the same origin as the RPC and WebSocket API. Use this when a workflow needs a custom operator surface instead of the built-in console.
 
 ```tsx
 const gateway = new Gateway({

--- a/packages/agents/tests/base-cli-agent-timeouts.test.js
+++ b/packages/agents/tests/base-cli-agent-timeouts.test.js
@@ -22,9 +22,11 @@ class TimedAgent extends BaseCliAgent {
 }
 describe("BaseCliAgent timeouts", () => {
     test("idle timeout resets on stdout activity", async () => {
-        const agent = new TimedAgent("for i in 1 2 3 4 5; do echo tick; sleep 0.05; done", { idleTimeoutMs: 150 });
+        const agent = new TimedAgent("for i in 1 2 3 4 5 6 7 8 9 10; do echo tick-$i; sleep 0.1; done", {
+            idleTimeoutMs: 500,
+        });
         const result = await agent.generate({ prompt: "run" });
-        expect(result.text).toContain("tick");
+        expect(result.text).toContain("tick-10");
     });
     test("idle timeout fails after inactivity", async () => {
         const agent = new TimedAgent("echo start; sleep 0.2; echo end", {

--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -2031,7 +2031,7 @@ export class SmithersDb {
    * @returns {RunnableEffect<void, SmithersError>}
    */
     insertCache(row) {
-        return this.write(`insert cache ${row.cacheKey}`, () => this.internalStorage.insertIgnore("_smithers_cache", row));
+        return this.write(`insert cache ${row.cacheKey}`, () => this.internalStorage.upsert("_smithers_cache", row, ["cacheKey"]));
     }
     /**
    * @param {Record<string, unknown>} row

--- a/packages/db/src/internal-schema.js
+++ b/packages/db/src/internal-schema.js
@@ -1,4 +1,4 @@
-import { blob, integer, sqliteTable, text, primaryKey, } from "drizzle-orm/sqlite-core";
+import { blob, foreignKey, integer, sqliteTable, text, primaryKey, } from "drizzle-orm/sqlite-core";
 export const smithersRuns = sqliteTable("_smithers_runs", {
     runId: text("run_id").primaryKey(),
     parentRunId: text("parent_run_id"),
@@ -63,6 +63,10 @@ export const smithersFrames = sqliteTable("_smithers_frames", {
     note: text("note"),
 }, (t) => ({
     pk: primaryKey({ columns: [t.runId, t.frameNo] }),
+    runFk: foreignKey({
+        columns: [t.runId],
+        foreignColumns: [smithersRuns.runId],
+    }).onDelete("cascade"),
 }));
 export const smithersApprovals = sqliteTable("_smithers_approvals", {
     runId: text("run_id").notNull(),
@@ -158,6 +162,10 @@ export const smithersNodeDiffs = sqliteTable("_smithers_node_diffs", {
     pk: primaryKey({
         columns: [t.runId, t.nodeId, t.iteration, t.baseRef],
     }),
+    runFk: foreignKey({
+        columns: [t.runId],
+        foreignColumns: [smithersRuns.runId],
+    }).onDelete("cascade"),
 }));
 export const smithersTimeTravelAudit = sqliteTable("_smithers_time_travel_audit", {
     id: integer("id").primaryKey({ autoIncrement: true }),
@@ -168,7 +176,12 @@ export const smithersTimeTravelAudit = sqliteTable("_smithers_time_travel_audit"
     timestampMs: integer("timestamp_ms").notNull(),
     result: text("result").notNull(),
     durationMs: integer("duration_ms"),
-});
+}, (t) => ({
+    runFk: foreignKey({
+        columns: [t.runId],
+        foreignColumns: [smithersRuns.runId],
+    }).onDelete("cascade"),
+}));
 export const smithersSandboxes = sqliteTable("_smithers_sandboxes", {
     runId: text("run_id").notNull(),
     sandboxId: text("sandbox_id").notNull(),

--- a/packages/db/tests/db-concurrent.test.js
+++ b/packages/db/tests/db-concurrent.test.js
@@ -193,17 +193,7 @@ describe("SmithersDb cross-adapter concurrency", () => {
 		}
 	});
 
-	// FIXME(real bug): each SmithersDb instance has its own per-instance
-	// transaction-turn queue (`acquireTransactionTurn`), but two adapters
-	// pointing at the same underlying drizzle client do NOT coordinate, so
-	// adapter B can call `BEGIN IMMEDIATE` while adapter A is still inside its
-	// transaction → "cannot start a transaction within a transaction" from
-	// bun:sqlite. Production code must hold a single SmithersDb per database
-	// connection (see packages/driver task-runtime), so this is latent rather
-	// than user-visible today, but the assumption is undocumented. This test
-	// surfaces the foot-gun; promote to a real test once the queue is hoisted
-	// to be keyed on the underlying client.
-	test.skip("transactions from two adapters serialise (no interleaving inside BEGIN..COMMIT)", async () => {
+	test("transactions from two adapters serialise (no interleaving inside BEGIN..COMMIT)", async () => {
 		const { sqlite, db } = createSharedDb();
 		try {
 			const a = new SmithersDb(db);

--- a/packages/db/tests/db-ensure.test.js
+++ b/packages/db/tests/db-ensure.test.js
@@ -131,6 +131,14 @@ describe("ensureSmithersTables", () => {
         '{}',
         'abc'
       );
+      CREATE TABLE _smithers_runs (
+        run_id TEXT PRIMARY KEY,
+        workflow_name TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at_ms INTEGER NOT NULL
+      );
+      INSERT INTO _smithers_runs (run_id, workflow_name, status, created_at_ms)
+        VALUES ('legacy-run', 'wf', 'running', 1);
     `);
         const db = drizzle(sqlite);
         ensureSmithersTables(db);

--- a/packages/db/tests/db-ensure.test.js
+++ b/packages/db/tests/db-ensure.test.js
@@ -131,14 +131,6 @@ describe("ensureSmithersTables", () => {
         '{}',
         'abc'
       );
-      CREATE TABLE _smithers_runs (
-        run_id TEXT PRIMARY KEY,
-        workflow_name TEXT NOT NULL,
-        status TEXT NOT NULL,
-        created_at_ms INTEGER NOT NULL
-      );
-      INSERT INTO _smithers_runs (run_id, workflow_name, status, created_at_ms)
-        VALUES ('legacy-run', 'wf', 'running', 1);
     `);
         const db = drizzle(sqlite);
         ensureSmithersTables(db);

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -2660,6 +2660,12 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
     const taskRoot = desc.worktreePath ?? toolConfig.rootDir;
     const stepCacheEnabled = cacheEnabled || Boolean(desc.cachePolicy);
     const cacheAgent = Array.isArray(desc.agent) ? desc.agent[0] : desc.agent;
+    const cachePolicyScope = desc.cachePolicy?.scope === "run" || desc.cachePolicy?.scope === "global"
+        ? desc.cachePolicy.scope
+        : "workflow";
+    const cachePolicyTtlMs = typeof desc.cachePolicy?.ttlMs === "number" && Number.isFinite(desc.cachePolicy.ttlMs)
+        ? Math.max(0, desc.cachePolicy.ttlMs)
+        : null;
     let heartbeatWatchdogFiber = null;
     try {
         if (taskSignal.aborted) {
@@ -2752,7 +2758,9 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                     cacheKeyDisabled = true;
                 }
                 cacheBase = {
-                    workflowName,
+                    cacheScope: cachePolicyScope,
+                    ...(cachePolicyScope === "run" ? { runId } : {}),
+                    ...(cachePolicyScope === "global" ? {} : { workflowName }),
                     nodeId: desc.nodeId,
                     iteration: desc.iteration,
                     outputTableName: desc.outputTableName,
@@ -2798,22 +2806,39 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
             if (cacheKey) {
                 const cachedRow = await Effect.runPromise(adapter.getCache(cacheKey));
                 if (cachedRow) {
-                    const parsed = JSON.parse(cachedRow.payloadJson);
-                    const valid = validateOutput(desc.outputTable, parsed);
-                    if (valid.ok) {
-                        payload = valid.data;
-                        cached = true;
-                        void Effect.runPromise(Metric.increment(cacheHits));
-                        logInfo("cache hit for task output", {
+                    const createdAtMs = Number(cachedRow.createdAtMs);
+                    const expired = cachePolicyTtlMs !== null &&
+                        Number.isFinite(createdAtMs) &&
+                        nowMs() - createdAtMs >= cachePolicyTtlMs;
+                    if (expired) {
+                        void Effect.runPromise(Metric.increment(cacheMisses));
+                        logInfo("cache entry expired for task output", {
                             runId,
                             nodeId: desc.nodeId,
                             iteration: desc.iteration,
                             attempt: attemptNo,
                             cacheKey,
+                            ttlMs: cachePolicyTtlMs,
                         }, "engine:task-cache");
                     }
                     else {
-                        void Effect.runPromise(Metric.increment(cacheMisses));
+                        const parsed = JSON.parse(cachedRow.payloadJson);
+                        const valid = validateOutput(desc.outputTable, parsed);
+                        if (valid.ok) {
+                            payload = valid.data;
+                            cached = true;
+                            void Effect.runPromise(Metric.increment(cacheHits));
+                            logInfo("cache hit for task output", {
+                                runId,
+                                nodeId: desc.nodeId,
+                                iteration: desc.iteration,
+                                attempt: attemptNo,
+                                cacheKey,
+                            }, "engine:task-cache");
+                        }
+                        else {
+                            void Effect.runPromise(Metric.increment(cacheMisses));
+                        }
                     }
                 }
                 else {

--- a/packages/engine/src/hot/watch.js
+++ b/packages/engine/src/hot/watch.js
@@ -1,6 +1,6 @@
 import { watch } from "node:fs";
-import { readdir } from "node:fs/promises";
-import { resolve } from "node:path";
+import { readdir, stat } from "node:fs/promises";
+import { basename, resolve } from "node:path";
 import { Effect } from "effect";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { logDebug, logInfo } from "@smithers-orchestrator/observability/logging";
@@ -12,13 +12,25 @@ const DEFAULT_IGNORE = [
     ".jj",
     ".smithers",
 ];
+const MIN_POLL_MS = 1000;
+const MAX_POLL_FILES = 5000;
+class HotWatchScanLimitError extends Error {
+    constructor() {
+        super(`Hot watch polling skipped after ${MAX_POLL_FILES} files.`);
+        this.name = "HotWatchScanLimitError";
+    }
+}
 export class WatchTree {
     watchers = [];
     rootDir;
     ignore;
     debounceMs;
     changedFiles = new Set();
+    fileSignatures = new Map();
     debounceTimer = null;
+    pollTimer = null;
+    polling = false;
+    pollingDisabled = false;
     waitResolve = null;
     closed = false;
     /**
@@ -53,6 +65,8 @@ export class WatchTree {
         this.closed = true;
         if (this.debounceTimer)
             clearTimeout(this.debounceTimer);
+        if (this.pollTimer)
+            clearTimeout(this.pollTimer);
         for (const w of this.watchers) {
             try {
                 w.close();
@@ -71,7 +85,29 @@ export class WatchTree {
     }
     startEffect() {
         return Effect.tryPromise({
-            try: () => this.watchDir(this.rootDir),
+            try: async () => {
+                try {
+                    this.fileSignatures = await this.scanFileSignatures(this.rootDir);
+                }
+                catch (error) {
+                    this.pollingDisabled = true;
+                    this.fileSignatures = new Map();
+                    if (error instanceof HotWatchScanLimitError) {
+                        logInfo("hot watch polling disabled by file count guard", {
+                            rootDir: this.rootDir,
+                            maxFiles: MAX_POLL_FILES,
+                        }, "hot:watch");
+                    }
+                    else {
+                        logInfo("hot watch polling disabled after initial scan failed", {
+                            rootDir: this.rootDir,
+                            errorName: error instanceof Error ? error.name : typeof error,
+                        }, "hot:watch");
+                    }
+                }
+                await this.watchDir(this.rootDir);
+                this.startPolling();
+            },
             catch: (cause) => toSmithersError(cause, "start hot watch tree"),
         }).pipe(Effect.annotateLogs({
             rootDir: this.rootDir,
@@ -105,6 +141,97 @@ export class WatchTree {
     shouldIgnore(name) {
         return this.ignore.includes(name) || name.startsWith(".");
     }
+    pollIntervalMs() {
+        return Math.max(MIN_POLL_MS, this.debounceMs * 4);
+    }
+    startPolling() {
+        if (this.pollTimer || this.closed || this.pollingDisabled)
+            return;
+        this.pollTimer = setTimeout(() => {
+            this.pollTimer = null;
+            void this.pollOnce().finally(() => {
+                this.startPolling();
+            });
+        }, this.pollIntervalMs());
+    }
+    async pollOnce() {
+        if (this.closed || this.polling || this.pollingDisabled)
+            return false;
+        this.polling = true;
+        try {
+            const next = await this.scanFileSignatures(this.rootDir);
+            return this.recordScanChanges(next);
+        }
+        catch (error) {
+            if (error instanceof HotWatchScanLimitError) {
+                this.pollingDisabled = true;
+                logInfo("hot watch polling disabled by file count guard", {
+                    rootDir: this.rootDir,
+                    maxFiles: MAX_POLL_FILES,
+                }, "hot:watch");
+            }
+            return false;
+        }
+        finally {
+            this.polling = false;
+        }
+    }
+    /**
+   * @param {string} dir
+   * @returns {Promise<Map<string, string>>}
+   */
+    async scanFileSignatures(dir) {
+        const files = new Map();
+        await this.scanDir(dir, files);
+        return files;
+    }
+    /**
+   * @param {string} dir
+   * @param {Map<string, string>} files
+   */
+    async scanDir(dir, files) {
+        if (this.closed)
+            return;
+        const baseName = basename(dir);
+        if (baseName && this.shouldIgnore(baseName) && dir !== this.rootDir)
+            return;
+        const entries = await readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (this.shouldIgnore(entry.name))
+                continue;
+            if (files.size >= MAX_POLL_FILES) {
+                throw new HotWatchScanLimitError();
+            }
+            const fullPath = resolve(dir, entry.name);
+            if (entry.isDirectory()) {
+                await this.scanDir(fullPath, files);
+            }
+            else if (entry.isFile()) {
+                const info = await stat(fullPath);
+                files.set(fullPath, `${info.mtimeMs}:${info.size}`);
+            }
+        }
+    }
+    /**
+   * @param {Map<string, string>} next
+   */
+    recordScanChanges(next) {
+        let changed = false;
+        for (const [filePath, signature] of next) {
+            if (this.fileSignatures.get(filePath) !== signature) {
+                this.onFileChange(filePath);
+                changed = true;
+            }
+        }
+        for (const filePath of this.fileSignatures.keys()) {
+            if (!next.has(filePath)) {
+                this.onFileChange(filePath);
+                changed = true;
+            }
+        }
+        this.fileSignatures = next;
+        return changed;
+    }
     /**
    * @param {string} dir
    * @returns {Promise<void>}
@@ -112,7 +239,7 @@ export class WatchTree {
     async watchDir(dir) {
         if (this.closed)
             return;
-        const baseName = dir.split("/").pop() ?? "";
+        const baseName = basename(dir);
         if (baseName && this.shouldIgnore(baseName) && dir !== this.rootDir)
             return;
         try {

--- a/packages/engine/tests/cache-policy-ttl-scope.test.jsx
+++ b/packages/engine/tests/cache-policy-ttl-scope.test.jsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource smithers-orchestrator */
 import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
 import { z } from "zod";
 import { Effect } from "effect";
 import { Workflow, Task, runWorkflow } from "smithers-orchestrator";
@@ -29,21 +30,28 @@ function countingAgent(id) {
 }
 
 describe("cachePolicy.ttlMs", () => {
-    test("ttlMs expiration causes re-execution", async () => {
-        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+    test("ttlMs expiration causes re-execution and refreshes the cache row", async () => {
+        const { smithers, outputs, dbPath, cleanup } = createTestSmithers(outputShape());
         const counter = countingAgent("ttl");
         try {
             const workflow = smithers(() => (
                 <Workflow name="ttl-cache">
-                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ ttlMs: 1 }}>
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ ttlMs: 1000 }}>
                         same prompt
                     </Task>
                 </Workflow>
             ));
 
             await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "ttl-r1" }));
-            await new Promise((resolve) => setTimeout(resolve, 20));
+            const sqlite = new Database(dbPath);
+            try {
+                sqlite.query("UPDATE _smithers_cache SET created_at_ms = ?").run(Date.now() - 5000);
+            }
+            finally {
+                sqlite.close();
+            }
             await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "ttl-r2" }));
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "ttl-r3" }));
 
             expect(counter.calls).toBe(2);
         }

--- a/packages/engine/tests/cache-policy-ttl-scope.test.jsx
+++ b/packages/engine/tests/cache-policy-ttl-scope.test.jsx
@@ -1,62 +1,158 @@
 /** @jsxImportSource smithers-orchestrator */
-// Tests for cachePolicy.ttlMs and cachePolicy.scope.
-//
-// These options are declared on `CachePolicy` in
-// packages/scheduler/src/CachePolicy.ts, but the engine implementation
-// in packages/engine/src/engine.js does NOT consult `ttlMs` or `scope`
-// when computing or invalidating cache keys (it only honors `by`,
-// `version`, and `key`). The tests below are kept skipped with FIXMEs
-// so they fail loudly the moment those features land.
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 import { Effect } from "effect";
 import { Workflow, Task, runWorkflow } from "smithers-orchestrator";
 import { createTestSmithers } from "../../smithers/tests/helpers.js";
 
-describe("cachePolicy.ttlMs (FIXME: not yet implemented in engine)", () => {
-    test.skip("FIXME(cache-ttl): ttlMs expiration causes re-execution", async () => {
-        const { smithers, outputs, cleanup } = createTestSmithers({
-            out: z.object({ v: z.number() }),
-        });
+function outputShape() {
+    return {
+        out: z.object({ v: z.number() }),
+    };
+}
+
+function countingAgent(id) {
+    let calls = 0;
+    return {
+        agent: {
+            id,
+            tools: {},
+            generate: async () => {
+                calls += 1;
+                return { output: { v: calls } };
+            },
+        },
+        get calls() {
+            return calls;
+        },
+    };
+}
+
+describe("cachePolicy.ttlMs", () => {
+    test("ttlMs expiration causes re-execution", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+        const counter = countingAgent("ttl");
         try {
-            let calls = 0;
-            const agent = {
-                id: "ttl",
-                tools: {},
-                generate: async () => { calls += 1; return { output: { v: calls } }; },
-            };
             const workflow = smithers(() => (
                 <Workflow name="ttl-cache">
-                    <Task id="t" output={outputs.out} agent={agent} cache={{ ttlMs: 1 }}>
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ ttlMs: 1 }}>
                         same prompt
                     </Task>
                 </Workflow>
             ));
-            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "r1" }));
-            // wait long enough that ttl is exceeded.
-            await new Promise((r) => setTimeout(r, 50));
-            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "r2" }));
-            expect(calls).toBe(2);
-        } finally {
+
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "ttl-r1" }));
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "ttl-r2" }));
+
+            expect(counter.calls).toBe(2);
+        }
+        finally {
             cleanup();
         }
     });
 });
 
-describe("cachePolicy.scope (FIXME: not yet implemented in engine)", () => {
-    test.skip("FIXME(cache-scope): scope=run keeps cache local to a single run", async () => {
-        // With scope=run, two separate runs of the same workflow with the
-        // same prompt should each re-execute (cache must NOT be shared
-        // across runIds).
-        expect(true).toBe(true);
+describe("cachePolicy.scope", () => {
+    test("scope=run keeps cache local to a single run", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+        const counter = countingAgent("scope-run");
+        try {
+            const workflow = smithers(() => (
+                <Workflow name="scope-run-cache">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "run" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "scope-run-r1" }));
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "scope-run-r2" }));
+
+            expect(counter.calls).toBe(2);
+        }
+        finally {
+            cleanup();
+        }
     });
-    test.skip("FIXME(cache-scope): scope=workflow shares cache across runs of the same workflow", async () => {
-        expect(true).toBe(true);
+
+    test("scope=workflow shares cache across runs of the same workflow", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+        const counter = countingAgent("scope-workflow");
+        try {
+            const workflow = smithers(() => (
+                <Workflow name="scope-workflow-cache">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "workflow" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "scope-workflow-r1" }));
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "scope-workflow-r2" }));
+
+            expect(counter.calls).toBe(1);
+        }
+        finally {
+            cleanup();
+        }
     });
-    test.skip("FIXME(cache-scope): scope=global shares across distinct workflows", async () => {
-        expect(true).toBe(true);
+
+    test("scope=global shares across distinct workflows", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+        const counter = countingAgent("scope-global");
+        try {
+            const first = smithers(() => (
+                <Workflow name="scope-global-a">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "global" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+            const second = smithers(() => (
+                <Workflow name="scope-global-b">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "global" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+
+            await Effect.runPromise(runWorkflow(first, { input: {}, runId: "scope-global-r1" }));
+            await Effect.runPromise(runWorkflow(second, { input: {}, runId: "scope-global-r2" }));
+
+            expect(counter.calls).toBe(1);
+        }
+        finally {
+            cleanup();
+        }
     });
-    test.skip("FIXME(cache-scope-collisions): two tasks with the same key but different scopes do not collide", async () => {
-        expect(true).toBe(true);
+
+    test("same task key with different scopes does not collide", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers(outputShape());
+        const counter = countingAgent("scope-collision");
+        try {
+            const globalWorkflow = smithers(() => (
+                <Workflow name="scope-collision">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "global" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+            const workflowScoped = smithers(() => (
+                <Workflow name="scope-collision">
+                    <Task id="t" output={outputs.out} agent={counter.agent} cache={{ scope: "workflow" }}>
+                        same prompt
+                    </Task>
+                </Workflow>
+            ));
+
+            await Effect.runPromise(runWorkflow(globalWorkflow, { input: {}, runId: "scope-collision-r1" }));
+            await Effect.runPromise(runWorkflow(workflowScoped, { input: {}, runId: "scope-collision-r2" }));
+
+            expect(counter.calls).toBe(2);
+        }
+        finally {
+            cleanup();
+        }
     });
 });

--- a/packages/sandbox/src/effect/socket-runner.js
+++ b/packages/sandbox/src/effect/socket-runner.js
@@ -1,8 +1,10 @@
 import { SocketRunner } from "@effect/cluster";
+import { existsSync } from "node:fs";
 import { mkdir, cp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { Effect, Layer } from "effect";
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+import { spawnCaptureEffect } from "@smithers-orchestrator/driver/child-process";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { SandboxEntityExecutor } from "./sandbox-entity.js";
 /** @typedef {import("../SandboxTransportConfig.ts").SandboxTransportConfig} SandboxTransportConfig */
@@ -21,6 +23,127 @@ function baseHandle(config) {
         requestPath: join(sandboxRoot, "request"),
         resultPath: join(sandboxRoot, "result"),
     };
+}
+const BWRAP_HOST_READ_PATHS = [
+    "/bin",
+    "/lib",
+    "/lib64",
+    "/usr",
+];
+const MACOS_SANDBOX_READ_PATHS = [
+    "/bin",
+    "/usr",
+    "/System",
+    "/Library",
+];
+const SANDBOX_EXEC_TIMEOUT_MS = 10 * 60 * 1000;
+const SANDBOX_EXEC_OUTPUT_BYTES = 1_000_000;
+const SANDBOX_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin";
+const SANDBOX_PROCESS_ENV = {
+    HOME: "/tmp",
+    PATH: SANDBOX_PATH,
+    TMPDIR: "/tmp",
+    LANG: "C.UTF-8",
+};
+/**
+ * @param {string} value
+ */
+function sandboxProfileString(value) {
+    return JSON.stringify(value);
+}
+/**
+ * @param {string} command
+ * @param {SandboxHandle} handle
+ */
+function bubblewrapArgs(command, handle) {
+    const args = [
+        "--die-with-parent",
+        "--unshare-all",
+        "--clearenv",
+        "--proc",
+        "/proc",
+        "--dev",
+        "/dev",
+        "--dir",
+        "/tmp",
+        "--dir",
+        "/workspace",
+        "--dir",
+        "/result",
+        "--setenv",
+        "HOME",
+        "/tmp",
+        "--setenv",
+        "PATH",
+        SANDBOX_PATH,
+    ];
+    for (const path of BWRAP_HOST_READ_PATHS) {
+        if (existsSync(path)) {
+            args.push("--ro-bind-try", path, path);
+        }
+    }
+    args.push("--bind", handle.requestPath, "/workspace", "--bind", handle.resultPath, "/result", "--chdir", "/workspace", "/bin/sh", "-lc", command);
+    return args;
+}
+/**
+ * @param {string} command
+ * @param {SandboxHandle} handle
+ */
+function sandboxExecArgs(command, handle) {
+    const readRules = MACOS_SANDBOX_READ_PATHS
+        .filter((path) => existsSync(path))
+        .map((path) => `(subpath ${sandboxProfileString(path)})`)
+        .join(" ");
+    const profile = [
+        "(version 1)",
+        "(deny default)",
+        "(allow process*)",
+        `(allow file-read* ${readRules} (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}))`,
+        `(allow file-write* (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}))`,
+    ].join("\n");
+    return ["-p", profile, "/bin/sh", "-lc", command];
+}
+/**
+ * @param {string} command
+ * @param {SandboxHandle} handle
+ */
+function executeLocalSandbox(command, handle) {
+    return Effect.gen(function* () {
+        let binary;
+        let args;
+        if (process.platform === "darwin") {
+            binary = typeof Bun !== "undefined" ? Bun.which("sandbox-exec") : null;
+            if (!binary) {
+                return yield* Effect.fail(new SmithersError("PROCESS_SPAWN_FAILED", "bubblewrap runtime on macOS requires `sandbox-exec` for fallback isolation.", { runtime: "bubblewrap" }));
+            }
+            args = sandboxExecArgs(command, handle);
+        }
+        else {
+            binary = typeof Bun !== "undefined" ? Bun.which("bwrap") : null;
+            if (!binary) {
+                return yield* Effect.fail(new SmithersError("PROCESS_SPAWN_FAILED", "Bubblewrap runtime requested but `bwrap` is not installed. Install bubblewrap (package: bubblewrap) or use runtime=\"docker\".", { runtime: "bubblewrap" }));
+            }
+            args = bubblewrapArgs(command, handle);
+        }
+        const result = yield* spawnCaptureEffect(binary, args, {
+            cwd: handle.requestPath,
+            env: SANDBOX_PROCESS_ENV,
+            timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
+            maxOutputBytes: SANDBOX_EXEC_OUTPUT_BYTES,
+            detached: true,
+        });
+        if (result.exitCode !== 0) {
+            return yield* Effect.fail(new SmithersError("SANDBOX_EXECUTION_FAILED", `Sandbox command exited with code ${result.exitCode ?? "null"}.`, {
+                runtime: handle.runtime,
+                runId: handle.runId,
+                sandboxId: handle.sandboxId,
+                command,
+                exitCode: result.exitCode,
+                stderr: result.stderr,
+            }));
+        }
+        return { exitCode: result.exitCode ?? 0 };
+    });
 }
 /** @type {Layer.Layer<SandboxEntityExecutor, never, never>} */
 export const BubblewrapSandboxExecutorLive = Layer.succeed(SandboxEntityExecutor, SandboxEntityExecutor.of({
@@ -55,8 +178,11 @@ export const BubblewrapSandboxExecutorLive = Layer.succeed(SandboxEntityExecutor
         },
         catch: (cause) => toSmithersError(cause, "ship sandbox bundle"),
     }),
-    execute: (_command, _handle) => Effect.succeed({ exitCode: 0 }),
+    execute: (command, handle) => executeLocalSandbox(command, handle),
     collect: (handle) => Effect.succeed({ bundlePath: handle.resultPath }),
-    cleanup: (_handle) => Effect.void,
+    cleanup: (handle) => Effect.tryPromise({
+        try: () => rm(handle.sandboxRoot, { recursive: true, force: true }),
+        catch: (cause) => toSmithersError(cause, "cleanup sandbox workspace"),
+    }),
 }));
 export const SandboxSocketRunner = SocketRunner;

--- a/packages/sandbox/src/effect/socket-runner.js
+++ b/packages/sandbox/src/effect/socket-runner.js
@@ -46,6 +46,26 @@ const SANDBOX_PROCESS_ENV = {
     LANG: "C.UTF-8",
 };
 /**
+ * @param {SandboxHandle} handle
+ */
+function sandboxTempPath(handle) {
+    return join(handle.sandboxRoot, "tmp");
+}
+/**
+ * @param {SandboxHandle} handle
+ */
+function sandboxProcessEnv(handle) {
+    if (process.platform !== "darwin") {
+        return SANDBOX_PROCESS_ENV;
+    }
+    const tempPath = sandboxTempPath(handle);
+    return {
+        ...SANDBOX_PROCESS_ENV,
+        HOME: tempPath,
+        TMPDIR: tempPath,
+    };
+}
+/**
  * @param {string} value
  */
 function sandboxProfileString(value) {
@@ -76,6 +96,9 @@ function bubblewrapArgs(command, handle) {
         "--setenv",
         "PATH",
         SANDBOX_PATH,
+        "--setenv",
+        "TMPDIR",
+        "/tmp",
     ];
     for (const path of BWRAP_HOST_READ_PATHS) {
         if (existsSync(path)) {
@@ -90,6 +113,7 @@ function bubblewrapArgs(command, handle) {
  * @param {SandboxHandle} handle
  */
 function sandboxExecArgs(command, handle) {
+    const tempPath = sandboxTempPath(handle);
     const readRules = MACOS_SANDBOX_READ_PATHS
         .filter((path) => existsSync(path))
         .map((path) => `(subpath ${sandboxProfileString(path)})`)
@@ -98,8 +122,8 @@ function sandboxExecArgs(command, handle) {
         "(version 1)",
         "(deny default)",
         "(allow process*)",
-        `(allow file-read* ${readRules} (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}))`,
-        `(allow file-write* (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}))`,
+        `(allow file-read* ${readRules} (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}) (subpath ${sandboxProfileString(tempPath)}))`,
+        `(allow file-write* (subpath ${sandboxProfileString(handle.requestPath)}) (subpath ${sandboxProfileString(handle.resultPath)}) (subpath ${sandboxProfileString(tempPath)}))`,
     ].join("\n");
     return ["-p", profile, "/bin/sh", "-lc", command];
 }
@@ -127,7 +151,7 @@ function executeLocalSandbox(command, handle) {
         }
         const result = yield* spawnCaptureEffect(binary, args, {
             cwd: handle.requestPath,
-            env: SANDBOX_PROCESS_ENV,
+            env: sandboxProcessEnv(handle),
             timeoutMs: SANDBOX_EXEC_TIMEOUT_MS,
             maxOutputBytes: SANDBOX_EXEC_OUTPUT_BYTES,
             detached: true,
@@ -165,6 +189,7 @@ export const BubblewrapSandboxExecutorLive = Layer.succeed(SandboxEntityExecutor
             try: async () => {
                 await mkdir(handle.requestPath, { recursive: true });
                 await mkdir(handle.resultPath, { recursive: true });
+                await mkdir(sandboxTempPath(handle), { recursive: true });
             },
             catch: (cause) => toSmithersError(cause, "create sandbox workspace"),
         });

--- a/packages/sandbox/tests/sandbox-isolation.test.js
+++ b/packages/sandbox/tests/sandbox-isolation.test.js
@@ -1,11 +1,10 @@
 // Sandbox isolation tests.
 //
-// Scope: this file does NOT exercise live container/jail isolation
+// Scope: this file does NOT require live container/jail binaries
 // (bubblewrap on Linux, sandbox-exec on macOS, docker, codeplane).
-// Those runtimes are environment-dependent and the local
-// `BubblewrapSandboxExecutorLive` layer is a no-op shim that just
-// creates request/result directories under `<rootDir>/.smithers/sandboxes/...`
-// (see packages/sandbox/src/effect/socket-runner.js).
+// Runtime-specific process execution is covered in transport-runners.test.js
+// with fake binaries so CI can validate the executor contract without a
+// privileged sandbox image.
 //
 // What IS enforceable in-process and exercised here:
 //   - resolveSandboxPath path traversal validation (../../, absolute paths, symlink
@@ -16,10 +15,8 @@
 //   - walkFiles handling of symlinks and deeply nested artifacts.
 //   - Cleanup of the sandbox temp directory after a write.
 //
-// FIXME: when a real container runtime is wired up, replace these with end-to-end
-// process-level tests: spawn a child inside the sandbox, attempt to read
-// `/etc/passwd`, expect EACCES; kill the child mid-run, then verify there are
-// no orphan processes via `ps`. The current local test stack cannot do that.
+// Full host isolation still needs environment-specific e2e coverage on a CI
+// image that includes bubblewrap or sandbox-exec.
 import { describe, expect, test } from "bun:test";
 import {
 	mkdtempSync,
@@ -235,16 +232,12 @@ describe("sandbox isolation: cleanup", () => {
 		expect(existsSync(bundlePath)).toBe(false);
 	});
 
-	// FIXME: testing "no orphan processes via ps" and "cleanup after crash
-	// (process killed mid-run)" requires spawning a real sandbox subprocess
-	// against bubblewrap/docker, which is unavailable in this unit-test
-	// environment. The bubblewrap executor in
-	// packages/sandbox/src/effect/socket-runner.js is a no-op shim. Promote
-	// these to e2e tests once a CI image with `bwrap` exists.
+	// Testing "no orphan processes via ps" and "cleanup after crash
+	// (process killed mid-run)" requires a CI image with a real sandbox binary.
 	test.skip("sandbox cleanup after timeout removes temp dir and leaves no orphan processes", () => {
-		// Requires real sandbox runtime; see file-top FIXME.
+		// Requires real sandbox runtime; see file-top scope note.
 	});
 	test.skip("sandbox cleanup after crash (process killed mid-run)", () => {
-		// Requires real sandbox runtime; see file-top FIXME.
+		// Requires real sandbox runtime; see file-top scope note.
 	});
 });

--- a/packages/sandbox/tests/transport-runners.test.js
+++ b/packages/sandbox/tests/transport-runners.test.js
@@ -187,6 +187,32 @@ function makeFakeBwrapBin() {
     return bwrapPath;
 }
 
+/**
+ * @param {string} captureDir
+ */
+function makeFakeSandboxExecBin(captureDir) {
+    const binDir = tempDir("smithers-fake-sandbox-exec-bin-");
+    const sandboxExecPath = join(binDir, "sandbox-exec");
+    writeFileSync(
+        sandboxExecPath,
+        [
+            "#!/bin/sh",
+            `printf '%s\\n' "$@" > ${JSON.stringify(join(captureDir, "args.txt"))}`,
+            `printf '%s\\n' "$HOME" > ${JSON.stringify(join(captureDir, "home.txt"))}`,
+            `printf '%s\\n' "$TMPDIR" > ${JSON.stringify(join(captureDir, "tmpdir.txt"))}`,
+            "last=''",
+            "for arg in \"$@\"; do",
+            "  last=\"$arg\"",
+            "done",
+            "/bin/sh -lc \"$last\"",
+            "",
+        ].join("\n"),
+        "utf8",
+    );
+    chmodSync(sandboxExecPath, 0o755);
+    return sandboxExecPath;
+}
+
 describe("sandbox transport runners", () => {
     test("bubblewrap executor creates, ships, executes, collects, and cleans up", async () => {
         const fakeBwrap = makeFakeBwrapBin();
@@ -284,6 +310,36 @@ describe("sandbox transport runners", () => {
                 expect(handle.runtime).toBe("bubblewrap");
                 expect(existsSync(handle.requestPath)).toBe(true);
                 expect(existsSync(handle.resultPath)).toBe(true);
+            }),
+        );
+    });
+
+    test("macOS fallback executes with a writable sandbox temp directory", async () => {
+        const captureDir = tempDir("smithers-sandbox-exec-capture-");
+        const fakeSandboxExec = makeFakeSandboxExecBin(captureDir);
+        await withPlatform("darwin", () =>
+            withBunWhich((command) => (command === "sandbox-exec" ? fakeSandboxExec : null), async () => {
+                const handle = await runExecutor(BubblewrapSandboxExecutorLive, (executor) =>
+                    executor.create(
+                        configFor(tempDir("smithers-sandbox-exec-"), "run-sandbox-exec-temp", "sandbox", "bubblewrap"),
+                    ),
+                );
+                try {
+                    await runExecutor(BubblewrapSandboxExecutorLive, (executor) =>
+                        executor.execute(
+                            'test -d "$TMPDIR" && test "$HOME" = "$TMPDIR" && printf ok > "$TMPDIR/check.txt" && printf ok > ../result/macos-temp.txt',
+                            handle,
+                        ),
+                    );
+                    const expectedTempPath = join(handle.sandboxRoot, "tmp");
+                    expect(readFileSync(join(captureDir, "home.txt"), "utf8").trim()).toBe(expectedTempPath);
+                    expect(readFileSync(join(captureDir, "tmpdir.txt"), "utf8").trim()).toBe(expectedTempPath);
+                    expect(readFileSync(join(captureDir, "args.txt"), "utf8")).toContain(expectedTempPath);
+                    expect(readFileSync(join(expectedTempPath, "check.txt"), "utf8")).toBe("ok");
+                    expect(readFileSync(join(handle.resultPath, "macos-temp.txt"), "utf8")).toBe("ok");
+                } finally {
+                    await runExecutor(BubblewrapSandboxExecutorLive, (executor) => executor.cleanup(handle));
+                }
             }),
         );
     });

--- a/packages/sandbox/tests/transport-runners.test.js
+++ b/packages/sandbox/tests/transport-runners.test.js
@@ -140,13 +140,22 @@ async function expectExecutorLifecycle(layer, config) {
     await runExecutor(layer, (executor) => executor.ship(bundlePath, handle));
     expect(readFileSync(join(handle.requestPath, "README.md"), "utf8")).toBe(`bundle:${config.runtime}`);
     expect(readFileSync(join(handle.requestPath, "nested", "file.txt"), "utf8")).toBe("payload");
-    expect(await runExecutor(layer, (executor) => executor.execute("smithers up bundle.tsx", handle))).toEqual({
+    const executeCommand = config.runtime === "bubblewrap"
+        ? "printf ok > ../result/executed.txt"
+        : "smithers up bundle.tsx";
+    expect(await runExecutor(layer, (executor) => executor.execute(executeCommand, handle))).toEqual({
         exitCode: 0,
     });
+    if (config.runtime === "bubblewrap") {
+        expect(readFileSync(join(handle.resultPath, "executed.txt"), "utf8")).toBe("ok");
+    }
     expect(await runExecutor(layer, (executor) => executor.collect(handle))).toEqual({
         bundlePath: handle.resultPath,
     });
     await expect(runExecutor(layer, (executor) => executor.cleanup(handle))).resolves.toBeUndefined();
+    if (config.runtime === "bubblewrap") {
+        expect(existsSync(handle.sandboxRoot)).toBe(false);
+    }
     return handle;
 }
 
@@ -158,15 +167,63 @@ function makeFakeDockerBin() {
     return binDir;
 }
 
+function makeFakeBwrapBin() {
+    const binDir = tempDir("smithers-fake-bwrap-bin-");
+    const bwrapPath = join(binDir, "bwrap");
+    writeFileSync(
+        bwrapPath,
+        [
+            "#!/bin/sh",
+            "last=''",
+            "for arg in \"$@\"; do",
+            "  last=\"$arg\"",
+            "done",
+            "/bin/sh -lc \"$last\"",
+            "",
+        ].join("\n"),
+        "utf8",
+    );
+    chmodSync(bwrapPath, 0o755);
+    return bwrapPath;
+}
+
 describe("sandbox transport runners", () => {
     test("bubblewrap executor creates, ships, executes, collects, and cleans up", async () => {
+        const fakeBwrap = makeFakeBwrapBin();
         await withPlatform("linux", () =>
-            withBunWhich((command) => (command === "bwrap" ? "/usr/bin/bwrap" : null), async () => {
+            withBunWhich((command) => (command === "bwrap" ? fakeBwrap : null), async () => {
                 await expectExecutorLifecycle(
                     BubblewrapSandboxExecutorLive,
                     configFor(tempDir("smithers-bubblewrap-"), "run-bwrap", "sandbox-bwrap", "bubblewrap"),
                 );
             }),
+        );
+    });
+
+    test("bubblewrap executor does not inherit host secrets", async () => {
+        const fakeBwrap = makeFakeBwrapBin();
+        await withEnv({ SMITHERS_SECRET_SHOULD_NOT_LEAK: "secret" }, () =>
+            withPlatform("linux", () =>
+                withBunWhich((command) => (command === "bwrap" ? fakeBwrap : null), async () => {
+                    const handle = await runExecutor(BubblewrapSandboxExecutorLive, (executor) =>
+                        executor.create(
+                            configFor(tempDir("smithers-bubblewrap-"), "run-bwrap-env", "sandbox", "bubblewrap"),
+                        ),
+                    );
+                    try {
+                        await runExecutor(BubblewrapSandboxExecutorLive, (executor) =>
+                            executor.execute(
+                                'test -z "$SMITHERS_SECRET_SHOULD_NOT_LEAK" && printf ok > ../result/env.txt',
+                                handle,
+                            ),
+                        );
+                        expect(readFileSync(join(handle.resultPath, "env.txt"), "utf8")).toBe("ok");
+                    } finally {
+                        await runExecutor(BubblewrapSandboxExecutorLive, (executor) => executor.cleanup(handle));
+                    }
+                    expect(existsSync(handle.sandboxRoot)).toBe(false);
+                }),
+            ),
         );
     });
 
@@ -180,6 +237,24 @@ describe("sandbox transport runners", () => {
                         ),
                     ),
                 ).rejects.toThrow("bwrap");
+            }),
+        );
+    });
+
+    test("bubblewrap executor fails when the sandboxed command fails", async () => {
+        const fakeBwrap = makeFakeBwrapBin();
+        await withPlatform("linux", () =>
+            withBunWhich((command) => (command === "bwrap" ? fakeBwrap : null), async () => {
+                const handle = await runExecutor(BubblewrapSandboxExecutorLive, (executor) =>
+                    executor.create(configFor(tempDir("smithers-bubblewrap-"), "run-bwrap-fail", "sandbox", "bubblewrap")),
+                );
+                try {
+                    await expect(
+                        runExecutor(BubblewrapSandboxExecutorLive, (executor) => executor.execute("exit 7", handle)),
+                    ).rejects.toThrow("Sandbox command exited with code 7");
+                } finally {
+                    await runExecutor(BubblewrapSandboxExecutorLive, (executor) => executor.cleanup(handle));
+                }
             }),
         );
     });

--- a/packages/server/src/GatewayOperatorUiConfig.ts
+++ b/packages/server/src/GatewayOperatorUiConfig.ts
@@ -1,0 +1,15 @@
+export type GatewayOperatorUiConfig = {
+  /**
+   * URL path for the built-in operator console.
+   * @default "/console"
+   */
+  path?: string;
+  /**
+   * Document title for the generated HTML shell.
+   */
+  title?: string;
+  /**
+   * JSON-serializable boot data exposed to the browser.
+   */
+  props?: Record<string, unknown>;
+};

--- a/packages/server/src/GatewayOptions.ts
+++ b/packages/server/src/GatewayOptions.ts
@@ -1,5 +1,6 @@
 import type { GatewayAuthConfig } from "./GatewayAuthConfig.js";
 import type { GatewayDefaults } from "./GatewayDefaults.js";
+import type { GatewayOperatorUiConfig } from "./GatewayOperatorUiConfig.js";
 import type { GatewayUiConfig } from "./GatewayUiConfig.js";
 
 export type GatewayOptions = {
@@ -8,6 +9,11 @@ export type GatewayOptions = {
   heartbeatMs?: number;
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;
+  /**
+   * Built-in browser console for operators. Set to false to disable it.
+   * @default { path: "/console" }
+   */
+  operatorUi?: GatewayOperatorUiConfig | false;
   defaults?: GatewayDefaults;
   maxBodyBytes?: number;
   maxPayload?: number;

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -40,10 +40,12 @@ import { recoverInProgressRewindAudits } from "@smithers-orchestrator/time-trave
 import { GATEWAY_EVENT_WINDOW_DEFAULT, SMITHERS_API_VERSION, getRequiredScopeForGatewayMethod, } from "@smithers-orchestrator/gateway/rpc";
 import { hasGatewayScope } from "@smithers-orchestrator/gateway/auth/scopes";
 import { createGatewayUiApp } from "./gatewayUi/createGatewayUiApp.js";
+import { DEFAULT_OPERATOR_UI_CLIENT_JS, DEFAULT_OPERATOR_UI_ENTRY } from "./gatewayUi/defaultOperatorUi.js";
 /** @typedef {import("./GatewayWebhookRunConfig.js").GatewayWebhookRunConfig} GatewayWebhookRunConfig */
 /** @typedef {import("./GatewayWebhookSignalConfig.js").GatewayWebhookSignalConfig} GatewayWebhookSignalConfig */
 /** @typedef {import("./ConnectRequest.js").ConnectRequest} ConnectRequest */
 /** @typedef {import("./GatewayAuthConfig.js").GatewayAuthConfig} GatewayAuthConfig */
+/** @typedef {import("./GatewayOperatorUiConfig.js").GatewayOperatorUiConfig} GatewayOperatorUiConfig */
 /** @typedef {import("./GatewayOptions.js").GatewayOptions} GatewayOptions */
 /** @typedef {import("./GatewayWebhookConfig.js").GatewayWebhookConfig} GatewayWebhookConfig */
 /** @typedef {import("node:http").IncomingMessage} IncomingMessage */
@@ -111,11 +113,12 @@ import { createGatewayUiApp } from "./gatewayUi/createGatewayUiApp.js";
  *   path: string;
  *   title?: string;
  *   props?: Record<string, unknown>;
+ *   builtin?: "operator";
  * }} ResolvedGatewayUiConfig
  */
 /**
  * @typedef {{
- *   kind: "gateway" | "workflow";
+ *   kind: "gateway" | "workflow" | "operator";
  *   workflowKey: string | null;
  *   config: ResolvedGatewayUiConfig;
  * }} GatewayUiMount
@@ -205,6 +208,25 @@ function resolveGatewayUiConfig(ui, fallbackPath) {
         ...(ui.props && typeof ui.props === "object" && !Array.isArray(ui.props)
             ? { props: ui.props }
             : {}),
+    };
+}
+/**
+ * @param {GatewayOperatorUiConfig | false | undefined} ui
+ * @returns {ResolvedGatewayUiConfig | null}
+ */
+function resolveDefaultOperatorUiConfig(ui) {
+    if (ui === false) {
+        return null;
+    }
+    const config = ui && typeof ui === "object" && !Array.isArray(ui) ? ui : {};
+    return {
+        entry: DEFAULT_OPERATOR_UI_ENTRY,
+        path: normalizeUiMountPath(config.path, "/console"),
+        title: typeof config.title === "string" ? config.title : "Smithers Operator Console",
+        props: config.props && typeof config.props === "object" && !Array.isArray(config.props)
+            ? config.props
+            : {},
+        builtin: "operator",
     };
 }
 
@@ -1197,6 +1219,7 @@ export class Gateway {
     requestTimeout;
     auth;
     ui;
+    operatorUi;
     uiApp;
     defaults;
     workflows = new Map();
@@ -1243,6 +1266,7 @@ export class Gateway {
             : Math.floor(assertPositiveFiniteInteger("requestTimeout", Number(options.requestTimeout)));
         this.auth = options.auth;
         this.ui = resolveGatewayUiConfig(options.ui, "/");
+        this.operatorUi = resolveDefaultOperatorUiConfig(options.operatorUi);
         this.uiApp = createGatewayUiApp({
             resolveMatch: (pathname) => this.resolveUiMatch(pathname),
             renderIndex: (match) => this.renderUiIndex(match),
@@ -1257,6 +1281,9 @@ export class Gateway {
         const mounts = [];
         if (this.ui) {
             mounts.push({ kind: "gateway", workflowKey: null, config: this.ui });
+        }
+        if (this.operatorUi && (!this.ui || this.ui.path !== this.operatorUi.path)) {
+            mounts.push({ kind: "operator", workflowKey: null, config: this.operatorUi });
         }
         for (const [workflowKey, entry] of this.workflows.entries()) {
             if (entry.ui) {
@@ -1352,6 +1379,9 @@ export class Gateway {
    * @returns {Promise<string>}
    */
     async bundleUiEntry(config) {
+        if (config.entry === DEFAULT_OPERATOR_UI_ENTRY) {
+            return DEFAULT_OPERATOR_UI_CLIENT_JS;
+        }
         const cached = this.uiAssetCache.get(config.entry);
         if (cached) {
             return cached;

--- a/packages/server/src/gatewayUi/defaultOperatorUi.js
+++ b/packages/server/src/gatewayUi/defaultOperatorUi.js
@@ -1,0 +1,469 @@
+export const DEFAULT_OPERATOR_UI_ENTRY = "smithers:default-operator-ui";
+
+function defaultOperatorUiClient() {
+const boot = globalThis.__SMITHERS_GATEWAY_UI__ ?? {};
+const root = document.getElementById("root");
+const storageKey = "smithers.gateway.console.token";
+function readStoredToken() {
+  try {
+    return sessionStorage.getItem(storageKey) ?? "";
+  } catch {
+    return "";
+  }
+}
+function writeStoredToken(value) {
+  try {
+    if (value) {
+      sessionStorage.setItem(storageKey, value);
+    } else {
+      sessionStorage.removeItem(storageKey);
+    }
+  } catch {
+    // Some embedded browsers disable Web Storage; the in-memory token remains usable.
+  }
+}
+const state = {
+  token: readStoredToken(),
+  health: null,
+  workflows: [],
+  runs: [],
+  approvals: [],
+  selectedWorkflow: "",
+  runInput: "{}",
+  status: "Loading",
+  error: "",
+  busy: false,
+};
+
+const css = `
+:root {
+  color-scheme: light;
+  --ink: #161616;
+  --muted: #6f6a61;
+  --line: #ded8ce;
+  --surface: #f7f3ec;
+  --panel: #fffaf2;
+  --accent: #235c58;
+  --accent-strong: #17413e;
+  --danger: #9f2e24;
+  --ok: #2f6b3f;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--ink);
+}
+button, input, textarea, select { font: inherit; }
+button {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: white;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+button.secondary {
+  background: transparent;
+  color: var(--accent);
+}
+button.danger {
+  background: transparent;
+  color: var(--danger);
+  border-color: var(--danger);
+}
+button:disabled { opacity: 0.55; cursor: not-allowed; }
+.shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 360px;
+}
+.nav {
+  border-right: 1px solid var(--line);
+  padding: 22px 18px;
+}
+.brand {
+  font-size: 24px;
+  font-weight: 760;
+  letter-spacing: 0;
+  margin-bottom: 24px;
+}
+.nav-section {
+  display: grid;
+  gap: 10px;
+  margin-top: 24px;
+}
+.label {
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.token {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 6px;
+  min-height: 34px;
+  padding: 0 10px;
+}
+.main {
+  padding: 24px;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 18px;
+}
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+.title {
+  font-size: 22px;
+  font-weight: 720;
+}
+.meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.pill {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0 10px;
+  color: var(--muted);
+  background: rgba(255,255,255,0.5);
+  font-size: 13px;
+}
+.pill.ok { color: var(--ok); border-color: rgba(47,107,63,0.35); }
+.pill.warn { color: var(--danger); border-color: rgba(159,46,36,0.35); }
+.launch {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  padding: 16px 0;
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) minmax(260px, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+}
+.field {
+  display: grid;
+  gap: 6px;
+}
+.field select, .field textarea {
+  border: 1px solid var(--line);
+  background: white;
+  border-radius: 6px;
+  padding: 9px 10px;
+}
+.field textarea {
+  min-height: 72px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+.runs {
+  overflow: auto;
+  display: grid;
+  align-content: start;
+}
+.run-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1.2fr) 120px 140px 1fr;
+  gap: 12px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+}
+.run-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+}
+.muted { color: var(--muted); }
+.side {
+  border-left: 1px solid var(--line);
+  background: var(--panel);
+  padding: 22px 18px;
+  display: grid;
+  align-content: start;
+  gap: 18px;
+}
+.side h2 {
+  font-size: 15px;
+  margin: 0;
+}
+.approval {
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
+  display: grid;
+  gap: 10px;
+}
+.approval-title {
+  font-weight: 680;
+}
+.approval-actions {
+  display: flex;
+  gap: 8px;
+}
+.empty {
+  color: var(--muted);
+  padding: 18px 0;
+}
+.error {
+  color: var(--danger);
+  min-height: 20px;
+}
+@media (max-width: 960px) {
+  .shell { grid-template-columns: 1fr; }
+  .nav, .side { border: 0; border-bottom: 1px solid var(--line); }
+  .main { padding: 18px; }
+  .launch { grid-template-columns: 1fr; }
+  .run-row { grid-template-columns: 1fr; }
+}
+`;
+
+function installStyles() {
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+function setToken(value) {
+  state.token = value;
+  writeStoredToken(value);
+}
+
+async function rpc(method, params = {}) {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (state.token) {
+    headers.set("authorization", "Bearer " + state.token);
+  }
+  const response = await fetch((boot.rpcPath ?? "/v1/rpc") + "/" + method, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(params),
+  });
+  const frame = await response.json().catch(() => null);
+  if (!response.ok || !frame?.ok) {
+    throw new Error(frame?.error?.message ?? "Gateway request failed");
+  }
+  return frame.payload;
+}
+
+function statusClass(status) {
+  if (status === "finished") return "ok";
+  if (status === "failed" || status === "cancelled") return "warn";
+  return "";
+}
+
+function formatAge(ms) {
+  if (!ms) return "unknown";
+  const seconds = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (seconds < 60) return seconds + "s ago";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return minutes + "m ago";
+  return Math.floor(minutes / 60) + "h ago";
+}
+
+function escapeText(value) {
+  return String(value ?? "").replace(/[&<>"']/g, (char) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[char]);
+}
+
+function renderRuns() {
+  if (state.runs.length === 0) {
+    return '<div class="empty">No runs found.</div>';
+  }
+  return state.runs.map((run) => `
+    <div class="run-row">
+      <div>
+        <div class="run-id">${escapeText(run.runId)}</div>
+        <div class="muted">${escapeText(run.workflowKey ?? run.workflowName ?? "workflow")}</div>
+      </div>
+      <div><span class="pill ${statusClass(run.status)}">${escapeText(run.status)}</span></div>
+      <div class="muted">${escapeText(formatAge(run.createdAtMs))}</div>
+      <div class="muted">${escapeText(run.triggeredBy ?? run.auth?.triggeredBy ?? "")}</div>
+    </div>
+  `).join("");
+}
+
+function renderApprovals() {
+  if (state.approvals.length === 0) {
+    return '<div class="empty">No pending approvals.</div>';
+  }
+  return state.approvals.map((approval, index) => `
+    <section class="approval">
+      <div>
+        <div class="approval-title">${escapeText(approval.requestTitle ?? approval.nodeId)}</div>
+        <div class="muted">${escapeText(approval.workflowKey)} / ${escapeText(approval.runId)}</div>
+      </div>
+      <div class="approval-actions">
+        <button data-approve="${index}">Approve</button>
+        <button class="danger" data-deny="${index}">Deny</button>
+      </div>
+    </section>
+  `).join("");
+}
+
+function renderWorkflows() {
+  const options = state.workflows.map((workflow) => {
+    const selected = workflow.key === state.selectedWorkflow ? " selected" : "";
+    return `<option value="${escapeText(workflow.key)}"${selected}>${escapeText(workflow.readableName ?? workflow.key)}</option>`;
+  }).join("");
+  return `<select id="workflow">${options || '<option value="">No workflows</option>'}</select>`;
+}
+
+function render() {
+  const activeRuns = state.runs.filter((run) => ["running", "waiting-approval", "waiting-event", "waiting-timer"].includes(run.status)).length;
+  root.innerHTML = `
+    <div class="shell">
+      <aside class="nav">
+        <div class="brand">Smithers Console</div>
+        <div class="nav-section">
+          <div class="label">Gateway</div>
+          <span class="pill ${state.health ? "ok" : "warn"}">${state.health ? "online" : "checking"}</span>
+          <span class="pill">${escapeText(state.health?.features?.join(", ") ?? "features pending")}</span>
+        </div>
+        <div class="nav-section">
+          <label class="label" for="token">Bearer token</label>
+          <input class="token" id="token" value="${escapeText(state.token)}" type="password" autocomplete="off">
+        </div>
+      </aside>
+      <main class="main">
+        <div class="topbar">
+          <div>
+            <div class="title">Operations</div>
+            <div class="muted">${escapeText(state.status)}</div>
+          </div>
+          <div class="meta">
+            <span class="pill">${state.workflows.length} workflows</span>
+            <span class="pill">${activeRuns} active</span>
+            <span class="pill">${state.approvals.length} approvals</span>
+            <button class="secondary" id="refresh">Refresh</button>
+          </div>
+        </div>
+        <form class="launch" id="launch">
+          <label class="field">
+            <span class="label">Workflow</span>
+            ${renderWorkflows()}
+          </label>
+          <label class="field">
+            <span class="label">Input JSON</span>
+            <textarea id="run-input" spellcheck="false">${escapeText(state.runInput)}</textarea>
+          </label>
+          <button type="submit" ${state.busy ? "disabled" : ""}>Launch</button>
+        </form>
+        <section class="runs">${renderRuns()}</section>
+      </main>
+      <aside class="side">
+        <div>
+          <h2>Pending Approvals</h2>
+          <div class="error">${escapeText(state.error)}</div>
+        </div>
+        ${renderApprovals()}
+      </aside>
+    </div>
+  `;
+  bind();
+}
+
+function bind() {
+  document.getElementById("token")?.addEventListener("input", (event) => {
+    setToken(event.target.value);
+  });
+  document.getElementById("workflow")?.addEventListener("change", (event) => {
+    state.selectedWorkflow = event.target.value;
+  });
+  document.getElementById("run-input")?.addEventListener("input", (event) => {
+    state.runInput = event.target.value;
+  });
+  document.getElementById("refresh")?.addEventListener("click", () => refresh());
+  document.getElementById("launch")?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    await launchRun();
+  });
+  for (const button of document.querySelectorAll("[data-approve]")) {
+    button.addEventListener("click", () => decideApproval(Number(button.dataset.approve), true));
+  }
+  for (const button of document.querySelectorAll("[data-deny]")) {
+    button.addEventListener("click", () => decideApproval(Number(button.dataset.deny), false));
+  }
+}
+
+async function refresh() {
+  state.error = "";
+  try {
+    const [health, workflows, runs, approvals] = await Promise.all([
+      rpc("health"),
+      rpc("listWorkflows", { limit: 100 }),
+      rpc("listRuns", { limit: 100 }),
+      rpc("listApprovals", { limit: 50 }),
+    ]);
+    state.health = health;
+    state.workflows = workflows;
+    state.runs = runs;
+    state.approvals = approvals;
+    if (!state.selectedWorkflow && workflows[0]) {
+      state.selectedWorkflow = workflows[0].key;
+    }
+    state.status = "Updated " + new Date().toLocaleTimeString();
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : String(error);
+    state.status = "Refresh failed";
+  }
+  render();
+}
+
+async function launchRun() {
+  state.busy = true;
+  state.error = "";
+  render();
+  try {
+    const input = JSON.parse(state.runInput || "{}");
+    await rpc("launchRun", { workflow: state.selectedWorkflow, input });
+    state.status = "Run launched";
+    await refresh();
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : String(error);
+    state.busy = false;
+    render();
+  }
+  state.busy = false;
+}
+
+async function decideApproval(index, approved) {
+  const approval = state.approvals[index];
+  if (!approval) return;
+  state.error = "";
+  try {
+    await rpc("submitApproval", {
+      runId: approval.runId,
+      nodeId: approval.nodeId,
+      iteration: approval.iteration ?? 0,
+      approved,
+      decision: { approved },
+    });
+    await refresh();
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : String(error);
+    render();
+  }
+}
+
+installStyles();
+render();
+refresh();
+setInterval(refresh, 5000);
+}
+
+export const DEFAULT_OPERATOR_UI_CLIENT_JS = `(${defaultOperatorUiClient.toString()})();\n`;

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -119,6 +119,22 @@ type GatewayDefaults$1 = {
     cliAgentTools?: "all" | "explicit-only";
 };
 
+type GatewayOperatorUiConfig$1 = {
+    /**
+     * URL path for the built-in operator console.
+     * @default "/console"
+     */
+    path?: string;
+    /**
+     * Document title for the generated HTML shell.
+     */
+    title?: string;
+    /**
+     * JSON-serializable boot data exposed to the browser.
+     */
+    props?: Record<string, unknown>;
+};
+
 type GatewayUiConfig$1 = {
     /**
      * Browser entry module for the React app. Smithers bundles this with Bun and
@@ -146,6 +162,11 @@ type GatewayOptions$1 = {
     heartbeatMs?: number;
     auth?: GatewayAuthConfig$1;
     ui?: GatewayUiConfig$1;
+    /**
+     * Built-in browser console for operators. Set to false to disable it.
+     * @default { path: "/console" }
+     */
+    operatorUi?: GatewayOperatorUiConfig$1 | false;
     defaults?: GatewayDefaults$1;
     maxBodyBytes?: number;
     maxPayload?: number;
@@ -267,6 +288,7 @@ declare class Gateway {
     requestTimeout: number;
     auth: GatewayAuthConfig$1 | undefined;
     ui: ResolvedGatewayUiConfig | null;
+    operatorUi: ResolvedGatewayUiConfig | null;
     uiApp: hono.Hono<hono_types.BlankEnv, hono_types.BlankSchema, "/">;
     defaults: GatewayDefaults$1 | undefined;
     workflows: Map<any, any>;
@@ -309,7 +331,7 @@ declare class Gateway {
    */
     uiBootConfig(mount: GatewayUiMount): {
         apiVersion: "v1";
-        kind: "workflow" | "gateway";
+        kind: "workflow" | "gateway" | "operator";
         workflowKey: string | null;
         mountPath: string;
         rpcPath: string;
@@ -727,6 +749,7 @@ type GatewayWebhookRunConfig = GatewayWebhookRunConfig$1;
 type GatewayWebhookSignalConfig = GatewayWebhookSignalConfig$1;
 type ConnectRequest = ConnectRequest$1;
 type GatewayAuthConfig = GatewayAuthConfig$1;
+type GatewayOperatorUiConfig = GatewayOperatorUiConfig$1;
 type GatewayOptions = GatewayOptions$1;
 type GatewayWebhookConfig = GatewayWebhookConfig$1;
 type IncomingMessage = node_http.IncomingMessage;
@@ -783,9 +806,10 @@ type ResolvedGatewayUiConfig = {
     path: string;
     title?: string;
     props?: Record<string, unknown>;
+    builtin?: "operator";
 };
 type GatewayUiMount = {
-    kind: "gateway" | "workflow";
+    kind: "gateway" | "workflow" | "operator";
     workflowKey: string | null;
     config: ResolvedGatewayUiConfig;
 };
@@ -1175,4 +1199,4 @@ type RunRow = _smithers_orchestrator_db_adapter_RunRow.RunRow;
 type ServerResponse = node_http.ServerResponse;
 type ServerOptions = ServerOptions$1;
 
-export { type AttemptRow, type ConnectRequest, type ConnectionState, DEVTOOLS_BACKPRESSURE_LIMIT, DEVTOOLS_EMPTY_ROOT_ID, DEVTOOLS_MAX_FRAME_NO, DEVTOOLS_POLL_INTERVAL_MS, DEVTOOLS_REBASELINE_INTERVAL, DEVTOOLS_RUN_ID_PATTERN, DEVTOOLS_TREE_MAX_DEPTH, type DevToolsEvent, type DevToolsNode, type DevToolsNodeType, DevToolsRouteError, type DiffSummary, type EventFrame, GATEWAY_FRAME_ID_MAX_LENGTH, GATEWAY_METHOD_NAME_MAX_LENGTH, GATEWAY_RPC_INPUT_MAX_BYTES, GATEWAY_RPC_INPUT_MAX_DEPTH, GATEWAY_RPC_MAX_ARRAY_LENGTH, GATEWAY_RPC_MAX_DEPTH, GATEWAY_RPC_MAX_PAYLOAD_BYTES, GATEWAY_RPC_MAX_STRING_LENGTH, Gateway, type GatewayAuthConfig, type GatewayDefaults, type GatewayMetricLabels, type GatewayOptions, type GatewayRegisterOptions, type GatewayRequestContext, type GatewayTokenGrant, type GatewayTransport, type GatewayUiConfig, type GatewayUiMount, type GatewayWebhookConfig, type GatewayWebhookRunConfig, type GatewayWebhookSignalConfig, type GetNodeDiffRouteResult, type HelloResponse, ITERATION_MAX, type IncomingMessage, type JumpResult, NODE_ID_PATTERN, NODE_OUTPUT_MAX_BYTES, NODE_OUTPUT_WARN_BYTES, type NodeOutputErrorCode, type NodeOutputResponse, NodeOutputRouteError, RUN_ID_PATTERN, type RegisteredWorkflow, type RequestFrame, type ResolvedGatewayUiConfig, type ResolvedRun, type ResponseFrame, type RunRow, type RunStartAuthContext, type ServeOptions, type ServerOptions, type ServerResponse, type SmithersWorkflow, assertGatewayInputDepthWithinBounds, createServeApp, emptyDevToolsRoot, getDevToolsSnapshotRoute, getGatewayInputDepth, getNodeDiffRoute, getNodeOutputRoute, jumpToFrameRoute, parseGatewayRequestFrame, parseXmlToDevToolsRoot, runFork, runPromise, runSync, snapshotFromFrameRow, startServer, startServerEffect, statusForRpcError, streamDevToolsRoute, summarizeBundle, validateFrameNoInput, validateFromSeqInput, validateGatewayMethodName, validateRequestedFrameNo, validateRunId };
+export { type AttemptRow, type ConnectRequest, type ConnectionState, DEVTOOLS_BACKPRESSURE_LIMIT, DEVTOOLS_EMPTY_ROOT_ID, DEVTOOLS_MAX_FRAME_NO, DEVTOOLS_POLL_INTERVAL_MS, DEVTOOLS_REBASELINE_INTERVAL, DEVTOOLS_RUN_ID_PATTERN, DEVTOOLS_TREE_MAX_DEPTH, type DevToolsEvent, type DevToolsNode, type DevToolsNodeType, DevToolsRouteError, type DiffSummary, type EventFrame, GATEWAY_FRAME_ID_MAX_LENGTH, GATEWAY_METHOD_NAME_MAX_LENGTH, GATEWAY_RPC_INPUT_MAX_BYTES, GATEWAY_RPC_INPUT_MAX_DEPTH, GATEWAY_RPC_MAX_ARRAY_LENGTH, GATEWAY_RPC_MAX_DEPTH, GATEWAY_RPC_MAX_PAYLOAD_BYTES, GATEWAY_RPC_MAX_STRING_LENGTH, Gateway, type GatewayAuthConfig, type GatewayDefaults, type GatewayMetricLabels, type GatewayOperatorUiConfig, type GatewayOptions, type GatewayRegisterOptions, type GatewayRequestContext, type GatewayTokenGrant, type GatewayTransport, type GatewayUiConfig, type GatewayUiMount, type GatewayWebhookConfig, type GatewayWebhookRunConfig, type GatewayWebhookSignalConfig, type GetNodeDiffRouteResult, type HelloResponse, ITERATION_MAX, type IncomingMessage, type JumpResult, NODE_ID_PATTERN, NODE_OUTPUT_MAX_BYTES, NODE_OUTPUT_WARN_BYTES, type NodeOutputErrorCode, type NodeOutputResponse, NodeOutputRouteError, RUN_ID_PATTERN, type RegisteredWorkflow, type RequestFrame, type ResolvedGatewayUiConfig, type ResolvedRun, type ResponseFrame, type RunRow, type RunStartAuthContext, type ServeOptions, type ServerOptions, type ServerResponse, type SmithersWorkflow, assertGatewayInputDepthWithinBounds, createServeApp, emptyDevToolsRoot, getDevToolsSnapshotRoute, getGatewayInputDepth, getNodeDiffRoute, getNodeOutputRoute, jumpToFrameRoute, parseGatewayRequestFrame, parseXmlToDevToolsRoot, runFork, runPromise, runSync, snapshotFromFrameRow, startServer, startServerEffect, statusForRpcError, streamDevToolsRoute, summarizeBundle, validateFrameNoInput, validateFromSeqInput, validateGatewayMethodName, validateRequestedFrameNo, validateRunId };

--- a/packages/server/tests/gateway-ui.test.jsx
+++ b/packages/server/tests/gateway-ui.test.jsx
@@ -91,6 +91,41 @@ describe("Gateway UI", () => {
     expect(await assetResponse.text()).toContain("Gateway Console");
   });
 
+  test("serves the built-in operator console by default", async () => {
+    gateway = new Gateway();
+    const server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+    const port = getPort(server);
+
+    const htmlResponse = await fetch(`http://127.0.0.1:${port}/console`);
+    expect(htmlResponse.status).toBe(200);
+    const html = await htmlResponse.text();
+    expect(html).toContain("<title>Smithers Operator Console</title>");
+    expect(html).toContain('"kind":"operator"');
+    expect(html).toContain('"mountPath":"/console"');
+    expect(html).toContain('/console/__smithers_ui/client.js');
+
+    const assetResponse = await fetch(`http://127.0.0.1:${port}/console/__smithers_ui/client.js`);
+    expect(assetResponse.status).toBe(200);
+    const asset = await assetResponse.text();
+    expect(asset).toContain("Smithers Console");
+    expect(asset).toContain("sessionStorage");
+    expect(asset).not.toContain("localStorage");
+    expect(asset).toContain('rpc("listWorkflows"');
+    expect(asset).toContain('rpc("listRuns"');
+    expect(asset).toContain('rpc("listApprovals"');
+    expect(asset).toContain('rpc("launchRun"');
+    expect(asset).toContain('rpc("submitApproval"');
+  });
+
+  test("allows the built-in operator console to be disabled", async () => {
+    gateway = new Gateway({ operatorUi: false });
+    const server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+    const port = getPort(server);
+
+    const response = await fetch(`http://127.0.0.1:${port}/console`);
+    expect(response.status).toBe(404);
+  });
+
   test("serves a workflow-level UI and exposes UI metadata through listWorkflows", async () => {
     tempDir = mkdtempSync(join(process.cwd(), ".smithers-workflow-ui-"));
     const dbPath = join(tempDir, "workflow.db");

--- a/packages/time-travel/src/jumpToFrame.js
+++ b/packages/time-travel/src/jumpToFrame.js
@@ -491,6 +491,7 @@ export async function jumpToFrame(input) {
   let lock = null;
   /** @type {number | null} */
   let auditRowId = null;
+  let skipTerminalAudit = false;
 
   try {
     return await withSpan(
@@ -528,6 +529,12 @@ export async function jumpToFrame(input) {
           },
         );
 
+        const run = await input.adapter.getRun(runId);
+        if (!run) {
+          skipTerminalAudit = true;
+          throw new JumpToFrameError("RunNotFound", `Run not found: ${runId}`);
+        }
+
         const rateLimit = await evaluateRewindRateLimit({
           adapter: input.adapter,
           runId,
@@ -561,11 +568,6 @@ export async function jumpToFrame(input) {
               durationMs: null,
             }),
         );
-
-        const run = await input.adapter.getRun(runId);
-        if (!run) {
-          throw new JumpToFrameError("RunNotFound", `Run not found: ${runId}`);
-        }
 
         const latestFrame = await readLatestFrame(input.adapter, runId);
         if (!latestFrame) {
@@ -964,7 +966,10 @@ export async function jumpToFrame(input) {
     // Persist the terminal audit state BEFORE releasing the lock so a second
     // caller cannot beat us to the rate-limit count.
     try {
-      if (auditRowId !== null) {
+      if (skipTerminalAudit) {
+        // No durable audit row can be attached when the parent run does not
+        // exist; the runs table owns rewind audit rows through a foreign key.
+      } else if (auditRowId !== null) {
         await updateRewindAuditRow(input.adapter, {
           id: auditRowId,
           result: auditResult,
@@ -984,13 +989,15 @@ export async function jumpToFrame(input) {
           durationMs,
         });
       }
-      await emitLog(input.onLog, "info", "jumpToFrame audit row written", {
-        runId: runIdForAudit,
-        fromFrameNo: fromFrameNoForAudit,
-        toFrameNo: toFrameNoForAudit,
-        caller,
-        result: auditResult,
-      });
+      if (!skipTerminalAudit) {
+        await emitLog(input.onLog, "info", "jumpToFrame audit row written", {
+          runId: runIdForAudit,
+          fromFrameNo: fromFrameNoForAudit,
+          toFrameNo: toFrameNoForAudit,
+          caller,
+          result: auditResult,
+        });
+      }
     } catch (auditError) {
       await emitLog(input.onLog, "error", "jumpToFrame audit write failed", {
         runId: runIdForAudit,


### PR DESCRIPTION
## Summary
- enforce run-owned SQLite foreign keys, legacy FK rebuild migrations, and cross-adapter transaction serialization
- make Bubblewrap sandbox execution real, cleanup-backed, and environment-isolated
- implement cache policy ttl/scope behavior and add a default operator console at /console
- add a standard CI test job with a pinned Bun version

## Verification
- pnpm test
- pnpm -r typecheck
- pnpm -r build
- pnpm lint (passes with 8 existing warnings)
- git diff --check