### PR TITLE
db: split SqlMessageStorage into lowercase module + cache upsert

### DIFF
--- a/packages/db/tests/db-adapter.test.js
+++ b/packages/db/tests/db-adapter.test.js
@@ -454,6 +454,21 @@ describe("SmithersDb adapter", () => {
         expect(cached).toBeDefined();
         expect(cached.payloadJson).toBe('{"v":1}');
     });
+    test("insertCache updates an existing cache row", async () => {
+        const { adapter } = createTestDb();
+        await adapter.insertCache(cacheRow("key-upsert", {
+            createdAtMs: 1,
+            payloadJson: '{"v":1}',
+        }));
+        await adapter.insertCache(cacheRow("key-upsert", {
+            createdAtMs: 2,
+            payloadJson: '{"v":2}',
+        }));
+        const cached = await adapter.getCache("key-upsert");
+        expect(cached).toBeDefined();
+        expect(cached?.createdAtMs).toBe(2);
+        expect(cached?.payloadJson).toBe('{"v":2}');
+    });
     test("getCache returns undefined for missing key", async () => {
         const { adapter } = createTestDb();
         const cached = await adapter.getCache("nonexistent");


### PR DESCRIPTION
Split 2/7 of #143 — original work by @cookesan.

## Summary
- Moves the `SqlMessageStorage` implementation out of the legacy PascalCase file (now a one-line re-export) into the canonical `packages/db/src/sql-message-storage.js`.
- Adds an upsert call for cache row inserts so a repeated `cache.set` on the same key refreshes the row instead of silently dropping the write (was `insertIgnore`, now `upsert(['cacheKey'])`).
- Adds coverage for the cache upsert path, concurrent writers, schema migrations, and nodeDiffCache invariants.

## Validation
- 7 files changed, +217/-875 (large delete is the file-rename collapse)

## Context
Part of #143 split into atomic per-domain PRs.