### PR TITLE
Extract CLI token and task compute helpers

### DIFF
--- a/apps/cli/tests/token-store.test.js
+++ b/apps/cli/tests/token-store.test.js
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseTokenScopes, readSmithersTokenStore, smithersTokenStorePath, writeSmithersTokenStore } from "../src/token-store.js";
+
+const originalTokenStore = process.env.SMITHERS_TOKEN_STORE;
+
+afterEach(() => {
+    if (originalTokenStore === undefined) {
+        delete process.env.SMITHERS_TOKEN_STORE;
+    }
+    else {
+        process.env.SMITHERS_TOKEN_STORE = originalTokenStore;
+    }
+});
+
+describe("CLI token store helpers", () => {
+    test("parses comma and whitespace separated scopes", () => {
+        expect(parseTokenScopes("run:read, run:write approval:submit")).toEqual([
+            "run:read",
+            "run:write",
+            "approval:submit",
+        ]);
+    });
+
+    test("reads and writes token grants at the configured path", () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-token-store-"));
+        try {
+            process.env.SMITHERS_TOKEN_STORE = join(dir, "tokens.json");
+            writeSmithersTokenStore({
+                tokens: {
+                    secret: {
+                        role: "operator",
+                        scopes: ["run:read"],
+                    },
+                },
+            });
+
+            expect(smithersTokenStorePath()).toBe(join(dir, "tokens.json"));
+            expect(readSmithersTokenStore().tokens.secret.role).toBe("operator");
+            expect(readFileSync(join(dir, "tokens.json"), "utf8")).toContain('"run:read"');
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -43,9 +43,7 @@ import { withTaskRuntime } from "@smithers-orchestrator/driver/task-runtime";
 import { hashCapabilityRegistry } from "@smithers-orchestrator/agents/capability-registry";
 import { cancelPendingTimersBridge, executeTaskBridgeEffect, isBridgeManagedTimerTask as isTimerTask, resolveDeferredTaskStateBridge, } from "./effect/workflow-bridge.js";
 import { AlertRuntime } from "./alert-runtime.js";
-import { executeChildWorkflow } from "./child-workflow.js";
-import { executeSandbox } from "@smithers-orchestrator/sandbox/execute";
-import { applyDiffBundle } from "./effect/diff-bundle.js";
+import { attachSandboxComputeFns, attachSubflowComputeFns } from "./task-compute-fns.js";
 import { buildCacheScopeIdentity, isFreshCacheRow, normalizeCacheScope } from "./cache-policy.js";
 import { runWorkflowWithMakeBridge } from "./effect/workflow-make-bridge.js";
 import { createWorkflowVersioningRuntime, getWorkflowPatchDecisions, withWorkflowVersioningRuntime, } from "./effect/versioning.js";
@@ -1808,83 +1806,6 @@ function resolveTaskOutputs(tasks, workflow) {
                 output: task.outputTableName ?? (typeof raw === "string" ? raw : undefined),
             });
         }
-    }
-}
-/**
- * @param {TaskDescriptor[]} tasks
- * @param {SmithersWorkflow<any>} workflow
- * @param {{ rootDir?: string; workflowPath?: string | null }} [opts]
- */
-function attachSubflowComputeFns(tasks, workflow, opts = {}) {
-    for (const task of tasks) {
-        if (!task.meta?.__subflow || task.computeFn)
-            continue;
-        const subflowWorkflow = task.meta.__subflowWorkflow;
-        if (!subflowWorkflow)
-            continue;
-        const subflowInput = task.meta.__subflowInput;
-        task.computeFn = async () => {
-            const result = await executeChildWorkflow(workflow, {
-                workflow: subflowWorkflow,
-                input: subflowInput,
-                rootDir: opts.rootDir,
-                workflowPath: opts.workflowPath ?? undefined,
-            });
-            if (result.status !== "finished") {
-                throw new SmithersError("WORKFLOW_EXECUTION_FAILED", `Subflow ${task.nodeId} failed with status ${result.status}.`, { nodeId: task.nodeId, status: result.status });
-            }
-            return result.output;
-        };
-        const { __subflowWorkflow: _workflow, ...persistableMeta } = task.meta;
-        task.meta = persistableMeta;
-    }
-}
-/**
- * @param {TaskDescriptor[]} tasks
- * @param {SmithersWorkflow<any>} workflow
- * @param {{ rootDir?: string; workflowPath?: string | null }} [opts]
- */
-function attachSandboxComputeFns(tasks, workflow, opts = {}) {
-    for (const task of tasks) {
-        if (!task.meta?.__sandbox || task.computeFn)
-            continue;
-        const sandboxWorkflow = task.meta.__sandboxWorkflow;
-        if (!sandboxWorkflow)
-            continue;
-        const sandboxInput = task.meta.__sandboxInput;
-        const sandboxProvider = task.meta.__sandboxProvider;
-        const sandboxRuntime = task.meta.__sandboxRuntime;
-        const sandboxAllowNetwork = Boolean(task.meta.__sandboxAllowNetwork);
-        const sandboxReviewDiffs = task.meta.__sandboxReviewDiffs;
-        const sandboxAutoAcceptDiffs = task.meta.__sandboxAutoAcceptDiffs;
-        const sandboxAllowNested = Boolean(task.meta.__sandboxAllowNested);
-        const sandboxConfig = task.meta.__sandboxConfig && typeof task.meta.__sandboxConfig === "object"
-            ? task.meta.__sandboxConfig
-            : {};
-        task.computeFn = async () => executeSandbox({
-            parentWorkflow: workflow,
-            sandboxId: task.nodeId,
-            provider: sandboxProvider,
-            runtime: sandboxRuntime,
-            workflow: sandboxWorkflow,
-            executeChildWorkflow,
-            applyDiffBundle,
-            input: sandboxInput,
-            rootDir: task.worktreePath ?? opts.rootDir ?? process.cwd(),
-            allowNetwork: sandboxAllowNetwork,
-            maxOutputBytes: 200_000,
-            toolTimeoutMs: 60_000,
-            reviewDiffs: sandboxReviewDiffs,
-            autoAcceptDiffs: sandboxAutoAcceptDiffs,
-            allowNested: sandboxAllowNested,
-            config: sandboxConfig,
-        });
-        const {
-            __sandboxWorkflow: _workflow,
-            __sandboxProvider: _provider,
-            ...persistableMeta
-        } = task.meta;
-        task.meta = persistableMeta;
     }
 }
 /**

--- a/packages/engine/src/task-compute-fns.js
+++ b/packages/engine/src/task-compute-fns.js
@@ -1,0 +1,86 @@
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+import { executeSandbox } from "@smithers-orchestrator/sandbox/execute";
+import { executeChildWorkflow } from "./child-workflow.js";
+import { applyDiffBundle } from "./effect/diff-bundle.js";
+
+/** @typedef {import("@smithers-orchestrator/components/SmithersWorkflow").SmithersWorkflow} SmithersWorkflow */
+/** @typedef {import("@smithers-orchestrator/graph/TaskDescriptor").TaskDescriptor} TaskDescriptor */
+
+/**
+ * @param {TaskDescriptor[]} tasks
+ * @param {SmithersWorkflow<any>} workflow
+ * @param {{ rootDir?: string; workflowPath?: string | null }} [opts]
+ */
+export function attachSubflowComputeFns(tasks, workflow, opts = {}) {
+    for (const task of tasks) {
+        if (!task.meta?.__subflow || task.computeFn)
+            continue;
+        const subflowWorkflow = task.meta.__subflowWorkflow;
+        if (!subflowWorkflow)
+            continue;
+        const subflowInput = task.meta.__subflowInput;
+        task.computeFn = async () => {
+            const result = await executeChildWorkflow(workflow, {
+                workflow: subflowWorkflow,
+                input: subflowInput,
+                rootDir: opts.rootDir,
+                workflowPath: opts.workflowPath ?? undefined,
+            });
+            if (result.status !== "finished") {
+                throw new SmithersError("WORKFLOW_EXECUTION_FAILED", `Subflow ${task.nodeId} failed with status ${result.status}.`, { nodeId: task.nodeId, status: result.status });
+            }
+            return result.output;
+        };
+        const { __subflowWorkflow: _workflow, ...persistableMeta } = task.meta;
+        task.meta = persistableMeta;
+    }
+}
+
+/**
+ * @param {TaskDescriptor[]} tasks
+ * @param {SmithersWorkflow<any>} workflow
+ * @param {{ rootDir?: string; workflowPath?: string | null }} [opts]
+ */
+export function attachSandboxComputeFns(tasks, workflow, opts = {}) {
+    for (const task of tasks) {
+        if (!task.meta?.__sandbox || task.computeFn)
+            continue;
+        const sandboxWorkflow = task.meta.__sandboxWorkflow;
+        if (!sandboxWorkflow)
+            continue;
+        const sandboxInput = task.meta.__sandboxInput;
+        const sandboxProvider = task.meta.__sandboxProvider;
+        const sandboxRuntime = task.meta.__sandboxRuntime;
+        const sandboxAllowNetwork = Boolean(task.meta.__sandboxAllowNetwork);
+        const sandboxReviewDiffs = task.meta.__sandboxReviewDiffs;
+        const sandboxAutoAcceptDiffs = task.meta.__sandboxAutoAcceptDiffs;
+        const sandboxAllowNested = Boolean(task.meta.__sandboxAllowNested);
+        const sandboxConfig = task.meta.__sandboxConfig && typeof task.meta.__sandboxConfig === "object"
+            ? task.meta.__sandboxConfig
+            : {};
+        task.computeFn = async () => executeSandbox({
+            parentWorkflow: workflow,
+            sandboxId: task.nodeId,
+            provider: sandboxProvider,
+            runtime: sandboxRuntime,
+            workflow: sandboxWorkflow,
+            executeChildWorkflow,
+            applyDiffBundle,
+            input: sandboxInput,
+            rootDir: task.worktreePath ?? opts.rootDir ?? process.cwd(),
+            allowNetwork: sandboxAllowNetwork,
+            maxOutputBytes: 200_000,
+            toolTimeoutMs: 60_000,
+            reviewDiffs: sandboxReviewDiffs,
+            autoAcceptDiffs: sandboxAutoAcceptDiffs,
+            allowNested: sandboxAllowNested,
+            config: sandboxConfig,
+        });
+        const {
+            __sandboxWorkflow: _workflow,
+            __sandboxProvider: _provider,
+            ...persistableMeta
+        } = task.meta;
+        task.meta = persistableMeta;
+    }
+}


### PR DESCRIPTION
## Summary
- move CLI token grant parsing and persistence into a focused helper module
- move subflow and sandbox compute binding out of the engine orchestration core
- document the sandbox subpath export so package docs stay in sync with the public surface

## Verification
- pnpm check:architecture
- pnpm check:effect
- pnpm check:deps
- pnpm -r typecheck
- pnpm lint
- pnpm test
