### PR TITLE
Add Workflow Studio and TUI demos

### DIFF
--- a/apps/smithers-demo/README.md
+++ b/apps/smithers-demo/README.md
@@ -1,0 +1,46 @@
+# Smithers Workflow Studio Demo
+
+This app demonstrates a React Flow-powered Smithers workflow studio. A prompt drives a generated workflow model, the model is rendered as a left-side node graph, and the matching Smithers React workflow code is shown on the right.
+
+## Run
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-demo dev
+```
+
+The Vite dev server opens on `http://127.0.0.1:5174` when the port is available.
+
+## React TUI + Cerebras
+
+The terminal demo uses `@dino-dna/react-tui` with `neo-blessed` and renders the generated workflow as a connected 2D node graph. It runs the same provider-backed debate workflow as the browser app:
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-tui-demo tui
+```
+
+Start it with one provider key set (`CEREBRAS_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`). The prompt input at the bottom regenerates the graph locally. `Run Workflow` switches the graph into running state, changes the action to `Cancel`, and shows `Done` after the provider workflow finishes. The default prompt is:
+
+```text
+Do a loop where you have two LMs debate communism versus capitalism and then have a judge LM output a final result.
+```
+
+For a non-interactive live provider check, set one provider key and run:
+
+```bash
+CEREBRAS_API_KEY=... pnpm --filter @smithers-orchestrator/smithers-demo cerebras:debate
+OPENAI_API_KEY=... pnpm --filter @smithers-orchestrator/smithers-demo cerebras:debate
+ANTHROPIC_API_KEY=... pnpm --filter @smithers-orchestrator/smithers-demo cerebras:debate
+```
+
+The browser app stores provider, model, and key settings in local browser settings. Defaults are Cerebras `gpt-oss-120b`, OpenAI `gpt-5.5`, and Claude `claude-opus-4.7`.
+
+## Validate
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-demo test
+pnpm --filter @smithers-orchestrator/smithers-demo build
+pnpm --filter @smithers-orchestrator/smithers-demo e2e
+pnpm --filter @smithers-orchestrator/smithers-tui-demo test
+```
+
+The layout tests assert that generated React Flow nodes do not overlap. The Playwright e2e test runs the real Workflow Studio in desktop and mobile viewports, verifies settings persistence, regenerates the graph from the bottom prompt composer, confirms provider-neutral `Run Workflow` copy, stubs provider output, and checks rendered React Flow nodes do not overlap. The TUI tests assert that terminal graph nodes render in 2D space with connections, do not overlap, and expose the Run Workflow -> Cancel -> Done state contract. The browser app also validates the generated layout in the UI and surfaces a `layout valid` or `layout overlap` badge beside the generated Smithers code.

--- a/apps/smithers-demo/index.html
+++ b/apps/smithers-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smithers Workflow Studio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/smithers-demo/package.json
+++ b/apps/smithers-demo/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@smithers-orchestrator/smithers-demo",
+  "version": "0.21.0",
+  "description": "Interactive Smithers workflow generator demo with React Flow visualization",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "e2e": "playwright test",
+    "preview": "vite preview --host 127.0.0.1",
+    "test": "vitest run tests/*.test.ts",
+    "cerebras:debate": "node src/run-cerebras-debate.mjs"
+  },
+  "dependencies": {
+    "@xyflow/react": "^12.10.2",
+    "dagre": "^0.8.5",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0",
+    "@types/dagre": "^0.7.54",
+    "@vitejs/plugin-react": "^6.0.2",
+    "vite": "^8.0.14",
+    "vitest": "^4.0.16"
+  }
+}

--- a/apps/smithers-demo/playwright.config.ts
+++ b/apps/smithers-demo/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:5174",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "pnpm --filter @smithers-orchestrator/smithers-demo dev -- --port 5174",
+    url: "http://127.0.0.1:5174",
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium-desktop",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 900 } },
+    },
+    {
+      name: "chromium-mobile",
+      use: { ...devices["Pixel 5"], viewport: { width: 393, height: 851 } },
+    },
+  ],
+});

--- a/apps/smithers-demo/src/App.tsx
+++ b/apps/smithers-demo/src/App.tsx
@@ -1,0 +1,285 @@
+import "@xyflow/react/dist/style.css";
+import {
+  Background,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type NodeProps,
+} from "@xyflow/react";
+import { useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import {
+  DEBATE_E2E_PROMPT,
+  defaultModelForProvider,
+  PROVIDER_OPTIONS,
+  runDebateWorkflow,
+} from "./cerebrasDebate.js";
+import { generateSmithersCode, generateWorkflowFromPrompt, SMITHERS_CAPABILITY_PROMPT } from "./workflowModel";
+import { validateLayout, workflowToFlow } from "./layout";
+import type { SmithersFlowNode } from "./layout";
+import "./styles.css";
+
+const examples = [
+  DEBATE_E2E_PROMPT,
+  "Build a docs generator workflow with implementation, tests, validation, and release approval",
+  "Research and audit a dependency update, implement the fix, then verify with tests",
+];
+
+function SmithersTaskNode({ data }: NodeProps<SmithersFlowNode>) {
+  return (
+    <div className={`smithers-node smithers-node-${data.kind}`}>
+      <Handle type="target" position={Position.Left} />
+      <div className="node-kicker">{data.kind}</div>
+      <div className="node-title">{data.label}</div>
+      <div className="node-output">{data.output}</div>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}
+
+const nodeTypes = {
+  smithersTask: SmithersTaskNode,
+};
+
+type ProviderId = "cerebras" | "openai" | "anthropic";
+
+type StoredSettings = {
+  provider?: ProviderId;
+  keys?: Partial<Record<ProviderId, string>>;
+  models?: Partial<Record<ProviderId, string>>;
+};
+
+const SETTINGS_KEY = "smithers-demo-provider-settings";
+
+function loadSettings(): Required<StoredSettings> {
+  if (typeof window === "undefined") {
+    return { provider: "cerebras", keys: {}, models: {} };
+  }
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(SETTINGS_KEY) ?? "{}") as StoredSettings;
+    return {
+      provider: parsed.provider ?? "cerebras",
+      keys: parsed.keys ?? {},
+      models: parsed.models ?? {},
+    };
+  } catch {
+    return { provider: "cerebras", keys: {}, models: {} };
+  }
+}
+
+function Studio() {
+  const [draft, setDraft] = useState(examples[0]);
+  const [prompt, setPrompt] = useState(examples[0]);
+  const [settings, setSettings] = useState(() => loadSettings());
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [generationState, setGenerationState] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [generationOutput, setGenerationOutput] = useState("");
+  const [localGenerationCount, setLocalGenerationCount] = useState(0);
+  const provider = settings.provider;
+  const apiKey = settings.keys[provider] ?? "";
+  const model = settings.models[provider] || defaultModelForProvider(provider);
+  const spec = useMemo(() => generateWorkflowFromPrompt(prompt), [prompt]);
+  const code = useMemo(() => generateSmithersCode(spec), [spec]);
+  const flow = useMemo(() => workflowToFlow(spec), [spec]);
+  const validation = useMemo(() => validateLayout(flow.nodes), [flow.nodes]);
+
+  useEffect(() => {
+    window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  function updateProvider(providerId: ProviderId) {
+    setSettings((current) => ({
+      ...current,
+      provider: providerId,
+      models: {
+        ...current.models,
+        [providerId]: current.models[providerId] || defaultModelForProvider(providerId),
+      },
+    }));
+  }
+
+  function updateApiKey(value: string) {
+    setSettings((current) => ({
+      ...current,
+      keys: {
+        ...current.keys,
+        [current.provider]: value,
+      },
+    }));
+  }
+
+  function updateModel(value: string) {
+    setSettings((current) => ({
+      ...current,
+      models: {
+        ...current.models,
+        [current.provider]: value,
+      },
+    }));
+  }
+
+  function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPrompt(draft);
+    setLocalGenerationCount((count) => count + 1);
+    setGenerationState("idle");
+    setGenerationOutput(
+      `Generated local Smithers graph and code for ${draft.length} characters.\n\nCapability prompt in use:\n${SMITHERS_CAPABILITY_PROMPT}`,
+    );
+  }
+
+  async function runWithProvider() {
+    setPrompt(draft);
+    setGenerationState("running");
+    setGenerationOutput(`Running ${PROVIDER_OPTIONS[provider].label} debate loop with ${model}...`);
+    try {
+      const result = await runDebateWorkflow({
+        apiKey,
+        provider,
+        model,
+        prompt: draft,
+        rounds: 2,
+        onStep: (step: { role: string; status: string; content?: string }) => {
+          if (step.status === "complete") {
+            setGenerationOutput((current) => `${current}\n\n[${step.role}]\n${step.content}`);
+          }
+        },
+      });
+      setGenerationState("done");
+      setGenerationOutput(
+        `${result.transcript.map((entry) => `[${entry.role}]\n${entry.content}`).join("\n\n")}\n\n[final]\n${result.finalResult}`,
+      );
+    } catch (error) {
+      setGenerationState("error");
+      setGenerationOutput(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  return (
+    <main className="app-shell">
+      <section className="topbar">
+        <div>
+          <p className="eyebrow">Smithers demo</p>
+          <h1>Workflow Studio</h1>
+        </div>
+        <div className="local-status" aria-live="polite">
+          {localGenerationCount === 0
+            ? "Local generation updates the graph and Smithers React code immediately."
+            : `Local generation updated ${localGenerationCount} time${localGenerationCount === 1 ? "" : "s"}.`}
+        </div>
+        <button className="settings-toggle" type="button" onClick={() => setSettingsOpen((open) => !open)}>
+          Settings
+        </button>
+        {settingsOpen ? (
+          <div className="settings-panel" aria-label="Provider settings">
+            <label>
+              <span>Provider</span>
+              <select
+                aria-label="Provider"
+                value={provider}
+                onChange={(event) => updateProvider(event.target.value as ProviderId)}
+              >
+                <option value="cerebras">Cerebras</option>
+                <option value="openai">OpenAI</option>
+                <option value="anthropic">Claude</option>
+              </select>
+            </label>
+            <label>
+              <span>API key</span>
+              <input
+                aria-label="Provider API key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => updateApiKey(event.target.value)}
+                placeholder={PROVIDER_OPTIONS[provider].envVar}
+              />
+            </label>
+            <label>
+              <span>Model</span>
+              <input
+                aria-label="Provider model"
+                value={model}
+                onChange={(event) => updateModel(event.target.value)}
+                placeholder={defaultModelForProvider(provider)}
+              />
+            </label>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="workspace">
+        <div className="graph-pane" aria-label="Generated workflow graph">
+          <ReactFlow
+            nodes={flow.nodes}
+            edges={flow.edges}
+            nodeTypes={nodeTypes}
+            fitView
+            fitViewOptions={{ padding: 0.2 }}
+            minZoom={0.35}
+          >
+            <Background gap={26} color="#e2e7ef" />
+            <Controls />
+          </ReactFlow>
+        </div>
+
+        <aside className="code-pane">
+          <div className="code-header">
+            <div>
+              <p className="eyebrow">Generated Smithers React code</p>
+              <h2>{spec.name}</h2>
+            </div>
+            <span className={validation.valid ? "status-ok" : "status-error"}>
+              {validation.valid ? "layout valid" : "layout overlap"}
+            </span>
+          </div>
+          <pre>
+            <code>{code}</code>
+          </pre>
+          <section className={`generation-output generation-${generationState}`} aria-label="Generation output">
+            <p className="eyebrow">{generationState === "idle" ? "Generation feedback" : "Provider output"}</p>
+            <div>{generationOutput || "Enter an API key in Settings and run the workflow to generate live output."}</div>
+          </section>
+        </aside>
+      </section>
+
+      <section className="bottom-composer" aria-label="Prompt composer">
+        <form className="chat-form" onSubmit={submit}>
+          <input
+            aria-label="Workflow prompt"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="Describe the Smithers workflow to generate"
+          />
+          <button type="submit">Generate</button>
+          <button type="button" disabled={generationState === "running"} onClick={runWithProvider}>
+            Run Workflow
+          </button>
+        </form>
+        <div className="prompt-row" aria-label="Example prompts">
+        {examples.map((example) => (
+          <button
+            key={example}
+            type="button"
+            onClick={() => {
+              setDraft(example);
+              setPrompt(example);
+            }}
+          >
+            {example}
+          </button>
+        ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function App() {
+  return (
+    <ReactFlowProvider>
+      <Studio />
+    </ReactFlowProvider>
+  );
+}

--- a/apps/smithers-demo/src/cerebrasDebate.js
+++ b/apps/smithers-demo/src/cerebrasDebate.js
@@ -1,0 +1,252 @@
+const CEREBRAS_CHAT_URL = "https://api.cerebras.ai/v1/chat/completions";
+const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
+const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
+
+export const DEFAULT_CEREBRAS_MODEL = "gpt-oss-120b";
+export const DEFAULT_OPENAI_MODEL = "gpt-5.5";
+export const DEFAULT_ANTHROPIC_MODEL = "claude-opus-4.7";
+export const DEBATE_E2E_PROMPT =
+  "Do a loop where you have two LMs debate communism versus capitalism and then have a judge LM output a final result.";
+
+export const PROVIDER_OPTIONS = {
+  cerebras: {
+    label: "Cerebras",
+    envVar: "CEREBRAS_API_KEY",
+    defaultModel: DEFAULT_CEREBRAS_MODEL,
+  },
+  openai: {
+    label: "OpenAI",
+    envVar: "OPENAI_API_KEY",
+    defaultModel: DEFAULT_OPENAI_MODEL,
+  },
+  anthropic: {
+    label: "Claude",
+    envVar: "ANTHROPIC_API_KEY",
+    defaultModel: DEFAULT_ANTHROPIC_MODEL,
+  },
+};
+
+/**
+ * @typedef {"cerebras" | "openai" | "anthropic"} ProviderId
+ * @typedef {{ role: string; content: string }} DebateEntry
+ * @typedef {{ role: string; status: "running" | "complete"; content?: string }} DebateStep
+ * @typedef {{
+ *   apiKey: string;
+ *   provider?: ProviderId;
+ *   model?: string;
+ *   messages: Array<{ role: string; content: string }>;
+ *   temperature?: number;
+ *   signal?: AbortSignal;
+ *   fetchImpl?: typeof fetch;
+ * }} ProviderChatArgs
+ * @typedef {(args: ProviderChatArgs) => Promise<string>} ProviderChat
+ * @typedef {{
+ *   apiKey: string;
+ *   provider?: ProviderId;
+ *   model?: string;
+ *   prompt?: string;
+ *   rounds?: number;
+ *   signal?: AbortSignal;
+ *   chat?: ProviderChat;
+ *   onStep?: (step: DebateStep) => void;
+ * }} DebateWorkflowArgs
+ * @typedef {{
+ *   prompt: string;
+ *   provider: ProviderId;
+ *   model: string;
+ *   rounds: number;
+ *   transcript: DebateEntry[];
+ *   finalResult: string;
+ * }} DebateWorkflowResult
+ */
+
+function assertNonEmpty(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required`);
+  }
+  return value.trim();
+}
+
+function normalizeProvider(provider) {
+  if (provider === "openai" || provider === "anthropic" || provider === "cerebras") return provider;
+  return "cerebras";
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error ? signal.reason : new Error("Workflow cancelled");
+  }
+}
+
+export function defaultModelForProvider(provider) {
+  return PROVIDER_OPTIONS[normalizeProvider(provider)]?.defaultModel ?? DEFAULT_CEREBRAS_MODEL;
+}
+
+function extractContent(responseJson, provider) {
+  const choice = responseJson?.choices?.[0];
+  const message = choice?.message;
+  const content =
+    message?.content ??
+    message?.reasoning_content ??
+    message?.reasoning ??
+    choice?.text ??
+    responseJson?.output_text;
+  if (typeof content !== "string" || content.length === 0) {
+    throw new Error(`${PROVIDER_OPTIONS[provider].label} response did not include message content`);
+  }
+  return content;
+}
+
+/** @param {ProviderChatArgs} args */
+export async function callProviderChat({
+  apiKey,
+  provider = "cerebras",
+  model,
+  messages,
+  temperature = 0.4,
+  signal,
+  fetchImpl = globalThis.fetch,
+}) {
+  const selectedProvider = normalizeProvider(provider);
+  const selectedModel = model || defaultModelForProvider(selectedProvider);
+  const key = assertNonEmpty(apiKey, `${PROVIDER_OPTIONS[selectedProvider].label} API key`);
+  if (typeof fetchImpl !== "function") {
+    throw new Error("A fetch implementation is required");
+  }
+  throwIfAborted(signal);
+
+  if (selectedProvider === "anthropic") {
+    const system = messages.find((message) => message.role === "system")?.content;
+    const anthropicMessages = messages
+      .filter((message) => message.role !== "system")
+      .map((message) => ({
+        role: message.role === "assistant" ? "assistant" : "user",
+        content: message.content,
+      }));
+
+    const response = await fetchImpl(ANTHROPIC_MESSAGES_URL, {
+      method: "POST",
+      signal,
+      headers: {
+        "x-api-key": key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: selectedModel,
+        system,
+        messages: anthropicMessages,
+        temperature,
+        max_tokens: 1200,
+      }),
+    });
+
+    const responseText = await response.text();
+    if (!response.ok) {
+      throw new Error(`Claude request failed (${response.status}): ${responseText}`);
+    }
+    const parsed = JSON.parse(responseText);
+    const content = parsed?.content?.find((part) => part?.type === "text")?.text;
+    if (typeof content !== "string" || content.length === 0) {
+      throw new Error("Claude response did not include text content");
+    }
+    return content;
+  }
+
+  const response = await fetchImpl(selectedProvider === "openai" ? OPENAI_CHAT_URL : CEREBRAS_CHAT_URL, {
+    method: "POST",
+    signal,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: selectedModel,
+      messages,
+      temperature,
+      max_completion_tokens: 1200,
+      ...(selectedProvider === "cerebras" ? { reasoning_effort: "low" } : {}),
+    }),
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(`${PROVIDER_OPTIONS[selectedProvider].label} request failed (${response.status}): ${responseText}`);
+  }
+
+  return extractContent(JSON.parse(responseText), selectedProvider);
+}
+
+export const callCerebrasChat = (args) => callProviderChat({ ...args, provider: "cerebras" });
+
+/**
+ * @param {DebateWorkflowArgs} args
+ * @returns {Promise<DebateWorkflowResult>}
+ */
+export async function runDebateWorkflow({
+  apiKey,
+  provider = "cerebras",
+  model,
+  prompt = DEBATE_E2E_PROMPT,
+  rounds = 2,
+  signal,
+  chat = callProviderChat,
+  onStep,
+}) {
+  const selectedProvider = normalizeProvider(provider);
+  const selectedModel = model || defaultModelForProvider(selectedProvider);
+  const debatePrompt = assertNonEmpty(prompt, "Debate prompt");
+  const transcript = [];
+
+  async function ask(role, system, user) {
+    throwIfAborted(signal);
+    onStep?.({ role, status: "running" });
+    const content = await chat({
+      apiKey,
+      provider: selectedProvider,
+      model: selectedModel,
+      signal,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    });
+    throwIfAborted(signal);
+    const entry = { role, content };
+    transcript.push(entry);
+    onStep?.({ role, status: "complete", content });
+    return content;
+  }
+
+  let context = debatePrompt;
+  for (let round = 1; round <= rounds; round += 1) {
+    const capitalism = await ask(
+      `capitalism-round-${round}`,
+      "You are one language model in a structured debate. Argue for capitalism with concrete claims, acknowledge tradeoffs, and respond directly to the opposing side. Return only the visible debate answer.",
+      `Round ${round}. Debate task: ${debatePrompt}\n\nTranscript so far:\n${context}`,
+    );
+    context += `\n\nCapitalism LM round ${round}:\n${capitalism}`;
+
+    const communism = await ask(
+      `communism-round-${round}`,
+      "You are one language model in a structured debate. Argue for communism with concrete claims, acknowledge tradeoffs, and respond directly to the opposing side. Return only the visible debate answer.",
+      `Round ${round}. Debate task: ${debatePrompt}\n\nTranscript so far:\n${context}`,
+    );
+    context += `\n\nCommunism LM round ${round}:\n${communism}`;
+  }
+
+  const finalResult = await ask(
+    "judge-final",
+    "You are a neutral judge language model. Evaluate the debate fairly and output a final result with winner, reasoning, and caveats. Return only the visible final judgment.",
+    `Judge this debate and output the final result.\n\nOriginal task:\n${debatePrompt}\n\nTranscript:\n${context}`,
+  );
+
+  return {
+    prompt: debatePrompt,
+    provider: selectedProvider,
+    model: selectedModel,
+    rounds,
+    transcript,
+    finalResult,
+  };
+}

--- a/apps/smithers-demo/src/layout.ts
+++ b/apps/smithers-demo/src/layout.ts
@@ -1,0 +1,128 @@
+import dagre from "dagre";
+import type { Edge, Node } from "@xyflow/react";
+import type { WorkflowNodeSpec, WorkflowSpec } from "./workflowModel";
+
+export type SmithersFlowData = WorkflowNodeSpec & {
+  status: "ready" | "running" | "blocked";
+};
+
+export type SmithersFlowNode = Node<SmithersFlowData>;
+
+export type LayoutOptions = {
+  nodeWidth?: number;
+  nodeHeight?: number;
+  rankdir?: "TB" | "LR";
+  ranksep?: number;
+  nodesep?: number;
+};
+
+export type Rect = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const DEFAULT_NODE_WIDTH = 220;
+const DEFAULT_NODE_HEIGHT = 96;
+
+function makeStatus(node: WorkflowNodeSpec): SmithersFlowData["status"] {
+  if (node.kind === "approval") return "blocked";
+  if (node.dependsOn.length === 0) return "running";
+  return "ready";
+}
+
+export function workflowToFlow(spec: WorkflowSpec, options: LayoutOptions = {}) {
+  const nodeWidth = options.nodeWidth ?? DEFAULT_NODE_WIDTH;
+  const nodeHeight = options.nodeHeight ?? DEFAULT_NODE_HEIGHT;
+  const graph = new dagre.graphlib.Graph();
+
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({
+    rankdir: options.rankdir ?? "LR",
+    ranksep: options.ranksep ?? 130,
+    nodesep: options.nodesep ?? 90,
+    marginx: 32,
+    marginy: 32,
+  });
+
+  for (const node of spec.nodes) {
+    graph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  }
+
+  for (const node of spec.nodes) {
+    for (const dependency of node.dependsOn) {
+      graph.setEdge(dependency, node.id);
+    }
+  }
+
+  dagre.layout(graph);
+
+  const nodes: SmithersFlowNode[] = spec.nodes.map((node) => {
+    const positioned = graph.node(node.id);
+    return {
+      id: node.id,
+      type: "smithersTask",
+      position: {
+        x: Math.round(positioned.x - nodeWidth / 2),
+        y: Math.round(positioned.y - nodeHeight / 2),
+      },
+      data: {
+        ...node,
+        status: makeStatus(node),
+      },
+      width: nodeWidth,
+      height: nodeHeight,
+    };
+  });
+
+  const edges: Edge[] = spec.nodes.flatMap((node) =>
+    node.dependsOn.map((dependency) => ({
+      id: `${dependency}->${node.id}`,
+      source: dependency,
+      target: node.id,
+      animated: node.kind === "approval",
+      type: "smoothstep",
+    })),
+  );
+
+  return { nodes, edges };
+}
+
+export function nodeRects(nodes: SmithersFlowNode[], options: LayoutOptions = {}): Rect[] {
+  const width = options.nodeWidth ?? DEFAULT_NODE_WIDTH;
+  const height = options.nodeHeight ?? DEFAULT_NODE_HEIGHT;
+  return nodes.map((node) => ({
+    id: node.id,
+    x: node.position.x,
+    y: node.position.y,
+    width,
+    height,
+  }));
+}
+
+export function findOverlappingRects(rects: Rect[], padding = 0) {
+  const overlaps: Array<[string, string]> = [];
+  for (let i = 0; i < rects.length; i += 1) {
+    for (let j = i + 1; j < rects.length; j += 1) {
+      const a = rects[i];
+      const b = rects[j];
+      const separated =
+        a.x + a.width + padding <= b.x ||
+        b.x + b.width + padding <= a.x ||
+        a.y + a.height + padding <= b.y ||
+        b.y + b.height + padding <= a.y;
+      if (!separated) overlaps.push([a.id, b.id]);
+    }
+  }
+  return overlaps;
+}
+
+export function validateLayout(nodes: SmithersFlowNode[], options: LayoutOptions = {}) {
+  const overlaps = findOverlappingRects(nodeRects(nodes, options), 12);
+  return {
+    valid: overlaps.length === 0,
+    overlaps,
+  };
+}

--- a/apps/smithers-demo/src/main.tsx
+++ b/apps/smithers-demo/src/main.tsx
@@ -1,0 +1,10 @@
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const root = document.getElementById("root");
+
+if (!root) {
+  throw new Error("Missing #root element");
+}
+
+createRoot(root).render(<App />);

--- a/apps/smithers-demo/src/run-cerebras-debate.mjs
+++ b/apps/smithers-demo/src/run-cerebras-debate.mjs
@@ -1,0 +1,35 @@
+import { DEBATE_E2E_PROMPT, defaultModelForProvider, PROVIDER_OPTIONS, runDebateWorkflow } from "./cerebrasDebate.js";
+
+const provider = process.env.OPENAI_API_KEY
+  ? "openai"
+  : process.env.ANTHROPIC_API_KEY
+    ? "anthropic"
+    : "cerebras";
+const apiKey = process.env.OPENAI_API_KEY ?? process.env.ANTHROPIC_API_KEY ?? process.env.CEREBRAS_API_KEY;
+const model = process.env.SMITHERS_MODEL ?? defaultModelForProvider(provider);
+const rounds = Number(process.env.CEREBRAS_DEBATE_ROUNDS ?? "2");
+
+if (!apiKey) {
+  console.error(
+    `Set one provider key before running: ${Object.values(PROVIDER_OPTIONS)
+      .map((option) => option.envVar)
+      .join(", ")}.`,
+  );
+  process.exit(1);
+}
+
+const result = await runDebateWorkflow({
+  apiKey,
+  provider,
+  model,
+  rounds,
+  prompt: DEBATE_E2E_PROMPT,
+  onStep: (step) => {
+    if (step.status === "complete") {
+      console.log(`\n[${step.role}]\n${step.content}`);
+    }
+  },
+});
+
+console.log("\n[final-result]");
+console.log(result.finalResult);

--- a/apps/smithers-demo/src/styles.css
+++ b/apps/smithers-demo/src/styles.css
@@ -1,0 +1,322 @@
+:root {
+  color: #182230;
+  background: #f5f7fb;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.app-shell {
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+}
+
+.topbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr auto;
+  gap: 12px 24px;
+  align-items: center;
+  padding: 18px 22px;
+  border-bottom: 1px solid #dce3ee;
+  background: #ffffff;
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  color: #607087;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  margin: 0;
+  line-height: 1.1;
+}
+
+h1 {
+  font-size: 30px;
+}
+
+h2 {
+  font-size: 18px;
+}
+
+.chat-form {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 10px;
+}
+
+.local-status {
+  color: #496077;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.chat-form input,
+.settings-panel input,
+.settings-panel select {
+  min-width: 0;
+  height: 44px;
+  padding: 0 14px;
+  border: 1px solid #cfd8e6;
+  border-radius: 8px;
+  background: #f9fbff;
+  color: #182230;
+}
+
+.chat-form button,
+.settings-toggle,
+.prompt-row button {
+  border: 1px solid #1f6f62;
+  border-radius: 8px;
+  background: #0f8f78;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.chat-form button,
+.settings-toggle {
+  height: 44px;
+  padding: 0 18px;
+}
+
+.settings-panel {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 190px minmax(240px, 1fr) minmax(180px, 0.45fr);
+  gap: 12px;
+  padding-top: 4px;
+}
+
+.settings-panel label {
+  display: grid;
+  gap: 5px;
+  color: #496077;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.chat-form button:disabled {
+  cursor: progress;
+  opacity: 0.65;
+}
+
+.workspace {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.12fr) minmax(380px, 0.88fr);
+  overflow: hidden;
+}
+
+.graph-pane {
+  min-height: 0;
+  background: #f1f5fa;
+}
+
+.react-flow {
+  border: 0;
+}
+
+.react-flow__controls {
+  border: 1px solid #d8e1ec;
+  border-radius: 8px;
+  box-shadow: 0 8px 18px rgb(20 35 55 / 10%);
+  overflow: hidden;
+}
+
+.code-pane {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  background: #111827;
+  color: #eef4ff;
+}
+
+.code-header {
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  align-items: center;
+  padding: 18px 20px;
+  border-bottom: 1px solid #263244;
+}
+
+.status-ok,
+.status-error {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 5px 9px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.status-ok {
+  color: #03291f;
+  background: #79e7c5;
+}
+
+.status-error {
+  color: #3d0808;
+  background: #ffaaa5;
+}
+
+pre {
+  min-width: 0;
+  overflow: auto;
+  margin: 0;
+  padding: 20px;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.generation-output {
+  max-height: 210px;
+  overflow: auto;
+  padding: 14px 20px 18px;
+  border-top: 1px solid #263244;
+  background: #0c1220;
+  color: #d8e2f1;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.generation-error {
+  color: #ffcbc7;
+}
+
+.generation-done {
+  color: #d9fbea;
+}
+
+.bottom-composer {
+  display: grid;
+  gap: 10px;
+  padding: 14px 22px 16px;
+  border-top: 1px solid #dce3ee;
+  background: #ffffff;
+}
+
+.prompt-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.prompt-row button {
+  min-height: 42px;
+  padding: 8px 12px;
+  background: #ffffff;
+  color: #145d51;
+  text-align: left;
+}
+
+.smithers-node {
+  width: 220px;
+  min-height: 96px;
+  display: grid;
+  gap: 6px;
+  align-content: center;
+  padding: 14px 16px;
+  border: 1px solid #d7e0eb;
+  border-left-width: 5px;
+  border-radius: 7px;
+  background: #ffffff;
+  box-shadow: 0 8px 18px rgb(30 42 60 / 10%);
+}
+
+.smithers-node-agent {
+  border-left-color: #0f8f78;
+}
+
+.smithers-node-approval {
+  border-left-color: #bf5b16;
+}
+
+.smithers-node-compute {
+  border-left-color: #356fd2;
+}
+
+.smithers-node-loop {
+  border-left-color: #6d56d8;
+}
+
+.smithers-node-branch,
+.smithers-node-signal,
+.smithers-node-timer {
+  border-left-color: #61738a;
+}
+
+.smithers-node-sandbox,
+.smithers-node-worktree {
+  border-left-color: #2670a9;
+}
+
+.smithers-node-human {
+  border-left-color: #a34d9f;
+}
+
+.node-kicker {
+  color: #607087;
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.node-title {
+  color: #182230;
+  font-size: 16px;
+  font-weight: 800;
+}
+
+.node-output {
+  overflow: hidden;
+  color: #607087;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .topbar,
+  .workspace,
+  .prompt-row,
+  .settings-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace {
+    grid-template-rows: 52vh 48vh;
+  }
+
+  .graph-pane {
+    border-right: 0;
+    border-bottom: 1px solid #dce3ee;
+  }
+
+  .chat-form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/smithers-demo/src/workflowModel.ts
+++ b/apps/smithers-demo/src/workflowModel.ts
@@ -1,0 +1,388 @@
+export type WorkflowKind =
+  | "agent"
+  | "compute"
+  | "approval"
+  | "parallel"
+  | "merge"
+  | "loop"
+  | "branch"
+  | "sandbox"
+  | "worktree"
+  | "timer"
+  | "signal"
+  | "human";
+
+export type WorkflowNodeSpec = {
+  id: string;
+  label: string;
+  kind: WorkflowKind;
+  output: string;
+  prompt: string;
+  dependsOn: string[];
+  parallelGroupId?: string;
+};
+
+export type WorkflowSpec = {
+  name: string;
+  description: string;
+  inputPrompt: string;
+  nodes: WorkflowNodeSpec[];
+};
+
+export const SMITHERS_CAPABILITY_PROMPT = `Generate a Smithers workflow that can use the full Smithers capability surface when relevant:
+- Task agents with typed Zod outputs, prompts, tool access, retries, timeouts, and structured summaries.
+- Sequence for deterministic step order.
+- Parallel and merge-queue for concurrent research, implementation, validation, or agent debates.
+- Ralph/Loop for iterative implement-review-fix or multi-round debate cycles.
+- Branch/decision routing for conditional follow-up work.
+- Approval and HumanTask for operator gates, decisions, selections, and final release approval.
+- Worktree and Sandbox for isolated code execution, patch validation, and review.
+- Scorers/evals for repeatable quality checks and judge tasks.
+- Memory recall/remember for durable context across long-running runs.
+- Timers, wait-for-event, and signals for async external coordination.
+- Saga and try/catch/finally for rollback and cleanup.
+- Continue-as-new for long horizon workflows.
+- Gateway/devtools observability so operators can inspect active runs.
+
+Return a workflow that makes control flow explicit in the graph and in the generated Smithers React code.`;
+
+const baseNodes: WorkflowNodeSpec[] = [
+  {
+    id: "intake",
+    label: "Intake",
+    kind: "agent",
+    output: "intake",
+    prompt: "Summarize the request, identify constraints, and list missing facts.",
+    dependsOn: [],
+  },
+  {
+    id: "plan",
+    label: "Plan",
+    kind: "agent",
+    output: "plan",
+    prompt: "Create an implementation plan with risk areas and verification steps.",
+    dependsOn: ["intake"],
+  },
+];
+
+function normalizePrompt(prompt: string) {
+  return prompt.trim().replace(/\s+/g, " ");
+}
+
+function includesAny(text: string, terms: string[]) {
+  return terms.some((term) => text.includes(term));
+}
+
+function slugify(value: string) {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 40);
+  return slug || "generated-workflow";
+}
+
+function outputSchemaFor(node: WorkflowNodeSpec) {
+  if (node.output === "finalResult") {
+    return "z.object({ winner: z.string(), reasoning: z.string(), caveats: z.array(z.string()).default([]) })";
+  }
+  if (node.kind === "approval") {
+    return "z.object({ approved: z.boolean(), note: z.string().nullable() })";
+  }
+  return "z.object({ summary: z.string(), evidence: z.array(z.string()).default([]) })";
+}
+
+export function generateWorkflowFromPrompt(prompt: string): WorkflowSpec {
+  const normalized = normalizePrompt(prompt);
+  const lower = normalized.toLowerCase();
+
+  if (
+    includesAny(lower, ["communism", "capitalism"]) &&
+    includesAny(lower, ["debate", "judge", "final result"])
+  ) {
+    return {
+      name: "communism-capitalism-debate-loop",
+      description: normalized,
+      inputPrompt: normalized,
+      nodes: [
+        {
+          id: "debate_loop",
+          label: "Debate Loop",
+          kind: "loop",
+          output: "debateLoop",
+          prompt: "Run two debate rounds, carrying the transcript forward each iteration.",
+          dependsOn: [],
+        },
+        {
+          id: "capitalism_round_1",
+          label: "Capitalism LM R1",
+          kind: "agent",
+          output: "capitalismRound1",
+          prompt: "Argue for capitalism in round 1 and set up concrete claims.",
+          dependsOn: ["debate_loop"],
+        },
+        {
+          id: "communism_round_1",
+          label: "Communism LM R1",
+          kind: "agent",
+          output: "communismRound1",
+          prompt: "Argue for communism in round 1 and respond to capitalism.",
+          dependsOn: ["capitalism_round_1"],
+        },
+        {
+          id: "capitalism_round_2",
+          label: "Capitalism LM R2",
+          kind: "agent",
+          output: "capitalismRound2",
+          prompt: "Rebut the communism LM and refine the capitalism case.",
+          dependsOn: ["communism_round_1"],
+        },
+        {
+          id: "communism_round_2",
+          label: "Communism LM R2",
+          kind: "agent",
+          output: "communismRound2",
+          prompt: "Rebut the capitalism LM and refine the communism case.",
+          dependsOn: ["capitalism_round_2"],
+        },
+        {
+          id: "judge_final",
+          label: "Judge LM",
+          kind: "agent",
+          output: "finalResult",
+          prompt: "Judge the debate and output the final result with winner, reasoning, and caveats.",
+          dependsOn: ["communism_round_2"],
+        },
+      ],
+    };
+  }
+
+  const nodes = [...baseNodes];
+
+  const wantsResearch = includesAny(lower, ["research", "discover", "investigate", "audit"]);
+  const wantsImplementation = includesAny(lower, ["build", "implement", "fix", "code", "generate"]);
+  const wantsDocs = includesAny(lower, ["docs", "documentation", "guide", "readme"]);
+  const wantsValidation = includesAny(lower, ["test", "validate", "verify", "qa", "review"]);
+  const wantsRelease = includesAny(lower, ["release", "deploy", "ship", "publish"]);
+  const wantsSandbox = includesAny(lower, ["sandbox", "isolate", "safe", "untrusted"]);
+  const wantsWorktree = includesAny(lower, ["worktree", "branch", "patch", "diff"]);
+  const wantsLoop = includesAny(lower, ["loop", "iterate", "retry", "review loop", "until"]);
+  const wantsHuman = includesAny(lower, ["human", "operator", "approval", "manual"]);
+  const wantsAsync = includesAny(lower, ["timer", "signal", "event", "webhook", "async"]);
+
+  if (wantsWorktree) {
+    nodes.push({
+      id: "worktree",
+      label: "Worktree",
+      kind: "worktree",
+      output: "worktree",
+      prompt: "Create or reuse an isolated worktree for patch generation and review.",
+      dependsOn: ["plan"],
+    });
+  }
+
+  if (wantsResearch) {
+    nodes.push({
+      id: "research",
+      label: "Research",
+      kind: "agent",
+      output: "research",
+      prompt: "Inspect the repository and external context, then produce concrete findings.",
+      dependsOn: [wantsWorktree ? "worktree" : "plan"],
+      parallelGroupId: "discovery",
+    });
+  }
+
+  if (wantsLoop) {
+    nodes.push({
+      id: "iteration_loop",
+      label: "Ralph Loop",
+      kind: "loop",
+      output: "iterationLoop",
+      prompt: "Repeat implementation and validation until the scorer and reviewer approve.",
+      dependsOn: [wantsResearch ? "research" : wantsWorktree ? "worktree" : "plan"],
+    });
+  }
+
+  if (wantsImplementation || !wantsDocs) {
+    nodes.push({
+      id: "implement",
+      label: "Implement",
+      kind: "agent",
+      output: "implementation",
+      prompt: "Make the requested code changes and keep the diff scoped.",
+      dependsOn: [wantsLoop ? "iteration_loop" : wantsResearch ? "research" : wantsWorktree ? "worktree" : "plan"],
+    });
+  }
+
+  if (wantsSandbox) {
+    nodes.push({
+      id: "sandbox_verify",
+      label: "Sandbox Verify",
+      kind: "sandbox",
+      output: "sandboxVerification",
+      prompt: "Run generated code or commands inside a sandbox and summarize failures.",
+      dependsOn: [nodes.some((node) => node.id === "implement") ? "implement" : "plan"],
+    });
+  }
+
+  if (wantsDocs) {
+    nodes.push({
+      id: "document",
+      label: "Document",
+      kind: "agent",
+      output: "documentation",
+      prompt: "Write user-facing documentation and a runnable example.",
+      dependsOn: [wantsImplementation ? "implement" : "plan"],
+      parallelGroupId: wantsValidation ? "quality" : undefined,
+    });
+  }
+
+  if (wantsValidation || wantsRelease) {
+    nodes.push({
+      id: "validate",
+      label: "Validate",
+      kind: "agent",
+      output: "validation",
+      prompt: "Run tests, type checks, and visual verification. Report failures with fixes.",
+      dependsOn: [
+        nodes.some((node) => node.id === "sandbox_verify")
+          ? "sandbox_verify"
+          : nodes.some((node) => node.id === "implement")
+            ? "implement"
+            : "plan",
+      ],
+      parallelGroupId: wantsDocs ? "quality" : undefined,
+    });
+  }
+
+  if (wantsAsync) {
+    nodes.push({
+      id: "external_signal",
+      label: "Wait/Signal",
+      kind: "signal",
+      output: "externalSignal",
+      prompt: "Wait for an external event or timer signal before finalizing.",
+      dependsOn: [nodes.at(-1)?.id ?? "plan"],
+    });
+  }
+
+  if (wantsRelease || wantsHuman) {
+    nodes.push({
+      id: "approval",
+      label: "Approval",
+      kind: "approval",
+      output: "approval",
+      prompt: "Ask a human operator to approve the release candidate.",
+      dependsOn: [nodes.some((node) => node.id === "validate") ? "validate" : (nodes.at(-1)?.id ?? "plan")],
+    });
+  }
+
+  if (wantsRelease) {
+    nodes.push({
+      id: "release",
+      label: "Release",
+      kind: "agent",
+      output: "release",
+      prompt: "Prepare release notes and publish the validated workflow.",
+      dependsOn: ["approval"],
+    });
+  }
+
+  if (!nodes.some((node) => node.id === "validate")) {
+    nodes.push({
+      id: "review",
+      label: "Review",
+      kind: "agent",
+      output: "review",
+      prompt: "Review the generated work for correctness, clarity, and missing tests.",
+      dependsOn: [nodes.at(-1)?.id ?? "plan"],
+    });
+  }
+
+  return {
+    name: slugify(normalized),
+    description: normalized || "Generate and validate a Smithers workflow.",
+    inputPrompt: normalized || "Build a Smithers workflow with implementation and validation.",
+    nodes,
+  };
+}
+
+export function generateSmithersCode(spec: WorkflowSpec) {
+  if (spec.name === "communism-capitalism-debate-loop") {
+    return generateDebateSmithersCode(spec);
+  }
+
+  const outputs = spec.nodes.map((node) => `  ${node.output}: ${outputSchemaFor(node)},`).join("\n");
+
+  const taskCode = spec.nodes
+    .map((node) => {
+      const needs =
+        node.dependsOn.length > 0
+          ? ` needs={{ ${node.dependsOn.map((id) => `${id}: "${id}"`).join(", ")} }}`
+          : "";
+      const approval = node.kind === "approval" ? " needsApproval approvalMode=\"decision\"" : "";
+      const meta = ` meta={{ kind: "${node.kind}" }}`;
+      return `      <Task id="${node.id}" output={outputs.${node.output}} agent={agent}${needs}${approval}>
+        {\`${node.prompt}\n\n${SMITHERS_CAPABILITY_PROMPT}\`}
+      </Task>`;
+    })
+    .join("\n\n");
+
+  return `import { createSmithers, Sequence, Task, Workflow } from "smithers-orchestrator";
+import { z } from "zod";
+
+const { smithers, outputs } = createSmithers({
+${outputs}
+});
+
+export default smithers((ctx) => (
+  <Workflow name="${spec.name}">
+    {/* ${SMITHERS_CAPABILITY_PROMPT.replaceAll("\n", "\n    ")} */}
+    <Sequence>
+${taskCode}
+    </Sequence>
+  </Workflow>
+));`;
+}
+
+function generateDebateSmithersCode(spec: WorkflowSpec) {
+  const outputs = spec.nodes.map((node) => `  ${node.output}: ${outputSchemaFor(node)},`).join("\n");
+
+  return `import { createSmithers, Ralph, Sequence, Task, Workflow } from "smithers-orchestrator";
+import { z } from "zod";
+
+const { smithers, outputs } = createSmithers({
+${outputs}
+});
+
+export default smithers((ctx) => (
+  <Workflow name="${spec.name}">
+    {/* ${SMITHERS_CAPABILITY_PROMPT.replaceAll("\n", "\n    ")} */}
+    <Sequence>
+      <Ralph id="debate_loop" maxIterations={2} until={() => false}>
+        <Task id="capitalism_round" output={outputs.capitalismRound1} agent={capitalismLm}>
+          {\`Argue for capitalism, respond to the prior communism argument, and append evidence to the transcript.
+
+Prompt: ${spec.inputPrompt}\`}
+        </Task>
+
+        <Task id="communism_round" output={outputs.communismRound1} agent={communismLm}>
+          {\`Argue for communism, respond to the prior capitalism argument, and append evidence to the transcript.
+
+Prompt: ${spec.inputPrompt}\`}
+        </Task>
+      </Ralph>
+
+      <Task
+        id="judge_final"
+        output={outputs.finalResult}
+        agent={judgeLm}
+        needs={{ debate: "debate_loop" }}
+      >
+        {\`Evaluate the two-LM debate fairly and output the final result with winner, reasoning, and caveats.\`}
+      </Task>
+    </Sequence>
+  </Workflow>
+));`;
+}

--- a/apps/smithers-demo/src/workflowRuntime.js
+++ b/apps/smithers-demo/src/workflowRuntime.js
@@ -1,0 +1,38 @@
+import { DEBATE_E2E_PROMPT } from "./cerebrasDebate.js";
+
+export function generateRuntimeWorkflowFromPrompt(prompt = DEBATE_E2E_PROMPT) {
+  const normalized = prompt.trim() || DEBATE_E2E_PROMPT;
+  const lower = normalized.toLowerCase();
+
+  if (lower.includes("communism") && lower.includes("capitalism") && lower.includes("debate")) {
+    return {
+      name: "communism-capitalism-debate-loop",
+      nodes: [
+        { id: "debate_loop", label: "Debate Loop", kind: "loop", dependsOn: [] },
+        { id: "capitalism_round_1", label: "Capitalism LM R1", kind: "agent", dependsOn: ["debate_loop"] },
+        { id: "communism_round_1", label: "Communism LM R1", kind: "agent", dependsOn: ["capitalism_round_1"] },
+        { id: "capitalism_round_2", label: "Capitalism LM R2", kind: "agent", dependsOn: ["communism_round_1"] },
+        { id: "communism_round_2", label: "Communism LM R2", kind: "agent", dependsOn: ["capitalism_round_2"] },
+        { id: "judge_final", label: "Judge LM", kind: "agent", dependsOn: ["communism_round_2"] },
+      ],
+    };
+  }
+
+  const nodes = [
+    { id: "intake", label: "Intake", kind: "agent", dependsOn: [] },
+    { id: "plan", label: "Plan", kind: "agent", dependsOn: ["intake"] },
+  ];
+  if (/(research|audit|investigate)/.test(lower)) nodes.push({ id: "research", label: "Research", kind: "agent", dependsOn: ["plan"] });
+  if (/(worktree|branch|patch|diff)/.test(lower)) nodes.push({ id: "worktree", label: "Worktree", kind: "worktree", dependsOn: [nodes.at(-1).id] });
+  if (/(loop|iterate|retry)/.test(lower)) nodes.push({ id: "iteration_loop", label: "Ralph Loop", kind: "loop", dependsOn: [nodes.at(-1).id] });
+  nodes.push({ id: "implement", label: "Implement", kind: "agent", dependsOn: [nodes.at(-1).id] });
+  if (/(sandbox|safe|isolate)/.test(lower)) nodes.push({ id: "sandbox_verify", label: "Sandbox Verify", kind: "sandbox", dependsOn: ["implement"] });
+  if (/(docs|documentation|readme)/.test(lower)) nodes.push({ id: "document", label: "Document", kind: "agent", dependsOn: ["implement"] });
+  nodes.push({ id: "validate", label: "Validate", kind: "agent", dependsOn: [nodes.at(-1).id] });
+  if (/(approval|human|operator|release|deploy|ship)/.test(lower)) nodes.push({ id: "approval", label: "Approval", kind: "approval", dependsOn: ["validate"] });
+
+  return {
+    name: normalized.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 40) || "generated-workflow",
+    nodes,
+  };
+}

--- a/apps/smithers-demo/tests/cerebrasDebate.e2e.test.ts
+++ b/apps/smithers-demo/tests/cerebrasDebate.e2e.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+import { callCerebrasChat, callProviderChat, DEBATE_E2E_PROMPT, runDebateWorkflow } from "../src/cerebrasDebate.js";
+
+describe("Cerebras debate e2e workflow", () => {
+  test("runs the required communism versus capitalism loop through a judge", async () => {
+    const calls: string[] = [];
+    const result = await runDebateWorkflow({
+      apiKey: "test-key",
+      prompt: DEBATE_E2E_PROMPT,
+      rounds: 2,
+      chat: async ({ messages }) => {
+        const role = String(messages[0].content).includes("neutral judge")
+          ? "judge"
+          : String(messages[0].content).includes("capitalism")
+            ? "capitalism"
+            : "communism";
+        calls.push(role);
+        return `${role} generated response`;
+      },
+    });
+
+    expect(result.prompt).toBe(DEBATE_E2E_PROMPT);
+    expect(calls).toEqual(["capitalism", "communism", "capitalism", "communism", "judge"]);
+    expect(result.transcript).toHaveLength(5);
+    expect(result.finalResult).toBe("judge generated response");
+  });
+
+  test("supports OpenAI and Claude provider request shapes", async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+
+    await callProviderChat({
+      provider: "openai",
+      apiKey: "openai-key",
+      model: "gpt-5.5",
+      messages: [{ role: "user", content: DEBATE_E2E_PROMPT }],
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), init: init ?? {} });
+        return new Response(JSON.stringify({ choices: [{ message: { content: "openai result" } }] }), {
+          status: 200,
+        });
+      }) as typeof fetch,
+    });
+
+    await callProviderChat({
+      provider: "anthropic",
+      apiKey: "anthropic-key",
+      model: "claude-opus-4.7",
+      messages: [
+        { role: "system", content: "judge fairly" },
+        { role: "user", content: DEBATE_E2E_PROMPT },
+      ],
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), init: init ?? {} });
+        return new Response(JSON.stringify({ content: [{ type: "text", text: "claude result" }] }), {
+          status: 200,
+        });
+      }) as typeof fetch,
+    });
+
+    expect(requests[0].url).toBe("https://api.openai.com/v1/chat/completions");
+    expect(requests[0].init.headers).toMatchObject({ Authorization: "Bearer openai-key" });
+    expect(JSON.parse(String(requests[0].init.body))).toMatchObject({ model: "gpt-5.5" });
+    expect(requests[1].url).toBe("https://api.anthropic.com/v1/messages");
+    expect(requests[1].init.headers).toMatchObject({ "x-api-key": "anthropic-key" });
+    expect(JSON.parse(String(requests[1].init.body))).toMatchObject({ model: "claude-opus-4.7" });
+  });
+
+  test("posts to the real Cerebras chat completions endpoint shape", async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const content = await callCerebrasChat({
+      apiKey: "test-key",
+      model: "gpt-oss-120b",
+      messages: [{ role: "user", content: DEBATE_E2E_PROMPT }],
+      fetchImpl: (async (url, init) => {
+        requests.push({ url: String(url), init: init ?? {} });
+        return new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "generated final result" } }],
+          }),
+          { status: 200 },
+        );
+      }) as typeof fetch,
+    });
+
+    expect(content).toBe("generated final result");
+    expect(requests[0].url).toBe("https://api.cerebras.ai/v1/chat/completions");
+    expect(requests[0].init.method).toBe("POST");
+    expect(requests[0].init.headers).toMatchObject({
+      Authorization: "Bearer test-key",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(requests[0].init.body))).toMatchObject({
+      model: "gpt-oss-120b",
+      messages: [{ role: "user", content: DEBATE_E2E_PROMPT }],
+    });
+  });
+
+  test("cancels a running provider workflow through AbortSignal", async () => {
+    const controller = new AbortController();
+    const calls: string[] = [];
+
+    await expect(
+      runDebateWorkflow({
+        apiKey: "test-key",
+        prompt: DEBATE_E2E_PROMPT,
+        signal: controller.signal,
+        chat: async ({ messages, signal }) => {
+          calls.push(String(messages[0].content));
+          controller.abort(new Error("Workflow cancelled"));
+          signal?.throwIfAborted();
+          return "should not complete";
+        },
+      }),
+    ).rejects.toThrow("Workflow cancelled");
+
+    expect(calls).toHaveLength(1);
+  });
+
+  const liveTest = process.env.CEREBRAS_API_KEY ? test : test.skip;
+
+  liveTest("generates a real Cerebras debate result when CEREBRAS_API_KEY is set", async () => {
+    const result = await runDebateWorkflow({
+      apiKey: process.env.CEREBRAS_API_KEY ?? "",
+      prompt: DEBATE_E2E_PROMPT,
+      rounds: 1,
+    });
+
+    expect(result.finalResult.length).toBeGreaterThan(20);
+    expect(result.transcript.at(-1)?.role).toBe("judge-final");
+  });
+});

--- a/apps/smithers-demo/tests/e2e/workflow-studio.spec.ts
+++ b/apps/smithers-demo/tests/e2e/workflow-studio.spec.ts
@@ -1,0 +1,94 @@
+import { expect, type Page, test } from "@playwright/test";
+
+async function expectNodesDoNotOverlap(page: Page) {
+  const boxes = await page.locator(".react-flow__node").evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const rect = node.getBoundingClientRect();
+      return {
+        text: node.textContent ?? "",
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+      };
+    }),
+  );
+
+  expect(boxes.length).toBeGreaterThanOrEqual(5);
+  for (let first = 0; first < boxes.length; first += 1) {
+    for (let second = first + 1; second < boxes.length; second += 1) {
+      const a = boxes[first];
+      const b = boxes[second];
+      const separated = a.right <= b.left + 1 || b.right <= a.left + 1 || a.bottom <= b.top + 1 || b.bottom <= a.top + 1;
+      expect(separated, `${a.text} overlaps ${b.text}`).toBe(true);
+    }
+  }
+}
+
+test("generates, lays out, persists settings, and runs a provider-backed workflow", async ({ page }) => {
+  let providerCall = 0;
+  await page.route("https://api.openai.com/v1/chat/completions", async (route) => {
+    providerCall += 1;
+    const body = route.request().postDataJSON();
+    expect(body.model).toBe("gpt-5.5");
+    expect(body.messages.at(0).role).toBe("system");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: `stubbed provider response ${providerCall}`,
+            },
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Workflow Studio" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Run Workflow" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Run (Cerebras|OpenAI|Claude)/ })).toHaveCount(0);
+  await expect(page.getByLabel("Generated workflow graph")).toContainText("Debate Loop");
+  await expect(page.getByLabel("Generated workflow graph")).toContainText("Judge LM");
+  await expect(page.getByText("layout valid")).toBeVisible();
+  await expectNodesDoNotOverlap(page);
+
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByLabel("Provider", { exact: true }).selectOption("openai");
+  await page.getByLabel("Provider API key").fill("test-openai-key");
+  await page.getByLabel("Provider model").fill("gpt-5.5");
+  await page.reload();
+  await page.getByRole("button", { name: "Settings" }).click();
+  await expect(page.getByLabel("Provider", { exact: true })).toHaveValue("openai");
+  await expect(page.getByLabel("Provider API key")).toHaveValue("test-openai-key");
+  await expect(page.getByLabel("Provider model")).toHaveValue("gpt-5.5");
+
+  await page.getByLabel("Workflow prompt").fill("Research and audit a dependency update, implement the fix, then verify with tests");
+  await page.getByRole("button", { name: "Generate" }).click();
+  await expect(page.getByLabel("Generated workflow graph")).toContainText("Research");
+  await expect(page.getByLabel("Generated workflow graph")).toContainText("Validate");
+  await expect(page.getByText("Local generation updated 1 time.")).toBeVisible();
+  await expectNodesDoNotOverlap(page);
+
+  await page.getByLabel("Workflow prompt").fill(
+    "Do a loop where you have two LMs debate communism versus capitalism and then have a judge LM output a final result.",
+  );
+  await page.getByRole("button", { name: "Run Workflow" }).click();
+  await expect(page.getByLabel("Generation output")).toContainText("Running OpenAI debate loop with gpt-5.5");
+  await expect(page.getByLabel("Generation output")).toContainText("[judge-final]");
+  await expect(page.getByLabel("Generation output")).toContainText("[final]");
+  expect(providerCall).toBe(5);
+});
+
+test("keeps the bottom composer usable on mobile", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByLabel("Generated workflow graph")).toContainText("Debate Loop");
+  await expect(page.getByLabel("Workflow prompt")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Generate" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Run Workflow" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Run (Cerebras|OpenAI|Claude)/ })).toHaveCount(0);
+  await expect(page.getByText("layout valid")).toBeVisible();
+});

--- a/apps/smithers-demo/tests/layout.test.ts
+++ b/apps/smithers-demo/tests/layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { findOverlappingRects, nodeRects, validateLayout, workflowToFlow } from "../src/layout";
+import { generateWorkflowFromPrompt } from "../src/workflowModel";
+
+describe("workflow layout", () => {
+  test("auto-layout spaces generated nodes without overlap", () => {
+    const spec = generateWorkflowFromPrompt(
+      "Research, build, document, test, validate, and release a multi-agent workflow",
+    );
+    const flow = workflowToFlow(spec);
+    const validation = validateLayout(flow.nodes);
+
+    expect(validation.valid).toBe(true);
+    expect(validation.overlaps).toEqual([]);
+    expect(nodeRects(flow.nodes)).toHaveLength(spec.nodes.length);
+  });
+
+  test("overlap detector fails when node rectangles collide", () => {
+    const overlaps = findOverlappingRects(
+      [
+        { id: "a", x: 0, y: 0, width: 220, height: 96 },
+        { id: "b", x: 30, y: 20, width: 220, height: 96 },
+      ],
+      12,
+    );
+
+    expect(overlaps).toEqual([["a", "b"]]);
+  });
+});

--- a/apps/smithers-demo/tests/workflowModel.test.ts
+++ b/apps/smithers-demo/tests/workflowModel.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { generateSmithersCode, generateWorkflowFromPrompt } from "../src/workflowModel";
+
+describe("workflow generation", () => {
+  test("generates Smithers React code and workflow nodes from chat prompt", () => {
+    const spec = generateWorkflowFromPrompt(
+      "Research docs, implement a workflow generator, test it, and release it",
+    );
+
+    expect(spec.nodes.map((node) => node.id)).toEqual([
+      "intake",
+      "plan",
+      "research",
+      "implement",
+      "document",
+      "validate",
+      "approval",
+      "release",
+    ]);
+
+    const code = generateSmithersCode(spec);
+    expect(code).toContain("<Workflow name=");
+    expect(code).toContain('<Task id="validate"');
+    expect(code).toContain('needs={{ implement: "implement" }}');
+  });
+
+  test("creates the required debate loop graph for the e2e prompt", () => {
+    const spec = generateWorkflowFromPrompt(
+      "Do a loop where you have two LMs debate communism versus capitalism and then have a judge LM output a final result.",
+    );
+
+    expect(spec.nodes.map((node) => node.id)).toEqual([
+      "debate_loop",
+      "capitalism_round_1",
+      "communism_round_1",
+      "capitalism_round_2",
+      "communism_round_2",
+      "judge_final",
+    ]);
+    expect(generateSmithersCode(spec)).toContain('id="judge_final"');
+  });
+});

--- a/apps/smithers-demo/tsconfig.json
+++ b/apps/smithers-demo/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsxImportSource": "react",
+    "noEmit": true,
+    "baseUrl": "."
+  },
+  "include": ["src", "tests/*.test.ts", "vite.config.ts"],
+  "exclude": ["tests/e2e", "src/tui-demo.mjs"]
+}

--- a/apps/smithers-demo/vite.config.ts
+++ b/apps/smithers-demo/vite.config.ts
@@ -1,0 +1,16 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5174,
+    strictPort: false,
+  },
+  preview: {
+    host: "127.0.0.1",
+    port: 4174,
+    strictPort: false,
+  },
+});

--- a/apps/smithers-tui-demo/package.json
+++ b/apps/smithers-tui-demo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@smithers-orchestrator/smithers-tui-demo",
+  "version": "0.21.0",
+  "description": "React TUI Smithers Cerebras debate demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "tui": "node src/tui-demo.mjs",
+    "smoke": "SMITHERS_TUI_SMOKE=1 node src/tui-demo.mjs",
+    "test": "node --test src/*.test.mjs && SMITHERS_TUI_SMOKE=1 node src/tui-demo.mjs"
+  },
+  "dependencies": {
+    "@dino-dna/react-tui": "^1.0.1",
+    "neo-blessed": "^0.2.0",
+    "react": "16.13.1"
+  }
+}

--- a/apps/smithers-tui-demo/src/tui-demo.mjs
+++ b/apps/smithers-tui-demo/src/tui-demo.mjs
@@ -1,0 +1,194 @@
+import React from "react";
+import blessed from "neo-blessed";
+import { createBlessedRenderer } from "@dino-dna/react-tui";
+import {
+  DEBATE_E2E_PROMPT,
+  defaultModelForProvider,
+  PROVIDER_OPTIONS,
+  runDebateWorkflow,
+} from "../../smithers-demo/src/cerebrasDebate.js";
+import { generateRuntimeWorkflowFromPrompt } from "../../smithers-demo/src/workflowRuntime.js";
+import { renderWorkflowGraph } from "./tuiGraph.mjs";
+import { buttonLabelForRunState, statusIdForRole } from "./tuiState.mjs";
+
+const screen = blessed.screen({
+  smartCSR: true,
+  title: "Smithers React TUI Demo",
+});
+
+screen.key(["C-c", "q"], () => process.exit(0));
+
+const render = createBlessedRenderer(blessed, screen);
+const container = blessed.box({ width: "100%", height: "100%" });
+screen.append(container);
+
+function App() {
+  const provider = process.env.OPENAI_API_KEY
+    ? "openai"
+    : process.env.ANTHROPIC_API_KEY
+      ? "anthropic"
+      : "cerebras";
+  const apiKey =
+    process.env.OPENAI_API_KEY ?? process.env.ANTHROPIC_API_KEY ?? process.env.CEREBRAS_API_KEY ?? "";
+  const envVar = PROVIDER_OPTIONS[provider].envVar;
+  const model = process.env.SMITHERS_TUI_MODEL ?? defaultModelForProvider(provider);
+  const [prompt, setPrompt] = React.useState(DEBATE_E2E_PROMPT);
+  const [runState, setRunState] = React.useState("idle");
+  const [status, setStatus] = React.useState(
+    apiKey
+      ? `${PROVIDER_OPTIONS[provider].label} ready from ${envVar}. Type a prompt, Generate the graph, or Run Workflow.`
+      : `Set ${envVar} before running this TUI. Graph regeneration still works locally.`,
+  );
+  const [nodeStatuses, setNodeStatuses] = React.useState({});
+  const abortRef = React.useRef(null);
+  const spec = generateRuntimeWorkflowFromPrompt(prompt);
+  const graph = renderWorkflowGraph(spec, nodeStatuses);
+
+  function resetRunState(nextStatus) {
+    abortRef.current = null;
+    setRunState("idle");
+    setNodeStatuses({});
+    if (nextStatus) setStatus(nextStatus);
+  }
+
+  function cancelRun() {
+    abortRef.current?.abort(new Error("Workflow cancelled"));
+    setRunState("cancelled");
+    setNodeStatuses((current) =>
+      Object.fromEntries(Object.entries(current).map(([id, state]) => [id, state === "running" ? "cancelled" : state])),
+    );
+    setStatus("Workflow cancelled. Edit the prompt or Run Workflow again.");
+  }
+
+  async function run() {
+    if (runState === "running") {
+      cancelRun();
+      return;
+    }
+    if (runState === "done") {
+      resetRunState(`Ready. Run Workflow starts ${PROVIDER_OPTIONS[provider].label} again.`);
+      return;
+    }
+    if (!apiKey) {
+      setStatus(`Set ${envVar} before running live generation.`);
+      return;
+    }
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRunState("running");
+    setNodeStatuses({});
+    setStatus(`Running ${PROVIDER_OPTIONS[provider].label} debate loop with ${model}...`);
+    try {
+      const result = await runDebateWorkflow({
+        apiKey,
+        provider,
+        model,
+        prompt,
+        rounds: 2,
+        signal: controller.signal,
+        onStep: (step) => {
+          setNodeStatuses((current) => ({
+            ...current,
+            [statusIdForRole(step.role)]: step.status === "complete" ? "complete" : "running",
+          }));
+        },
+      });
+      abortRef.current = null;
+      setRunState("done");
+      setNodeStatuses((current) => ({ ...current, judge_final: "complete" }));
+      setStatus(`Done. ${result.transcript.length} workflow steps completed. Press Done to reset.`);
+    } catch (error) {
+      abortRef.current = null;
+      if (controller.signal.aborted) {
+        setRunState("cancelled");
+        setStatus("Workflow cancelled. Edit the prompt or Run Workflow again.");
+      } else {
+        setRunState("error");
+        setNodeStatuses((current) =>
+          Object.fromEntries(Object.entries(current).map(([id, state]) => [id, state === "running" ? "error" : state])),
+        );
+        setStatus(error instanceof Error ? error.message : String(error));
+      }
+    }
+  }
+
+  function regenerate(value) {
+    const nextPrompt = value || DEBATE_E2E_PROMPT;
+    abortRef.current?.abort(new Error("Workflow cancelled"));
+    setPrompt(nextPrompt);
+    setRunState("idle");
+    setNodeStatuses({});
+    setStatus(`Graph regenerated with ${generateRuntimeWorkflowFromPrompt(nextPrompt).nodes.length} nodes.`);
+  }
+
+  return React.createElement(
+    "box",
+    { width: "100%", height: "100%", border: "line", label: " Smithers Workflow TUI " },
+    React.createElement("text", {
+      top: 1,
+      left: 2,
+      width: "80%",
+      content: `${PROVIDER_OPTIONS[provider].label}  |  ${model}  |  ${apiKey ? `${envVar} set` : `${envVar} missing`}`,
+    }),
+    React.createElement("button", {
+      top: 1,
+      right: 2,
+      width: 18,
+      height: 3,
+      border: "line",
+      content: buttonLabelForRunState(runState),
+      align: "center",
+      valign: "middle",
+      mouse: true,
+      keys: true,
+      onPress: run,
+    }),
+    React.createElement("text", { top: 4, left: 2, width: "96%", content: status }),
+    React.createElement("box", {
+      top: 6,
+      left: 2,
+      right: 2,
+      bottom: 5,
+      border: "line",
+      scrollable: true,
+      alwaysScroll: true,
+      keys: true,
+      mouse: true,
+      content: graph,
+      label: runState === "running" ? " Workflow running " : " Workflow graph ",
+    }),
+    React.createElement("textbox", {
+      bottom: 1,
+      left: 2,
+      right: 22,
+      height: 3,
+      border: "line",
+      inputOnFocus: true,
+      onSubmit: regenerate,
+      label: " Workflow prompt ",
+    }),
+    React.createElement("button", {
+      bottom: 1,
+      right: 2,
+      width: 18,
+      height: 3,
+      border: "line",
+      content: "Generate",
+      align: "center",
+      valign: "middle",
+      mouse: true,
+      keys: true,
+      onPress: () => regenerate(prompt),
+    }),
+  );
+}
+
+render(React.createElement(App), container);
+screen.render();
+
+if (process.env.SMITHERS_TUI_SMOKE === "1") {
+  setTimeout(() => {
+    screen.destroy();
+    process.exit(0);
+  }, 50);
+}

--- a/apps/smithers-tui-demo/src/tuiGraph.mjs
+++ b/apps/smithers-tui-demo/src/tuiGraph.mjs
@@ -1,0 +1,174 @@
+const NODE_WIDTH = 24;
+const NODE_HEIGHT = 4;
+const MAX_COLUMNS = 3;
+
+function writeText(canvas, row, column, text) {
+  if (row < 0 || row >= canvas.length) return;
+  for (let index = 0; index < text.length; index += 1) {
+    const target = column + index;
+    if (target >= 0 && target < canvas[row].length) {
+      canvas[row][target] = text[index];
+    }
+  }
+}
+
+function writeBox(canvas, row, column, width, height, lines) {
+  writeText(canvas, row, column, `+${"-".repeat(width - 2)}+`);
+  for (let offset = 1; offset < height - 1; offset += 1) {
+    writeText(canvas, row + offset, column, `|${" ".repeat(width - 2)}|`);
+  }
+  writeText(canvas, row + height - 1, column, `+${"-".repeat(width - 2)}+`);
+  lines.slice(0, height - 2).forEach((line, index) => {
+    writeText(canvas, row + index + 1, column + 2, line.slice(0, width - 4).padEnd(width - 4));
+  });
+}
+
+function writeHorizontal(canvas, row, fromColumn, toColumn) {
+  const start = Math.min(fromColumn, toColumn);
+  const end = Math.max(fromColumn, toColumn);
+  for (let column = start; column <= end; column += 1) {
+    if (row >= 0 && row < canvas.length && column >= 0 && column < canvas[row].length && canvas[row][column] === " ") {
+      canvas[row][column] = "-";
+    }
+  }
+}
+
+function writeVertical(canvas, column, fromRow, toRow) {
+  const start = Math.min(fromRow, toRow);
+  const end = Math.max(fromRow, toRow);
+  for (let row = start; row <= end; row += 1) {
+    if (row >= 0 && row < canvas.length && column >= 0 && column < canvas[row].length && canvas[row][column] === " ") {
+      canvas[row][column] = "|";
+    }
+  }
+}
+
+function markerForStatus(status) {
+  if (status === "running") return "RUN";
+  if (status === "complete") return "OK ";
+  if (status === "cancelled") return "CAN";
+  if (status === "error") return "ERR";
+  return "RDY";
+}
+
+function compactLabel(label) {
+  return label.replace("Capitalism", "Cap").replace("Communism", "Com").replace("Debate Loop", "Debate");
+}
+
+function compactId(id) {
+  return id
+    .replace("capitalism", "cap")
+    .replace("communism", "com")
+    .replace("round", "r")
+    .replace("judge_final", "judge");
+}
+
+export function layoutWorkflowGraph(spec) {
+  const byId = new Map(spec.nodes.map((node) => [node.id, node]));
+  const layerById = new Map();
+
+  function layerFor(node) {
+    if (layerById.has(node.id)) return layerById.get(node.id);
+    const layer =
+      node.dependsOn.length === 0
+        ? 0
+        : Math.max(...node.dependsOn.map((dependency) => layerFor(byId.get(dependency) ?? { dependsOn: [] }))) + 1;
+    layerById.set(node.id, layer);
+    return layer;
+  }
+
+  spec.nodes.forEach(layerFor);
+
+  const layers = new Map();
+  for (const node of spec.nodes) {
+    const layer = layerById.get(node.id) ?? 0;
+    layers.set(layer, [...(layers.get(layer) ?? []), node]);
+  }
+
+  const maxLayer = Math.max(...layers.keys(), 0);
+  const maxLaneCount = Math.max(...Array.from(layers.values()).map((nodes) => nodes.length), 1);
+  const columnSpacing = NODE_WIDTH + 8;
+  const rowSpacing = NODE_HEIGHT + 1;
+  const columnCount = Math.min(maxLayer + 1, MAX_COLUMNS);
+  const rowBandCount = Math.floor(maxLayer / MAX_COLUMNS) + 1;
+  const width = (columnCount - 1) * columnSpacing + NODE_WIDTH + 4;
+  const height = rowBandCount * maxLaneCount * rowSpacing + 2;
+  const positions = new Map();
+
+  for (const [layer, nodes] of layers.entries()) {
+    nodes.forEach((node, lane) => {
+      positions.set(node.id, {
+        x: 2 + (layer % MAX_COLUMNS) * columnSpacing,
+        y: 1 + (Math.floor(layer / MAX_COLUMNS) * maxLaneCount + lane) * rowSpacing,
+      });
+    });
+  }
+
+  return {
+    width,
+    height,
+    positions,
+    nodeWidth: NODE_WIDTH,
+    nodeHeight: NODE_HEIGHT,
+  };
+}
+
+export function findTuiNodeOverlaps(spec) {
+  const layout = layoutWorkflowGraph(spec);
+  const rects = spec.nodes.map((node) => {
+    const position = layout.positions.get(node.id);
+    return {
+      id: node.id,
+      left: position.x,
+      top: position.y,
+      right: position.x + layout.nodeWidth,
+      bottom: position.y + layout.nodeHeight,
+    };
+  });
+  const overlaps = [];
+
+  for (let first = 0; first < rects.length; first += 1) {
+    for (let second = first + 1; second < rects.length; second += 1) {
+      const a = rects[first];
+      const b = rects[second];
+      if (a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top) {
+        overlaps.push([a.id, b.id]);
+      }
+    }
+  }
+
+  return overlaps;
+}
+
+export function renderWorkflowGraph(spec, statuses = {}) {
+  const layout = layoutWorkflowGraph(spec);
+  const canvas = Array.from({ length: layout.height }, () => Array.from({ length: layout.width }, () => " "));
+
+  for (const node of spec.nodes) {
+    const target = layout.positions.get(node.id);
+    for (const dependencyId of node.dependsOn) {
+      const source = layout.positions.get(dependencyId);
+      if (!source || !target) continue;
+      const sourceX = source.x + layout.nodeWidth;
+      const sourceY = source.y + 1;
+      const targetX = target.x - 1;
+      const targetY = target.y + 1;
+      const elbowX = Math.floor((sourceX + targetX) / 2);
+      writeHorizontal(canvas, sourceY, sourceX, elbowX);
+      writeVertical(canvas, elbowX, sourceY, targetY);
+      writeHorizontal(canvas, targetY, elbowX, targetX);
+      writeText(canvas, targetY, targetX, ">");
+    }
+  }
+
+  for (const node of spec.nodes) {
+    const position = layout.positions.get(node.id);
+    const status = statuses[node.id] ?? "ready";
+    writeBox(canvas, position.y, position.x, layout.nodeWidth, layout.nodeHeight, [
+      `${markerForStatus(status)} ${compactLabel(node.label)}`,
+      `[${node.kind}] ${compactId(node.id)}`,
+    ]);
+  }
+
+  return canvas.map((row) => row.join("").trimEnd()).join("\n").trimEnd();
+}

--- a/apps/smithers-tui-demo/src/tuiGraph.test.mjs
+++ b/apps/smithers-tui-demo/src/tuiGraph.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DEBATE_E2E_PROMPT } from "../../smithers-demo/src/cerebrasDebate.js";
+import { generateRuntimeWorkflowFromPrompt } from "../../smithers-demo/src/workflowRuntime.js";
+import { findTuiNodeOverlaps, layoutWorkflowGraph, renderWorkflowGraph } from "./tuiGraph.mjs";
+
+test("renders workflow nodes in two-dimensional space with visible connections", () => {
+  const spec = generateRuntimeWorkflowFromPrompt(DEBATE_E2E_PROMPT);
+  const graph = renderWorkflowGraph(spec, {
+    debate_loop: "complete",
+    capitalism_round_1: "running",
+  });
+
+  assert.match(graph, /Debate/);
+  assert.match(graph, /Cap LM R1/);
+  assert.match(graph, />/);
+  assert.match(graph, /OK\s+Debate/);
+  assert.match(graph, /RUN Cap LM R1/);
+
+  const lines = graph.split("\n");
+  const debateLine = lines.findIndex((line) => line.includes("Debate"));
+  const capitalismLine = lines.findIndex((line) => line.includes("Cap LM R1"));
+  assert.equal(debateLine, capitalismLine, "dependent nodes should occupy shared 2D rows rather than a vertical list");
+  assert.ok(lines[debateLine].indexOf("Cap LM R1") > lines[debateLine].indexOf("Debate"));
+});
+
+test("keeps terminal graph node boxes from overlapping", () => {
+  const spec = generateRuntimeWorkflowFromPrompt("Research, patch, sandbox, document, validate, and ship");
+  const layout = layoutWorkflowGraph(spec);
+
+  assert.equal(findTuiNodeOverlaps(spec).length, 0);
+  assert.ok(layout.width > layout.nodeWidth * 2);
+  assert.ok(layout.height >= layout.nodeHeight);
+});

--- a/apps/smithers-tui-demo/src/tuiState.mjs
+++ b/apps/smithers-tui-demo/src/tuiState.mjs
@@ -1,0 +1,10 @@
+export function buttonLabelForRunState(runState) {
+  if (runState === "running") return "Cancel";
+  if (runState === "done") return "Done";
+  return "Run Workflow";
+}
+
+export function statusIdForRole(role) {
+  if (role === "judge-final") return "judge_final";
+  return role.replaceAll("-", "_");
+}

--- a/apps/smithers-tui-demo/src/tuiState.test.mjs
+++ b/apps/smithers-tui-demo/src/tuiState.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buttonLabelForRunState, statusIdForRole } from "./tuiState.mjs";
+
+test("run button switches from run to cancel to done", () => {
+  assert.equal(buttonLabelForRunState("idle"), "Run Workflow");
+  assert.equal(buttonLabelForRunState("running"), "Cancel");
+  assert.equal(buttonLabelForRunState("done"), "Done");
+  assert.equal(buttonLabelForRunState("cancelled"), "Run Workflow");
+});
+
+test("maps workflow runtime roles back to TUI graph node ids", () => {
+  assert.equal(statusIdForRole("capitalism-round-1"), "capitalism_round_1");
+  assert.equal(statusIdForRole("communism-round-2"), "communism_round_2");
+  assert.equal(statusIdForRole("judge-final"), "judge_final");
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -211,6 +211,7 @@
           "examples/tools-agent",
           "examples/multi-agent-review",
           "examples/dynamic-plan",
+          "examples/workflow-studio-demo",
           "examples/loop",
           {
             "group": "Workflow Samples",

--- a/docs/examples/workflow-studio-demo.mdx
+++ b/docs/examples/workflow-studio-demo.mdx
@@ -1,0 +1,52 @@
+---
+title: Workflow Studio Demo
+description: Generate Smithers workflows from a chat prompt and inspect the React Flow graph beside the generated Smithers code.
+---
+
+The Smithers Workflow Studio demo lives in `apps/smithers-demo`. It is a Vite React app that uses React Flow (`@xyflow/react`) to render Smithers workflow nodes with automatic Dagre layout.
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-demo dev
+```
+
+The browser demo has synchronized surfaces:
+
+- A bottom prompt composer for regenerating the workflow graph and code.
+- A settings panel with provider, model, and local API key settings.
+- A React Flow graph on the left with generated Smithers task nodes.
+- Generated Smithers React code on the right, produced from the same workflow model as the graph.
+
+Provider defaults:
+
+- Cerebras: `gpt-oss-120b` with `CEREBRAS_API_KEY`
+- OpenAI: `gpt-5.5` with `OPENAI_API_KEY`
+- Claude: `claude-opus-4.7` with `ANTHROPIC_API_KEY`
+
+The same package also includes a terminal demo built with `@dino-dna/react-tui`:
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-tui-demo tui
+```
+
+The TUI reads `CEREBRAS_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` from the environment, renders a connected 2D workflow graph, and keeps the prompt composer at the bottom for local graph regeneration. Running the workflow switches the graph to execution status, changes the action to `Cancel`, and changes it to `Done` after the provider workflow completes. The default workflow prompt is:
+
+```text
+Do a loop where you have two LMs debate communism versus capitalism and then have a judge LM output a final result.
+```
+
+For a non-interactive live provider verification, set one provider key and run:
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-demo cerebras:debate
+```
+
+Run the demo checks with:
+
+```bash
+pnpm --filter @smithers-orchestrator/smithers-demo test
+pnpm --filter @smithers-orchestrator/smithers-demo build
+pnpm --filter @smithers-orchestrator/smithers-demo e2e
+pnpm --filter @smithers-orchestrator/smithers-tui-demo test
+```
+
+The layout tests fail if generated node rectangles overlap, which protects the visual spacing contract for generated diagrams. The Playwright e2e test runs the real Workflow Studio in desktop and mobile viewports, checks settings persistence, verifies prompt regeneration, confirms provider-neutral `Run Workflow` copy, stubs provider output, and asserts rendered React Flow nodes do not overlap. The TUI tests also fail if the terminal graph collapses back into a list, if terminal node boxes overlap, or if the Run Workflow -> Cancel -> Done button contract regresses.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "lint": "oxlint --react-plugin --node-plugin --import-plugin --ignore-path .gitignore -A react/no-children-prop -A unicorn/no-thenable --ignore-pattern 'packages/*/src/**/*.d.ts' packages/*/src packages/*/tests",
     "lint:fix": "oxlint --react-plugin --node-plugin --import-plugin --ignore-path .gitignore -A react/no-children-prop -A unicorn/no-thenable --ignore-pattern 'packages/*/src/**/*.d.ts' --fix --fix-suggestions packages/*/src packages/*/tests",
     "cli": "bun run apps/cli/src/index.js",
+    "demo:smithers": "pnpm --filter @smithers-orchestrator/smithers-demo dev",
+    "demo:smithers:tui": "pnpm --filter @smithers-orchestrator/smithers-tui-demo tui",
     "test": "node scripts/check-single-effect-version.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-architecture-budget.mjs && pnpm -r test",
     "check:effect": "node scripts/check-single-effect-version.mjs",
     "check:deps": "node scripts/check-dependency-boundaries.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 5.99.1(react@19.2.5)
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -151,7 +151,7 @@ importers:
         version: link:packages/smithers
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
       twitter-api-v2:
         specifier: ^1.29.0
         version: 1.29.0
@@ -276,7 +276,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -301,10 +301,53 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+
+  apps/smithers-demo:
+    dependencies:
+      '@xyflow/react':
+        specifier: ^12.10.2
+        version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      dagre:
+        specifier: ^0.8.5
+        version: 0.8.5
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      '@types/dagre':
+        specifier: ^0.7.54
+        version: 0.7.54
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+
+  apps/smithers-tui-demo:
+    dependencies:
+      '@dino-dna/react-tui':
+        specifier: ^1.0.1
+        version: 1.0.1(react@16.13.1)
+      neo-blessed:
+        specifier: ^0.2.0
+        version: 0.2.0
+      react:
+        specifier: 16.13.1
+        version: 16.13.1
 
   e2e:
     dependencies:
@@ -344,7 +387,7 @@ importers:
         version: 7.6.13
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -360,7 +403,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -394,7 +437,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -449,7 +492,7 @@ importers:
         version: 5.99.1(react@19.2.5)
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)
@@ -508,7 +551,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -517,7 +560,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -548,7 +591,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -636,7 +679,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -649,7 +692,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -658,7 +701,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -671,7 +714,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -687,7 +730,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -718,7 +761,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -752,7 +795,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -783,7 +826,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -823,7 +866,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -835,7 +878,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -866,7 +909,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       effect:
         specifier: 3.21.1
         version: 3.21.1
@@ -906,7 +949,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -925,7 +968,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -962,7 +1005,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -1026,7 +1069,7 @@ importers:
         version: link:../graph
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1129,7 +1172,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -1169,7 +1212,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1194,7 +1237,7 @@ importers:
         version: 0.89.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
       '@types/bun':
         specifier: latest
-        version: 1.3.13
+        version: 1.3.14
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -1403,6 +1446,11 @@ packages:
   '@clack/prompts@0.10.1':
     resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
 
+  '@dino-dna/react-tui@1.0.1':
+    resolution: {integrity: sha512-wyLuVEIqibueoP9YkJymghSJffgR6yZFflT2nYyE635GMUrQi9rY2Fi23FPRoiEDMhscuHmTzwFEbLTH2cbdEg==}
+    peerDependencies:
+      react: ^16
+
   '@effect/cluster@0.58.0':
     resolution: {integrity: sha512-0Zog7s7XdntWcTqdqWPoj6nc7hPaWIzp0k0DsFUWyCynXNPK9dAtgFrSce04NhddNqqbhtZck/lhuqJwNBrprQ==}
     peerDependencies:
@@ -1490,6 +1538,15 @@ packages:
       '@effect/platform': ^0.96.0
       '@effect/rpc': ^0.75.0
       effect: 3.21.1
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1697,35 +1754,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
     resolution: {integrity: sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
     resolution: {integrity: sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
     resolution: {integrity: sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.3':
     resolution: {integrity: sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
     resolution: {integrity: sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==}
@@ -1750,20 +1802,24 @@ packages:
   '@mariozechner/pi-agent-core@0.70.2':
     resolution: {integrity: sha512-g1hIdKyDwmQOoBGO0R4OhpemKeMENeK0vE5FJtuQKqEcsdCAkVBgZAK6aZUARYZVxMA718JS6WPLFWoddzjD7g==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-agent-core instead going forward
 
   '@mariozechner/pi-ai@0.70.2':
     resolution: {integrity: sha512-+30LRPjXsXF+oI96DvGWMbdPGeqoLJvadh6UPev7wx2DzhC9FEqXkQcoMZ0usbCm7E9pl8ua8a9s/pQ5ikaUbg==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-ai instead going forward
     hasBin: true
 
   '@mariozechner/pi-coding-agent@0.70.2':
     resolution: {integrity: sha512-asfNqV89HKAmKvJ1wENBY/UQMIf77kLtkzBrvXnMQV4YbH7D/6KT+VeVzPG6zm5PAZP2UtdLY9B9Cge7IxH37w==}
     engines: {node: '>=20.6.0'}
+    deprecated: please use @earendil-works/pi-coding-agent instead going forward
     hasBin: true
 
   '@mariozechner/pi-tui@0.70.2':
     resolution: {integrity: sha512-PtKC0NepnrYcqMx6MXkWTrBzC9tI62KeC6w940oT46lCbfvgmfqXciR15+9BZpxxc1H4jd3CMrKsmOPVeUqZ0A==}
     engines: {node: '>=20.0.0'}
+    deprecated: please use @earendil-works/pi-tui instead going forward
 
   '@mdx-js/esbuild@3.1.1':
     resolution: {integrity: sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ==}
@@ -1824,6 +1880,12 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
+
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -1888,6 +1950,9 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
+
   '@oxlint/binding-android-arm-eabi@1.60.0':
     resolution: {integrity: sha512-YdeJKaZckDQL1qa62a1aKq/goyq48aX3yOxaaWqWb4sau4Ee4IiLbamftNLU3zbePky6QsDj6thnSSzHRBjDfA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1935,56 +2000,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.60.0':
     resolution: {integrity: sha512-eDYDXZGhQAXyn6GwtwiX/qcLS0HlOLPJ/+iiIY8RYr+3P8oKBmgKxADLlniL6FtWfE7pPk7IGN9/xvDEvDvFeg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.60.0':
     resolution: {integrity: sha512-nxehly5XYBHUWI9VJX1bqCf9j/B43DaK/aS/T1fcxCpX3PA4Rm9BB54nPD1CKayT8xg6REN1ao+01hSRNgy8OA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.60.0':
     resolution: {integrity: sha512-j1qf/NaUfOWQutjeoooNG1Q0zsK0XGmSu1uDLq3cctquRF3j7t9Hxqf/76ehCc5GEUAanth2W4Fa+XT1RFg/nw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.60.0':
     resolution: {integrity: sha512-YELKPRefQ/q/h3RUmeRfPCUhh2wBvgV1RyZ/F9M9u8cDyXsQW2ojv1DeWQTt466yczDITjZnIOg/s05pk7Ve2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.60.0':
     resolution: {integrity: sha512-JkO3C6Gki7Y6h/MiIkFKvHFOz98/YWvQ4WYbK9DLXACMP2rjULzkeGyAzorJE5S1dzLQGFgeqvN779kSFwoV1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.60.0':
     resolution: {integrity: sha512-XjKHdFVCpZZZSWBCKyyqCq65s2AKXykMXkjLoKYODrD+f5toLhlwsMESscu8FbgnJQ4Y/dpR/zdazsahmgBJIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.60.0':
     resolution: {integrity: sha512-js29ZWIuPhNWzY8NC7KoffEMEeWG105vbmm+8EOJsC+T/jHBiKIJEUF78+F/IrgEWMMP9N0kRND4Pp75+xAhKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.60.0':
     resolution: {integrity: sha512-H+PUITKHk04stFpWj3x3Kg08Afp/bcXSBi0EhasR5a0Vw7StXHTzdl655PUI0fB4qdh2Wsu6Dsi+3ACxPoyQnA==}
@@ -2039,42 +2096,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2097,6 +2148,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2127,6 +2183,98 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -2162,79 +2310,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -2265,6 +2400,9 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@seznam/compose-react-refs@1.0.6':
+    resolution: {integrity: sha512-izzOXQfeQLonzrIQb8u6LQ8dk+ymz3WXTIXjvOlTXHq6sbzROg3NWU+9TTAOpEoK9Bth24/6F/XrfHJ5yR5n6Q==}
 
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
@@ -2484,17 +2622,44 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
-  '@types/bun@1.3.13':
-    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
   '@types/bun@1.3.14':
     resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/dagre@0.7.54':
+    resolution: {integrity: sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -2550,10 +2715,65 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vitejs/plugin-react@6.0.2':
+    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
+  '@yarnpkg/lockfile@1.1.0':
+    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -2605,6 +2825,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -2613,8 +2837,15 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -2651,9 +2882,16 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -2695,6 +2933,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2722,6 +2964,12 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  ci-info@2.0.0:
+    resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
@@ -2747,6 +2995,9 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -2761,6 +3012,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -2778,12 +3032,57 @@ packages:
     resolution: {integrity: sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww==}
     engines: {node: '>=18'}
 
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  dagre@0.8.5:
+    resolution: {integrity: sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -2969,6 +3268,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -3046,6 +3348,10 @@ packages:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
     engines: {node: '>= 16'}
@@ -3104,12 +3410,19 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
+  find-yarn-workspace-root@2.0.0:
+    resolution: {integrity: sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -3128,6 +3441,18 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3176,6 +3501,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
@@ -3190,6 +3519,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphlib@2.1.8:
+    resolution: {integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3251,6 +3583,10 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -3274,8 +3610,17 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
+  is-ci@2.0.0:
+    resolution: {integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==}
+    hasBin: true
+
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -3292,12 +3637,20 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3308,6 +3661,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
@@ -3325,17 +3681,93 @@ packages:
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  klaw-sync@6.0.0:
+    resolution: {integrity: sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==}
+
   koffi@2.16.1:
     resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
 
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3348,11 +3780,18 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -3501,6 +3940,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
@@ -3516,6 +3959,9 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3546,6 +3992,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -3553,9 +4004,17 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo-blessed@0.2.0:
+    resolution: {integrity: sha512-C2kC4K+G2QnNQFXUIxTQvqmrdSIzGTX1ZRKeDW6ChmvPRw8rTkTEJzbEQHiHy06d36PCl/yMOCjquCRV8SpSQw==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
+
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
   node-abi@3.89.0:
     resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
@@ -3585,12 +4044,19 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -3603,6 +4069,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   oxlint@1.60.0:
     resolution: {integrity: sha512-tnRzTWiWJ9pg3ftRWnD0+Oqh78L6ZSwcEudvCZaER0PIqiAnNyXj5N1dPwjmNpDalkKS9m/WMLN1CTPUBPmsgw==}
@@ -3645,9 +4115,22 @@ packages:
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
+  patch-package@6.5.1:
+    resolution: {integrity: sha512-I/4Zsalfhc6bphmJTlrLoOcAF87jcxko4q0qsv4bGcurbr8IskEOtdnt9iCmsQVGL1B+iUhSQqweyTLJfCF9rA==}
+    engines: {node: '>=10', npm: '>5'}
+    hasBin: true
+
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -3669,6 +4152,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3683,6 +4170,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -3702,11 +4199,18 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
@@ -3756,11 +4260,24 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-reconciler@0.25.1:
+    resolution: {integrity: sha512-R5UwsIvRcSs3w8n9k3tBoTtUHdVhu9u84EG7E5M0Jk9F5i6DA1pQzPfUZd6opYWGy56MJOtV3VADzy6DRwYDjw==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^16.13.1
+
   react-reconciler@0.33.0:
     resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
       react: ^19.2.0
+
+  react@16.13.1:
+    resolution: {integrity: sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -3820,6 +4337,16 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rolldown@1.0.2:
+    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -3835,8 +4362,15 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.19.1:
+    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3854,9 +4388,17 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
+
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -3878,6 +4420,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3889,6 +4434,10 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -3902,6 +4451,10 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -3913,12 +4466,18 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3978,12 +4537,31 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.2:
+    resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -4087,9 +4665,18 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4112,13 +4699,106 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite@8.0.14:
+    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -4143,6 +4823,10 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -4171,6 +4855,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4650,6 +5349,13 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@dino-dna/react-tui@1.0.1(react@16.13.1)':
+    dependencies:
+      '@seznam/compose-react-refs': 1.0.6
+      patch-package: 6.5.1
+      react: 16.13.1
+      react-reconciler: 0.25.1(react@16.13.1)
+
   '@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.1)
@@ -4738,6 +5444,22 @@ snapshots:
       '@effect/platform': 0.96.0(effect@3.21.1)
       '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
       effect: 3.21.1
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -5074,6 +5796,13 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
   '@nodable/entities@2.1.0': {}
 
   '@opentelemetry/api-logs@0.214.0':
@@ -5132,6 +5861,8 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@oxc-project/types@0.132.0': {}
 
   '@oxlint/binding-android-arm-eabi@1.60.0':
     optional: true
@@ -5250,6 +5981,10 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5272,6 +6007,57 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.2':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -5347,6 +6133,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@seznam/compose-react-refs@1.0.6': {}
 
   '@silvia-odwyer/photon-node@0.3.4': {}
 
@@ -5674,21 +6462,52 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 25.6.0
-
-  '@types/bun@1.3.13':
-    dependencies:
-      bun-types: 1.3.13
 
   '@types/bun@1.3.14':
     dependencies:
       bun-types: 1.3.14
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/dagre@0.7.54': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -5745,6 +6564,77 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  '@yarnpkg/lockfile@1.1.0': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -5787,13 +6677,19 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
 
   astring@1.9.0: {}
 
+  at-least-node@1.0.0: {}
+
   bail@2.0.2: {}
+
+  balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
@@ -5838,9 +6734,18 @@ snapshots:
 
   bowser@2.14.1: {}
 
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   buffer-crc32@0.2.13: {}
 
@@ -5880,6 +6785,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -5900,6 +6807,10 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
+
+  ci-info@2.0.0: {}
+
+  classcat@5.0.5: {}
 
   cli-highlight@2.1.11:
     dependencies:
@@ -5928,6 +6839,8 @@ snapshots:
 
   commander@4.1.1: {}
 
+  concat-map@0.0.1: {}
+
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
@@ -5935,6 +6848,8 @@ snapshots:
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -5949,6 +6864,14 @@ snapshots:
     dependencies:
       luxon: 3.7.2
 
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5956,6 +6879,47 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  dagre@0.8.5:
+    dependencies:
+      graphlib: 2.1.8
+      lodash: 4.18.1
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -6042,6 +7006,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6151,6 +7117,8 @@ snapshots:
 
   expand-template@2.0.3: {}
 
+  expect-type@1.3.0: {}
+
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
@@ -6244,6 +7212,10 @@ snapshots:
 
   file-uri-to-path@1.0.0: {}
 
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -6256,6 +7228,10 @@ snapshots:
       - supports-color
 
   find-my-way-ts@0.1.6: {}
+
+  find-yarn-workspace-root@2.0.0:
+    dependencies:
+      micromatch: 4.0.8
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -6272,6 +7248,18 @@ snapshots:
   fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -6336,6 +7324,15 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
@@ -6352,6 +7349,10 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphlib@2.1.8:
+    dependencies:
+      lodash: 4.18.1
 
   has-flag@4.0.0: {}
 
@@ -6453,6 +7454,11 @@ snapshots:
       yaml: 2.8.3
       zod: 4.3.6
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -6470,7 +7476,13 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
+  is-ci@2.0.0:
+    dependencies:
+      ci-info: 2.0.0
+
   is-decimal@2.0.1: {}
+
+  is-docker@2.2.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -6482,15 +7494,23 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-number@7.0.0: {}
+
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isexe@2.0.0: {}
 
   jose@6.2.2: {}
 
   joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
 
   json-bigint@1.0.0:
     dependencies:
@@ -6507,6 +7527,12 @@ snapshots:
 
   json-schema@0.4.0: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -6518,10 +7544,63 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  klaw-sync@6.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+
   koffi@2.16.1:
     optional: true
 
   kubernetes-types@1.30.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -6529,9 +7608,15 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  lodash@4.18.1: {}
+
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@11.3.5: {}
 
@@ -6858,6 +7943,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mime-db@1.54.0: {}
 
   mime-types@3.0.2:
@@ -6869,6 +7959,10 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
 
@@ -6909,11 +8003,17 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.12: {}
+
   napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
 
+  neo-blessed@0.2.0: {}
+
   netmask@2.1.1: {}
+
+  nice-try@1.0.5: {}
 
   node-abi@3.89.0:
     dependencies:
@@ -6938,6 +8038,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6946,10 +8048,17 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
   openai@6.26.0(ws@8.20.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.20.0
       zod: 4.3.6
+
+  os-tmpdir@1.0.2: {}
 
   oxlint@1.60.0:
     optionalDependencies:
@@ -7018,7 +8127,28 @@ snapshots:
 
   partial-json@0.1.7: {}
 
+  patch-package@6.5.1:
+    dependencies:
+      '@yarnpkg/lockfile': 1.1.0
+      chalk: 4.1.2
+      cross-spawn: 6.0.6
+      find-yarn-workspace-root: 2.0.0
+      fs-extra: 9.1.0
+      is-ci: 2.0.0
+      klaw-sync: 6.0.0
+      minimist: 1.2.8
+      open: 7.4.2
+      rimraf: 2.7.1
+      semver: 5.7.2
+      slash: 2.0.0
+      tmp: 0.0.33
+      yaml: 1.10.3
+
   path-expression-matcher@1.5.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@2.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -7035,6 +8165,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -7047,11 +8179,26 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(yaml@2.8.3):
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss-load-config@6.0.1(postcss@8.5.15)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
+      postcss: 8.5.15
       yaml: 2.8.3
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prebuild-install@7.1.3:
     dependencies:
@@ -7067,6 +8214,12 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   proper-lockfile@4.1.2:
     dependencies:
@@ -7143,10 +8296,26 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-is@16.13.1: {}
+
+  react-reconciler@0.25.1(react@16.13.1):
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      react: 16.13.1
+      scheduler: 0.19.1
+
   react-reconciler@0.33.0(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react@16.13.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
 
   react@19.2.5: {}
 
@@ -7229,6 +8398,31 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
+  rolldown@1.0.2:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.2
+      '@rolldown/binding-darwin-arm64': 1.0.2
+      '@rolldown/binding-darwin-x64': 1.0.2
+      '@rolldown/binding-freebsd-x64': 1.0.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
+      '@rolldown/binding-linux-arm64-gnu': 1.0.2
+      '@rolldown/binding-linux-arm64-musl': 1.0.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
+      '@rolldown/binding-linux-s390x-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-gnu': 1.0.2
+      '@rolldown/binding-linux-x64-musl': 1.0.2
+      '@rolldown/binding-openharmony-arm64': 1.0.2
+      '@rolldown/binding-wasm32-wasi': 1.0.2
+      '@rolldown/binding-win32-arm64-msvc': 1.0.2
+      '@rolldown/binding-win32-x64-msvc': 1.0.2
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -7274,7 +8468,14 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.19.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+
   scheduler@0.27.0: {}
+
+  semver@5.7.2: {}
 
   semver@7.7.4: {}
 
@@ -7305,9 +8506,15 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
+
+  shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
 
@@ -7339,6 +8546,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-concat@1.0.1: {}
@@ -7350,6 +8559,8 @@ snapshots:
       simple-concat: 1.0.1
 
   sisteransi@1.0.5: {}
+
+  slash@2.0.0: {}
 
   smart-buffer@4.2.0: {}
 
@@ -7366,6 +8577,8 @@ snapshots:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.6.1:
     optional: true
 
@@ -7373,9 +8586,13 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -7453,12 +8670,26 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
@@ -7482,7 +8713,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -7493,7 +8724,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.15)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -7502,6 +8733,7 @@ snapshots:
       tinyglobby: 0.2.16
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.15
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -7570,7 +8802,13 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@2.0.1: {}
+
   unpipe@1.0.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 
@@ -7590,11 +8828,61 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   web-streams-polyfill@3.3.3: {}
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -7607,6 +8895,8 @@ snapshots:
   ws@8.20.0: {}
 
   y18n@5.0.8: {}
+
+  yaml@1.10.3: {}
 
   yaml@2.8.3: {}
 
@@ -7634,5 +8924,12 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## What changed

- Adds `apps/smithers-demo`, a Vite/React Workflow Studio with React Flow graph visualization, generated Smithers React code, provider settings, prompt regeneration, and provider-backed workflow execution.
- Adds `apps/smithers-tui-demo`, a React TUI demo with a connected 2D workflow graph, bottom prompt composer, and Run Workflow -> Cancel -> Done execution state.
- Adds docs and root scripts for the browser and TUI demos.
- Adds unit, layout, TUI smoke, and Playwright desktop/mobile e2e coverage.

## Validation

- `pnpm --filter @smithers-orchestrator/smithers-demo test`
- `pnpm --filter @smithers-orchestrator/smithers-demo build`
- `pnpm --filter @smithers-orchestrator/smithers-demo e2e`
- `pnpm --filter @smithers-orchestrator/smithers-tui-demo test`
- Live Cerebras debate workflow was validated locally with `CEREBRAS_API_KEY` set before the split.
