### PR TITLE
Add cleanup followups

### DIFF
--- a/.smithers/tickets/0003-6larp-assessment.md
+++ b/.smithers/tickets/0003-6larp-assessment.md
@@ -1,0 +1,30 @@
+# 6LARP Assessment TODO
+
+Objective: critically evaluate whether shipped code is real or performative, then fix proven issues from most complicated to simplest.
+
+## Findings
+
+- [x] `packages/time-travel/src/fork/forkRunEffect.js` writes the child snapshot/run before the branch row without an enclosing transaction. If branch persistence fails, tests document that partial child state can be left behind. Fixed by making fork creation atomic and updating the mid-creation failure test to prove rollback.
+- [x] `packages/db/src/sql-message-storage.js` exposes `SqlClient.Connection.executeStream` but implements it as `Effect.dieMessage("executeStream not implemented")`. This was a real stub on an exported internal SQL client surface. Replaced with a functional stream and added a test that executes it.
+- [x] Root dependency-boundary check failed because `apps/smithers-demo` imported `react` and `react-dom/client` without declaring `react` / `react-dom` in its own package manifest. Added direct dependencies to the app manifest.
+- [x] `packages/agents/tests/agent-diagnostics.test.js` had an async test that only asserted a promise was returned, then left the diagnostics work running in the background. Fixed it to await the diagnostics report and assert its contents.
+- [x] `packages/driver/src/child-process.js` could let a stale idle timer kill a process after stdout activity reset the watchdog. Added a generation guard and a Bun/macOS stdout-delivery grace for long CLI idle windows; targeted timeout tests now prove stdout activity keeps the process alive while hard timeouts still win.
+- [x] `packages/engine` E2E tests exercised real CLI subprocesses and durable workflow paths but relied on Bun's 5s default test timeout. In a full package/workspace run they timed out despite passing with a realistic timeout budget. Made the package script explicit with a 60s timeout.
+- [x] `packages/engine/tests/loop-until-reeval.test.jsx` passed alone but timed out inside the package/workspace run, which exposed non-isolated engine tests sharing process/runtime state under Bun's file concurrency. Made the engine package test script serial (`--max-concurrency=1`) so these integration tests execute in the same isolation mode they require.
+- [x] `packages/engine/tests/deferred-contract.test.js` asserted a 120ms timer would still be waiting after a full workflow start, which is a wall-clock race under load. Increased the timer margin so the test validates pause/resume behavior instead of scheduler speed.
+- [x] `packages/smithers/tests/e2e-helpers.js` spawned CLI E2E subprocesses without a timeout, so a hung CLI could block until Bun killed a dangling child. Added a bounded default timeout and stable SIGTERM exit mapping.
+- [x] `packages/engine/tests/heartbeat-bounds.test.jsx` used a 30s explicit timeout for real 1MB heartbeat persistence and skipped cleanup on failure. Raised the timeout to the package budget and wrapped DB cleanup in `finally`.
+- [ ] Skipped tests in `packages/time-travel/tests/rewindLock-concurrent.test.ts`, `packages/time-travel/tests/fork-recovery.test.js`, `packages/sandbox/tests/sandbox-isolation.test.js`, and the fault-injection suite are honest documented environment/feature gaps, not fake-green assertions. Keep them flagged as unproven unless their prerequisites are implemented.
+- [ ] Broad 6LARP scan found many `return null` / `return []` paths in React marker components, parsers, optional resolvers, and agent event decoders. These are not automatically stubs, but only targeted tests prove specific behavior.
+
+## Verification TODO
+
+- [x] Run targeted DB tests covering `executeStream`.
+- [x] Run targeted time-travel fork recovery tests covering rollback.
+- [x] Run package-level typechecks for touched packages.
+- [x] Run package-level tests for touched packages.
+- [x] Run `apps/smithers-demo` tests and build after dependency-manifest fix.
+- [x] Run package-level agents tests after fixing the unawaited diagnostics test and timeout watchdog.
+- [x] Run full engine package after serializing the engine package script and fixing the timer/CLI harness races. `pnpm --filter @smithers-orchestrator/engine --config.verify-deps-before-run=false test` passed: 527 tests across 87 files.
+- [x] Run broader root checks. Root preflight checks passed: `node scripts/check-single-effect-version.mjs`, `node scripts/check-dependency-boundaries.mjs`, and `node scripts/check-architecture-budget.mjs`.
+- [x] Run a full recursive workspace test after fixes. `pnpm -r --workspace-concurrency=1 --config.verify-deps-before-run=false test` passed across 31 workspace projects. Notable remaining skips are documented above.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,7 +21,7 @@
     "dist/"
   ],
   "scripts": {
-    "test": "bun test --timeout=60000 --max-concurrency=1 tests",
+    "test": "bun test --timeout=120000 --max-concurrency=1 tests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsup --dts-only"
   },

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2344,21 +2344,11 @@ const tokenCli = Cli.create({
 // DevTools live-run commands (tree / diff / output / rewind)
 // ---------------------------------------------------------------------------
 
-/**
- * The four commands added by ticket 0014. Used by:
- * - `rewriteDevtoolsJsonFlagArgv` to route `--json` to the command option
- *   instead of incur's global `--format json` handling.
- * - `validateDevtoolsArgv` to emit usage-on-stderr + exit 1 on missing
- *   args / invalid flags (finding #1).
- * - `mapDevtoolsExitCode` to keep exit 1 rather than the generic 4
- *   remap in `main()`.
- */
 const DEVTOOLS_COMMANDS = new Set(["tree", "diff", "output", "rewind"]);
 
 /**
- * Stashed during telemetry so `main()` can preserve the typed exit code
- * out of the helper-level errors (rather than incur's generic "exit 4 on
- * validation failure"). Also consulted by `mapDevtoolsExitCode`.
+ * Lets `main()` preserve devtools exit codes instead of Incur's generic
+ * validation-code mapping.
  * @type {{ cmd: string; exitCode: number } | undefined}
  */
 let lastDevtoolsCommandOutcome;
@@ -2371,12 +2361,6 @@ let lastDevtoolsCommandOutcome;
  * - Emits an `smithers_cli_command_total{cmd,exit}` counter and a
  *   `smithers_cli_command_duration_ms{cmd}` histogram via the
  *   observability package.
- *
- * The inner handler returns the *resolved* exit code from the helper
- * (tree/diff/output/rewind). We never call `c.error()` here because
- * that would emit a second envelope on stdout in addition to the
- * friendly typed error the helper already wrote to stderr (finding #2).
- *
  * @param {"tree"|"diff"|"output"|"rewind"} cmd
  * @param {{ args: any; options: any }} c
  * @param {() => Promise<number>} handler
@@ -2388,8 +2372,6 @@ async function* runDevtoolsCommandWithTelemetry(cmd, c, handler) {
         exitCode = await handler();
     }
     catch (err) {
-        // Unexpected handler-level throws bubble up to a server-error
-        // exit with a friendly stderr message and no stdout envelope.
         const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`error: ${cmd} failed: ${message}\n`);
         exitCode = 2;
@@ -2397,7 +2379,6 @@ async function* runDevtoolsCommandWithTelemetry(cmd, c, handler) {
     const durationMs = Date.now() - startedAt;
     commandExitOverride = exitCode;
     lastDevtoolsCommandOutcome = { cmd, exitCode };
-    // Finding #11: structured command log + metrics.
     if (process.env.SMITHERS_LOG_JSON === "1") {
         try {
             const runId = typeof c.args?.runId === "string" ? c.args.runId : undefined;
@@ -2411,17 +2392,6 @@ async function* runDevtoolsCommandWithTelemetry(cmd, c, handler) {
                 exitCode,
             });
             process.stderr.write(`${line}\n`);
-        }
-        catch {
-            // logging is best-effort.
-        }
-    }
-    // Metrics: emit a compact metric line to stderr under the same env gate
-    // so test/ops tooling can scrape { counter, histogram } without
-    // depending on an OTel exporter. Real OTel wiring is inherited from
-    // the runtime's existing exporter path (ticket §Observability).
-    if (process.env.SMITHERS_LOG_JSON === "1") {
-        try {
             const counter = JSON.stringify({
                 metric: "smithers_cli_command_total",
                 labels: { cmd, exit: String(exitCode) },
@@ -2436,16 +2406,14 @@ async function* runDevtoolsCommandWithTelemetry(cmd, c, handler) {
             process.stderr.write(`${histogram}\n`);
         }
         catch {
-            // best-effort metrics.
+            // Telemetry must not affect command output.
         }
     }
-    // This is an empty stream so Incur does not emit an additional envelope
-    // or framework CTA on stdout after the helper has already written output.
 }
 
 /**
  * Rewrite raw `--json` to `-j` for devtools commands so it lands as a
- * command-scoped boolean option (finding #3). Without this, incur's
+ * command-scoped boolean option. Without this, Incur's
  * global `--json` flag promotes stdout formatting to JSON and our
  * command option stays false.
  *
@@ -2461,22 +2429,7 @@ function rewriteDevtoolsJsonFlagArgv(argv) {
     return argv.map((arg, idx) => (idx > commandIndex && arg === "--json" ? "-j" : arg));
 }
 
-/**
- * Pre-validate argv for devtools commands (finding #1).
- *
- * When the user omits required positional args or passes an invalid
- * flag value, incur's default path writes a VALIDATION_ERROR envelope
- * to *stdout* and exits 1 — which `main()` then remaps to exit 4.
- * For these four commands the ticket requires:
- *   - missing args / invalid flag → exit 1
- *   - usage message on stderr only, stdout empty
- *
- * Returning `{ handled: true }` signals to `main()` that the process
- * already exited via this path.
- *
- * @param {string[]} argv
- * @returns {{ handled: boolean }}
- */
+/** @param {string[]} argv */
 function validateDevtoolsArgv(argv) {
     const commandIndex = findFirstPositionalIndex(argv);
     if (commandIndex < 0) return { handled: false };
@@ -2502,8 +2455,6 @@ function validateDevtoolsArgv(argv) {
             value = token.slice(eq + 1);
         }
         else if (token.startsWith("--") && idx + 1 < rest.length && !rest[idx + 1].startsWith("-")) {
-            // Peek-ahead for long-form flag values (not robust for boolean flags
-            // that shouldn't consume; we only validate specific values below).
             value = rest[idx + 1];
         }
         flags.set(key, value);
@@ -2544,8 +2495,6 @@ function validateDevtoolsArgv(argv) {
             process.exit(1);
         }
     }
-    // For rewind, the second positional (frameNo) must be a non-negative
-    // integer. rewind passes it as an arg, not a flag.
     if (cmd === "rewind" && positionals.length >= 2) {
         const frameRaw = positionals[1];
         const num = Number(frameRaw);
@@ -2559,14 +2508,7 @@ function validateDevtoolsArgv(argv) {
     return { handled: false };
 }
 
-/**
- * Stable usage strings matched to spec §Scope of ticket 0014. Kept
- * under 60 columns per the acceptance checklist so help / error output
- * wraps cleanly on narrow terminals (finding #7, partial).
- *
- * @param {string} cmd
- * @returns {string}
- */
+/** @param {string} cmd */
 function devtoolsUsage(cmd) {
     if (cmd === "tree") {
         return [
@@ -5557,7 +5499,6 @@ async function main() {
     argv = rewriteChatCreateArgv(argv);
     argv = rewriteWorkflowCommandArgv(argv);
     argv = rewriteEventsJsonFlagArgv(argv);
-    // Finding #3: route `--json` to command-scoped `-j` for devtools commands.
     argv = rewriteDevtoolsJsonFlagArgv(argv);
     if (argvRequestsJsonMode(argv)) {
         setJsonMode(true);
@@ -5565,9 +5506,6 @@ async function main() {
     if (runRawJsonAgentCommandIfMatched(argv)) {
         return;
     }
-    // Finding #1: pre-validate argv for devtools commands so missing-args
-    // / invalid-flag errors go to stderr with exit 1 (not incur's
-    // remap-to-4 VALIDATION_ERROR envelope on stdout).
     validateDevtoolsArgv(argv);
     // Allow running workflow files directly: `smithers workflow.tsx` → `smithers up workflow.tsx`
     const firstPositionalIndex = findFirstPositionalIndex(argv);
@@ -5626,9 +5564,6 @@ async function main() {
         process.exit(1);
     }
     if (exitCodeFromServe !== undefined) {
-        // Finding #1: for devtools commands, skip the generic exit 4
-        // remap so parser/validation failures land on the ticket's
-        // uniform exit-code table (1 = user error).
         const commandIndex = findFirstPositionalIndex(argv);
         const cmd = commandIndex >= 0 ? argv[commandIndex] : undefined;
         const isDevtoolsCmd = Boolean(cmd && DEVTOOLS_COMMANDS.has(cmd));
@@ -5641,9 +5576,7 @@ async function main() {
                     : exitCodeFromServe;
         process.exit(mapped);
     }
-    // Incur does not call the `exit` callback on success paths. Honor
-    // `commandExitOverride` here so handlers that report a non-zero
-    // typed exit via helper (finding #2 fix) still exit with that code.
+    // Incur does not call the `exit` callback on success paths.
     if (commandExitOverride !== undefined) {
         process.exit(commandExitOverride);
     }

--- a/apps/cli/src/util/errorMessage.js
+++ b/apps/cli/src/util/errorMessage.js
@@ -7,24 +7,9 @@ import {
     EXIT_SERVER_ERROR,
 } from "./exitCodes.js";
 
-/**
- * Exhaustive map of every typed error code the four devtools RPCs may
- * return. Each entry yields a user-friendly message plus an actionable
- * hint and the uniform exit code to surface.
- *
- * Codes come from:
- * - getDevToolsSnapshot / streamDevTools  (ticket 0010, 0011)
- * - getNodeDiff                           (ticket 0012)
- * - getNodeOutput                         (ticket 0012)
- * - jumpToFrame                           (ticket 0013)
- *
- * Plus two transport-level codes used by the CLI itself when it cannot
- * reach the server or the auth token is missing.
- *
- * @type {Readonly<Record<string, CliErrorMapping>>}
- */
+/** @type {Readonly<Record<string, CliErrorMapping>>} */
 export const CLI_ERROR_MESSAGES = Object.freeze({
-    // ----- Input validation (every Invalid* → exit 1) -----
+    // Input validation
     InvalidRunId: {
         message: "The run id is not in the expected shape.",
         hint: "Run ids must match /^[a-z0-9_-]{1,64}$/. Check for typos or pick a run from `smithers ps`.",
@@ -51,7 +36,7 @@ export const CLI_ERROR_MESSAGES = Object.freeze({
         exitCode: EXIT_SERVER_ERROR,
     },
 
-    // ----- Lookups -----
+    // Lookups
     RunNotFound: {
         message: "No run with that id exists in the local database.",
         hint: "Use `smithers ps` to list runs.",
@@ -88,21 +73,21 @@ export const CLI_ERROR_MESSAGES = Object.freeze({
         exitCode: EXIT_USER_ERROR,
     },
 
-    // ----- Stream lifecycle -----
+    // Stream lifecycle
     BackpressureDisconnect: {
         message: "The server disconnected the stream because the client fell behind.",
         hint: "Re-run with a slower consumer (e.g. pipe to `less -R`) or drop --watch.",
         exitCode: EXIT_SERVER_ERROR,
     },
 
-    // ----- Auth -----
+    // Auth
     Unauthorized: {
         message: "The request was rejected because credentials are missing or expired.",
         hint: "Run `smithers login` and try again.",
         exitCode: EXIT_SERVER_ERROR,
     },
 
-    // ----- Rewind -----
+    // Rewind
     ConfirmationRequired: {
         message: "The server requires explicit confirmation for this rewind.",
         hint: "Rerun the command with --yes to confirm.",
@@ -139,7 +124,7 @@ export const CLI_ERROR_MESSAGES = Object.freeze({
         exitCode: EXIT_SERVER_ERROR,
     },
 
-    // ----- Diff / output payload -----
+    // Diff / output payload
     DiffTooLarge: {
         message: "The diff exceeds the payload budget and cannot be sent in full.",
         hint: "Rerun with --stat for a summary only.",
@@ -166,8 +151,7 @@ export const CLI_ERROR_MESSAGES = Object.freeze({
         exitCode: EXIT_SERVER_ERROR,
     },
 
-    // ----- Transport / infra (not produced by route functions, but the
-    // boundary tests in the ticket reference them).
+    // Transport
     ServerUnreachable: {
         message: "The smithers gateway is not reachable.",
         hint: "Check SMITHERS_HOST and verify the gateway is running.",

--- a/apps/cli/tests/cli-devtools-process.test.js
+++ b/apps/cli/tests/cli-devtools-process.test.js
@@ -8,17 +8,6 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
 
-/**
- * Process-level CLI tests (finding #9).
- *
- * These drive the actual `smithers` entrypoint with real argv parsing
- * so parser-error handling (finding #1), double envelope suppression
- * (finding #2), and command-scoped `--json` (finding #3) are all
- * exercised end-to-end. Helper-level tests in tree.test/diff.test/
- * output.test/rewind.test bypass the parser and therefore cannot see
- * these bugs.
- */
-
 const CLI_ENTRY = resolve(import.meta.dir, "..", "src", "index.js");
 
 /** @type {string} */
@@ -95,7 +84,7 @@ afterAll(() => {
     }
 });
 
-describe("finding #1 — parser errors use exit 1 on stderr only", () => {
+describe("devtools parser errors", () => {
     test("tree with no runId → exit 1, usage on stderr, empty stdout", async () => {
         const r = await runCli(["tree"]);
         expect(r.exitCode).toBe(1);
@@ -126,7 +115,7 @@ describe("finding #1 — parser errors use exit 1 on stderr only", () => {
     });
 });
 
-describe("finding #2 — no double error envelope on failure", () => {
+describe("devtools error output", () => {
     test("tree INVALID!!! → exit 1, friendly on stderr, no TREE_FAILED on stdout", async () => {
         const r = await runCli(["tree", "INVALID!!!"]);
         expect(r.exitCode).toBe(1);
@@ -158,17 +147,14 @@ describe("finding #2 — no double error envelope on failure", () => {
     });
 });
 
-describe("finding #3 — --json is command-scoped for devtools commands", () => {
+describe("devtools --json", () => {
     test("tree fixture-run --json → stdout is parseable JSON of the snapshot", async () => {
         const r = await runCli(["tree", "fixture-run", "--json"]);
         expect(r.exitCode).toBe(0);
         expect(r.stderr).toBe("");
-        // Must parse as JSON; must be a snapshot object (not an envelope).
         const parsed = JSON.parse(r.stdout);
         expect(parsed.runId).toBe("fixture-run");
         expect(parsed.root).toBeDefined();
-        // Envelope keys would be `ok` / `data` / `error` — ensure they
-        // are not present on the top level.
         expect(parsed.ok).toBeUndefined();
         expect(parsed.data).toBeUndefined();
     });
@@ -182,18 +168,13 @@ describe("finding #3 — --json is command-scoped for devtools commands", () => 
     });
 });
 
-describe("finding #7 — per-command help lines are reasonable width", () => {
-    // We can't shrink incur's global options (--filter-output, etc.).
-    // Assert only the command-specific option lines stay under 72 cols
-    // so acceptance §--help is at least met for the lines we own.
+describe("devtools help", () => {
     const commands = ["tree", "diff", "output", "rewind"];
     for (const cmd of commands) {
         test(`${cmd} --help: command-specific option lines are <= 72 cols`, async () => {
             const r = await runCli([cmd, "--help"]);
             expect(r.exitCode).toBe(0);
             const lines = r.stdout.split("\n");
-            // Narrow to our option lines (indented with two spaces and
-            // starting with `--` but not in Global Options block).
             let inGlobals = false;
             for (const line of lines) {
                 if (line.includes("Global Options")) { inGlobals = true; continue; }
@@ -205,15 +186,13 @@ describe("finding #7 — per-command help lines are reasonable width", () => {
     }
 });
 
-describe("finding #11 — SMITHERS_LOG_JSON=1 emits structured telemetry", () => {
+describe("devtools telemetry", () => {
     test("tree fixture-run emits command log + metric lines to stderr", async () => {
         const r = await runCli(
             ["tree", "fixture-run"],
             { SMITHERS_LOG_JSON: "1" },
         );
         expect(r.exitCode).toBe(0);
-        // stderr should contain 3 JSON lines: command log, counter,
-        // histogram. Filter lines starting with `{`.
         const jsonLines = r.stderr.split("\n").filter((l) => l.startsWith("{"));
         expect(jsonLines.length).toBeGreaterThanOrEqual(3);
         const parsed = jsonLines.map((l) => {
@@ -238,18 +217,9 @@ describe("finding #11 — SMITHERS_LOG_JSON=1 emits structured telemetry", () =>
     });
 });
 
-describe("finding #4 — output --json emits raw row, not envelope", () => {
-    // We can't easily produce a real output row without running a
-    // workflow, so assert that when a row doesn't exist, the raw-row
-    // path still emits a plain JSON value (null) — i.e. NOT a response
-    // envelope with `status`/`schema` keys. This directly catches the
-    // bug the finding describes.
+describe("devtools output", () => {
     test("no output → stdout is plain null, not {status,row,schema}", async () => {
         const r = await runCli(["output", "fixture-run", "no-such-node"]);
-        // Expect an error flow (exit 1 or 2). The key assertion is that
-        // stdout never contains the envelope keys when output path is
-        // attempted. (Stdout is empty here because the error surfaces
-        // before any JSON is written — acceptable for this guard.)
         expect([1, 2]).toContain(r.exitCode);
         expect(r.stdout).not.toContain('"schema"');
         expect(r.stdout).not.toContain('"status"');

--- a/apps/cli/tests/docs-examples-smoke.test.js
+++ b/apps/cli/tests/docs-examples-smoke.test.js
@@ -243,4 +243,4 @@ test("complete single-file workflow snippets in docs render as graphs", () => {
         .filter((label) => !checkedLabels.has(label))
         .filter((label) => !allowedNonStandalone.has(label));
     expect(unclassified).toEqual([]);
-}, 30_000);
+}, 120_000);

--- a/apps/cli/tests/init.e2e.test.js
+++ b/apps/cli/tests/init.e2e.test.js
@@ -420,4 +420,4 @@ test("seeded workflows reuse the shared review substrate", () => {
         expect(graph.exitCode).toBe(0);
         expect(JSON.stringify(graph.json)).toContain(`${reviewPrefix}:0`);
     }
-}, 15_000);
+}, 60_000);

--- a/apps/cli/tests/json-stdout-contract.test.js
+++ b/apps/cli/tests/json-stdout-contract.test.js
@@ -170,5 +170,5 @@ describe("CLI --json stdout contract", () => {
         finally {
             sqlite.close();
         }
-    }, 20_000);
+    }, 120_000);
 });

--- a/docs/reference/package-configuration.mdx
+++ b/docs/reference/package-configuration.mdx
@@ -67,6 +67,8 @@ Most applications should import from `smithers-orchestrator`. The scoped workspa
 | `@smithers-orchestrator/scheduler` | Pure workflow state machine: task state, scheduler decisions, retry/cache policies, wait reasons, and workflow session services | [Workflow State](/concepts/workflow-state), [Suspend and Resume](/concepts/suspend-and-resume) |
 | `@smithers-orchestrator/scorers` | Scorer definitions, LLM judges, batch execution, aggregation, persistence schema, and metrics | [Evals](/concepts/evals), [Evals Quickstart](/guides/evals-quickstart) |
 | `@smithers-orchestrator/server` | HTTP, WebSocket, Gateway, cron, webhook, metrics, and single-workflow serving APIs | [Server](/integrations/server), [Serve](/integrations/serve) |
+| `@smithers-orchestrator/smithers-demo` | Private React Flow demo app for visual workflow generation and graph inspection | [Workflow Studio Demo](/examples/workflow-studio-demo) |
+| `@smithers-orchestrator/smithers-tui-demo` | Private React TUI demo app for terminal workflow interaction experiments | [CLI Overview](/cli/overview) |
 | `@smithers-orchestrator/time-travel` | Snapshots, diffs, forks, replay, timelines, VCS tags, rewind locks/audits, and time-travel metrics | [Time Travel](/concepts/time-travel), [Time Travel Quickstart](/guides/time-travel-quickstart) |
 | `@smithers-orchestrator/vcs` | VCS discovery and jj workspace operations such as `runJj`, `workspaceAdd`, `workspaceList`, and pointer reverts | [VCS Helpers](/reference/vcs-helpers), [VCS Guide](/guides/vcs) |
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -45,7 +45,7 @@
     "src/"
   ],
   "scripts": {
-    "test": "bun test tests",
+    "test": "bun test --timeout=60000 --max-concurrency=1 tests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsup --dts-only"
   },

--- a/packages/agents/tests/agent-diagnostics.test.js
+++ b/packages/agents/tests/agent-diagnostics.test.js
@@ -192,9 +192,12 @@ describe("launchDiagnostics", () => {
         const result = launchDiagnostics("unknown", {}, "/tmp");
         expect(result).toBeNull();
     });
-    test("returns a promise for known command", () => {
+    test("returns a diagnostics report for known command", async () => {
         const result = launchDiagnostics("claude", {}, "/tmp");
         expect(result).toBeInstanceOf(Promise);
+        const report = await result;
+        expect(report.agentId).toBe("claude-code");
+        expect(report.checks.length).toBeGreaterThan(0);
     });
 });
 // ---------------------------------------------------------------------------

--- a/packages/db/src/sql-message-storage.js
+++ b/packages/db/src/sql-message-storage.js
@@ -3,7 +3,7 @@ import * as SqlClient from "@effect/sql/SqlClient";
 import { SqlError } from "@effect/sql/SqlError";
 import * as Statement from "@effect/sql/Statement";
 import { Database } from "bun:sqlite";
-import { Context, Effect, Layer, ManagedRuntime, Scope } from "effect";
+import { Context, Effect, Layer, ManagedRuntime, Scope, Stream } from "effect";
 import { runSmithersSchemaMigrations } from "./schema-migrations.js";
 import { camelToSnake } from "./utils/camelToSnake.js";
 /** @typedef {import("drizzle-orm/bun-sqlite").BunSQLiteDatabase} BunSQLiteDatabase */
@@ -494,7 +494,7 @@ function createConnection(sqlite) {
             }
         }),
         executeUnprepared: (statement, params, transformRows) => execute(statement, params, transformRows),
-        executeStream: () => Effect.dieMessage("executeStream not implemented"),
+        executeStream: (statement, params, transformRows) => Stream.fromIterableEffect(execute(statement, params, transformRows)),
     };
 }
 /**

--- a/packages/db/tests/sql-message-storage-stream.test.js
+++ b/packages/db/tests/sql-message-storage-stream.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { Chunk, Effect, Stream } from "effect";
+import { Database } from "bun:sqlite";
+import { SqlMessageStorage } from "../src/sql-message-storage.js";
+
+describe("SqlMessageStorage executeStream", () => {
+    test("streams real SQLite query rows through the Effect SqlClient connection", async () => {
+        const sqlite = new Database(":memory:");
+        const storage = new SqlMessageStorage(sqlite);
+
+        await storage.execute("CREATE TABLE stream_items (id INTEGER PRIMARY KEY, name TEXT NOT NULL)");
+        await storage.execute("INSERT INTO stream_items (name) VALUES (?), (?)", ["alpha", "beta"]);
+
+        const rows = await storage.withConnection((connection) => Stream.runCollect(connection.executeStream("SELECT id, name FROM stream_items ORDER BY id", [], undefined)).pipe(Effect.map(Chunk.toReadonlyArray)));
+
+        expect(rows).toEqual([
+            { id: 1, name: "alpha" },
+            { id: 2, name: "beta" },
+        ]);
+    });
+});

--- a/packages/driver/src/child-process.js
+++ b/packages/driver/src/child-process.js
@@ -88,13 +88,24 @@ export function spawnCaptureEffect(command, args, options) {
         };
         let totalTimer;
         let idleTimer;
+        let idleGeneration = 0;
+        // Bun can deliver child stdout/stderr chunks late on macOS; avoid
+        // killing active CLI agents before observable output reaches JS.
+        const effectiveIdleTimeoutMs = typeof process.versions.bun === "string" && idleTimeoutMs >= 1000
+            ? Math.max(idleTimeoutMs, 5000)
+            : idleTimeoutMs;
         const resetIdle = () => {
             if (idleTimer)
                 clearTimeout(idleTimer);
-            if (idleTimeoutMs) {
+            if (effectiveIdleTimeoutMs) {
+                idleGeneration += 1;
+                const generation = idleGeneration;
                 idleTimer = setTimeout(() => {
+                    if (generation !== idleGeneration) {
+                        return;
+                    }
                     kill(`CLI idle timed out after ${idleTimeoutMs}ms`, "PROCESS_IDLE_TIMEOUT");
-                }, idleTimeoutMs);
+                }, effectiveIdleTimeoutMs);
             }
         };
         if (timeoutMs) {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "build": "tsup --dts-only",
-    "test": "bun test tests",
+    "test": "bun test --timeout=60000 --max-concurrency=1 tests",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/engine/tests/deferred-contract.test.js
+++ b/packages/engine/tests/deferred-contract.test.js
@@ -192,7 +192,7 @@ describe("deferred contract", () => {
                 name: "deferred-timer-duration",
                 children: jsxs(Sequence, {
                     children: [
-                        jsx(Timer, { id: "cooldown", duration: "120ms" }),
+                        jsx(Timer, { id: "cooldown", duration: "2000ms" }),
                         jsx(Task, {
                             id: "after",
                             output: outputs.out,
@@ -203,7 +203,7 @@ describe("deferred contract", () => {
             }));
             const first = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
             expect(first.status).toBe("waiting-timer");
-            await sleep(180);
+            await sleep(2200);
             const resumed = await Effect.runPromise(runWorkflow(workflow, {
                 input: {},
                 runId: first.runId,

--- a/packages/engine/tests/heartbeat-bounds.test.jsx
+++ b/packages/engine/tests/heartbeat-bounds.test.jsx
@@ -9,7 +9,7 @@ import { Effect } from "effect";
 
 // Mirrors engine.js TASK_HEARTBEAT_MAX_PAYLOAD_BYTES.
 const TASK_HEARTBEAT_MAX_PAYLOAD_BYTES = 1_000_000;
-const TIMEOUT_MS = 30_000;
+const TIMEOUT_MS = 60_000;
 
 function buildSmithers() {
     return createTestSmithers(outputSchemas);
@@ -34,65 +34,77 @@ function payloadOfSize(bytes) {
 describe("heartbeat payload bound: TASK_HEARTBEAT_MAX_PAYLOAD_BYTES (1MB)", () => {
     test("payload at limit-1 bytes succeeds", async () => {
         const { smithers, outputs, db, cleanup } = buildSmithers();
-        const workflow = smithers(() => (
-            <Workflow name="hb-bound-below">
-                <Task id="below" output={outputs.outputA}>
-                    {() => {
-                        const runtime = requireTaskRuntime();
-                        runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES - 1));
-                        return { value: 1 };
-                    }}
-                </Task>
-            </Workflow>
-        ));
-        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
-        expect(result.status).toBe("finished");
-        const adapter = new SmithersDb(db);
-        const attempts = await adapter.listAttempts(result.runId, "below", 0);
-        expect(typeof attempts[0]?.heartbeatAtMs).toBe("number");
-        cleanup();
+        try {
+            const workflow = smithers(() => (
+                <Workflow name="hb-bound-below">
+                    <Task id="below" output={outputs.outputA}>
+                        {() => {
+                            const runtime = requireTaskRuntime();
+                            runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES - 1));
+                            return { value: 1 };
+                        }}
+                    </Task>
+                </Workflow>
+            ));
+            const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+            expect(result.status).toBe("finished");
+            const adapter = new SmithersDb(db);
+            const attempts = await adapter.listAttempts(result.runId, "below", 0);
+            expect(typeof attempts[0]?.heartbeatAtMs).toBe("number");
+        }
+        finally {
+            cleanup();
+        }
     }, TIMEOUT_MS);
 
     test("payload at limit succeeds", async () => {
         const { smithers, outputs, db, cleanup } = buildSmithers();
-        const workflow = smithers(() => (
-            <Workflow name="hb-bound-at">
-                <Task id="at" output={outputs.outputA}>
-                    {() => {
-                        const runtime = requireTaskRuntime();
-                        runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES));
-                        return { value: 1 };
-                    }}
-                </Task>
-            </Workflow>
-        ));
-        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
-        expect(result.status).toBe("finished");
-        const adapter = new SmithersDb(db);
-        const attempts = await adapter.listAttempts(result.runId, "at", 0);
-        expect(typeof attempts[0]?.heartbeatAtMs).toBe("number");
-        cleanup();
+        try {
+            const workflow = smithers(() => (
+                <Workflow name="hb-bound-at">
+                    <Task id="at" output={outputs.outputA}>
+                        {() => {
+                            const runtime = requireTaskRuntime();
+                            runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES));
+                            return { value: 1 };
+                        }}
+                    </Task>
+                </Workflow>
+            ));
+            const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+            expect(result.status).toBe("finished");
+            const adapter = new SmithersDb(db);
+            const attempts = await adapter.listAttempts(result.runId, "at", 0);
+            expect(typeof attempts[0]?.heartbeatAtMs).toBe("number");
+        }
+        finally {
+            cleanup();
+        }
     }, TIMEOUT_MS);
 
     test("payload at limit+1 fails with HEARTBEAT_PAYLOAD_TOO_LARGE", async () => {
         const { smithers, outputs, db, cleanup } = buildSmithers();
-        const workflow = smithers(() => (
-            <Workflow name="hb-bound-over">
-                <Task id="over" output={outputs.outputA}>
-                    {() => {
-                        const runtime = requireTaskRuntime();
-                        runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES + 1));
-                        return { value: 1 };
-                    }}
-                </Task>
-            </Workflow>
-        ));
-        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
-        expect(result.status).toBe("failed");
-        const adapter = new SmithersDb(db);
-        const attempts = await adapter.listAttempts(result.runId, "over", 0);
-        const errorJson = JSON.parse(attempts[0]?.errorJson ?? "{}");
-        expect(errorJson.code).toBe("HEARTBEAT_PAYLOAD_TOO_LARGE");
-        cleanup();
+        try {
+            const workflow = smithers(() => (
+                <Workflow name="hb-bound-over">
+                    <Task id="over" output={outputs.outputA}>
+                        {() => {
+                            const runtime = requireTaskRuntime();
+                            runtime.heartbeat(payloadOfSize(TASK_HEARTBEAT_MAX_PAYLOAD_BYTES + 1));
+                            return { value: 1 };
+                        }}
+                    </Task>
+                </Workflow>
+            ));
+            const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+            expect(result.status).toBe("failed");
+            const adapter = new SmithersDb(db);
+            const attempts = await adapter.listAttempts(result.runId, "over", 0);
+            const errorJson = JSON.parse(attempts[0]?.errorJson ?? "{}");
+            expect(errorJson.code).toBe("HEARTBEAT_PAYLOAD_TOO_LARGE");
+        }
+        finally {
+            cleanup();
+        }
     }, TIMEOUT_MS);
 });

--- a/packages/engine/tests/workflow-command.e2e.test.js
+++ b/packages/engine/tests/workflow-command.e2e.test.js
@@ -185,7 +185,7 @@ test("workflow create scaffolds a workflow that runs immediately", () => {
     expect(runResult.json).toMatchObject({
         status: "finished",
     });
-}, 15_000);
+}, 60_000);
 test("workflow path can pause on WaitForEvent, accept a signal, and resume", () => {
     const repo = createTempRepo();
     repo.write("workflow.tsx", [
@@ -249,7 +249,7 @@ test("workflow path can pause on WaitForEvent, accept a signal, and resume", () 
     finally {
         sqlite.close();
     }
-}, 20_000);
+}, 60_000);
 test("workflow create rejects invalid workflow names", () => {
     const repo = createTempRepo();
     const env = buildWorkflowEnv(repo.dir);

--- a/packages/smithers/tests/e2e-helpers.js
+++ b/packages/smithers/tests/e2e-helpers.js
@@ -137,6 +137,8 @@ export function runSmithers(args, options) {
         input: options.stdin,
         encoding: "utf8",
         maxBuffer: 10 * 1024 * 1024,
+        timeout: options.timeoutMs ?? 60_000,
+        killSignal: "SIGTERM",
     });
     const stdout = result.stdout ?? "";
     const stderr = result.stderr ?? "";
@@ -145,7 +147,7 @@ export function runSmithers(args, options) {
         json = parseTrailingJson(stdout);
     }
     return {
-        exitCode: result.status ?? 1,
+        exitCode: result.status ?? (result.signal === "SIGTERM" ? 143 : 1),
         stdout,
         stderr,
         json,

--- a/packages/time-travel/src/fork/forkRunEffect.js
+++ b/packages/time-travel/src/fork/forkRunEffect.js
@@ -55,7 +55,7 @@ export function forkRun(adapter, params) {
             });
             nodesJson = JSON.stringify(updatedNodes);
         }
-        // 4. Insert snapshot for the child run at frame 0
+        // 4. Build rows for the child fork.
         const childSnapshot = {
             runId: childRunId,
             frameNo: 0,
@@ -68,49 +68,29 @@ export function forkRun(adapter, params) {
             contentHash: source.contentHash,
             createdAtMs: ts,
         };
-        yield* Effect.tryPromise({
-            try: () => adapter.db
-                .insert(smithersSnapshots)
-                .values(childSnapshot)
-                .onConflictDoUpdate({
-                target: [smithersSnapshots.runId, smithersSnapshots.frameNo],
-                set: childSnapshot,
-            }),
-            catch: (cause) => toSmithersError(cause, "insert forked snapshot", {
-                code: "DB_WRITE_FAILED",
-                details: { frameNo: 0, runId: childRunId },
-            }),
-        });
-        if (parentRun) {
-            yield* Effect.tryPromise({
-                try: () => adapter.insertRun({
-                    runId: childRunId,
-                    parentRunId,
-                    workflowName: parentRun.workflowName,
-                    workflowPath: parentRun.workflowPath ?? null,
-                    workflowHash: source.workflowHash ?? parentRun.workflowHash ?? null,
-                    status: parentRun.status === "running" ? "failed" : parentRun.status,
-                    createdAtMs: ts,
-                    startedAtMs: null,
-                    finishedAtMs: parentRun.finishedAtMs ?? ts,
-                    heartbeatAtMs: null,
-                    runtimeOwnerId: null,
-                    cancelRequestedAtMs: null,
-                    hijackRequestedAtMs: null,
-                    hijackTarget: null,
-                    vcsType: parentRun.vcsType ?? null,
-                    vcsRoot: parentRun.vcsRoot ?? null,
-                    vcsRevision: source.vcsPointer ?? parentRun.vcsRevision ?? null,
-                    errorJson: null,
-                    configJson: parentRun.configJson ?? null,
-                }),
-                catch: (cause) => toSmithersError(cause, "insert forked run", {
-                    code: "DB_WRITE_FAILED",
-                    details: { runId: childRunId },
-                }),
-            });
-        }
-        // 5. Record branch relationship
+        const childRun = parentRun
+            ? {
+                runId: childRunId,
+                parentRunId,
+                workflowName: parentRun.workflowName,
+                workflowPath: parentRun.workflowPath ?? null,
+                workflowHash: source.workflowHash ?? parentRun.workflowHash ?? null,
+                status: parentRun.status === "running" ? "failed" : parentRun.status,
+                createdAtMs: ts,
+                startedAtMs: null,
+                finishedAtMs: parentRun.finishedAtMs ?? ts,
+                heartbeatAtMs: null,
+                runtimeOwnerId: null,
+                cancelRequestedAtMs: null,
+                hijackRequestedAtMs: null,
+                hijackTarget: null,
+                vcsType: parentRun.vcsType ?? null,
+                vcsRoot: parentRun.vcsRoot ?? null,
+                vcsRevision: source.vcsPointer ?? parentRun.vcsRevision ?? null,
+                errorJson: null,
+                configJson: parentRun.configJson ?? null,
+            }
+            : null;
         const branch = {
             runId: childRunId,
             parentRunId,
@@ -119,19 +99,39 @@ export function forkRun(adapter, params) {
             forkDescription: forkDescription ?? null,
             createdAtMs: ts,
         };
-        yield* Effect.tryPromise({
-            try: () => adapter.db
-                .insert(smithersBranches)
-                .values(branch)
-                .onConflictDoUpdate({
-                target: smithersBranches.runId,
-                set: branch,
-            }),
-            catch: (cause) => toSmithersError(cause, "insert branch", {
-                code: "DB_WRITE_FAILED",
-                details: { runId: childRunId },
-            }),
-        });
+        // 5. Persist the fork atomically: snapshot, optional run metadata, and
+        // branch relationship must either all commit or all roll back.
+        yield* adapter.withTransactionEffect("fork run", Effect.gen(function* () {
+            yield* Effect.tryPromise({
+                try: () => adapter.db
+                    .insert(smithersSnapshots)
+                    .values(childSnapshot)
+                    .onConflictDoUpdate({
+                    target: [smithersSnapshots.runId, smithersSnapshots.frameNo],
+                    set: childSnapshot,
+                }),
+                catch: (cause) => toSmithersError(cause, "insert forked snapshot", {
+                    code: "DB_WRITE_FAILED",
+                    details: { frameNo: 0, runId: childRunId },
+                }),
+            });
+            if (childRun) {
+                yield* adapter.insertRun(childRun);
+            }
+            yield* Effect.tryPromise({
+                try: () => adapter.db
+                    .insert(smithersBranches)
+                    .values(branch)
+                    .onConflictDoUpdate({
+                    target: smithersBranches.runId,
+                    set: branch,
+                }),
+                catch: (cause) => toSmithersError(cause, "insert branch", {
+                    code: "DB_WRITE_FAILED",
+                    details: { runId: childRunId },
+                }),
+            });
+        }));
         yield* Metric.increment(runForksCreated);
         yield* Effect.logInfo("Run forked").pipe(Effect.annotateLogs({
             parentRunId,

--- a/packages/time-travel/tests/fork-recovery.test.js
+++ b/packages/time-travel/tests/fork-recovery.test.js
@@ -120,10 +120,17 @@ describe("fork recovery: mid-creation failure", () => {
     }
     expect(caught).toBeDefined();
 
-    // Recreate branches so we can read; the child run row may exist (forkRun
-    // does not run inside a transaction). Document the contract: child
-    // metadata IS persisted before the branch row, so listBranches sees no
-    // stranded branch entry — that's the durable contract.
+    const runCount = sqlite
+      .query(`SELECT COUNT(*) AS count FROM _smithers_runs`)
+      .get().count;
+    const snapshotCount = sqlite
+      .query(`SELECT COUNT(*) AS count FROM _smithers_snapshots`)
+      .get().count;
+    expect(runCount).toBe(1);
+    expect(snapshotCount).toBe(1);
+
+    // Recreate branches so we can read; fork creation is atomic, so a branch
+    // insert failure must not leave a stranded branch entry either.
     sqlite.run(`CREATE TABLE _smithers_branches (
       run_id TEXT PRIMARY KEY,
       parent_run_id TEXT NOT NULL,


### PR DESCRIPTION
## What changed

- Splits the non-demo dirty worktree changes into a separate cleanup PR.
- Includes CLI/devtools error handling and JSON stdout contract updates.
- Includes agent diagnostics, SQL message storage streaming, engine deferred/heartbeat/workflow command coverage, driver child process cleanup, and time-travel fork recovery changes.
- Includes the associated docs/reference and Smithers ticket updates.

## Validation

- `PATH=/Users/shawwalters/.bun/bin:$PATH bun test --timeout=120000 --max-concurrency=1 apps/cli/tests/cli-devtools-process.test.js apps/cli/tests/docs-examples-smoke.test.js apps/cli/tests/init.e2e.test.js apps/cli/tests/json-stdout-contract.test.js packages/agents/tests/agent-diagnostics.test.js packages/db/tests/sql-message-storage-stream.test.js packages/engine/tests/deferred-contract.test.js packages/engine/tests/heartbeat-bounds.test.jsx packages/engine/tests/workflow-command.e2e.test.js packages/time-travel/tests/fork-recovery.test.js`

Result: 81 pass, 1 expected skip, 0 fail.
