### PR TITLE
snapshot: local main work (eval-suite hardening, demo, tickets, devtools tests)

### DIFF
--- a/.smithers/agents.ts
+++ b/.smithers/agents.ts
@@ -1,16 +1,14 @@
 // smithers-source: generated
 // Source of truth: ~/.smithers/accounts.json (managed via `smithers agent add|list|remove`)
-import { homedir } from "node:os";
-import path from "node:path";
-import { type AgentLike, CodexAgent as SmithersCodexAgent } from "smithers-orchestrator";
+import { type AgentLike, ClaudeCodeAgent as SmithersClaudeCodeAgent } from "smithers-orchestrator";
 
 export const providers = {
-  codex1: new SmithersCodexAgent({ model: "gpt-5.4-codex", configDir: "/tmp/smithers-test/accounts/codex-1", skipGitRepoCheck: true, cwd: process.cwd() }),
+  claude1: new SmithersClaudeCodeAgent({ cwd: process.cwd(), yolo: true }),
 } as const;
 
 export const agents = {
-  codex: [providers.codex1],
-  cheapFast: [providers.codex1],
-  smart: [providers.codex1],
-  smartTool: [providers.codex1],
+  claude: [providers.claude1],
+  cheapFast: [providers.claude1],
+  smart: [providers.claude1],
+  smartTool: [providers.claude1],
 } as const satisfies Record<string, AgentLike[]>;

--- a/.smithers/tickets/.parked-kanban-demo/smithers/0022-fault-injection-e2e-matrix.md
+++ b/.smithers/tickets/.parked-kanban-demo/smithers/0022-fault-injection-e2e-matrix.md
@@ -1,0 +1,103 @@
+# Fault-Injection E2E Test Matrix
+
+> Target repo: **smithers**
+> Source: memo §7 · roadmap Phase 0 → Phase 2
+
+## Problem
+
+Every reliability claim in the memo needs a reproducible test, or it
+regresses. "We think we fixed it" is not enough for an orchestrator users
+leave running unattended.
+
+## Goal
+
+A named, maintained E2E matrix covering the crash/recovery failure modes
+enumerated in the memo. Runs on every PR; soak subset runs nightly.
+
+## Scope
+
+### Crash / resume / stale ownership (§A)
+
+1. Kill engine mid-task; assert run → `stale` within SLO, supervisor
+   takes over, resume completes with exactly-one delivery of side effects
+   (verified via 0019 dedupe keys).
+2. Kill sandbox; engine alive. Heartbeat timeout → documented retry/fail.
+3. Restart during `waiting-approval`; approval persists; decision resumes
+   the correct node at the correct iteration.
+4. Restart during `waiting-event`; signal correlates after restart.
+5. Restart during `waiting-timer`; timer fires exactly once post-restart.
+6. Concurrent `resume` + supervisor takeover; one wins via epoch (0017).
+7. `continueAsNew`; lineage traversable via `smithers inspect --lineage`.
+
+### Inspector truthfulness (§B)
+
+8. Active run with frequent tool calls; inspector never shows `idle`.
+9. Subscriber disconnect → reconnect with `afterSeq`; no event gap; no
+   manual refresh.
+10. Node unmount after selection; ghost state preserved (0015 fields).
+11. Frame scrub for view-only time travel; engine state untouched.
+12. `rewind`; VCS reverted; subsequent frames reflect rewound state;
+    audit entry exists (0018).
+13. Error bubble-up: collapsed ancestor shows failure marker.
+
+### Remote control plane (§C)
+
+14. Gateway: launch/approve/signal/cancel/resume round-trip over
+    authenticated RPC.
+15. Drop WebSocket mid-stream → reconnect with `afterSeq`; no gap, no
+    dup.
+16. N=5 subscribers on one run; bounded memory; consistent state.
+17. Webhook signal with invalid signature → rejected + audited.
+18. Cron + manual trigger overlapping; documented dedupe/concurrency.
+
+### Runtime / sandbox (§D, blocked on jjhub/0002)
+
+19. Auth persistence across workspace suspend/resume.
+20. Browser automation task in reference runtime.
+21. File + VCS pointer integrity across repeated runs.
+22. Secret injection; no secrets in logs (redaction test).
+23. Network-denied task vs policy-allowed task behavior.
+
+### Safety / side effects (§E)
+
+24. Retry a `sideEffect: write, idempotent: false` tool without a key →
+    blocks on `ReplayUnsafeApproval`.
+25. Approval scope denial; audit record.
+26. Diff-review-required sandbox mode; accept / reject semantics.
+27. Scorer failure blocks destructive downstream step.
+
+### Soak (§F, nightly)
+
+28. 10+ min live stream on busy run; RSS within budget (publish
+    budget in the test).
+29. Repeated cron runs over 2 hours; no stuck scheduler.
+30. Long-lived JJHub workspace, repeated runs; stable behavior.
+
+## Files
+
+- `e2e/faults/` (new) — one file per test case, named after its row.
+- `e2e/harness/` (new) — fault-injection primitives: `killProcess`,
+  `dropWebSocket`, `freezeSqliteLock`, `stallSandbox`, `skewClock`,
+  `corruptHeartbeat`.
+- `e2e/budgets/` (new) — memory/latency budgets as JSON.
+- `.github/workflows/faults.yml` (PR), `faults-nightly.yml` (soak).
+
+## Testing (meta)
+
+- Each fault primitive has a unit test proving it actually injects.
+- Flake budget: 0 flakes per 100 CI runs before a fault is promoted from
+  nightly-only to per-PR. Track in `e2e/flake-log.md`.
+
+## Acceptance
+
+- [ ] All 30 cases implemented or explicitly skipped with a ticket link.
+- [ ] Per-PR subset < 10 min wall time.
+- [ ] Nightly soak < 2h wall time.
+- [ ] Budgets enforced (test fails on regression, not just recorded).
+- [ ] Every fault primitive reusable from any test.
+
+## Blocks
+
+- Some rows depend on 0015–0020, jjhub/0001–0002, 0019.
+- Matrix grows as new failure modes are discovered — this is not a
+  one-shot ticket; it's the home for ongoing reliability coverage.

--- a/.smithers/tickets/0001-demo-quickstart-typo-pass.md
+++ b/.smithers/tickets/0001-demo-quickstart-typo-pass.md
@@ -1,0 +1,13 @@
+# Demo: proofread the quickstart docs
+
+Review `docs/quickstart.mdx` for small typo and punctuation issues.
+
+Required change:
+
+- In the final paragraph, change `For a full worked example see` to `For a full worked example, see`.
+
+Constraints:
+
+- Keep the scope to typo/punctuation polish in `docs/quickstart.mdx`.
+- Do not rewrite the page or change its technical meaning.
+- Run a lightweight verification such as `git diff -- docs/quickstart.mdx` and summarize the exact edit.

--- a/.smithers/tickets/0002-demo-devtools-nested-task-test.md
+++ b/.smithers/tickets/0002-demo-devtools-nested-task-test.md
@@ -1,0 +1,13 @@
+# Demo: add a nested DevTools tree unit test
+
+Add one focused unit test to `packages/devtools/tests/treeUtilities.test.ts`.
+
+Required change:
+
+- Add a test under the existing `collectTasks` suite that verifies `collectTasks` returns tasks in stable depth-first order when a task is nested inside an extra child container, such as a `sequence` inside the existing `parallel` branch.
+
+Constraints:
+
+- Keep the change limited to `packages/devtools/tests/treeUtilities.test.ts`.
+- Do not change production code unless the new test exposes a real bug.
+- Run `bun test packages/devtools/tests/treeUtilities.test.ts` and report the result.

--- a/.smithers/workflows/dynamic-demo.tsx
+++ b/.smithers/workflows/dynamic-demo.tsx
@@ -1,0 +1,138 @@
+// smithers-source: authored
+// smithers-display-name: Dynamic Task Demo
+/** @jsxImportSource smithers-orchestrator */
+import { createSmithers } from "smithers-orchestrator";
+import { z } from "zod/v4";
+
+const inputSchema = z.object({
+  delayMs: z.number().int().min(0).max(30000).default(3000),
+  maxIterations: z.number().int().min(1).max(500).default(120),
+});
+
+const phaseSchema = z.object({
+  cycle: z.number().int(),
+  phase: z.string(),
+  added: z.array(z.string()),
+  removed: z.array(z.string()),
+  active: z.array(z.string()),
+  summary: z.string(),
+});
+
+const stepSchema = z.object({
+  cycle: z.number().int(),
+  phase: z.string(),
+  step: z.string(),
+  summary: z.string(),
+});
+
+const { Workflow, Task, Sequence, Parallel, Loop, smithers, outputs } = createSmithers({
+  input: inputSchema,
+  phase: phaseSchema,
+  step: stepSchema,
+});
+
+type Stage = {
+  id: string;
+  title: string;
+  steps: Array<{ id: string; title: string; summary: string }>;
+};
+
+const stages: Stage[] = [
+  {
+    id: "intake",
+    title: "Intake",
+    steps: [
+      { id: "read-context", title: "Read Context", summary: "Review the demo brief and current run state." },
+      { id: "inventory-files", title: "Inventory Files", summary: "List the docs and tickets that would be inspected." },
+    ],
+  },
+  {
+    id: "fanout",
+    title: "Fan Out Review",
+    steps: [
+      { id: "docs-pass", title: "Docs Pass", summary: "Check documentation structure and headings." },
+      { id: "tests-pass", title: "Tests Pass", summary: "Check existing test coverage targets." },
+      { id: "api-pass", title: "API Pass", summary: "Review command and schema surfaces." },
+      { id: "gui-pass", title: "GUI Pass", summary: "Review the DevTools task tree expectations." },
+    ],
+  },
+  {
+    id: "narrow",
+    title: "Narrow Focus",
+    steps: [
+      { id: "risk-summary", title: "Risk Summary", summary: "Collapse the fan-out into the highest signal risks." },
+    ],
+  },
+  {
+    id: "handoff",
+    title: "Handoff",
+    steps: [
+      { id: "demo-notes", title: "Demo Notes", summary: "Prepare notes for the next visible state change." },
+      { id: "cleanup-queue", title: "Cleanup Queue", summary: "Remove completed work from the active set." },
+      { id: "next-cycle", title: "Next Cycle", summary: "Seed the next intake cycle." },
+    ],
+  },
+];
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+const stepNames = (stage: Stage) => stage.steps.map((step) => step.title);
+
+export default smithers((ctx) => {
+  const delayMs = ctx.input.delayMs ?? 3000;
+  const maxIterations = ctx.input.maxIterations ?? 120;
+  const iteration = ctx.iteration;
+  const stage = stages[iteration % stages.length];
+  const previousStage = iteration === 0 ? null : stages[(iteration - 1) % stages.length];
+  const added = previousStage ? stepNames(stage).filter((name) => !stepNames(previousStage).includes(name)) : stepNames(stage);
+  const removed = previousStage ? stepNames(previousStage).filter((name) => !stepNames(stage).includes(name)) : [];
+
+  return (
+    <Workflow name="dynamic-demo">
+      <Loop id="dynamic-task-tree" until={false} maxIterations={maxIterations} onMaxReached="return-last">
+        <Sequence>
+          <Task id={`dynamic:${stage.id}:announce`} output={outputs.phase}>
+            {async () => {
+              await sleep(delayMs);
+              return {
+                cycle: iteration,
+                phase: stage.title,
+                added,
+                removed,
+                active: stepNames(stage),
+                summary:
+                  iteration === 0
+                    ? `Starting with ${stage.title}; adding ${added.join(", ")}.`
+                    : `Switching from ${previousStage?.title} to ${stage.title}; adding ${added.join(", ") || "none"} and removing ${removed.join(", ") || "none"}.`,
+              };
+            }}
+          </Task>
+
+          <Parallel maxConcurrency={2}>
+            {stage.steps.map((step, index) => (
+              <Task key={step.id} id={`dynamic:${stage.id}:${step.id}`} output={outputs.step}>
+                {async () => {
+                  await sleep(delayMs + index * 450);
+                  return {
+                    cycle: iteration,
+                    phase: stage.title,
+                    step: step.title,
+                    summary: step.summary,
+                  };
+                }}
+              </Task>
+            ))}
+          </Parallel>
+        </Sequence>
+      </Loop>
+
+      <Task id="dynamic:complete" output={outputs.step}>
+        {{
+          cycle: maxIterations,
+          phase: "Complete",
+          step: "Demo Complete",
+          summary: "Dynamic task tree demo finished after the requested iterations.",
+        }}
+      </Task>
+    </Workflow>
+  );
+});

--- a/apps/cli/src/eval-suite.js
+++ b/apps/cli/src/eval-suite.js
@@ -147,7 +147,17 @@ function jsonContains(actual, expected) {
         if (!Array.isArray(actual) || actual.length < expected.length) {
             return false;
         }
-        return expected.every((entry, index) => jsonContains(actual[index], entry));
+        const matchedActualIndexes = new Set();
+        return expected.every((entry) => {
+            const matchIndex = actual.findIndex((actualEntry, index) => {
+                return !matchedActualIndexes.has(index) && jsonContains(actualEntry, entry);
+            });
+            if (matchIndex < 0) {
+                return false;
+            }
+            matchedActualIndexes.add(matchIndex);
+            return true;
+        });
     }
     return jsonEquals(actual, expected);
 }

--- a/apps/cli/tests/eval-suite.test.js
+++ b/apps/cli/tests/eval-suite.test.js
@@ -79,6 +79,38 @@ describe("eval suite helpers", () => {
         ]);
     });
 
+    test("matches partial output array entries outside the prefix", () => {
+        const testCase = {
+            id: "array-contains",
+            name: "array-contains",
+            input: {},
+            annotations: {},
+            expected: {
+                status: "finished",
+                outputContains: {
+                    result: [
+                        { prompt: "B" },
+                        { prompt: "C" },
+                    ],
+                },
+            },
+            metadata: {},
+        };
+        const result = evaluateEvalCaseResult(testCase, {
+            status: "finished",
+            output: {
+                result: [
+                    { prompt: "A", summary: "first" },
+                    { prompt: "B", summary: "second" },
+                    { prompt: "C", summary: "third" },
+                ],
+            },
+        });
+
+        expect(result.passed).toBe(true);
+        expect(result.assertions.find((assertion) => assertion.name === "outputContains")?.passed).toBe(true);
+    });
+
     test("supports continued status and structured error matching", () => {
         const testCase = {
             id: "error",

--- a/docs/guides/evals-quickstart.mdx
+++ b/docs/guides/evals-quickstart.mdx
@@ -34,7 +34,7 @@ Case files can be JSONL, a JSON array, or an object with a `cases` array:
 
 Supported `expected` checks:
 
-- `status`: one of `finished`, `failed`, `cancelled`, `waiting-approval`, `waiting-event`, or `waiting-timer`
+- `status`: one of `finished`, `continued`, `failed`, `cancelled`, `waiting-approval`, `waiting-event`, or `waiting-timer`
 - `output`: exact JSON match against the workflow result output
 - `outputContains`: recursive partial JSON match
 - `errorContains`: substring match against thrown errors

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -24,4 +24,4 @@ Resume after a crash:
 bunx smithers-orchestrator up workflow.tsx --run-id <run-id> --resume true
 ```
 
-For a full worked example see the [Tour](/tour). For every CLI command see the [CLI catalog](/cli/overview).
+For a full worked example, see the [Tour](/tour). For every CLI command see the [CLI catalog](/cli/overview).

--- a/packages/devtools/tests/treeUtilities.test.ts
+++ b/packages/devtools/tests/treeUtilities.test.ts
@@ -143,6 +143,99 @@ describe("collectTasks", () => {
     };
     expect(collectTasks(node)).toEqual([]);
   });
+
+  test("returns tasks in depth-first order through nested containers", () => {
+    const root: DevToolsNode = {
+      id: 1,
+      type: "workflow",
+      name: "Root",
+      props: { name: "Root" },
+      depth: 0,
+      children: [
+        {
+          id: 2,
+          type: "sequence",
+          name: "Sequence",
+          props: {},
+          depth: 1,
+          children: [
+            {
+              id: 3,
+              type: "task",
+              name: "Task",
+              props: {},
+              task: { nodeId: "task-a", kind: "static" },
+              depth: 2,
+              children: [],
+            },
+          ],
+        },
+        {
+          id: 4,
+          type: "parallel",
+          name: "Parallel",
+          props: {},
+          depth: 1,
+          children: [
+            {
+              id: 5,
+              type: "task",
+              name: "Task",
+              props: {},
+              task: { nodeId: "task-b", kind: "compute" },
+              depth: 2,
+              children: [],
+            },
+            {
+              id: 6,
+              type: "sequence",
+              name: "NestedSequence",
+              props: {},
+              depth: 2,
+              children: [
+                {
+                  id: 7,
+                  type: "task",
+                  name: "Task",
+                  props: {},
+                  task: { nodeId: "task-c", kind: "static" },
+                  depth: 3,
+                  children: [],
+                },
+                {
+                  id: 8,
+                  type: "task",
+                  name: "Task",
+                  props: {},
+                  task: { nodeId: "task-d", kind: "agent", agent: "gpt-5" },
+                  depth: 3,
+                  children: [],
+                },
+              ],
+            },
+            {
+              id: 9,
+              type: "task",
+              name: "Task",
+              props: {},
+              task: { nodeId: "task-e", kind: "static" },
+              depth: 2,
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const tasks = collectTasks(root);
+    expect(tasks.map((t) => t.task?.nodeId)).toEqual([
+      "task-a",
+      "task-b",
+      "task-c",
+      "task-d",
+      "task-e",
+    ]);
+  });
 });
 
 describe("printTree", () => {


### PR DESCRIPTION
**Snapshot PR — preserves local main work in flight so nothing is lost.**

This branch is local main (12 commits ahead of `origin/main`) plus 1 new commit on top for previously-uncommitted WIP. Opening it as a PR so the work is captured remotely and reviewable.

Not intended as a clean atomic feature PR — review and cherry-pick what's mergeable; the rest stays preserved on the remote branch.

## What's in here

### New commit on top (was WIP)
- `eval: relax outputContains array matching + docs continued status` — loosens `jsonContains` so an expected array can match entries anywhere in actual (not just prefix), adds covering test, adds `continued` to docs status list.

### Local main commits (12 ahead of origin/main, oldest → newest)
- `a2931717e` *(empty commit — checkpoint, no diff)*
- `400eb2ddc` *(empty commit — checkpoint, no diff)*
- `9015c0130 merge: ticket/0001-demo-quickstart-typo-pass`
- `6c9a3945f merge: ticket/0002-demo-devtools-nested-task-test`
- `fb16bf813 docs(quickstart): add comma to worked-example sentence`
- `13943564f test(devtools): cover nested depth-first task ordering`
- `c2ac09196 chore(tickets): add demo quickstart and devtools nested-task tickets`
- `5c387dca7 chore(tickets): park fault-injection e2e matrix`
- `d7a485932 chore(smithers): swap codex provider for claude code agent`
- `06d894b30 feat(demo): rebuild demo as keyboard-driven slide deck`
- `b800a4b9e feat(demo): add dynamic task workflow`
- `39fbd30f2 Add eval suites for workflow regression (#142)` *(this is the local copy of #142, which already landed on `origin/main` as `db3fe3480` — will collapse on merge)*

## Suggested next steps
- Cherry-pick the standalone commits you want to land (docs typo, devtools test, agent swap, eval WIP).
- Decide whether the demo/ticket work belongs upstream or stays local-only.
- The 2 empty commits can be dropped during cleanup; they're preserved here only so the snapshot is faithful.