### PR TITLE
control-plane: add hosted package + rebrand + production hardening guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Smithers
 
-Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+Smithers is a durable control plane for long-running coding agents.
+
+Write agent workflows as TypeScript, run them for minutes or days, and keep the operational contract in one place: crash recovery, retries, human approvals, replay, evals, sandbox review, and Gateway APIs.
 
 ## Getting started
 
@@ -8,9 +10,9 @@ Smithers powers TypeScript teams to run long AI coding workflows that survive cr
 bunx smithers-orchestrator@latest init
 ```
 
-This will scaffold a `.smithers/` folder with common simple preconfigured workflows ready to use right away.
+This scaffolds a `.smithers/` folder with canonical workflows for implementation, review, debugging, planning, audits, and long-horizon missions.
 
-Use the `smithers` cli to work with smithers.
+Use the `smithers` CLI or Gateway console to operate runs.
 
 ## [See Docs](https://smithers.sh)
 
@@ -46,7 +48,7 @@ export default smithers((ctx) => (
 ));
 ```
 
-Each task output is validated against its Zod schema and persisted to SQLite. If the process crashes, Smithers resumes from the last completed node.
+Each task output is validated against its Zod schema and persisted to SQLite. If the process crashes, Smithers resumes from the last completed node without re-running completed work.
 
 ## Components
 
@@ -83,6 +85,16 @@ smithers ps
 smithers workflow list
 smithers approve abc123 --node review
 ```
+
+## Gateway Console
+
+```ts
+import { Gateway } from "smithers-orchestrator/gateway";
+
+const gateway = new Gateway({ ui: true });
+```
+
+The built-in console mounts at `/console` and gives operators a browser surface for workflow inventory, active runs, and approval decisions. Custom Gateway UIs can still be mounted with `ui: { entry, path, title, props }`.
 
 ## Eval suites
 

--- a/docs/concepts/caching.mdx
+++ b/docs/concepts/caching.mdx
@@ -5,4 +5,12 @@ description: Folded into How It Works.
 
 This material is now in [How It Works](/how-it-works#caching).
 
-Cached payloads are revalidated against the current output schema on every hit; mismatches are treated as misses. Service instances are never part of the cache key — encode model/provider changes by bumping `cache.version`.
+Cached payloads are revalidated against the current output schema on every hit; mismatches are treated as misses. Service instances are never part of the cache key; encode model/provider changes by bumping `cache.version`.
+
+Cache policy controls reuse explicitly:
+
+- `key` overrides the task ID portion of the cache identity.
+- `scope: "run"` reuses output only inside the same run.
+- `scope: "workflow"` reuses output across runs of the same workflow.
+- `scope: "global"` reuses output across workflow names.
+- `ttlMs` expires stale rows; expired rows are recomputed and refreshed.

--- a/docs/deployment/control-plane.mdx
+++ b/docs/deployment/control-plane.mdx
@@ -1,0 +1,120 @@
+---
+title: Control Plane
+description: Organization, project, identity, billing, usage, secret-reference, and audit primitives for hosted Smithers deployments.
+---
+
+Smithers ships local Gateway and runtime primitives, plus a durable control-plane store for deployments that need multi-tenant product boundaries. The store is intentionally small: it gives hosted services a tested schema for the objects enterprise buyers ask about, while leaving payment collection, identity-provider handshakes, and secret-value reads to the hosted service.
+
+## What Ships
+
+Import the store from the public facade:
+
+```ts
+import { ControlPlaneStore } from "smithers-orchestrator/control-plane";
+```
+
+Or from the scoped package:
+
+```ts
+import { ControlPlaneStore } from "@smithers-orchestrator/control-plane";
+```
+
+The store creates SQLite tables for:
+
+- organizations
+- teams and team membership
+- projects and project team grants
+- billing account records
+- identity-provider records for SAML/OIDC configuration
+- usage events, summaries, and quota checks
+- secret manager references, not secret values
+- audit events and org audit export
+
+```ts
+const store = new ControlPlaneStore(sqlite);
+
+const org = store.createOrg({
+  orgId: "org_acme",
+  slug: "acme",
+  name: "Acme",
+});
+
+const project = store.createProject({
+  orgId: org.orgId,
+  projectId: "project_app",
+  slug: "app",
+  name: "App",
+});
+
+store.recordUsage({
+  orgId: org.orgId,
+  projectId: project.projectId,
+  runId: "run_123",
+  metric: "agent_runtime_ms",
+  quantity: 42_000,
+  unit: "ms",
+});
+
+store.setUsageLimit({
+  orgId: org.orgId,
+  projectId: project.projectId,
+  metric: "agent_runtime_ms",
+  unit: "ms",
+  period: "monthly",
+  limitQuantity: 10_000_000,
+});
+
+store.upsertIdentityProvider({
+  orgId: org.orgId,
+  providerId: "idp_okta",
+  type: "saml",
+  issuer: "https://acme.okta.com",
+  ssoUrl: "https://acme.okta.com/app/smithers/sso/saml",
+  certificateRef: "vault://identity/acme-okta-cert",
+});
+
+store.putSecretRef({
+  orgId: org.orgId,
+  projectId: project.projectId,
+  name: "deploy-token",
+  provider: "aws-secrets-manager",
+  ref: "arn:aws:secretsmanager:us-east-1:123:secret:deploy",
+});
+
+const quota = store.checkUsageLimit({
+  orgId: org.orgId,
+  projectId: project.projectId,
+  metric: "agent_runtime_ms",
+  unit: "ms",
+  period: "monthly",
+});
+
+const audit = store.exportOrgAudit({ orgId: org.orgId });
+```
+
+Foreign keys are enabled during setup. Deleting an org cascades to its projects, teams, identity providers, usage rows, usage limits, secret references, and audit rows.
+
+## Hosted Boundary
+
+A hosted Smithers service should layer these primitives behind:
+
+- SSO/SAML or OIDC authentication
+- billing provider checkout and invoices
+- cloud object storage for large artifacts
+- managed secret provider reads at worker runtime
+- audit export delivery and retention policy
+- SLAs, support, compliance controls, and incident response
+
+The open-source package owns the durable data contract. The hosted service owns identity, payment collection, tenant isolation, compliance operations, and infrastructure support.
+
+## Gateway Console
+
+Use the built-in console when you need an operator surface before building a custom app:
+
+```ts
+import { Gateway } from "smithers-orchestrator/gateway";
+
+const gateway = new Gateway({ ui: true });
+```
+
+It mounts at `/console` and uses stable Gateway RPCs for workflow inventory, active runs, and approval decisions. For branded or domain-specific operations, pass `ui: { entry, path, title, props }` and build a custom Gateway UI.

--- a/docs/deployment/production-hardening.mdx
+++ b/docs/deployment/production-hardening.mdx
@@ -1,0 +1,107 @@
+---
+title: Production Hardening
+description: Operate Smithers with durable storage, scoped access, bounded execution, and auditable workflows.
+---
+
+Smithers can run long-lived agent workflows, so production deployments need a stricter posture than a local quickstart. Treat the Gateway, database, workflow modules, and sandbox workers as one operational boundary.
+
+## Required Checks
+
+Run these checks before promoting a workflow module:
+
+```bash
+pnpm check:effect
+pnpm check:deps
+pnpm check:architecture
+pnpm -r typecheck
+pnpm test
+```
+
+The default CI workflow runs the same test gate on pull requests and pushes to `main`.
+
+## Persistence
+
+Use one SQLite database file per deployment and place it on durable storage. The internal tables are created and migrated idempotently on startup.
+
+Recommended database practices:
+
+- Back up the database file and its WAL files together.
+- Keep `PRAGMA foreign_keys = ON`; Smithers enables it during schema setup and uses referential checks for core run artifacts.
+- Keep run IDs stable across resume attempts.
+- Use the Gateway event stream sequence numbers for reconnects; clients should resume from the last seen `seq`.
+- Avoid manually deleting internal rows. Delete whole runs through supported administrative paths so dependent frames, node diffs, and audit rows stay consistent.
+
+## Access Control
+
+Expose the Gateway only behind TLS. Use scoped bearer grants for automation and short TTLs for human-triggered actions.
+
+Recommended scopes by client type:
+
+| Client | Typical scopes |
+| ------ | -------------- |
+| Run dashboard | `run:read`, `approval:read` |
+| Launch automation | `run:read`, `run:write` |
+| Approval inbox | `run:read`, `approval:read`, `approval:submit` |
+| Operator tools | `run:read`, `run:write`, `approval:submit` |
+
+Rotate token grants regularly and revoke grants when a user, CI job, or integration no longer needs access.
+
+For multi-tenant deployments, store tenant-level orgs, projects, teams, usage, secret references, and audit events with `ControlPlaneStore` from `smithers-orchestrator/control-plane`. Keep identity-provider assertions and billing-provider webhooks outside SQLite, then write normalized grants and audit events into the control-plane tables.
+
+## Execution Boundary
+
+Sandbox tasks isolate the Smithers control plane from bundle collection and diff application:
+
+- request and result bundles are written under the run sandbox directory
+- bundle manifests are size-bounded
+- patch and artifact paths are checked against path traversal
+- produced diffs require review unless `autoAcceptDiffs` is enabled
+- sandbox records and events are persisted for audit
+
+Treat `allowNetwork`, container images, environment variables, ports, volumes, and CPU or memory limits as runtime-specific controls. Verify the selected runtime enforces the controls you depend on before running untrusted workflows. For high-risk code generation, run sandbox workers in a separate account, namespace, or machine with no ambient production credentials.
+
+## Secrets
+
+Never pass long-lived credentials through workflow input. Prefer short-lived tokens from the caller, scoped environment injection at the worker boundary, or a secret manager mounted only into the worker process that needs it.
+
+Operational rules:
+
+- Do not store provider keys in SQLite rows, run input, task output, or event payloads.
+- Redact logs before forwarding them to shared observability sinks.
+- Split launch permissions from approval permissions for workflows that can write files, create pull requests, or deploy.
+
+## Cache Policy
+
+Use cache policy keys deliberately:
+
+- `scope: "run"` keeps reuse inside one run.
+- `scope: "workflow"` shares reuse across runs of the same workflow.
+- `scope: "global"` shares reuse across workflow names.
+- `ttlMs` bounds staleness; expired cache rows are treated as misses and refreshed.
+- `version` should change whenever prompt, model, provider, tool behavior, or output semantics change.
+
+Cached payloads are still validated against the current output schema on every hit. A schema mismatch is a cache miss.
+
+## Audit Trail
+
+For incident review, preserve:
+
+- Gateway access logs
+- Smithers run events
+- `_smithers_time_travel_audit` rows
+- sandbox bundle metadata and review decisions
+- approval decisions, notes, and actor IDs
+- deployment version and workflow module revision
+
+Keep the audit log append-only from the perspective of normal operators.
+
+## Release Checklist
+
+Before a production release:
+
+- CI is green on typecheck, dependency checks, and tests.
+- Database backups have been restored in a staging environment.
+- Gateway tokens are scoped and have bounded TTLs.
+- Sandbox runtime enforcement has been tested against the intended threat model.
+- Approval paths have a named owner and a fallback owner.
+- Logs are retained long enough to investigate delayed workflow failures.

--- a/docs/deployment/reference.mdx
+++ b/docs/deployment/reference.mdx
@@ -5,6 +5,8 @@ description: Deploy the stable Gateway with SQLite, scoped bearer auth, and a re
 
 The reference deployment is the lower-level Gateway path for teams that do not want JJHub. It runs one Gateway process, one SQLite database file, and a TLS reverse proxy.
 
+For multi-tenant hosted deployments, pair the Gateway with the [Control Plane](/deployment/control-plane) package for orgs, projects, teams, billing account records, usage events, secret references, and audit export.
+
 ## Docker Compose
 
 From the repo root:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "Smithers",
-  "description": "AI workflow orchestration framework",
+  "description": "Durable control plane for long-running coding agents",
   "theme": "mint",
   "colors": {
     "primary": "#00D2A0"
@@ -47,7 +47,9 @@
           "cli/overview",
           "guides/evals-quickstart",
           "guides/tui",
-          "deployment/reference"
+          "deployment/reference",
+          "deployment/control-plane",
+          "deployment/production-hardening"
         ]
       },
       {
@@ -62,7 +64,8 @@
               "workflows/mission",
               "workflows/kanban",
               "workflows/ralph",
-              "workflows/workflow-skill"
+              "workflows/workflow-skill",
+              "workflows/catalog"
             ]
           },
           {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Smithers
-description: Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+description: Durable control plane for long-running coding agents.
 ---
 
-Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+Smithers is a durable control plane for long-running coding agents. It gives TypeScript teams crash recovery, retries, human approvals, replay, evals, sandbox review, and Gateway APIs in one workflow runtime.
 
 ```tsx
 /** @jsxImportSource smithers-orchestrator */
@@ -32,7 +32,7 @@ bunx smithers-orchestrator init
 bunx smithers-orchestrator up workflow.tsx --input '{"name":"world"}'
 ```
 
-Outputs are validated by Zod, persisted to SQLite, and survive crashes. Resume with `--resume true`.
+Outputs are validated by Zod, persisted to SQLite, and survive crashes. Resume with `--resume true`, or expose the Gateway console with `new Gateway({ ui: true })`.
 
 ## Read next
 
@@ -40,5 +40,6 @@ Outputs are validated by Zod, persisted to SQLite, and survive crashes. Resume w
 - [How It Works](/how-it-works) — the render → execute → persist loop.
 - [Components](/components/workflow) — JSX surface reference.
 - [CLI](/cli/overview) — every command in one table.
+- [Control Plane](/deployment/control-plane) — org/project, metering, secret-reference, and audit primitives.
 - [Recipes](/recipes) — common patterns.
 - [Types](/reference/types) — public TypeScript surface.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: What Smithers is and when to use it.
 ---
 
-Smithers is a durable workflow runtime. Smithers survive crashes and handle approvals, retries, and restarts.
+Smithers is a durable control plane for long-running coding agents. Smithers workflows survive crashes and handle approvals, retries, restarts, replay, evals, and operator visibility.
 
 You write a workflow as a JSX tree, and Smithers repeatedly renders it every "tick". Each render answers: given what has already finished, what can run now? Tasks produce outputs validated by Zod schemas; the runtime persists them to SQLite. Crashes, restarts, and approvals are first-class — the runtime resumes from the last persisted state without re-running completed work.
 
@@ -28,6 +28,7 @@ Use Smithers when:
 - you need crash recovery
 - humans must approve or answer questions mid-run
 - different tasks need different models, tools, or policies
+- operators need a Gateway API or browser console for active runs
 
 Don't use it for a single prompt → single response. That's just an `Agent.generate(...)` call.
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1,6 +1,6 @@
 # Smithers
 
-> Smithers — durable AI workflow orchestration as a JSX runtime.
+> Smithers — durable control plane for long-running coding agents.
 > Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This file contains the core Smithers documentation. Read top to bottom for a complete picture of the runtime, JSX surface, CLI, and components.
@@ -19,9 +19,9 @@ Changelogs are not included; see /docs/changelogs/ on the docs site.
 
 ## Smithers
 
-> Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+> Smithers is a durable control plane for long-running coding agents.
 
-Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+Smithers gives TypeScript teams crash recovery, retries, human approvals, replay, evals, sandbox review, and Gateway APIs in one workflow runtime.
 
 ```tsx
 /** @jsxImportSource smithers-orchestrator */

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,6 +1,6 @@
 # Smithers — full documentation
 
-> Durable AI workflow orchestration as a JSX runtime.
+> Durable control plane for long-running coding agents.
 > Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This is the complete Smithers documentation in one file. It is the concatenation of every fragment listed in /llms.txt.
@@ -20,7 +20,7 @@ Changelogs are not included; see /docs/changelogs/ on the docs site.
 ===============================================================================
 # Smithers
 
-> Smithers — durable AI workflow orchestration as a JSX runtime.
+> Smithers — durable control plane for long-running coding agents.
 > Repo: github.com/smithersai/smithers · Package: smithers-orchestrator (npm)
 
 This file contains the core Smithers documentation. Read top to bottom for a complete picture of the runtime, JSX surface, CLI, and components.
@@ -39,9 +39,9 @@ Changelogs are not included; see /docs/changelogs/ on the docs site.
 
 ## Smithers
 
-> Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+> Smithers is a durable control plane for long-running coding agents.
 
-Smithers powers TypeScript teams to run long AI coding workflows that survive crashes and handle approvals, retries, and restarts
+Smithers gives TypeScript teams crash recovery, retries, human approvals, replay, evals, sandbox review, and Gateway APIs in one workflow runtime.
 
 ```tsx
 /** @jsxImportSource smithers-orchestrator */

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Smithers
 
-Durable AI workflow orchestration as a JSX runtime.
+Durable control plane for long-running coding agents.
 
 ## Documentation
 

--- a/docs/reference/package-configuration.mdx
+++ b/docs/reference/package-configuration.mdx
@@ -30,6 +30,7 @@ Use the subpath form to import only the surface you need.
 | `smithers-orchestrator/scorers` | `./src/scorers.js` | Eval scorers: `createScorer`, `llmJudge`, `aggregateScores` |
 | `smithers-orchestrator/memory` | `./src/memory.js` | Cross-run facts, message history, processors, and metrics |
 | `smithers-orchestrator/openapi` | `./src/openapi.js` | Generate AI SDK tools from OpenAPI specs |
+| `smithers-orchestrator/control-plane` | `./src/control-plane.js` | Organization, project, billing, usage, secret-reference, and audit primitives |
 
 The PI plugin is published as the separate `@smithers-orchestrator/pi-plugin` package. The old `smithers-orchestrator/pi-plugin` and `smithers-orchestrator/pi-extension` subpaths are no longer exported.
 
@@ -44,6 +45,7 @@ Most applications should import from `smithers-orchestrator`. The scoped workspa
 | `@smithers-orchestrator/accounts` | Subscription and API-key account registry helpers: `listAccounts`, `addAccount`, `removeAccount`, `getAccount`, `accountToProviderEnv` | [CLI Agents](/integrations/cli-agents) |
 | `@smithers-orchestrator/agents` | AI SDK and CLI agent adapters, CLI capability reports, agent contracts, and tool capability registry | [CLI Agents](/integrations/cli-agents), [SDK Agents](/integrations/sdk-agents) |
 | `@smithers-orchestrator/components` | JSX workflow components such as `Task`, `Workflow`, `Approval`, `Sandbox`, `Timer`, `Signal`, and control-flow components | [Components](/concepts/control-flow) |
+| `@smithers-orchestrator/control-plane` | Durable organization, project, team, billing, usage, secret-reference, and audit primitives for hosted deployments | [Control Plane](/deployment/control-plane) |
 | `@smithers-orchestrator/db` | SQLite/Drizzle adapter, table setup, run-state derivation, schema helpers, and output tables | [Data Model](/concepts/data-model), [Run State](/runtime/run-state) |
 | `@smithers-orchestrator/devtools` | Snapshot, tree, diff, node lookup, task collection, and DevTools run-store helpers behind the CLI inspect commands | [Debugging](/guides/debugging), [CLI Overview](/cli/overview) |
 | `@smithers-orchestrator/driver` | Runtime driver contracts: `RunOptions`, `RunResult`, `RunStatus`, `SmithersCtx`, outputs, task runtime, interop, and child process helpers | [Run Workflow](/runtime/run-workflow), [Execution Model](/concepts/execution-model) |
@@ -80,6 +82,9 @@ import { createScorer, llmJudge } from "smithers-orchestrator/scorers";
 
 // MDX plugin (in preload.ts)
 import { mdxPlugin } from "smithers-orchestrator/mdx-plugin";
+
+// Control-plane primitives
+import { ControlPlaneStore } from "smithers-orchestrator/control-plane";
 ```
 
 ## TypeScript Configuration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smithers-monorepo",
   "version": "0.20.4",
-  "description": "AI workflow orchestration with JSX",
+  "description": "Durable control plane for long-running coding agents",
   "author": "William Cory",
   "license": "MIT",
   "private": true,
@@ -30,7 +30,8 @@
     "./serve": "./packages/server/src/serve.js",
     "./scorers": "./packages/scorers/src/index.js",
     "./memory": "./packages/memory/src/index.js",
-    "./openapi": "./packages/openapi/src/index.js"
+    "./openapi": "./packages/openapi/src/index.js",
+    "./control-plane": "./packages/smithers/src/control-plane.js"
   },
   "engines": {
     "bun": ">=1.3.0"
@@ -91,6 +92,7 @@
     "@smithers-orchestrator/agents": "workspace:*",
     "@smithers-orchestrator/cli": "workspace:*",
     "@smithers-orchestrator/components": "workspace:*",
+    "@smithers-orchestrator/control-plane": "workspace:*",
     "@smithers-orchestrator/db": "workspace:*",
     "@smithers-orchestrator/devtools": "workspace:*",
     "@smithers-orchestrator/driver": "workspace:*",

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@smithers-orchestrator/control-plane",
+  "version": "0.20.4",
+  "description": "Durable organization, project, billing, usage, secret-reference, and audit primitives for hosted Smithers control planes.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./*": {
+      "types": "./src/index.d.ts",
+      "import": "./src/*.js",
+      "default": "./src/*.js"
+    }
+  },
+  "files": [
+    "src/"
+  ],
+  "scripts": {
+    "test": "bun test tests",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsup --dts-only"
+  },
+  "dependencies": {
+    "@smithers-orchestrator/errors": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "~5.9.3"
+  }
+}

--- a/packages/control-plane/src/index.d.ts
+++ b/packages/control-plane/src/index.d.ts
@@ -1,0 +1,152 @@
+import { Database } from 'bun:sqlite';
+
+type ControlPlaneSqlite = Database | {
+  exec(sql: string): unknown;
+  query(sql: string): {
+    run(...params: unknown[]): unknown;
+    get(...params: unknown[]): Record<string, unknown> | null;
+    all(...params: unknown[]): Array<Record<string, unknown>>;
+  };
+};
+
+type ControlPlaneOrg = {
+  orgId: string;
+  slug: string;
+  name: string;
+  createdAtMs: number;
+};
+
+type ControlPlaneTeam = {
+  orgId: string;
+  teamId: string;
+  slug: string;
+  name: string;
+  createdAtMs: number;
+};
+
+type ControlPlaneProject = {
+  orgId: string;
+  projectId: string;
+  slug: string;
+  name: string;
+  metadata: Record<string, unknown>;
+  createdAtMs: number;
+};
+
+type ControlPlaneBillingAccount = {
+  orgId: string;
+  plan: string;
+  billingCustomerId: string | null;
+  status: string;
+  updatedAtMs: number;
+};
+
+type ControlPlaneIdentityProvider = {
+  orgId: string;
+  providerId: string;
+  type: string;
+  issuer: string;
+  ssoUrl: string | null;
+  certificateRef: string | null;
+  status: string;
+  metadata: Record<string, unknown>;
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+type ControlPlaneUsageEvent = {
+  id: number;
+  orgId: string;
+  projectId: string | null;
+  runId: string | null;
+  metric: string;
+  quantity: number;
+  unit: string;
+  observedAtMs: number;
+  metadata: Record<string, unknown>;
+};
+
+type ControlPlaneUsageLimit = {
+  orgId: string;
+  projectId: string | null;
+  metric: string;
+  unit: string;
+  period: string;
+  limitQuantity: number;
+  updatedAtMs: number;
+};
+
+type ControlPlaneUsageLimitCheck = ControlPlaneUsageLimit & {
+  usedQuantity: number;
+  remainingQuantity: number;
+  exceeded: boolean;
+};
+
+type ControlPlaneUsageSummary = {
+  orgId: string;
+  metric: string;
+  unit: string;
+  quantity: number;
+};
+
+type ControlPlaneSecretRef = {
+  orgId: string;
+  projectId: string | null;
+  name: string;
+  provider: string;
+  ref: string;
+  createdBy: string | null;
+  createdAtMs: number;
+  rotatedAtMs: number | null;
+};
+
+type ControlPlaneAuditEvent = {
+  id: number;
+  orgId: string;
+  projectId: string | null;
+  actorId: string | null;
+  action: string;
+  targetType: string;
+  targetId: string | null;
+  occurredAtMs: number;
+  metadata: Record<string, unknown>;
+};
+
+type ControlPlaneExport = {
+  exportedAtMs: number;
+  org: ControlPlaneOrg;
+  projects: ControlPlaneProject[];
+  teams: ControlPlaneTeam[];
+  billing: ControlPlaneBillingAccount | null;
+  identityProviders: ControlPlaneIdentityProvider[];
+  usage: ControlPlaneUsageSummary[];
+  usageLimits: ControlPlaneUsageLimit[];
+  secretRefs: ControlPlaneSecretRef[];
+  auditEvents: ControlPlaneAuditEvent[];
+};
+
+declare function ensureControlPlaneTables(sqlite: ControlPlaneSqlite): void;
+
+declare class ControlPlaneStore {
+  constructor(sqlite: ControlPlaneSqlite);
+
+  createOrg(input: { orgId?: string; slug: string; name: string; createdAtMs?: number }): ControlPlaneOrg;
+  getOrg(orgId: string): ControlPlaneOrg | null;
+  createTeam(input: { orgId: string; teamId?: string; slug: string; name: string; createdAtMs?: number }): ControlPlaneTeam;
+  addTeamMember(input: { orgId: string; teamId: string; userId: string; role?: string; createdAtMs?: number }): void;
+  createProject(input: { orgId: string; projectId?: string; slug: string; name: string; metadata?: Record<string, unknown>; createdAtMs?: number }): ControlPlaneProject;
+  addProjectTeam(input: { orgId: string; projectId: string; teamId: string; role?: string; createdAtMs?: number }): void;
+  upsertBillingAccount(input: { orgId: string; plan: string; billingCustomerId?: string | null; status?: string; updatedAtMs?: number }): ControlPlaneBillingAccount;
+  upsertIdentityProvider(input: { orgId: string; providerId?: string; type: string; issuer: string; ssoUrl?: string | null; certificateRef?: string | null; status?: string; metadata?: Record<string, unknown>; createdAtMs?: number; updatedAtMs?: number }): ControlPlaneIdentityProvider;
+  listIdentityProviders(input: { orgId: string; status?: string }): ControlPlaneIdentityProvider[];
+  recordUsage(input: { orgId: string; projectId?: string | null; runId?: string | null; metric: string; quantity: number; unit?: string; observedAtMs?: number; metadata?: Record<string, unknown> }): ControlPlaneUsageEvent;
+  summarizeUsage(input: { orgId: string; sinceMs?: number; untilMs?: number }): ControlPlaneUsageSummary[];
+  setUsageLimit(input: { orgId: string; projectId?: string | null; metric: string; unit?: string; period?: string; limitQuantity: number; updatedAtMs?: number }): ControlPlaneUsageLimit;
+  checkUsageLimit(input: { orgId: string; projectId?: string | null; metric: string; unit?: string; period?: string; sinceMs?: number; untilMs?: number }): ControlPlaneUsageLimitCheck | null;
+  putSecretRef(input: { orgId: string; projectId?: string | null; name: string; provider: string; ref: string; createdBy?: string | null; createdAtMs?: number; rotatedAtMs?: number | null }): ControlPlaneSecretRef;
+  listSecretRefs(input: { orgId: string; projectId?: string | null }): ControlPlaneSecretRef[];
+  recordAuditEvent(input: { orgId: string; projectId?: string | null; actorId?: string | null; action: string; targetType: string; targetId?: string | null; occurredAtMs?: number; metadata?: Record<string, unknown> }): ControlPlaneAuditEvent;
+  exportOrgAudit(input: { orgId: string; sinceMs?: number; untilMs?: number; exportedAtMs?: number }): ControlPlaneExport;
+}
+
+export { type ControlPlaneAuditEvent, type ControlPlaneBillingAccount, type ControlPlaneExport, type ControlPlaneIdentityProvider, type ControlPlaneOrg, type ControlPlaneProject, type ControlPlaneSecretRef, type ControlPlaneSqlite, ControlPlaneStore, type ControlPlaneTeam, type ControlPlaneUsageEvent, type ControlPlaneUsageLimit, type ControlPlaneUsageLimitCheck, type ControlPlaneUsageSummary, ensureControlPlaneTables };

--- a/packages/control-plane/src/index.js
+++ b/packages/control-plane/src/index.js
@@ -1,0 +1,1064 @@
+import { randomUUID } from "node:crypto";
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+
+/**
+ * @typedef {import("./index.d.ts").ControlPlaneSqlite} ControlPlaneSqlite
+ * @typedef {import("./index.d.ts").ControlPlaneOrg} ControlPlaneOrg
+ * @typedef {import("./index.d.ts").ControlPlaneTeam} ControlPlaneTeam
+ * @typedef {import("./index.d.ts").ControlPlaneProject} ControlPlaneProject
+ * @typedef {import("./index.d.ts").ControlPlaneBillingAccount} ControlPlaneBillingAccount
+ * @typedef {import("./index.d.ts").ControlPlaneIdentityProvider} ControlPlaneIdentityProvider
+ * @typedef {import("./index.d.ts").ControlPlaneUsageEvent} ControlPlaneUsageEvent
+ * @typedef {import("./index.d.ts").ControlPlaneUsageLimit} ControlPlaneUsageLimit
+ * @typedef {import("./index.d.ts").ControlPlaneUsageLimitCheck} ControlPlaneUsageLimitCheck
+ * @typedef {import("./index.d.ts").ControlPlaneUsageSummary} ControlPlaneUsageSummary
+ * @typedef {import("./index.d.ts").ControlPlaneSecretRef} ControlPlaneSecretRef
+ * @typedef {import("./index.d.ts").ControlPlaneAuditEvent} ControlPlaneAuditEvent
+ * @typedef {import("./index.d.ts").ControlPlaneExport} ControlPlaneExport
+ */
+
+const SLUG_RE = /^(?:[a-z0-9]|[a-z0-9][a-z0-9-]{0,62}[a-z0-9])$/;
+const ID_RE = /^[A-Za-z0-9:_-]{1,128}$/;
+
+/**
+ * @param {ControlPlaneSqlite} sqlite
+ */
+export function ensureControlPlaneTables(sqlite) {
+    sqlite.exec("PRAGMA foreign_keys = ON");
+    sqlite.exec(`
+CREATE TABLE IF NOT EXISTS _smithers_cp_orgs (
+  org_id TEXT PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_teams (
+  org_id TEXT NOT NULL,
+  team_id TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, team_id),
+  UNIQUE (org_id, slug),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_team_members (
+  org_id TEXT NOT NULL,
+  team_id TEXT NOT NULL,
+  user_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, team_id, user_id),
+  FOREIGN KEY (org_id, team_id) REFERENCES _smithers_cp_teams(org_id, team_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_projects (
+  org_id TEXT NOT NULL,
+  project_id TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  name TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, project_id),
+  UNIQUE (org_id, slug),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_project_teams (
+  org_id TEXT NOT NULL,
+  project_id TEXT NOT NULL,
+  team_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, project_id, team_id),
+  FOREIGN KEY (org_id, project_id) REFERENCES _smithers_cp_projects(org_id, project_id) ON DELETE CASCADE,
+  FOREIGN KEY (org_id, team_id) REFERENCES _smithers_cp_teams(org_id, team_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_billing_accounts (
+  org_id TEXT PRIMARY KEY,
+  plan TEXT NOT NULL,
+  billing_customer_id TEXT,
+  status TEXT NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_identity_providers (
+  org_id TEXT NOT NULL,
+  provider_id TEXT NOT NULL,
+  type TEXT NOT NULL,
+  issuer TEXT NOT NULL,
+  sso_url TEXT,
+  certificate_ref TEXT,
+  status TEXT NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, provider_id),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS _smithers_cp_idp_org_status_idx
+  ON _smithers_cp_identity_providers(org_id, status);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_usage_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  org_id TEXT NOT NULL,
+  project_id TEXT,
+  run_id TEXT,
+  metric TEXT NOT NULL,
+  quantity REAL NOT NULL,
+  unit TEXT NOT NULL,
+  observed_at_ms INTEGER NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE,
+  FOREIGN KEY (org_id, project_id) REFERENCES _smithers_cp_projects(org_id, project_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS _smithers_cp_usage_org_time_idx
+  ON _smithers_cp_usage_events(org_id, observed_at_ms);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_usage_limits (
+  org_id TEXT NOT NULL,
+  project_key TEXT NOT NULL,
+  project_id TEXT,
+  metric TEXT NOT NULL,
+  unit TEXT NOT NULL,
+  period TEXT NOT NULL,
+  limit_quantity REAL NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (org_id, project_key, metric, unit, period),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS _smithers_cp_usage_limits_org_idx
+  ON _smithers_cp_usage_limits(org_id, metric, unit, period);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_secret_refs (
+  org_id TEXT NOT NULL,
+  project_key TEXT NOT NULL,
+  project_id TEXT,
+  name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  ref TEXT NOT NULL,
+  created_by TEXT,
+  created_at_ms INTEGER NOT NULL,
+  rotated_at_ms INTEGER,
+  PRIMARY KEY (org_id, project_key, name),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE,
+  FOREIGN KEY (org_id, project_id) REFERENCES _smithers_cp_projects(org_id, project_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS _smithers_cp_audit_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  org_id TEXT NOT NULL,
+  project_id TEXT,
+  actor_id TEXT,
+  action TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT,
+  occurred_at_ms INTEGER NOT NULL,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE,
+  FOREIGN KEY (org_id, project_id) REFERENCES _smithers_cp_projects(org_id, project_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS _smithers_cp_audit_org_time_idx
+  ON _smithers_cp_audit_events(org_id, occurred_at_ms);
+`);
+    migrateSecretRefsProjectKey(sqlite);
+}
+
+/**
+ * @param {ControlPlaneSqlite} sqlite
+ */
+function migrateSecretRefsProjectKey(sqlite) {
+    const columns = sqlite.query("PRAGMA table_info(_smithers_cp_secret_refs)").all();
+    if (columns.some((column) => String(column.name) === "project_key")) {
+        return;
+    }
+    sqlite.exec(`
+ALTER TABLE _smithers_cp_secret_refs RENAME TO _smithers_cp_secret_refs_legacy;
+
+CREATE TABLE _smithers_cp_secret_refs (
+  org_id TEXT NOT NULL,
+  project_key TEXT NOT NULL,
+  project_id TEXT,
+  name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  ref TEXT NOT NULL,
+  created_by TEXT,
+  created_at_ms INTEGER NOT NULL,
+  rotated_at_ms INTEGER,
+  PRIMARY KEY (org_id, project_key, name),
+  FOREIGN KEY (org_id) REFERENCES _smithers_cp_orgs(org_id) ON DELETE CASCADE,
+  FOREIGN KEY (org_id, project_id) REFERENCES _smithers_cp_projects(org_id, project_id) ON DELETE CASCADE
+);
+
+INSERT OR REPLACE INTO _smithers_cp_secret_refs (
+  org_id, project_key, project_id, name, provider, ref, created_by, created_at_ms, rotated_at_ms
+)
+SELECT
+  org_id,
+  COALESCE(project_id, '__org__') AS project_key,
+  project_id,
+  name,
+  provider,
+  ref,
+  created_by,
+  created_at_ms,
+  rotated_at_ms
+FROM _smithers_cp_secret_refs_legacy
+ORDER BY created_at_ms;
+
+DROP TABLE _smithers_cp_secret_refs_legacy;
+`);
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ */
+function nonEmptyString(field, value) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        throw new SmithersError("INVALID_INPUT", `${field} is required.`);
+    }
+    return value.trim();
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ */
+function optionalId(field, value) {
+    const id = typeof value === "string" && value.trim() ? value.trim() : randomUUID();
+    if (!ID_RE.test(id)) {
+        throw new SmithersError("INVALID_INPUT", `${field} must match ${ID_RE}.`, { field });
+    }
+    return id;
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ */
+function requiredId(field, value) {
+    const id = nonEmptyString(field, value);
+    if (!ID_RE.test(id)) {
+        throw new SmithersError("INVALID_INPUT", `${field} must match ${ID_RE}.`, { field });
+    }
+    return id;
+}
+
+/**
+ * @param {string} field
+ * @param {unknown} value
+ */
+function slug(field, value) {
+    const out = nonEmptyString(field, value);
+    if (!SLUG_RE.test(out)) {
+        throw new SmithersError("INVALID_INPUT", `${field} must be a lowercase slug.`, { field });
+    }
+    return out;
+}
+
+/**
+ * @param {unknown} value
+ */
+function jsonObject(value) {
+    if (value === undefined) {
+        return {};
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new SmithersError("INVALID_INPUT", "metadata must be a JSON object.");
+    }
+    return value;
+}
+
+/**
+ * @param {unknown} value
+ */
+function parseJsonObject(value) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+        return {};
+    }
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+}
+
+/**
+ * @param {unknown} value
+ */
+function timestamp(value) {
+    const n = value === undefined ? Date.now() : Number(value);
+    if (!Number.isFinite(n) || n < 0) {
+        throw new SmithersError("INVALID_INPUT", "timestamp must be a non-negative finite number.");
+    }
+    return Math.floor(n);
+}
+
+/**
+ * @param {unknown} value
+ */
+function quantity(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 0) {
+        throw new SmithersError("INVALID_INPUT", "quantity must be a non-negative finite number.");
+    }
+    return n;
+}
+
+/**
+ * @param {string | null} projectId
+ */
+function projectKey(projectId) {
+    return projectId ?? "__org__";
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneOrg}
+ */
+function orgRow(row) {
+    return {
+        orgId: String(row.orgId),
+        slug: String(row.slug),
+        name: String(row.name),
+        createdAtMs: Number(row.createdAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneTeam}
+ */
+function teamRow(row) {
+    return {
+        orgId: String(row.orgId),
+        teamId: String(row.teamId),
+        slug: String(row.slug),
+        name: String(row.name),
+        createdAtMs: Number(row.createdAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneProject}
+ */
+function projectRow(row) {
+    return {
+        orgId: String(row.orgId),
+        projectId: String(row.projectId),
+        slug: String(row.slug),
+        name: String(row.name),
+        metadata: parseJsonObject(row.metadataJson),
+        createdAtMs: Number(row.createdAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneBillingAccount}
+ */
+function billingRow(row) {
+    return {
+        orgId: String(row.orgId),
+        plan: String(row.plan),
+        billingCustomerId: row.billingCustomerId === null ? null : String(row.billingCustomerId),
+        status: String(row.status),
+        updatedAtMs: Number(row.updatedAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneIdentityProvider}
+ */
+function identityProviderRow(row) {
+    return {
+        orgId: String(row.orgId),
+        providerId: String(row.providerId),
+        type: String(row.type),
+        issuer: String(row.issuer),
+        ssoUrl: row.ssoUrl === null ? null : String(row.ssoUrl),
+        certificateRef: row.certificateRef === null ? null : String(row.certificateRef),
+        status: String(row.status),
+        metadata: parseJsonObject(row.metadataJson),
+        createdAtMs: Number(row.createdAtMs),
+        updatedAtMs: Number(row.updatedAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneUsageEvent}
+ */
+function usageRow(row) {
+    return {
+        id: Number(row.id),
+        orgId: String(row.orgId),
+        projectId: row.projectId === null ? null : String(row.projectId),
+        runId: row.runId === null ? null : String(row.runId),
+        metric: String(row.metric),
+        quantity: Number(row.quantity),
+        unit: String(row.unit),
+        observedAtMs: Number(row.observedAtMs),
+        metadata: parseJsonObject(row.metadataJson),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneUsageLimit}
+ */
+function usageLimitRow(row) {
+    return {
+        orgId: String(row.orgId),
+        projectId: row.projectId === null ? null : String(row.projectId),
+        metric: String(row.metric),
+        unit: String(row.unit),
+        period: String(row.period),
+        limitQuantity: Number(row.limitQuantity),
+        updatedAtMs: Number(row.updatedAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneSecretRef}
+ */
+function secretRefRow(row) {
+    return {
+        orgId: String(row.orgId),
+        projectId: row.projectId === null ? null : String(row.projectId),
+        name: String(row.name),
+        provider: String(row.provider),
+        ref: String(row.ref),
+        createdBy: row.createdBy === null ? null : String(row.createdBy),
+        createdAtMs: Number(row.createdAtMs),
+        rotatedAtMs: row.rotatedAtMs === null ? null : Number(row.rotatedAtMs),
+    };
+}
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {ControlPlaneAuditEvent}
+ */
+function auditRow(row) {
+    return {
+        id: Number(row.id),
+        orgId: String(row.orgId),
+        projectId: row.projectId === null ? null : String(row.projectId),
+        actorId: row.actorId === null ? null : String(row.actorId),
+        action: String(row.action),
+        targetType: String(row.targetType),
+        targetId: row.targetId === null ? null : String(row.targetId),
+        occurredAtMs: Number(row.occurredAtMs),
+        metadata: parseJsonObject(row.metadataJson),
+    };
+}
+
+/**
+ * @param {ControlPlaneSqlite} sqlite
+ * @param {string} orgId
+ * @param {string} projectId
+ */
+function assertProjectExists(sqlite, orgId, projectId) {
+    const row = sqlite.query(`
+SELECT 1 AS ok
+FROM _smithers_cp_projects
+WHERE org_id = ? AND project_id = ?
+LIMIT 1
+`).get(orgId, projectId);
+    if (!row) {
+        throw new SmithersError("INVALID_INPUT", `Control-plane project not found: ${projectId}`, { orgId, projectId });
+    }
+}
+
+export class ControlPlaneStore {
+    /** @type {ControlPlaneSqlite} */
+    sqlite;
+
+    /**
+     * @param {ControlPlaneSqlite} sqlite
+     */
+    constructor(sqlite) {
+        this.sqlite = sqlite;
+        ensureControlPlaneTables(sqlite);
+    }
+
+    /**
+     * @param {{ orgId?: string; slug: string; name: string; createdAtMs?: number }} input
+     * @returns {ControlPlaneOrg}
+     */
+    createOrg(input) {
+        const orgId = optionalId("orgId", input.orgId);
+        const createdAtMs = timestamp(input.createdAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_orgs (org_id, slug, name, created_at_ms)
+VALUES (?, ?, ?, ?)
+`).run(orgId, slug("slug", input.slug), nonEmptyString("name", input.name), createdAtMs);
+        this.recordAuditEvent({
+            orgId,
+            actorId: "system",
+            action: "org.create",
+            targetType: "org",
+            targetId: orgId,
+            occurredAtMs: createdAtMs,
+        });
+        return this.getOrg(orgId);
+    }
+
+    /**
+     * @param {string} orgId
+     * @returns {ControlPlaneOrg | null}
+     */
+    getOrg(orgId) {
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, slug, name, created_at_ms AS createdAtMs
+FROM _smithers_cp_orgs
+WHERE org_id = ?
+LIMIT 1
+`).get(requiredId("orgId", orgId));
+        return row ? orgRow(row) : null;
+    }
+
+    /**
+     * @param {{ orgId: string; teamId?: string; slug: string; name: string; createdAtMs?: number }} input
+     * @returns {ControlPlaneTeam}
+     */
+    createTeam(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const teamId = optionalId("teamId", input.teamId);
+        const createdAtMs = timestamp(input.createdAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_teams (org_id, team_id, slug, name, created_at_ms)
+VALUES (?, ?, ?, ?, ?)
+`).run(orgId, teamId, slug("slug", input.slug), nonEmptyString("name", input.name), createdAtMs);
+        this.recordAuditEvent({
+            orgId,
+            action: "team.create",
+            targetType: "team",
+            targetId: teamId,
+            occurredAtMs: createdAtMs,
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, team_id AS teamId, slug, name, created_at_ms AS createdAtMs
+FROM _smithers_cp_teams
+WHERE org_id = ? AND team_id = ?
+LIMIT 1
+`).get(orgId, teamId);
+        return teamRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; teamId: string; userId: string; role?: string; createdAtMs?: number }} input
+     */
+    addTeamMember(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const teamId = requiredId("teamId", input.teamId);
+        const userId = requiredId("userId", input.userId);
+        const role = nonEmptyString("role", input.role ?? "member");
+        const createdAtMs = timestamp(input.createdAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_team_members (org_id, team_id, user_id, role, created_at_ms)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(org_id, team_id, user_id) DO UPDATE SET role = excluded.role
+`).run(orgId, teamId, userId, role, createdAtMs);
+        this.recordAuditEvent({
+            orgId,
+            actorId: userId,
+            action: "team.member.upsert",
+            targetType: "team",
+            targetId: teamId,
+            occurredAtMs: createdAtMs,
+            metadata: { role },
+        });
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string; slug: string; name: string; metadata?: Record<string, unknown>; createdAtMs?: number }} input
+     * @returns {ControlPlaneProject}
+     */
+    createProject(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = optionalId("projectId", input.projectId);
+        const metadata = jsonObject(input.metadata);
+        const createdAtMs = timestamp(input.createdAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_projects (org_id, project_id, slug, name, metadata_json, created_at_ms)
+VALUES (?, ?, ?, ?, ?, ?)
+`).run(orgId, projectId, slug("slug", input.slug), nonEmptyString("name", input.name), JSON.stringify(metadata), createdAtMs);
+        this.recordAuditEvent({
+            orgId,
+            projectId,
+            action: "project.create",
+            targetType: "project",
+            targetId: projectId,
+            occurredAtMs: createdAtMs,
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, slug, name, metadata_json AS metadataJson, created_at_ms AS createdAtMs
+FROM _smithers_cp_projects
+WHERE org_id = ? AND project_id = ?
+LIMIT 1
+`).get(orgId, projectId);
+        return projectRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; projectId: string; teamId: string; role?: string; createdAtMs?: number }} input
+     */
+    addProjectTeam(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = requiredId("projectId", input.projectId);
+        const teamId = requiredId("teamId", input.teamId);
+        const role = nonEmptyString("role", input.role ?? "viewer");
+        const createdAtMs = timestamp(input.createdAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_project_teams (org_id, project_id, team_id, role, created_at_ms)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(org_id, project_id, team_id) DO UPDATE SET role = excluded.role
+`).run(orgId, projectId, teamId, role, createdAtMs);
+        this.recordAuditEvent({
+            orgId,
+            projectId,
+            action: "project.team.upsert",
+            targetType: "team",
+            targetId: teamId,
+            occurredAtMs: createdAtMs,
+            metadata: { role },
+        });
+    }
+
+    /**
+     * @param {{ orgId: string; plan: string; billingCustomerId?: string | null; status?: string; updatedAtMs?: number }} input
+     * @returns {ControlPlaneBillingAccount}
+     */
+    upsertBillingAccount(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const updatedAtMs = timestamp(input.updatedAtMs);
+        const status = nonEmptyString("status", input.status ?? "active");
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_billing_accounts (org_id, plan, billing_customer_id, status, updated_at_ms)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(org_id) DO UPDATE SET
+  plan = excluded.plan,
+  billing_customer_id = excluded.billing_customer_id,
+  status = excluded.status,
+  updated_at_ms = excluded.updated_at_ms
+`).run(orgId, nonEmptyString("plan", input.plan), input.billingCustomerId ?? null, status, updatedAtMs);
+        this.recordAuditEvent({
+            orgId,
+            action: "billing.account.upsert",
+            targetType: "billing_account",
+            targetId: orgId,
+            occurredAtMs: updatedAtMs,
+            metadata: { plan: input.plan, status },
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, plan, billing_customer_id AS billingCustomerId, status, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_billing_accounts
+WHERE org_id = ?
+LIMIT 1
+`).get(orgId);
+        return billingRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; providerId?: string; type: "saml" | "oidc" | string; issuer: string; ssoUrl?: string | null; certificateRef?: string | null; status?: string; metadata?: Record<string, unknown>; createdAtMs?: number; updatedAtMs?: number }} input
+     * @returns {ControlPlaneIdentityProvider}
+     */
+    upsertIdentityProvider(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const providerId = optionalId("providerId", input.providerId);
+        const metadata = jsonObject(input.metadata);
+        const updatedAtMs = timestamp(input.updatedAtMs);
+        const createdAtMs = timestamp(input.createdAtMs ?? updatedAtMs);
+        const status = nonEmptyString("status", input.status ?? "active");
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_identity_providers (
+  org_id, provider_id, type, issuer, sso_url, certificate_ref, status, metadata_json, created_at_ms, updated_at_ms
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(org_id, provider_id) DO UPDATE SET
+  type = excluded.type,
+  issuer = excluded.issuer,
+  sso_url = excluded.sso_url,
+  certificate_ref = excluded.certificate_ref,
+  status = excluded.status,
+  metadata_json = excluded.metadata_json,
+  updated_at_ms = excluded.updated_at_ms
+`).run(
+            orgId,
+            providerId,
+            nonEmptyString("type", input.type),
+            nonEmptyString("issuer", input.issuer),
+            input.ssoUrl ? nonEmptyString("ssoUrl", input.ssoUrl) : null,
+            input.certificateRef ? nonEmptyString("certificateRef", input.certificateRef) : null,
+            status,
+            JSON.stringify(metadata),
+            createdAtMs,
+            updatedAtMs,
+        );
+        this.recordAuditEvent({
+            orgId,
+            action: "identity_provider.upsert",
+            targetType: "identity_provider",
+            targetId: providerId,
+            occurredAtMs: updatedAtMs,
+            metadata: { type: input.type, status },
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, provider_id AS providerId, type, issuer, sso_url AS ssoUrl, certificate_ref AS certificateRef, status, metadata_json AS metadataJson, created_at_ms AS createdAtMs, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_identity_providers
+WHERE org_id = ? AND provider_id = ?
+LIMIT 1
+`).get(orgId, providerId);
+        return identityProviderRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; status?: string }} input
+     * @returns {ControlPlaneIdentityProvider[]}
+     */
+    listIdentityProviders(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const status = input.status ? nonEmptyString("status", input.status) : null;
+        const sql = status
+            ? `
+SELECT org_id AS orgId, provider_id AS providerId, type, issuer, sso_url AS ssoUrl, certificate_ref AS certificateRef, status, metadata_json AS metadataJson, created_at_ms AS createdAtMs, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_identity_providers
+WHERE org_id = ? AND status = ?
+ORDER BY provider_id
+`
+            : `
+SELECT org_id AS orgId, provider_id AS providerId, type, issuer, sso_url AS ssoUrl, certificate_ref AS certificateRef, status, metadata_json AS metadataJson, created_at_ms AS createdAtMs, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_identity_providers
+WHERE org_id = ?
+ORDER BY provider_id
+`;
+        const args = status ? [orgId, status] : [orgId];
+        return this.sqlite.query(sql).all(...args).map(identityProviderRow);
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null; runId?: string | null; metric: string; quantity: number; unit?: string; observedAtMs?: number; metadata?: Record<string, unknown> }} input
+     * @returns {ControlPlaneUsageEvent}
+     */
+    recordUsage(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId ? requiredId("projectId", input.projectId) : null;
+        const observedAtMs = timestamp(input.observedAtMs);
+        const metadata = jsonObject(input.metadata);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_usage_events (org_id, project_id, run_id, metric, quantity, unit, observed_at_ms, metadata_json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+            orgId,
+            projectId,
+            input.runId ? requiredId("runId", input.runId) : null,
+            nonEmptyString("metric", input.metric),
+            quantity(input.quantity),
+            nonEmptyString("unit", input.unit ?? "count"),
+            observedAtMs,
+            JSON.stringify(metadata),
+        );
+        const id = this.sqlite.query("SELECT last_insert_rowid() AS id").get().id;
+        const row = this.sqlite.query(`
+SELECT id, org_id AS orgId, project_id AS projectId, run_id AS runId, metric, quantity, unit, observed_at_ms AS observedAtMs, metadata_json AS metadataJson
+FROM _smithers_cp_usage_events
+WHERE id = ?
+LIMIT 1
+`).get(id);
+        return usageRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; sinceMs?: number; untilMs?: number }} input
+     * @returns {ControlPlaneUsageSummary[]}
+     */
+    summarizeUsage(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const sinceMs = input.sinceMs === undefined ? 0 : timestamp(input.sinceMs);
+        const untilMs = input.untilMs === undefined ? Number.MAX_SAFE_INTEGER : timestamp(input.untilMs);
+        return this.sqlite.query(`
+SELECT org_id AS orgId, metric, unit, SUM(quantity) AS quantity
+FROM _smithers_cp_usage_events
+WHERE org_id = ? AND observed_at_ms >= ? AND observed_at_ms <= ?
+GROUP BY org_id, metric, unit
+ORDER BY metric, unit
+`).all(orgId, sinceMs, untilMs).map((row) => ({
+            orgId: String(row.orgId),
+            metric: String(row.metric),
+            unit: String(row.unit),
+            quantity: Number(row.quantity),
+        }));
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null; metric: string; unit?: string; period?: string; limitQuantity: number; updatedAtMs?: number }} input
+     * @returns {ControlPlaneUsageLimit}
+     */
+    setUsageLimit(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId ? requiredId("projectId", input.projectId) : null;
+        if (projectId) {
+            assertProjectExists(this.sqlite, orgId, projectId);
+        }
+        const metric = nonEmptyString("metric", input.metric);
+        const unit = nonEmptyString("unit", input.unit ?? "count");
+        const period = nonEmptyString("period", input.period ?? "monthly");
+        const limitValue = quantity(input.limitQuantity);
+        const updatedAtMs = timestamp(input.updatedAtMs);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_usage_limits (org_id, project_key, project_id, metric, unit, period, limit_quantity, updated_at_ms)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(org_id, project_key, metric, unit, period) DO UPDATE SET
+  project_id = excluded.project_id,
+  limit_quantity = excluded.limit_quantity,
+  updated_at_ms = excluded.updated_at_ms
+`).run(orgId, projectKey(projectId), projectId, metric, unit, period, limitValue, updatedAtMs);
+        this.recordAuditEvent({
+            orgId,
+            projectId,
+            action: "usage_limit.upsert",
+            targetType: "usage_limit",
+            targetId: projectId ?? orgId,
+            occurredAtMs: updatedAtMs,
+            metadata: { metric, unit, period, limitQuantity: limitValue },
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, metric, unit, period, limit_quantity AS limitQuantity, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_usage_limits
+WHERE org_id = ? AND project_key = ? AND metric = ? AND unit = ? AND period = ?
+LIMIT 1
+`).get(orgId, projectKey(projectId), metric, unit, period);
+        return usageLimitRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null; metric: string; unit?: string; period?: string; sinceMs?: number; untilMs?: number }} input
+     * @returns {ControlPlaneUsageLimitCheck | null}
+     */
+    checkUsageLimit(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId ? requiredId("projectId", input.projectId) : null;
+        const metric = nonEmptyString("metric", input.metric);
+        const unit = nonEmptyString("unit", input.unit ?? "count");
+        const period = nonEmptyString("period", input.period ?? "monthly");
+        const limitRowRaw = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, metric, unit, period, limit_quantity AS limitQuantity, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_usage_limits
+WHERE org_id = ? AND project_key = ? AND metric = ? AND unit = ? AND period = ?
+LIMIT 1
+`).get(orgId, projectKey(projectId), metric, unit, period);
+        if (!limitRowRaw) {
+            return null;
+        }
+        const sinceMs = input.sinceMs === undefined ? 0 : timestamp(input.sinceMs);
+        const untilMs = input.untilMs === undefined ? Number.MAX_SAFE_INTEGER : timestamp(input.untilMs);
+        const usageSql = projectId
+            ? `
+SELECT COALESCE(SUM(quantity), 0) AS usedQuantity
+FROM _smithers_cp_usage_events
+WHERE org_id = ? AND project_id = ? AND metric = ? AND unit = ? AND observed_at_ms >= ? AND observed_at_ms <= ?
+`
+            : `
+SELECT COALESCE(SUM(quantity), 0) AS usedQuantity
+FROM _smithers_cp_usage_events
+WHERE org_id = ? AND metric = ? AND unit = ? AND observed_at_ms >= ? AND observed_at_ms <= ?
+`;
+        const usageArgs = projectId
+            ? [orgId, projectId, metric, unit, sinceMs, untilMs]
+            : [orgId, metric, unit, sinceMs, untilMs];
+        const usageRowRaw = this.sqlite.query(usageSql).get(...usageArgs);
+        const limit = usageLimitRow(limitRowRaw);
+        const usedQuantity = Number(usageRowRaw?.usedQuantity ?? 0);
+        const remainingQuantity = Math.max(0, limit.limitQuantity - usedQuantity);
+        return {
+            ...limit,
+            usedQuantity,
+            remainingQuantity,
+            exceeded: usedQuantity > limit.limitQuantity,
+        };
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null; name: string; provider: string; ref: string; createdBy?: string | null; createdAtMs?: number; rotatedAtMs?: number | null }} input
+     * @returns {ControlPlaneSecretRef}
+     */
+    putSecretRef(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId ? requiredId("projectId", input.projectId) : null;
+        if (projectId) {
+            assertProjectExists(this.sqlite, orgId, projectId);
+        }
+        const secretProjectKey = projectKey(projectId);
+        const name = nonEmptyString("name", input.name);
+        const createdAtMs = timestamp(input.createdAtMs);
+        const rotatedAtMs = input.rotatedAtMs === undefined || input.rotatedAtMs === null
+            ? null
+            : timestamp(input.rotatedAtMs);
+        const provider = nonEmptyString("provider", input.provider);
+        const ref = nonEmptyString("ref", input.ref);
+        const createdBy = input.createdBy ? requiredId("createdBy", input.createdBy) : null;
+        this.sqlite.query(`
+DELETE FROM _smithers_cp_secret_refs
+WHERE org_id = ? AND project_key = ? AND name = ?
+`).run(orgId, secretProjectKey, name);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_secret_refs (org_id, project_key, project_id, name, provider, ref, created_by, created_at_ms, rotated_at_ms)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+            orgId,
+            secretProjectKey,
+            projectId,
+            name,
+            provider,
+            ref,
+            createdBy,
+            createdAtMs,
+            rotatedAtMs,
+        );
+        this.recordAuditEvent({
+            orgId,
+            projectId,
+            actorId: createdBy,
+            action: "secret_ref.upsert",
+            targetType: "secret_ref",
+            targetId: name,
+            occurredAtMs: rotatedAtMs ?? createdAtMs,
+            metadata: { provider },
+        });
+        const row = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, name, provider, ref, created_by AS createdBy, created_at_ms AS createdAtMs, rotated_at_ms AS rotatedAtMs
+FROM _smithers_cp_secret_refs
+WHERE org_id = ? AND project_key = ? AND name = ?
+LIMIT 1
+`).get(orgId, secretProjectKey, name);
+        return secretRefRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null }} input
+     * @returns {ControlPlaneSecretRef[]}
+     */
+    listSecretRefs(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId === undefined ? undefined : input.projectId;
+        const sql = projectId === undefined
+            ? `
+SELECT org_id AS orgId, project_id AS projectId, name, provider, ref, created_by AS createdBy, created_at_ms AS createdAtMs, rotated_at_ms AS rotatedAtMs
+FROM _smithers_cp_secret_refs
+WHERE org_id = ?
+ORDER BY name
+`
+            : `
+SELECT org_id AS orgId, project_id AS projectId, name, provider, ref, created_by AS createdBy, created_at_ms AS createdAtMs, rotated_at_ms AS rotatedAtMs
+FROM _smithers_cp_secret_refs
+WHERE org_id = ? AND project_key = ?
+ORDER BY name
+`;
+        const args = projectId === undefined ? [orgId] : [orgId, projectKey(projectId ? requiredId("projectId", projectId) : null)];
+        return this.sqlite.query(sql).all(...args).map(secretRefRow);
+    }
+
+    /**
+     * @param {{ orgId: string; projectId?: string | null; actorId?: string | null; action: string; targetType: string; targetId?: string | null; occurredAtMs?: number; metadata?: Record<string, unknown> }} input
+     * @returns {ControlPlaneAuditEvent}
+     */
+    recordAuditEvent(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const projectId = input.projectId ? requiredId("projectId", input.projectId) : null;
+        const occurredAtMs = timestamp(input.occurredAtMs);
+        const metadata = jsonObject(input.metadata);
+        this.sqlite.query(`
+INSERT INTO _smithers_cp_audit_events (org_id, project_id, actor_id, action, target_type, target_id, occurred_at_ms, metadata_json)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`).run(
+            orgId,
+            projectId,
+            input.actorId ? requiredId("actorId", input.actorId) : null,
+            nonEmptyString("action", input.action),
+            nonEmptyString("targetType", input.targetType),
+            input.targetId ? requiredId("targetId", input.targetId) : null,
+            occurredAtMs,
+            JSON.stringify(metadata),
+        );
+        const id = this.sqlite.query("SELECT last_insert_rowid() AS id").get().id;
+        const row = this.sqlite.query(`
+SELECT id, org_id AS orgId, project_id AS projectId, actor_id AS actorId, action, target_type AS targetType, target_id AS targetId, occurred_at_ms AS occurredAtMs, metadata_json AS metadataJson
+FROM _smithers_cp_audit_events
+WHERE id = ?
+LIMIT 1
+`).get(id);
+        return auditRow(row);
+    }
+
+    /**
+     * @param {{ orgId: string; sinceMs?: number; untilMs?: number; exportedAtMs?: number }} input
+     * @returns {ControlPlaneExport}
+     */
+    exportOrgAudit(input) {
+        const orgId = requiredId("orgId", input.orgId);
+        const org = this.getOrg(orgId);
+        if (!org) {
+            throw new SmithersError("INVALID_INPUT", `Control-plane org not found: ${orgId}`, { orgId });
+        }
+        const sinceMs = input.sinceMs === undefined ? 0 : timestamp(input.sinceMs);
+        const untilMs = input.untilMs === undefined ? Number.MAX_SAFE_INTEGER : timestamp(input.untilMs);
+        const projects = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, slug, name, metadata_json AS metadataJson, created_at_ms AS createdAtMs
+FROM _smithers_cp_projects
+WHERE org_id = ?
+ORDER BY slug
+`).all(orgId).map(projectRow);
+        const teams = this.sqlite.query(`
+SELECT org_id AS orgId, team_id AS teamId, slug, name, created_at_ms AS createdAtMs
+FROM _smithers_cp_teams
+WHERE org_id = ?
+ORDER BY slug
+`).all(orgId).map(teamRow);
+        const billingRaw = this.sqlite.query(`
+SELECT org_id AS orgId, plan, billing_customer_id AS billingCustomerId, status, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_billing_accounts
+WHERE org_id = ?
+LIMIT 1
+`).get(orgId);
+        const identityProviders = this.sqlite.query(`
+SELECT org_id AS orgId, provider_id AS providerId, type, issuer, sso_url AS ssoUrl, certificate_ref AS certificateRef, status, metadata_json AS metadataJson, created_at_ms AS createdAtMs, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_identity_providers
+WHERE org_id = ?
+ORDER BY provider_id
+`).all(orgId).map(identityProviderRow);
+        const usageLimits = this.sqlite.query(`
+SELECT org_id AS orgId, project_id AS projectId, metric, unit, period, limit_quantity AS limitQuantity, updated_at_ms AS updatedAtMs
+FROM _smithers_cp_usage_limits
+WHERE org_id = ?
+ORDER BY project_key, metric, unit, period
+`).all(orgId).map(usageLimitRow);
+        const auditEvents = this.sqlite.query(`
+SELECT id, org_id AS orgId, project_id AS projectId, actor_id AS actorId, action, target_type AS targetType, target_id AS targetId, occurred_at_ms AS occurredAtMs, metadata_json AS metadataJson
+FROM _smithers_cp_audit_events
+WHERE org_id = ? AND occurred_at_ms >= ? AND occurred_at_ms <= ?
+ORDER BY occurred_at_ms, id
+`).all(orgId, sinceMs, untilMs).map(auditRow);
+        return {
+            exportedAtMs: timestamp(input.exportedAtMs),
+            org,
+            projects,
+            teams,
+            billing: billingRaw ? billingRow(billingRaw) : null,
+            identityProviders,
+            usage: this.summarizeUsage({ orgId, sinceMs, untilMs }),
+            usageLimits,
+            secretRefs: this.listSecretRefs({ orgId }),
+            auditEvents,
+        };
+    }
+}

--- a/packages/control-plane/tests/control-plane.test.js
+++ b/packages/control-plane/tests/control-plane.test.js
@@ -1,0 +1,359 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { ControlPlaneStore, ensureControlPlaneTables } from "../src/index.js";
+
+function makeStore() {
+  const sqlite = new Database(":memory:");
+  const store = new ControlPlaneStore(sqlite);
+  return { sqlite, store };
+}
+
+describe("ControlPlaneStore", () => {
+  test("accepts one-character org, team, and project slugs", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      const org = store.createOrg({ orgId: "org_x", slug: "x", name: "X", createdAtMs: 1 });
+      const team = store.createTeam({ orgId: org.orgId, teamId: "team_a", slug: "a", name: "A", createdAtMs: 2 });
+      const project = store.createProject({ orgId: org.orgId, projectId: "project_b", slug: "b", name: "B", createdAtMs: 3 });
+      expect(team.slug).toBe("a");
+      expect(project.slug).toBe("b");
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("creates org, team, project, billing account, usage rows, and audit export", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      const org = store.createOrg({ orgId: "org_acme", slug: "acme", name: "Acme", createdAtMs: 10 });
+      const team = store.createTeam({ orgId: org.orgId, teamId: "team_ops", slug: "ops", name: "Operators", createdAtMs: 20 });
+      store.addTeamMember({ orgId: org.orgId, teamId: team.teamId, userId: "user_1", role: "admin", createdAtMs: 30 });
+      const project = store.createProject({
+        orgId: org.orgId,
+        projectId: "project_app",
+        slug: "app",
+        name: "App",
+        metadata: { environment: "prod" },
+        createdAtMs: 40,
+      });
+      store.addProjectTeam({ orgId: org.orgId, projectId: project.projectId, teamId: team.teamId, role: "operator", createdAtMs: 50 });
+      const billing = store.upsertBillingAccount({
+        orgId: org.orgId,
+        plan: "business",
+        billingCustomerId: "cus_123",
+        status: "trialing",
+        updatedAtMs: 60,
+      });
+      const idp = store.upsertIdentityProvider({
+        orgId: org.orgId,
+        providerId: "idp_okta",
+        type: "saml",
+        issuer: "https://acme.okta.com",
+        ssoUrl: "https://acme.okta.com/app/smithers/sso/saml",
+        certificateRef: "vault://identity/acme-okta-cert",
+        metadata: { domains: ["acme.test"] },
+        createdAtMs: 65,
+        updatedAtMs: 65,
+      });
+      const usageLimit = store.setUsageLimit({
+        orgId: org.orgId,
+        projectId: project.projectId,
+        metric: "agent_runtime_ms",
+        unit: "ms",
+        period: "monthly",
+        limitQuantity: 250,
+        updatedAtMs: 66,
+      });
+      const firstUsage = store.recordUsage({
+        orgId: org.orgId,
+        projectId: project.projectId,
+        runId: "run_1",
+        metric: "agent_runtime_ms",
+        quantity: 125,
+        unit: "ms",
+        observedAtMs: 70,
+        metadata: { workflow: "review" },
+      });
+      store.recordUsage({
+        orgId: org.orgId,
+        projectId: project.projectId,
+        runId: "run_2",
+        metric: "agent_runtime_ms",
+        quantity: 75,
+        unit: "ms",
+        observedAtMs: 80,
+      });
+
+      expect(billing).toMatchObject({ orgId: "org_acme", plan: "business", status: "trialing" });
+      expect(idp).toMatchObject({
+        orgId: "org_acme",
+        providerId: "idp_okta",
+        type: "saml",
+        status: "active",
+        metadata: { domains: ["acme.test"] },
+      });
+      expect(store.listIdentityProviders({ orgId: org.orgId })).toEqual([idp]);
+      expect(usageLimit).toMatchObject({
+        orgId: "org_acme",
+        projectId: "project_app",
+        metric: "agent_runtime_ms",
+        limitQuantity: 250,
+      });
+      expect(store.checkUsageLimit({
+        orgId: org.orgId,
+        projectId: project.projectId,
+        metric: "agent_runtime_ms",
+        unit: "ms",
+        period: "monthly",
+      })).toMatchObject({
+        limitQuantity: 250,
+        usedQuantity: 200,
+        remainingQuantity: 50,
+        exceeded: false,
+      });
+      expect(firstUsage).toMatchObject({
+        orgId: "org_acme",
+        projectId: "project_app",
+        metric: "agent_runtime_ms",
+        quantity: 125,
+        metadata: { workflow: "review" },
+      });
+      expect(store.summarizeUsage({ orgId: org.orgId })).toEqual([
+        { orgId: "org_acme", metric: "agent_runtime_ms", unit: "ms", quantity: 200 },
+      ]);
+
+      const exported = store.exportOrgAudit({ orgId: org.orgId, exportedAtMs: 100 });
+      expect(exported.org).toEqual(org);
+      expect(exported.projects).toEqual([project]);
+      expect(exported.teams).toEqual([team]);
+      expect(exported.billing).toEqual(billing);
+      expect(exported.identityProviders).toEqual([idp]);
+      expect(exported.usage).toEqual([
+        { orgId: "org_acme", metric: "agent_runtime_ms", unit: "ms", quantity: 200 },
+      ]);
+      expect(exported.usageLimits).toEqual([usageLimit]);
+      expect(exported.auditEvents.map((event) => event.action)).toEqual([
+        "org.create",
+        "team.create",
+        "team.member.upsert",
+        "project.create",
+        "project.team.upsert",
+        "billing.account.upsert",
+        "identity_provider.upsert",
+        "usage_limit.upsert",
+      ]);
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("stores secret manager references without storing secret values", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      store.createOrg({ orgId: "org_secure", slug: "secure", name: "Secure", createdAtMs: 1 });
+      store.createProject({ orgId: "org_secure", projectId: "project_api", slug: "api", name: "API", createdAtMs: 2 });
+      const ref = store.putSecretRef({
+        orgId: "org_secure",
+        projectId: "project_api",
+        name: "deploy-token",
+        provider: "aws-secrets-manager",
+        ref: "arn:aws:secretsmanager:us-east-1:123:secret:deploy",
+        createdBy: "user_ops",
+        createdAtMs: 3,
+      });
+      const rotated = store.putSecretRef({
+        orgId: "org_secure",
+        projectId: "project_api",
+        name: "deploy-token",
+        provider: "aws-secrets-manager",
+        ref: "arn:aws:secretsmanager:us-east-1:123:secret:deploy-v2",
+        createdBy: "user_ops",
+        createdAtMs: 4,
+      });
+
+      expect(ref).toMatchObject({
+        name: "deploy-token",
+        provider: "aws-secrets-manager",
+        ref: "arn:aws:secretsmanager:us-east-1:123:secret:deploy",
+      });
+      const rawRows = sqlite.query("SELECT * FROM _smithers_cp_secret_refs").all();
+      expect(rawRows).toHaveLength(1);
+      expect(JSON.stringify(rawRows)).not.toContain("super-secret-value");
+      expect(store.listSecretRefs({ orgId: "org_secure", projectId: "project_api" })).toEqual([rotated]);
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("org-wide secret refs rotate through the non-null project key", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      store.createOrg({ orgId: "org_secret_org", slug: "secret-org", name: "Secret Org", createdAtMs: 1 });
+      store.putSecretRef({
+        orgId: "org_secret_org",
+        name: "billing-token",
+        provider: "vault",
+        ref: "vault://billing-token-v1",
+        createdAtMs: 2,
+      });
+      const rotated = store.putSecretRef({
+        orgId: "org_secret_org",
+        name: "billing-token",
+        provider: "vault",
+        ref: "vault://billing-token-v2",
+        createdAtMs: 3,
+      });
+
+      expect(store.listSecretRefs({ orgId: "org_secret_org", projectId: null })).toEqual([rotated]);
+      const rawRows = sqlite.query("SELECT project_key AS projectKey, project_id AS projectId, name, ref FROM _smithers_cp_secret_refs").all();
+      expect(rawRows).toEqual([
+        {
+          projectKey: "__org__",
+          projectId: null,
+          name: "billing-token",
+          ref: "vault://billing-token-v2",
+        },
+      ]);
+      expect(() =>
+        sqlite.query(`
+INSERT INTO _smithers_cp_secret_refs (org_id, project_key, project_id, name, provider, ref, created_at_ms)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`).run("org_secret_org", "__org__", null, "billing-token", "vault", "vault://billing-token-v3", 4),
+      ).toThrow();
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("usage limits support org-wide and project-scoped quota checks", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      store.createOrg({ orgId: "org_limits", slug: "limits", name: "Limits", createdAtMs: 1 });
+      store.createProject({ orgId: "org_limits", projectId: "project_one", slug: "one", name: "One", createdAtMs: 2 });
+      store.createProject({ orgId: "org_limits", projectId: "project_two", slug: "two", name: "Two", createdAtMs: 3 });
+      store.setUsageLimit({ orgId: "org_limits", metric: "runs", unit: "count", period: "daily", limitQuantity: 3, updatedAtMs: 4 });
+      store.setUsageLimit({ orgId: "org_limits", projectId: "project_one", metric: "runs", unit: "count", period: "daily", limitQuantity: 1, updatedAtMs: 5 });
+      store.recordUsage({ orgId: "org_limits", projectId: "project_one", metric: "runs", quantity: 2, unit: "count", observedAtMs: 6 });
+      store.recordUsage({ orgId: "org_limits", projectId: "project_two", metric: "runs", quantity: 1, unit: "count", observedAtMs: 7 });
+
+      expect(store.checkUsageLimit({ orgId: "org_limits", metric: "runs", unit: "count", period: "daily" })).toMatchObject({
+        usedQuantity: 3,
+        remainingQuantity: 0,
+        exceeded: false,
+      });
+      expect(store.checkUsageLimit({ orgId: "org_limits", projectId: "project_one", metric: "runs", unit: "count", period: "daily" })).toMatchObject({
+        usedQuantity: 2,
+        remainingQuantity: 0,
+        exceeded: true,
+      });
+      expect(() =>
+        store.setUsageLimit({ orgId: "org_limits", projectId: "project_missing", metric: "runs", limitQuantity: 1 }),
+      ).toThrow("Control-plane project not found");
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("foreign keys prevent orphan projects and cascade org deletion", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      expect(() =>
+        store.createProject({
+          orgId: "missing",
+          projectId: "project_missing",
+          slug: "missing",
+          name: "Missing",
+        }),
+      ).toThrow();
+
+      store.createOrg({ orgId: "org_delete", slug: "delete", name: "Delete", createdAtMs: 1 });
+      store.createProject({ orgId: "org_delete", projectId: "project_delete", slug: "project", name: "Project", createdAtMs: 2 });
+      store.recordUsage({ orgId: "org_delete", projectId: "project_delete", metric: "runs", quantity: 1, observedAtMs: 3 });
+
+      sqlite.query("DELETE FROM _smithers_cp_orgs WHERE org_id = ?").run("org_delete");
+      expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_cp_projects").get().count).toBe(0);
+      expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_cp_usage_events").get().count).toBe(0);
+      expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_cp_audit_events").get().count).toBe(0);
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("ensureControlPlaneTables is idempotent", () => {
+    const sqlite = new Database(":memory:");
+    try {
+      ensureControlPlaneTables(sqlite);
+      ensureControlPlaneTables(sqlite);
+      const tables = sqlite
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE '_smithers_cp_%' ORDER BY name")
+        .all()
+        .map((row) => row.name);
+      expect(tables).toContain("_smithers_cp_orgs");
+      expect(tables).toContain("_smithers_cp_audit_events");
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("migrates legacy nullable secret-ref primary keys to project_key", () => {
+    const sqlite = new Database(":memory:");
+    try {
+      sqlite.exec(`
+CREATE TABLE _smithers_cp_orgs (
+  org_id TEXT PRIMARY KEY,
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL,
+  created_at_ms INTEGER NOT NULL
+);
+INSERT INTO _smithers_cp_orgs (org_id, slug, name, created_at_ms)
+VALUES ('org_legacy', 'legacy', 'Legacy', 1);
+CREATE TABLE _smithers_cp_secret_refs (
+  org_id TEXT NOT NULL,
+  project_id TEXT,
+  name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  ref TEXT NOT NULL,
+  created_by TEXT,
+  created_at_ms INTEGER NOT NULL,
+  rotated_at_ms INTEGER,
+  PRIMARY KEY (org_id, project_id, name)
+);
+INSERT INTO _smithers_cp_secret_refs (org_id, project_id, name, provider, ref, created_at_ms)
+VALUES ('org_legacy', NULL, 'token', 'vault', 'vault://old', 2);
+INSERT INTO _smithers_cp_secret_refs (org_id, project_id, name, provider, ref, created_at_ms)
+VALUES ('org_legacy', NULL, 'token', 'vault', 'vault://new', 3);
+`);
+      ensureControlPlaneTables(sqlite);
+      const columns = sqlite.query("PRAGMA table_info(_smithers_cp_secret_refs)").all().map((column) => column.name);
+      expect(columns).toContain("project_key");
+      const store = new ControlPlaneStore(sqlite);
+      expect(store.listSecretRefs({ orgId: "org_legacy", projectId: null })).toEqual([
+        expect.objectContaining({
+          name: "token",
+          ref: "vault://new",
+          projectId: null,
+        }),
+      ]);
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("rejects audit export for unknown orgs with a control-plane error", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      expect(() => store.exportOrgAudit({ orgId: "org_missing" })).toThrow("Control-plane org not found");
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+});

--- a/packages/control-plane/tsconfig.json
+++ b/packages/control-plane/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "types": ["bun-types"],
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "allowJs": true,
+    "allowImportingTsExtensions": true,
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/control-plane/tsup.config.ts
+++ b/packages/control-plane/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { index: "src/index.js" },
+  dts: { only: true, resolve: false },
+  outDir: "src",
+  clean: false,
+  format: ["esm"],
+  silent: false,
+});

--- a/packages/smithers/package.json
+++ b/packages/smithers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smithers-orchestrator",
   "version": "0.20.4",
-  "description": "Public Smithers facade and workflow authoring convenience package",
+  "description": "Public Smithers facade for durable coding-agent workflows and Gateway operation",
   "type": "module",
   "sideEffects": false,
   "exports": {
@@ -24,6 +24,11 @@
       "types": "./src/gateway-react.d.ts",
       "import": "./src/gateway-react.js",
       "default": "./src/gateway-react.js"
+    },
+    "./control-plane": {
+      "types": "./src/control-plane.d.ts",
+      "import": "./src/control-plane.js",
+      "default": "./src/control-plane.js"
     },
     "./*": {
       "types": "./src/index.d.ts",
@@ -50,6 +55,7 @@
     "@smithers-orchestrator/agents": "workspace:*",
     "@smithers-orchestrator/cli": "workspace:*",
     "@smithers-orchestrator/components": "workspace:*",
+    "@smithers-orchestrator/control-plane": "workspace:*",
     "@smithers-orchestrator/db": "workspace:*",
     "@smithers-orchestrator/driver": "workspace:*",
     "@smithers-orchestrator/engine": "workspace:*",

--- a/packages/smithers/src/control-plane.d.ts
+++ b/packages/smithers/src/control-plane.d.ts
@@ -1,0 +1,1 @@
+export * from "@smithers-orchestrator/control-plane";

--- a/packages/smithers/src/control-plane.js
+++ b/packages/smithers/src/control-plane.js
@@ -1,0 +1,1 @@
+export * from "@smithers-orchestrator/control-plane";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@smithers-orchestrator/components':
         specifier: workspace:*
         version: link:packages/components
+      '@smithers-orchestrator/control-plane':
+        specifier: workspace:*
+        version: link:packages/control-plane
       '@smithers-orchestrator/db':
         specifier: workspace:*
         version: link:packages/db
@@ -254,7 +257,7 @@ importers:
         version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -328,7 +331,7 @@ importers:
         version: 11.10.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -449,10 +452,23 @@ importers:
         version: 1.3.13
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
+  packages/control-plane:
+    dependencies:
+      '@smithers-orchestrator/errors':
+        specifier: workspace:*
+        version: link:../errors
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -479,10 +495,10 @@ importers:
         version: link:../scheduler
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       drizzle-zod:
         specifier: ^0.8.3
-        version: 0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13))(zod@4.3.6)
+        version: 0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14))(zod@4.3.6)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -604,7 +620,7 @@ importers:
         version: 9.0.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -695,7 +711,7 @@ importers:
         version: link:../errors
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -726,7 +742,7 @@ importers:
         version: link:../scheduler
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -936,7 +952,7 @@ importers:
         version: link:../scheduler
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -994,7 +1010,7 @@ importers:
         version: 5.5.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -1035,6 +1051,9 @@ importers:
       '@smithers-orchestrator/components':
         specifier: workspace:*
         version: link:../components
+      '@smithers-orchestrator/control-plane':
+        specifier: workspace:*
+        version: link:../control-plane
       '@smithers-orchestrator/db':
         specifier: workspace:*
         version: link:../db
@@ -1094,7 +1113,7 @@ importers:
         version: 9.0.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -1140,7 +1159,7 @@ importers:
         version: link:../vcs
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -1678,30 +1697,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
     resolution: {integrity: sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
     resolution: {integrity: sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
     resolution: {integrity: sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.3':
     resolution: {integrity: sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
     resolution: {integrity: sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==}
@@ -1911,48 +1935,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.60.0':
     resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.60.0':
     resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.60.0':
     resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.60.0':
     resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.60.0':
     resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.60.0':
     resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.60.0':
     resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.60.0':
     resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
@@ -2007,36 +2039,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2124,66 +2162,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -2439,6 +2490,9 @@ packages:
   '@types/bun@1.3.13':
     resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2612,6 +2666,9 @@ packages:
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -5625,6 +5682,10 @@ snapshots:
     dependencies:
       bun-types: 1.3.13
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -5794,6 +5855,10 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.6.0
+
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
       esbuild: 0.27.7
@@ -5937,9 +6002,16 @@ snapshots:
       better-sqlite3: 11.10.0
       bun-types: 1.3.13
 
-  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13))(zod@4.3.6):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 11.10.0
+      bun-types: 1.3.14
+
+  drizzle-zod@0.8.3(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14))(zod@4.3.6):
     dependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.13)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
       zod: 4.3.6
 
   dunder-proto@1.0.1:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -174,6 +174,13 @@
         "./packages/components/src/*.js",
         "./packages/components/src/*/index.js"
       ],
+      "@smithers-orchestrator/control-plane": [
+        "./packages/control-plane/src/index.js"
+      ],
+      "@smithers-orchestrator/control-plane/*": [
+        "./packages/control-plane/src/*.js",
+        "./packages/control-plane/src/*/index.js"
+      ],
       "@smithers-orchestrator/react-reconciler": [
         "./packages/react-reconciler/src/index.js"
       ],


### PR DESCRIPTION
Split 7/7 of #143 — original work by @cookesan.

## Summary
Adds the new `@smithers-orchestrator/control-plane` workspace package with hosted multi-tenant primitives:
- organizations, projects, teams, identity-provider records
- usage events with per-org limit checks
- secret-reference records (pointers, not values)
- billing account records + audit export

**Wires the package into the monorepo:**
- root `tsconfig.json` path mappings (`@smithers-orchestrator/control-plane`)
- root `package.json` devDeps + `./control-plane` subpath export
- `pnpm-lock.yaml` workspace entries + transitive `bun-types@1.3.13→1.3.14` bumps (downstream of `@types/bun: latest` devDep on control-plane)
- `packages/smithers` re-exports for `smithers-orchestrator/control-plane`
- `e2e-helpers` registers the new workspace
- new `docs/deployment/control-plane.mdx` operator guide

**Rebrand** the project as a "durable control plane for long-running coding agents": `README`, `docs/index.mdx`, `docs/introduction.mdx`, `docs/docs.json` description, `llms-{core,full,}.txt`. README and `docs/docs.json` were 3-way merged to preserve the eval-suite content that landed in #142 after this PR opened.

**Cross-subsystem `docs/deployment/production-hardening.mdx` guide** (persistence, access control, execution boundary, secrets, cache policy). Expands `docs/concepts/caching.mdx`, `docs/reference/package-configuration.mdx`, and `docs/deployment/reference.mdx` to document the new control-plane surface and cache scopes.

## Validation
- 25 files changed, +2029/-37
- All JSON files validated (`JSON.parse`)
- Workspace package builds independently via `tsup.config.ts`

## Context
Part of #143 split into atomic per-domain PRs. This is the largest of the 7 since the control-plane package is a single coherent introduction. Depends on no other split PR.