### PR TITLE
Add Smithers prompt optimization with provider support

### DIFF
--- a/.smithers/workflows/studio-parity-swarm.tsx
+++ b/.smithers/workflows/studio-parity-swarm.tsx
@@ -209,6 +209,9 @@ const repoRootProbe = spawnSync("jj", ["root"], { encoding: "utf8" });
 const repoRoot = repoRootProbe.status === 0 ? repoRootProbe.stdout.trim() : process.cwd();
 
 type ParityTicket = z.infer<typeof parityTicketSchema>;
+type TicketImplementation = z.infer<typeof ticketImplementationSchema>;
+type TicketValidation = z.infer<typeof ticketValidationSchema>;
+type TicketReview = z.infer<typeof ticketReviewSchema>;
 
 function latestForTicket<T extends { ticketId: string }>(rows: T[] | undefined, ticketId: string): T | undefined {
   return [...(rows ?? [])].reverse().find((row) => row.ticketId === ticketId);
@@ -271,16 +274,16 @@ function agentForTicket(ticket: ParityTicket, index: number): AgentLike[] {
 }
 
 function ticketDone(ticketId: string, ctx: any) {
-  const implementation = latestForTicket(ctx.outputs.implementation, ticketId);
-  const validation = latestForTicket(ctx.outputs.validation, ticketId);
-  const review = latestForTicket(ctx.outputs.review, ticketId);
+  const implementation = latestForTicket<TicketImplementation>(ctx.outputs.implementation, ticketId);
+  const validation = latestForTicket<TicketValidation>(ctx.outputs.validation, ticketId);
+  const review = latestForTicket<TicketReview>(ctx.outputs.review, ticketId);
   return Boolean(implementation?.status === "implemented" && validation?.allPassed && review?.approved);
 }
 
 function ticketFeedback(ticketId: string, ctx: any) {
-  const implementation = latestForTicket(ctx.outputs.implementation, ticketId);
-  const validation = latestForTicket(ctx.outputs.validation, ticketId);
-  const review = latestForTicket(ctx.outputs.review, ticketId);
+  const implementation = latestForTicket<TicketImplementation>(ctx.outputs.implementation, ticketId);
+  const validation = latestForTicket<TicketValidation>(ctx.outputs.validation, ticketId);
+  const review = latestForTicket<TicketReview>(ctx.outputs.review, ticketId);
   const parts: string[] = [];
   if (implementation && implementation.status !== "implemented") {
     parts.push([

--- a/.smithers/workflows/studio-parity-swarm.tsx
+++ b/.smithers/workflows/studio-parity-swarm.tsx
@@ -1,0 +1,644 @@
+// smithers-display-name: Smithers Studio Parity Swarm
+/** @jsxImportSource smithers-orchestrator */
+import {
+  AntigravityAgent,
+  ClaudeCodeAgent,
+  CodexAgent,
+  GeminiAgent,
+  KimiAgent,
+  MergeQueue,
+  Parallel,
+  Sequence,
+  Task,
+  Worktree,
+  createSmithers,
+  type AgentLike,
+} from "smithers-orchestrator";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { z } from "zod/v4";
+
+const ticketKindSchema = z.enum([
+  "feature",
+  "ui",
+  "terminal",
+  "test-only",
+  "review-existing",
+  "gateway",
+  "ci",
+  "bugfix",
+]);
+
+const difficultySchema = z.enum(["easy", "medium", "hard", "critical"]);
+
+const parityTicketSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  kind: ticketKindSchema,
+  difficulty: difficultySchema,
+  priority: z.number().min(0).max(100),
+  requiresUi: z.boolean().default(false),
+  testsOnly: z.boolean().default(false),
+  summary: z.string(),
+  acceptanceCriteria: z.array(z.string()).default([]),
+  filesLikely: z.array(z.string()).default([]),
+  testPlan: z.array(z.string()).default([]),
+});
+
+const discoverySchema = z.object({
+  complete: z.boolean().default(false),
+  rationale: z.string(),
+  tickets: z.array(parityTicketSchema).max(16).default([]),
+});
+
+const ticketImplementationSchema = z.object({
+  ticketId: z.string(),
+  status: z.enum(["implemented", "partial", "blocked"]).default("implemented"),
+  summary: z.string(),
+  researchNotes: z.array(z.string()).default([]),
+  planSummary: z.string(),
+  filesChanged: z.array(z.string()).default([]),
+  testsAddedOrUpdated: z.array(z.string()).default([]),
+  commandsRun: z.array(z.string()).default([]),
+});
+
+const ticketValidationSchema = z.object({
+  ticketId: z.string(),
+  allPassed: z.boolean(),
+  summary: z.string(),
+  commandsRun: z.array(z.string()).default([]),
+  failingSummary: z.string().nullable().default(null),
+});
+
+const ticketReviewSchema = z.object({
+  ticketId: z.string(),
+  approved: z.boolean(),
+  reviewer: z.string(),
+  feedback: z.string(),
+  issues: z.array(z.object({
+    severity: z.enum(["critical", "major", "minor", "nit"]),
+    title: z.string(),
+    file: z.string().nullable().default(null),
+    description: z.string(),
+  })).default([]),
+});
+
+const ticketResultSchema = z.object({
+  ticketId: z.string(),
+  branch: z.string(),
+  worktreePath: z.string(),
+  lgtm: z.boolean(),
+  summary: z.string(),
+});
+
+const mergeResultSchema = z.object({
+  ticketId: z.string(),
+  mergedToMain: z.boolean(),
+  branch: z.string(),
+  summary: z.string(),
+  conflicts: z.array(z.string()).default([]),
+  commandsRun: z.array(z.string()).default([]),
+});
+
+const ciResultSchema = z.object({
+  allPassed: z.boolean(),
+  summary: z.string(),
+  commands: z.array(z.object({
+    command: z.string(),
+    exitCode: z.number().nullable(),
+    stdout: z.string(),
+    stderr: z.string(),
+  })).default([]),
+});
+
+const finalAuditSchema = z.object({
+  complete: z.boolean(),
+  summary: z.string(),
+  remainingTickets: z.array(z.string()).default([]),
+  evidence: z.array(z.string()).default([]),
+});
+
+function currentJjCommit(): string | null {
+  const result = spawnSync("jj", ["log", "-r", "@", "--no-graph", "--template", "commit_id ++ \"\\n\""], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  return result.stdout.trim() || null;
+}
+
+const defaultWorktreeBase = process.env.SMITHERS_STUDIO_BASE_BRANCH?.trim() || currentJjCommit() || "main";
+
+const inputSchema = z.object({
+  maxConcurrency: z.number().int().min(1).max(16).default(16),
+  maxBatches: z.number().int().min(1).max(12).default(6),
+  perTicketIterations: z.number().int().min(1).max(8).default(5),
+  runFullE2E: z.boolean().default(true),
+  baseBranch: z.string().min(1).default(defaultWorktreeBase),
+});
+
+const { Workflow, Loop, smithers, outputs } = createSmithers({
+  input: inputSchema,
+  discovery: discoverySchema,
+  implementation: ticketImplementationSchema,
+  validation: ticketValidationSchema,
+  review: ticketReviewSchema,
+  ticketResult: ticketResultSchema,
+  merge: mergeResultSchema,
+  ci: ciResultSchema,
+  finalAudit: finalAuditSchema,
+});
+
+const codexModel = process.env.SMITHERS_STUDIO_CODEX_MODEL?.trim();
+const codex = new CodexAgent({
+  ...(codexModel ? { model: codexModel } : {}),
+  sandbox: "danger-full-access",
+  dangerouslyBypassApprovalsAndSandbox: true,
+  skipGitRepoCheck: true,
+});
+const claude = new ClaudeCodeAgent({
+  model: process.env.SMITHERS_STUDIO_CLAUDE_MODEL ?? "claude-sonnet-4-20250514",
+  permissionMode: "bypassPermissions",
+  dangerouslySkipPermissions: true,
+});
+const gemini = new GeminiAgent({
+  model: process.env.SMITHERS_STUDIO_GEMINI_MODEL ?? "gemini-3.1-pro-preview",
+  yolo: true,
+});
+const antigravity = new AntigravityAgent({
+  model: process.env.SMITHERS_STUDIO_ANTIGRAVITY_MODEL ?? "gemini-3.1-pro-preview",
+  yolo: true,
+  dangerouslySkipPermissions: true,
+});
+const kimi = new KimiAgent({
+  finalMessageOnly: true,
+  quiet: true,
+});
+
+function commandExists(command: string): boolean {
+  const probe = process.platform === "win32"
+    ? spawnSync("where", [command], { stdio: "ignore" })
+    : spawnSync("which", [command], { stdio: "ignore" });
+  return probe.status === 0;
+}
+
+const availableAgents = {
+  antigravity: commandExists("agy"),
+  claude: commandExists("claude"),
+  codex: commandExists("codex"),
+  gemini: process.env.SMITHERS_STUDIO_ENABLE_GEMINI === "1" && commandExists("gemini"),
+  kimi: process.env.SMITHERS_STUDIO_ENABLE_KIMI === "1" && commandExists("kimi"),
+};
+
+function availableChain(entries: Array<[keyof typeof availableAgents, AgentLike]>): AgentLike[] {
+  const chain = entries
+    .filter(([name]) => availableAgents[name])
+    .map(([, agent]) => agent);
+  return chain.length > 0 ? chain : [codex];
+}
+
+const codexChain: AgentLike[] = availableChain([["codex", codex], ["claude", claude], ["kimi", kimi]]);
+const claudeChain: AgentLike[] = availableChain([["claude", claude], ["codex", codex], ["kimi", kimi]]);
+const geminiChain: AgentLike[] = availableChain([["gemini", gemini], ["claude", claude], ["codex", codex], ["kimi", kimi]]);
+const antigravityChain: AgentLike[] = availableChain([["antigravity", antigravity], ["gemini", gemini], ["claude", claude], ["codex", codex], ["kimi", kimi]]);
+const reviewChain: AgentLike[] = availableChain([["codex", codex], ["claude", claude], ["kimi", kimi]]);
+const discoveryChain: AgentLike[] = availableChain([["codex", codex], ["claude", claude], ["kimi", kimi]]);
+const agentTaskRetries = 3;
+const repoRootProbe = spawnSync("jj", ["root"], { encoding: "utf8" });
+const repoRoot = repoRootProbe.status === 0 ? repoRootProbe.stdout.trim() : process.cwd();
+
+type ParityTicket = z.infer<typeof parityTicketSchema>;
+
+function latestForTicket<T extends { ticketId: string }>(rows: T[] | undefined, ticketId: string): T | undefined {
+  return [...(rows ?? [])].reverse().find((row) => row.ticketId === ticketId);
+}
+
+function latest<T>(rows: T[] | undefined): T | undefined {
+  return rows && rows.length > 0 ? rows[rows.length - 1] : undefined;
+}
+
+function latestLgtmResults(results: Array<z.infer<typeof ticketResultSchema>>) {
+  const byTicket = new Map<string, z.infer<typeof ticketResultSchema>>();
+  for (const result of results) {
+    if (result.lgtm) {
+      byTicket.set(result.ticketId, result);
+    }
+  }
+  return [...byTicket.values()];
+}
+
+function slug(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 80) || "ticket";
+}
+
+function worktreeForTicket(ticketId: string) {
+  return join(repoRoot, ".smithers", "workflows", ".worktrees", `studio-parity-${slug(ticketId)}`);
+}
+
+function worktreeBase(ctx: any) {
+  return process.env.SMITHERS_STUDIO_BASE_BRANCH?.trim() || currentJjCommit() || ctx.input.baseBranch;
+}
+
+function ticketScopedPorts(ticketId: string) {
+  const suffix = Number(ticketId.match(/(\d+)$/)?.[1] ?? "0");
+  const offset = Number.isFinite(suffix) ? suffix : Math.abs(hashString(ticketId) % 400);
+  return {
+    appPort: 5500 + offset,
+    gatewayPort: 7400 + offset,
+  };
+}
+
+function hashString(value: string) {
+  let hash = 0;
+  for (const char of value) {
+    hash = (hash * 31 + char.charCodeAt(0)) | 0;
+  }
+  return hash;
+}
+
+function agentForTicket(ticket: ParityTicket, index: number): AgentLike[] {
+  if (ticket.requiresUi || ticket.kind === "ui" || ticket.kind === "terminal") {
+    return antigravityChain;
+  }
+  if (ticket.testsOnly || ticket.kind === "test-only" || ticket.difficulty === "easy") {
+    return claudeChain;
+  }
+  if (ticket.difficulty === "hard" || ticket.difficulty === "critical" || ticket.kind === "gateway") {
+    return codexChain;
+  }
+  return index % 2 === 0 ? codexChain : claudeChain;
+}
+
+function ticketDone(ticketId: string, ctx: any) {
+  const implementation = latestForTicket(ctx.outputs.implementation, ticketId);
+  const validation = latestForTicket(ctx.outputs.validation, ticketId);
+  const review = latestForTicket(ctx.outputs.review, ticketId);
+  return Boolean(implementation?.status === "implemented" && validation?.allPassed && review?.approved);
+}
+
+function ticketFeedback(ticketId: string, ctx: any) {
+  const implementation = latestForTicket(ctx.outputs.implementation, ticketId);
+  const validation = latestForTicket(ctx.outputs.validation, ticketId);
+  const review = latestForTicket(ctx.outputs.review, ticketId);
+  const parts: string[] = [];
+  if (implementation && implementation.status !== "implemented") {
+    parts.push([
+      `IMPLEMENTATION SELF-CHECK ${implementation.status.toUpperCase()}:`,
+      implementation.summary,
+      implementation.commandsRun?.length ? `Commands run:\n${implementation.commandsRun.map((command) => `- ${command}`).join("\n")}` : "",
+    ].filter(Boolean).join("\n"));
+  }
+  if (validation && !validation.allPassed) {
+    parts.push(`VALIDATION FAILED:\n${validation.failingSummary ?? validation.summary}`);
+  }
+  if (review && !review.approved) {
+    parts.push(`REVIEW NOT LGTM:\n${review.feedback}`);
+    for (const issue of review.issues ?? []) {
+      parts.push(`- [${issue.severity}] ${issue.title}: ${issue.description}${issue.file ? ` (${issue.file})` : ""}`);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+function parityBacklogBrief() {
+  return [
+    "Active app: apps/smithers-studio-2 is the new Studio UI being built. Preserve it and move parity work into it when the ticket touches the new UI shell.",
+    "Runtime: no UI-only mock data; Vite and Electrobun must hit the same workspace backend and Smithers Gateway contracts.",
+    "Fixture realism: Playwright fixtures are fine only when data flows through Gateway RPC/SSE, filesystem, SQLite, CLI, and workspace routes.",
+    "Terminal: replace generic terminal rendering with a libghostty-backed React/web terminal. Research @wterm/ghostty and @wterm/react first.",
+    "Chat: provider/model selection, supervised/full-access runtime mode, branching/regeneration, transcript search, markdown/syntax highlighting, real attachments, web-search toggle, structured /diff, streaming auto-scroll.",
+    "Slash commands: full inventory, route side effects, robust key-value parser, dynamic conflicts, real fuzzy matching or explicit substring contract.",
+    "Workflows/prompts/approvals: unsaved prompt preview, dynamic inputs, launch validation, iteration-aware approvals, adaptive layouts.",
+    "Runs/dashboard/inspection: iteration-safe approve/deny, progress for approval runs, active elapsed timer, cancelled/failed semantics, source error surfacing, snapshots/fork/replay.",
+    "Landings/issues/workspaces: JJHub state filters, unified diffs, complete issue CRUD, workspace restore naming/selection.",
+    "Scores/memory/search: scoped metrics, stale async protection, discontiguous line numbers, recall metadata.",
+    "Transport/platform: production SSE parser tests, CLI timeout kill path, unknown status preservation, explicit approval decoding.",
+    "All accepted work needs tests: Playwright for visible behavior, backend/unit tests for transport/parser/model invariants.",
+  ].join("\n- ");
+}
+
+function discoveryPrompt(previousResults: unknown[], previousAudit: unknown) {
+  return [
+    "You are the primary Codex discovery agent for Smithers Studio parity. Use the configured Codex model; if SMITHERS_STUDIO_CODEX_MODEL is set, it is expected to point at the user's requested Codex 5.5-class model.",
+    "Pick the 16 best next tickets to run in parallel. Do not plan a separate phase; each ticket assignee must research, plan, implement, and test in one task.",
+    "Include past unreviewed Studio features in the backlog: existing work must be code-reviewed and updated until LGTM.",
+    "Important: apps/smithers-studio-2 is active user work for the new Studio version. Never delete it, remove its package references, or treat it as a disposable static sibling app.",
+    "Prioritize high-leverage work that moves the active Studio UI, apps/smithers-studio-2, toward the user's exact goal: real data, Gateway, .smithers detection, GUI parity, and Playwright coverage. Use apps/smithers-studio as existing implementation context when useful, but do not erase the v2 app.",
+    "Use realistic E2E fixtures. Do not ask agents to add static React mocks or fake UI state.",
+    "Classify UI and terminal work as requiresUi. Classify tests-only work as testsOnly.",
+    "",
+    "Known backlog:",
+    `- ${parityBacklogBrief()}`,
+    "",
+    "Previous ticket results:",
+    JSON.stringify(previousResults, null, 2),
+    "",
+    "Previous final audit:",
+    JSON.stringify(previousAudit ?? null, null, 2),
+    "",
+    "Return complete=true only if there are no meaningful parity, test, review, fixture-realism, merge, or CI gaps left.",
+  ].join("\n");
+}
+
+function implementationPrompt(ticket: ParityTicket, feedback: string) {
+  const ports = ticketScopedPorts(ticket.id);
+  return [
+    `Ticket ${ticket.id}: ${ticket.title}`,
+    ticket.summary,
+    "",
+    "Research, plan, implement, and test this ticket in one pass. Do not stop after a plan.",
+    `Return ticketId exactly "${ticket.id}". If you cannot do that, return status=blocked with the reason.`,
+    "You are working toward Smithers Studio parity for the active new Studio UI in apps/smithers-studio-2. Existing apps/smithers-studio code may be used as implementation context, but do not erase or bypass the v2 app.",
+    "Respect current code style. Avoid unrelated refactors. Do not remove user work.",
+    "Protect apps/smithers-studio-2. It is active user work for the new Studio version, not reference code and not a mock. Do not delete it, remove it from the workspace, remove root scripts that point at it, or satisfy gates by making it disappear.",
+    "Runtime code must use real workspace/Gateway/CLI/filesystem/SQLite paths. Tests may use realistic fixtures, but not UI-only mock data.",
+    "If this touches terminal UI, use the Ghostty/libghostty React path: research @wterm/ghostty plus @wterm/react and wire the app toward that rather than xterm.js or plain text.",
+    "If this is UI work, use Playwright screenshots/assertions where relevant.",
+    "If this is tests-only work, add/repair tests that prove existing real behavior through backend or E2E contracts.",
+    "",
+    "Before returning status=implemented, run your own review/CI gate:",
+    "- Re-read the acceptance criteria and any previous validation/review feedback.",
+    "- Explicitly fix every previous review issue or explain why the issue is no longer applicable in summary.",
+    "- Inspect package.json and run real package-owned scripts; do not invent missing commands.",
+    "- Run typecheck/build plus focused backend or Playwright checks for touched behavior.",
+    "- Treat validation, review, merge, and final CI as predictable gates: your work must pass the validationPrompt checks, survive strict code review, merge cleanly, and not break shared CI.",
+    `- For Playwright or Gateway fixture checks in this ticket, avoid shared ports: use SMITHERS_STUDIO_TEST_PORT=${ports.appPort} SMITHERS_STUDIO_GATEWAY_TEST_PORT=${ports.gatewayPort}.`,
+    "- Post-merge CI currently runs Studio 2 preservation/typecheck/build, plus legacy Studio parity checks: pnpm --dir apps/smithers-studio-2 run typecheck; pnpm --dir apps/smithers-studio-2 run build; pnpm --dir apps/smithers-studio run typecheck; pnpm --dir apps/smithers-studio run build:web; pnpm --dir apps/smithers-studio run test:backend; and, when full E2E is enabled, pnpm --dir apps/smithers-studio exec playwright test tests/connected-gateway.spec.ts --reporter=line.",
+    "- At minimum for apps/smithers-studio-2 or apps/smithers-studio changes, run the relevant subset of those CI commands plus any focused package tests for the files you touched.",
+    "- If package.json has test or test:mock-data-guard and your change touches runtime, fixtures, tests, or app routing, run those scripts too.",
+    "- If you changed Gateway/client/server packages, also run their package-owned focused tests after inspecting package.json.",
+    "- Before finishing, inspect your diff for unresolved TODO shortcuts, TypeScript scope errors, fixture paths missing from the worktree, static mock data, and UI behavior that is only hard-coded for tests.",
+    "- If Playwright depends on fixture workflow frontends, verify required files such as tests/fixtures/workspace/.smithers/workflows/*/manifest.json and frontend dist/index.html exist in your worktree.",
+    "- Include the exact commands you ran and what remains unverified in commandsRun/summary.",
+    "- If a relevant check fails, a required script is missing in your worktree, or a check was not run, return status=partial or blocked with the exact command and failure.",
+    "- Do not add hard-coded route mocks, runtime mock data, or UI-only shortcuts. Do not delete or hide apps/smithers-studio-2.",
+    "- Fixtures are allowed only when they exercise realistic filesystem, SQLite, Gateway, SSE, CLI, or browser behavior.",
+    "",
+    "Acceptance criteria:",
+    ticket.acceptanceCriteria.map((item) => `- ${item}`).join("\n"),
+    "",
+    "Likely files:",
+    ticket.filesLikely.map((item) => `- ${item}`).join("\n"),
+    "",
+    "Test plan:",
+    ticket.testPlan.map((item) => `- ${item}`).join("\n"),
+    feedback ? `\nPrevious loop feedback to fix:\n${feedback}` : "",
+  ].join("\n");
+}
+
+function validationPrompt(ticket: ParityTicket, implementation?: z.infer<typeof ticketImplementationSchema>) {
+  const ports = ticketScopedPorts(ticket.id);
+  return [
+    `Validate ticket ${ticket.id}: ${ticket.title}`,
+    `Return ticketId exactly "${ticket.id}". Never substitute an inferred id such as "unknown" or a package name.`,
+    implementation
+      ? `Implementation self-report:\n${JSON.stringify({
+        status: implementation.status,
+        summary: implementation.summary,
+        commandsRun: implementation.commandsRun,
+      }, null, 2)}`
+      : "No implementation self-report is available yet; inspect the worktree directly.",
+    "Run the most relevant commands. Prefer real backend/unit tests plus focused Playwright for visible behavior.",
+    "Do not approve by inspection only. Return allPassed=false with failingSummary if anything relevant fails or was not run.",
+    "If the implementation self-report is partial or blocked, return allPassed=false unless you independently verify the named gap is now resolved.",
+    `Use ticket-scoped ports for Playwright/Gateway fixture commands: SMITHERS_STUDIO_TEST_PORT=${ports.appPort} SMITHERS_STUDIO_GATEWAY_TEST_PORT=${ports.gatewayPort}. Do not use shared default ports in parallel validation.`,
+    "If those ticket-scoped ports are busy, rerun once with another unused SMITHERS_STUDIO_TEST_PORT and SMITHERS_STUDIO_GATEWAY_TEST_PORT pair before failing on a port conflict.",
+    "Do not set allPassed=true unless acceptance-relevant behavior was exercised through production code and package-owned scripts, including test:mock-data-guard when present.",
+    "For apps/smithers-studio, inspect package.json first. Common commands currently include:",
+    "- pnpm --dir apps/smithers-studio-2 run typecheck",
+    "- pnpm --dir apps/smithers-studio-2 run build",
+    "- pnpm --dir apps/smithers-studio run typecheck",
+    "- pnpm --dir apps/smithers-studio run build:web",
+    "- pnpm --dir apps/smithers-studio run test:backend",
+    `- SMITHERS_STUDIO_TEST_PORT=${ports.appPort} SMITHERS_STUDIO_GATEWAY_TEST_PORT=${ports.gatewayPort} pnpm --dir apps/smithers-studio exec playwright test tests/connected-gateway.spec.ts --reporter=line`,
+  ].join("\n");
+}
+
+function reviewPrompt(
+  ticket: ParityTicket,
+  implementation?: z.infer<typeof ticketImplementationSchema>,
+  validation?: z.infer<typeof ticketValidationSchema>,
+) {
+  return [
+    `Review ticket ${ticket.id}: ${ticket.title}`,
+    `Return ticketId exactly "${ticket.id}".`,
+    implementation
+      ? `Implementation self-report:\n${JSON.stringify({
+        status: implementation.status,
+        summary: implementation.summary,
+        commandsRun: implementation.commandsRun,
+      }, null, 2)}`
+      : "No implementation self-report is available yet; inspect the worktree directly.",
+    validation
+      ? `Validation result:\n${JSON.stringify({
+        allPassed: validation.allPassed,
+        summary: validation.summary,
+        failingSummary: validation.failingSummary,
+        commandsRun: validation.commandsRun,
+      }, null, 2)}`
+      : "No validation result is available yet; inspect the worktree directly.",
+    "You are the mandatory reviewer. Do not edit files.",
+    "Review the current worktree against the user goal and the ticket acceptance criteria.",
+    "Reject any change that deletes apps/smithers-studio-2, removes its package/workspace references, or treats it as a forbidden static sibling app.",
+    "Reject if implementation status is partial/blocked, validation failed, validation was too shallow, used the wrong ticketId, skipped relevant package-owned tests, or only asserted local test copies/static shortcuts.",
+    "Return approved=true only when the code is LGTM, tests are meaningful, fixture data remains realistic E2E data, and no static UI mock shortcuts were added.",
+    "For terminal work, reject unless the implementation clearly uses or is intentionally staged toward @wterm/ghostty/@wterm/react/libghostty.",
+    "Findings should include severity, title, file, and description.",
+  ].join("\n");
+}
+
+function mergePrompt(result: z.infer<typeof ticketResultSchema>) {
+  return [
+    `Merge ticket ${result.ticketId} back into the main working tree.`,
+    `Source worktree: ${result.worktreePath}`,
+    `Source branch: ${result.branch}`,
+    "",
+    "Use the repo's VCS safely. Prefer jj/git merge mechanics when possible; otherwise carefully apply the source worktree diff.",
+    "Do not discard unrelated current working-tree changes.",
+    "Never merge deletions of apps/smithers-studio-2 or package/lockfile changes whose purpose is to remove that app. It is active user work.",
+    "Resolve conflicts if possible. If not possible, report mergedToMain=false and list conflicts.",
+    "After merging, run focused checks relevant to the ticket. Full CI runs later.",
+  ].join("\n");
+}
+
+function runCommand(command: string, args: string[], timeoutMs: number) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...process.env },
+    timeout: timeoutMs,
+  });
+  return {
+    command: [command, ...args].join(" "),
+    exitCode: result.status,
+    stdout: (result.stdout ?? "").slice(-20_000),
+    stderr: (result.stderr ?? result.error?.message ?? "").slice(-20_000),
+  };
+}
+
+function runCi(runFullE2E: boolean) {
+  const commands = [
+    ["pnpm", ["--dir", "apps/smithers-studio-2", "run", "typecheck"]],
+    ["pnpm", ["--dir", "apps/smithers-studio-2", "run", "build"]],
+    ["pnpm", ["--dir", "apps/smithers-studio", "run", "typecheck"]],
+    ["pnpm", ["--dir", "apps/smithers-studio", "run", "build:web"]],
+    ["pnpm", ["--dir", "apps/smithers-studio", "run", "test:backend"]],
+  ] as const;
+  const results = commands.map(([command, args]) => runCommand(command, [...args], 20 * 60_000));
+  if (runFullE2E) {
+    results.push(runCommand(
+      "pnpm",
+      ["--dir", "apps/smithers-studio", "exec", "playwright", "test", "tests/connected-gateway.spec.ts", "--reporter=line"],
+      6 * 60_000,
+    ));
+  }
+  const failed = results.filter((result) => result.exitCode !== 0);
+  return {
+    allPassed: failed.length === 0,
+    summary: failed.length === 0
+      ? "All configured Smithers Studio CI commands passed."
+      : `${failed.length} configured CI command(s) failed.`,
+    commands: results,
+  };
+}
+
+function finalAuditPrompt(ci: unknown, merges: unknown[], results: unknown[]) {
+  return [
+    "Audit Smithers Studio against the full user goal. Be strict.",
+    "Goal: no runtime mock data; real Smithers Gateway/data; .smithers detection; Vite and Electrobun modes; 100% parity with attempted ../gui features; Playwright tests for all features.",
+    "Do not mark complete unless every requirement is proven by current code and verification.",
+    "",
+    "Known backlog:",
+    `- ${parityBacklogBrief()}`,
+    "",
+    "Ticket results:",
+    JSON.stringify(results, null, 2),
+    "",
+    "Merge results:",
+    JSON.stringify(merges, null, 2),
+    "",
+    "CI result:",
+    JSON.stringify(ci, null, 2),
+    "",
+    "Return complete=false with remainingTickets unless the app is genuinely at the requested end state.",
+  ].join("\n");
+}
+
+export default smithers((ctx) => {
+  const discovered = latest(ctx.outputs.discovery);
+  const finalAudit = latest(ctx.outputs.finalAudit);
+  const ticketResults = ctx.outputs.ticketResult ?? [];
+  const mergeResults = ctx.outputs.merge ?? [];
+  const latestCi = latest(ctx.outputs.ci);
+  const done = finalAudit?.complete === true;
+  const tickets = discovered?.tickets ?? [];
+
+  return (
+    <Workflow name="studio-parity-swarm">
+      <Loop id="studio-parity-batches" until={done} maxIterations={ctx.input.maxBatches} onMaxReached="return-last">
+        <Sequence>
+          <Task id="discover-next-16" output={outputs.discovery} agent={discoveryChain} retries={agentTaskRetries} timeoutMs={45 * 60_000} heartbeatTimeoutMs={10 * 60_000}>
+            {discoveryPrompt(ticketResults, finalAudit)}
+          </Task>
+
+          {tickets.length > 0 ? (
+            <Parallel maxConcurrency={ctx.input.maxConcurrency}>
+              {tickets.map((ticket, index) => {
+                const ticketSlug = slug(ticket.id);
+                const worktreePath = worktreeForTicket(ticket.id);
+                const branch = `studio-parity/${ticketSlug}`;
+                const feedback = ticketFeedback(ticket.id, ctx);
+                const lgtm = ticketDone(ticket.id, ctx);
+                const implementation = latestForTicket(ctx.outputs.implementation, ticket.id);
+                const validation = latestForTicket(ctx.outputs.validation, ticket.id);
+                return (
+                  <Worktree key={ticket.id} path={worktreePath} branch={branch} baseBranch={worktreeBase(ctx)}>
+                    <Sequence>
+                      <Loop id={`ticket-${ticketSlug}-review-loop`} until={lgtm} maxIterations={ctx.input.perTicketIterations} onMaxReached="return-last">
+                        <Sequence>
+                          <Task
+                            id={`ticket-${ticketSlug}-implement`}
+                            output={outputs.implementation}
+                            agent={agentForTicket(ticket, index)}
+                            retries={agentTaskRetries}
+                            timeoutMs={60 * 60_000}
+                            heartbeatTimeoutMs={10 * 60_000}
+                          >
+                            {implementationPrompt(ticket, feedback)}
+                          </Task>
+                          <Task
+                            id={`ticket-${ticketSlug}-validate`}
+                            output={outputs.validation}
+                            agent={claudeChain}
+                            retries={agentTaskRetries}
+                            timeoutMs={35 * 60_000}
+                            heartbeatTimeoutMs={10 * 60_000}
+                          >
+                            {validationPrompt(ticket, implementation)}
+                          </Task>
+                          <Task
+                            id={`ticket-${ticketSlug}-review`}
+                            output={outputs.review}
+                            agent={reviewChain}
+                            retries={agentTaskRetries}
+                            timeoutMs={35 * 60_000}
+                            heartbeatTimeoutMs={10 * 60_000}
+                          >
+                            {reviewPrompt(ticket, implementation, validation)}
+                          </Task>
+                          {ticketDone(ticket.id, ctx) ? (
+                            <Task id={`ticket-${ticketSlug}-result`} output={outputs.ticketResult}>
+                              {{
+                                ticketId: ticket.id,
+                                branch,
+                                worktreePath,
+                                lgtm: true,
+                                summary: `Ticket ${ticket.id} reached validation + review LGTM.`,
+                              }}
+                            </Task>
+                          ) : null}
+                        </Sequence>
+                      </Loop>
+                    </Sequence>
+                  </Worktree>
+                );
+              })}
+            </Parallel>
+          ) : null}
+
+          <MergeQueue id="studio-parity-merge-queue" maxConcurrency={1}>
+            {latestLgtmResults(ticketResults).map((result) => (
+              <Task
+                key={result.ticketId}
+                id={`merge-${slug(result.ticketId)}`}
+                output={outputs.merge}
+                agent={reviewChain}
+                retries={agentTaskRetries}
+                timeoutMs={45 * 60_000}
+                heartbeatTimeoutMs={10 * 60_000}
+              >
+                {mergePrompt(result)}
+              </Task>
+            ))}
+          </MergeQueue>
+
+          <Task id="studio-parity-ci" output={outputs.ci} timeoutMs={90 * 60_000}>
+            {() => runCi(ctx.input.runFullE2E)}
+          </Task>
+
+          <Task
+            id="studio-parity-final-audit"
+            output={outputs.finalAudit}
+            agent={reviewChain}
+            retries={agentTaskRetries}
+            timeoutMs={45 * 60_000}
+            heartbeatTimeoutMs={10 * 60_000}
+          >
+            {finalAuditPrompt(latestCi, mergeResults, ticketResults)}
+          </Task>
+        </Sequence>
+      </Loop>
+    </Workflow>
+  );
+});

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Each task output is validated against its Zod schema and persisted to SQLite. If
 smithers up workflow.tsx --input '{"description": "Fix bug"}'
 smithers up workflow.tsx --run-id abc123 --resume true
 smithers eval workflow.tsx --cases evals/smoke.jsonl --suite smoke
+smithers optimize workflow.tsx --cases evals/smoke.jsonl --provider cerebras --model gpt-oss-120b
 smithers ps
 smithers workflow list
 smithers approve abc123 --node review
@@ -110,6 +111,21 @@ smithers eval workflow.tsx --cases evals/smoke.jsonl --suite smoke --force
 ```
 
 Reports are written to `.smithers/evals/<suite>.json` and the command exits non-zero when any case fails.
+
+## Prompt optimization
+
+Run GEPA-style prompt optimization against an eval suite:
+
+```bash
+smithers optimize workflow.tsx \
+  --cases evals/smoke.jsonl \
+  --suite smoke-gepa \
+  --provider cerebras \
+  --model gpt-oss-120b \
+  --artifact .smithers/optimizations/smoke-gepa.json
+```
+
+Smithers runs a baseline eval, generates prompt patches, reruns the suite with the candidate artifact, and writes the artifact only when the optimized score improves. Reuse the artifact with `smithers eval --optimization .smithers/optimizations/smoke-gepa.json`.
 
 ## Hot Reload
 

--- a/apps/cli/src/AgentAvailability.ts
+++ b/apps/cli/src/AgentAvailability.ts
@@ -1,7 +1,7 @@
 import type { AgentAvailabilityStatus } from "./AgentAvailabilityStatus.ts";
 
 export type AgentAvailability = {
-    id: "claude" | "codex" | "opencode" | "antigravity" | "gemini" | "pi" | "kimi" | "amp";
+    id: "claude" | "codex" | "antigravity" | "gemini" | "pi" | "opencode" | "kimi" | "amp";
     displayName: string;
     binary: string;
     deprecated?: boolean;

--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -31,8 +31,12 @@ const DETECTORS = [
         id: "opencode",
         displayName: "OpenCode",
         binary: "opencode",
-        authSignals: (homeDir) => [join(homeDir, ".local", "share", "opencode", "auth.json")],
-        apiKeys: ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        authSignals: (homeDir) => [
+            join(homeDir, ".local", "share", "opencode", "auth.json"),
+            join(homeDir, ".config", "opencode"),
+            join(homeDir, ".local", "share", "opencode"),
+        ],
+        apiKeys: ["OPENCODE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"],
         setupHint: "Install the OpenCode CLI and run `opencode auth login`, or set a provider API key.",
     },
     {
@@ -77,17 +81,6 @@ const DETECTORS = [
         authSignals: (homeDir) => [join(homeDir, ".pi", "agent", "auth.json")],
         apiKeys: [],
         setupHint: "Install and authenticate the `pi` CLI.",
-    },
-    {
-        id: "opencode",
-        displayName: "OpenCode",
-        binary: "opencode",
-        authSignals: (homeDir) => [
-            join(homeDir, ".config", "opencode"),
-            join(homeDir, ".local", "share", "opencode"),
-        ],
-        apiKeys: ["OPENCODE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
-        setupHint: "Install the OpenCode CLI and authenticate a provider, or set a provider API key.",
     },
     {
         id: "kimi",
@@ -169,7 +162,7 @@ const CONSTRUCTORS = {
     },
     opencode: {
         importName: "OpenCodeAgent",
-        expr: 'new SmithersOpenCodeAgent({ model: "anthropic/claude-sonnet-4-5", cwd: process.cwd() })',
+        expr: 'new SmithersOpenCodeAgent({ model: "anthropic/claude-opus-4-20250514", cwd: process.cwd() })',
     },
     antigravity: {
         importName: "AntigravityAgent",
@@ -182,10 +175,6 @@ const CONSTRUCTORS = {
     pi: {
         importName: "PiAgent",
         expr: 'new SmithersPiAgent({ provider: "openai", model: "gpt-5.3-codex" })',
-    },
-    opencode: {
-        importName: "OpenCodeAgent",
-        expr: 'new SmithersOpenCodeAgent({ model: "anthropic/claude-opus-4-20250514", cwd: process.cwd() })',
     },
     kimi: {
         importName: "KimiAgent",

--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -79,6 +79,17 @@ const DETECTORS = [
         setupHint: "Install and authenticate the `pi` CLI.",
     },
     {
+        id: "opencode",
+        displayName: "OpenCode",
+        binary: "opencode",
+        authSignals: (homeDir) => [
+            join(homeDir, ".config", "opencode"),
+            join(homeDir, ".local", "share", "opencode"),
+        ],
+        apiKeys: ["OPENCODE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+        setupHint: "Install the OpenCode CLI and authenticate a provider, or set a provider API key.",
+    },
+    {
         id: "kimi",
         displayName: "Kimi",
         binary: "kimi",
@@ -171,6 +182,10 @@ const CONSTRUCTORS = {
     pi: {
         importName: "PiAgent",
         expr: 'new SmithersPiAgent({ provider: "openai", model: "gpt-5.3-codex" })',
+    },
+    opencode: {
+        importName: "OpenCodeAgent",
+        expr: 'new SmithersOpenCodeAgent({ model: "anthropic/claude-opus-4-20250514", cwd: process.cwd() })',
     },
     kimi: {
         importName: "KimiAgent",

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -1603,6 +1603,49 @@ async function executeEvalPlan(input) {
     return { ...report, reportPath };
 }
 /**
+ * @param {{
+ *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
+ *   workflowPath: string;
+ *   cases: Array<Record<string, any>>;
+ * }} input
+ */
+async function discoverOptimizablePromptTasksForCases(input) {
+    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
+    /** @type {Map<string, ReturnType<typeof discoverOptimizablePromptTasks>[number]>} */
+    const discovered = new Map();
+    for (const testCase of input.cases) {
+        const ctx = new SmithersCtx({
+            runId: `optimize-discovery-${testCase.id ?? crypto.randomUUID()}`,
+            iteration: 0,
+            input: testCase?.input ?? {},
+            outputs: {},
+            zodToKeyName: input.workflow.zodToKeyName,
+        });
+        const snap = await Effect.runPromise(renderFrame(input.workflow, ctx, {
+            baseRootDir: dirname(resolvedWorkflowPath),
+            workflowPath: resolvedWorkflowPath,
+        }));
+        for (const task of discoverOptimizablePromptTasks(snap.tasks)) {
+            const existing = discovered.get(task.nodeId);
+            if (!existing) {
+                discovered.set(task.nodeId, {
+                    ...task,
+                    promptSamples: [{ caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
+                });
+                continue;
+            }
+            const samples = Array.isArray(existing.promptSamples) ? existing.promptSamples : [];
+            if (!samples.some((sample) => sample.promptHash === task.promptHash)) {
+                discovered.set(task.nodeId, {
+                    ...existing,
+                    promptSamples: [...samples, { caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
+                });
+            }
+        }
+    }
+    return [...discovered.values()];
+}
+/**
  * @param {string} intervalRaw
  * @param {string} staleThresholdRaw
  * @param {number} maxConcurrent
@@ -2931,23 +2974,14 @@ const cli = Cli.create({
             const adapter = new SmithersDb(workflow.db);
             await assertEvalRunIdsAvailable(adapter, [...baselinePlan.cases, ...optimizedPlan.cases]);
             setupSqliteCleanup(workflow);
-            const resolvedWorkflowPath = resolve(process.cwd(), workflowPath);
             const reportDir = c.options.reportDir
                 ? resolve(process.cwd(), c.options.reportDir)
                 : resolve(process.cwd(), ".smithers", "optimizations", "reports");
-            const firstCase = loadedCases.cases[0];
-            const ctx = new SmithersCtx({
-                runId: "optimize-discovery",
-                iteration: 0,
-                input: firstCase?.input ?? {},
-                outputs: {},
-                zodToKeyName: workflow.zodToKeyName,
+            const promptTasks = await discoverOptimizablePromptTasksForCases({
+                workflow,
+                workflowPath,
+                cases: loadedCases.cases,
             });
-            const snap = await Effect.runPromise(renderFrame(workflow, ctx, {
-                baseRootDir: dirname(resolvedWorkflowPath),
-                workflowPath: resolvedWorkflowPath,
-            }));
-            const promptTasks = discoverOptimizablePromptTasks(snap.tasks);
             if (promptTasks.length === 0) {
                 throw new SmithersError("INVALID_INPUT", "No agent-backed prompt tasks were found to optimize.", {
                     workflowPath,

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2,13 +2,13 @@
 import { setJsonMode } from "./util/logger.ts";
 import { findFirstPositionalIndex, parseMcpSurfaceArgv, rewriteBareResumeFlagArgv } from "./argv-utils.js";
 import { CLI_JSON_ARGUMENT_MAX_BYTES, parseJsonArgument, parseJsonInput } from "./json-args.js";
-import { resolve, dirname, basename, extname, join } from "node:path";
+import { resolve, dirname, basename } from "node:path";
 import { pathToFileURL } from "node:url";
 import { readFileSync, existsSync, openSync, statSync } from "node:fs";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Effect, Fiber } from "effect";
 import { Cli, Mcp as IncurMcp, z } from "incur";
-import { OPTIMIZATION_ARTIFACT_ENV, isRunHeartbeatFresh, runWorkflow, renderFrame, resolveSchema } from "@smithers-orchestrator/engine";
+import { isRunHeartbeatFresh, runWorkflow, renderFrame, resolveSchema } from "@smithers-orchestrator/engine";
 import { mdxPlugin } from "./mdx-plugin.js";
 import { approveNode, denyNode } from "@smithers-orchestrator/engine/approvals";
 import { signalRun } from "@smithers-orchestrator/engine/signals";
@@ -55,16 +55,7 @@ import {
 } from "./eval-suite.js";
 import { initOptions, runInitCommand } from "./init-command.js";
 import { startersArgs, startersOptions, runStartersCommand } from "./starter-gallery-command.js";
-import {
-    OPTIMIZER_PROVIDER_IDS,
-    buildProviderGepaPatches,
-    discoverOptimizablePromptTasks,
-    renderOptimizationReport,
-    resolveOptimizerProviderModel,
-    scoreOptimizationReport,
-    writeCandidateOptimizationArtifact,
-    writeOptimizationArtifact,
-} from "./optimize-suite.js";
+import { optimizeOptions, runOptimizeCommand, withOptimizationArtifactEnv } from "./optimize-command.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1270,24 +1261,6 @@ const evalOptions = z.object({
     toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
     optimization: z.string().optional().describe("Apply a Smithers optimization artifact while running the eval suite"),
 });
-const optimizeOptions = z.object({
-    cases: z.string().describe("JSON or JSONL eval case file"),
-    suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
-    provider: z.enum(OPTIMIZER_PROVIDER_IDS).default("cerebras").describe("GEPA patch generator provider"),
-    model: z.string().optional().describe("Optimizer model for provider-backed GEPA"),
-    artifact: z.string().optional().describe("Write the optimized prompt artifact to this path"),
-    reportDir: z.string().optional().describe("Directory for baseline and optimized eval reports"),
-    minImprovement: z.number().default(0.000001).describe("Minimum required absolute score improvement"),
-    maxCases: z.number().int().min(1).optional().describe("Run only the first N cases"),
-    concurrency: z.number().int().min(1).max(16).default(1).describe("Number of eval cases to run at once"),
-    maxConcurrency: z.number().int().min(1).optional().describe("Per-workflow max task concurrency"),
-    root: z.string().optional().describe("Tool sandbox root directory"),
-    log: z.boolean().default(true).describe("Enable NDJSON event log file output"),
-    logDir: z.string().optional().describe("NDJSON event logs directory"),
-    allowNetwork: z.boolean().default(false).describe("Allow bash tool network requests"),
-    maxOutputBytes: z.number().int().min(1).optional().describe("Max bytes a single tool call can return"),
-    toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
-});
 const superviseOptions = z.object({
     dryRun: z.boolean().default(false).describe("Show which stale runs would be resumed, without acting"),
     interval: z.string().default("10s").describe("Poll interval (e.g. 10s, 30s, 1m)"),
@@ -1483,167 +1456,6 @@ async function runWithLimit(items, limit, worker) {
         }
     }));
     return results;
-}
-/**
- * @template T
- * @param {string | null | undefined} artifactPath
- * @param {() => Promise<T>} execute
- * @returns {Promise<T>}
- */
-async function withOptimizationArtifactEnv(artifactPath, execute) {
-    const previous = process.env[OPTIMIZATION_ARTIFACT_ENV];
-    if (artifactPath) {
-        process.env[OPTIMIZATION_ARTIFACT_ENV] = artifactPath;
-    }
-    else {
-        delete process.env[OPTIMIZATION_ARTIFACT_ENV];
-    }
-    try {
-        return await execute();
-    }
-    finally {
-        if (previous === undefined) {
-            delete process.env[OPTIMIZATION_ARTIFACT_ENV];
-        }
-        else {
-            process.env[OPTIMIZATION_ARTIFACT_ENV] = previous;
-        }
-    }
-}
-/**
- * @param {{
- *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
- *   workflowPath: string;
- *   plan: ReturnType<typeof buildEvalPlan>;
- *   options: Record<string, any>;
- *   reportPath?: string;
- *   optimizationArtifact?: string | null;
- * }} input
- */
-async function executeEvalPlan(input) {
-    ensureSmithersTables(input.workflow.db);
-    const schema = resolveSchema(input.workflow.db);
-    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
-    const rootDir = input.options.root ? resolve(process.cwd(), input.options.root) : dirname(resolvedWorkflowPath);
-    const logDir = input.options.log ? input.options.logDir : null;
-    const abort = setupAbortSignal();
-    const startedAtMs = Date.now();
-    const results = await withOptimizationArtifactEnv(input.optimizationArtifact, () => runWithLimit(input.plan.cases, input.options.concurrency ?? 1, async (testCase) => {
-        const caseStartedAtMs = Date.now();
-        process.stderr.write(`[eval:${input.plan.suiteId}] ${testCase.id} -> ${testCase.runId}\n`);
-        try {
-            const result = await Effect.runPromise(runWorkflow(input.workflow, {
-                input: testCase.input,
-                runId: testCase.runId,
-                workflowPath: resolvedWorkflowPath,
-                maxConcurrency: input.options.maxConcurrency,
-                rootDir,
-                logDir,
-                allowNetwork: input.options.allowNetwork,
-                maxOutputBytes: input.options.maxOutputBytes,
-                toolTimeoutMs: input.options.toolTimeoutMs,
-                annotations: {
-                    suiteId: input.plan.suiteId,
-                    caseId: testCase.id,
-                    ...testCase.annotations,
-                },
-                signal: abort.signal,
-            }));
-            const output = await loadOutputs(input.workflow.db, schema, testCase.runId);
-            const durationMs = Date.now() - caseStartedAtMs;
-            const evaluation = evaluateEvalCaseResult(testCase, {
-                ...result,
-                output,
-            });
-            return {
-                caseId: testCase.id,
-                runId: testCase.runId,
-                expectedStatus: testCase.expected.status,
-                status: result.status,
-                passed: evaluation.passed,
-                assertions: evaluation.assertions,
-                durationMs,
-                input: testCase.input,
-                ...(input.options.includeOutput === false ? {} : { output }),
-                metadata: testCase.metadata,
-            };
-        }
-        catch (err) {
-            const errorMessage = err?.message ?? String(err);
-            const durationMs = Date.now() - caseStartedAtMs;
-            const evaluation = evaluateEvalCaseResult(testCase, {
-                status: "error",
-                error: err,
-            });
-            return {
-                caseId: testCase.id,
-                runId: testCase.runId,
-                expectedStatus: testCase.expected.status,
-                status: "error",
-                passed: evaluation.passed,
-                assertions: evaluation.assertions,
-                durationMs,
-                input: testCase.input,
-                error: errorMessage,
-                metadata: testCase.metadata,
-            };
-        }
-    }));
-    const finishedAtMs = Date.now();
-    let report = buildEvalReport({
-        plan: input.plan,
-        results,
-        startedAtMs,
-        finishedAtMs,
-    });
-    const reportPath = writeEvalReport(process.cwd(), report, {
-        path: input.reportPath,
-        force: true,
-    });
-    return { ...report, reportPath };
-}
-/**
- * @param {{
- *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
- *   workflowPath: string;
- *   cases: Array<Record<string, any>>;
- * }} input
- */
-async function discoverOptimizablePromptTasksForCases(input) {
-    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
-    /** @type {Map<string, ReturnType<typeof discoverOptimizablePromptTasks>[number]>} */
-    const discovered = new Map();
-    for (const testCase of input.cases) {
-        const ctx = new SmithersCtx({
-            runId: `optimize-discovery-${testCase.id ?? crypto.randomUUID()}`,
-            iteration: 0,
-            input: testCase?.input ?? {},
-            outputs: {},
-            zodToKeyName: input.workflow.zodToKeyName,
-        });
-        const snap = await Effect.runPromise(renderFrame(input.workflow, ctx, {
-            baseRootDir: dirname(resolvedWorkflowPath),
-            workflowPath: resolvedWorkflowPath,
-        }));
-        for (const task of discoverOptimizablePromptTasks(snap.tasks)) {
-            const existing = discovered.get(task.nodeId);
-            if (!existing) {
-                discovered.set(task.nodeId, {
-                    ...task,
-                    promptSamples: [{ caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
-                });
-                continue;
-            }
-            const samples = Array.isArray(existing.promptSamples) ? existing.promptSamples : [];
-            if (!samples.some((sample) => sample.promptHash === task.promptHash)) {
-                discovered.set(task.nodeId, {
-                    ...existing,
-                    promptSamples: [...samples, { caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
-                });
-            }
-        }
-    }
-    return [...discovered.values()];
 }
 /**
  * @param {string} intervalRaw
@@ -2944,116 +2756,17 @@ const cli = Cli.create({
     options: optimizeOptions,
     alias: { cases: "c", suite: "s", provider: "p", model: "m", artifact: "a", concurrency: "j" },
     async run(c) {
-        const fail = (opts) => {
-            commandExitOverride = opts.exitCode ?? 1;
-            return c.error(opts);
-        };
-        try {
-            const workflowPath = resolveWorkflowPathForEval(c.args.workflow);
-            const loadedCases = loadEvalCases(process.cwd(), c.options.cases, {
-                maxCases: c.options.maxCases,
-            });
-            const runLabel = defaultEvalRunLabel();
-            const suiteBase = c.options.suite ?? `${basename(c.options.cases, extname(c.options.cases))}-opt`;
-            const baselinePlan = buildEvalPlan({
-                suiteId: `${suiteBase}-baseline`,
-                runLabel,
-                workflowPath,
-                casesPath: c.options.cases,
-                loadedCases,
-            });
-            const optimizedPlan = buildEvalPlan({
-                suiteId: `${suiteBase}-optimized`,
-                runLabel,
-                workflowPath,
-                casesPath: c.options.cases,
-                loadedCases,
-            });
-            const workflow = await loadWorkflow(workflowPath);
-            ensureSmithersTables(workflow.db);
-            const adapter = new SmithersDb(workflow.db);
-            await assertEvalRunIdsAvailable(adapter, [...baselinePlan.cases, ...optimizedPlan.cases]);
-            setupSqliteCleanup(workflow);
-            const reportDir = c.options.reportDir
-                ? resolve(process.cwd(), c.options.reportDir)
-                : resolve(process.cwd(), ".smithers", "optimizations", "reports");
-            const promptTasks = await discoverOptimizablePromptTasksForCases({
-                workflow,
-                workflowPath,
-                cases: loadedCases.cases,
-            });
-            if (promptTasks.length === 0) {
-                throw new SmithersError("INVALID_INPUT", "No agent-backed prompt tasks were found to optimize.", {
-                    workflowPath,
-                });
-            }
-            const baselineReport = await executeEvalPlan({
-                workflow,
-                workflowPath,
-                plan: baselinePlan,
-                options: {
-                    ...c.options,
-                    includeOutput: true,
-                },
-                reportPath: join(reportDir, `${baselinePlan.suiteId}.json`),
-            });
-            const promptPatches = await buildProviderGepaPatches({
-                provider: c.options.provider,
-                model: c.options.model,
-                promptTasks,
-                cases: loadedCases.cases,
-                baselineReport,
-            });
-            if (Object.keys(promptPatches).length === 0) {
-                throw new SmithersError("INVALID_INPUT", "GEPA did not produce any prompt patches.", {
-                    provider: c.options.provider,
-                });
-            }
-            const candidateArtifactPath = writeCandidateOptimizationArtifact(process.cwd(), promptPatches);
-            const optimizedReport = await executeEvalPlan({
-                workflow,
-                workflowPath,
-                plan: optimizedPlan,
-                options: {
-                    ...c.options,
-                    includeOutput: true,
-                },
-                reportPath: join(reportDir, `${optimizedPlan.suiteId}.json`),
-                optimizationArtifact: candidateArtifactPath,
-            });
-            const baselineScore = scoreOptimizationReport(baselineReport);
-            const optimizedScore = scoreOptimizationReport(optimizedReport);
-            const improvement = optimizedScore.score - baselineScore.score;
-            if (improvement < c.options.minImprovement) {
-                return fail({
-                    code: "OPTIMIZATION_NO_IMPROVEMENT",
-                    message: `Optimized score did not improve enough: baseline=${baselineScore.score.toFixed(4)} optimized=${optimizedScore.score.toFixed(4)} requiredDelta=${c.options.minImprovement}`,
-                    exitCode: 1,
-                });
-            }
-            const { artifact } = writeOptimizationArtifact({
-                root: process.cwd(),
-                workflowPath,
-                requestedPath: c.options.artifact,
-                provider: c.options.provider,
-                model: resolveOptimizerProviderModel(c.options.provider, c.options.model) ?? "provider-default",
-                promptTasks,
-                promptPatches,
-                baselineReport,
-                candidateReport: optimizedReport,
-            });
-            if (c.format === "json" || c.format === "jsonl" || formatRequestedJsonOutput()) {
-                return c.ok({ optimization: artifact });
-            }
-            process.stdout.write(`${renderOptimizationReport(artifact)}\n`);
-            return c.ok(undefined);
-        }
-        catch (err) {
-            if (err instanceof SmithersError) {
-                return fail({ code: err.code, message: err.message, exitCode: 4 });
-            }
-            return fail({ code: "OPTIMIZATION_FAILED", message: err?.message ?? String(err), exitCode: 1 });
-        }
+        return runOptimizeCommand(c, {
+            defaultEvalRunLabel,
+            formatRequestedJsonOutput,
+            loadWorkflow,
+            resolveWorkflowPathForEval,
+            setupAbortSignal,
+            setupSqliteCleanup,
+            setCommandExitOverride: (exitCode) => {
+                commandExitOverride = exitCode;
+            },
+        });
     },
 })
     // =========================================================================

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2,13 +2,13 @@
 import { setJsonMode } from "./util/logger.ts";
 import { findFirstPositionalIndex, parseMcpSurfaceArgv, rewriteBareResumeFlagArgv } from "./argv-utils.js";
 import { CLI_JSON_ARGUMENT_MAX_BYTES, parseJsonArgument, parseJsonInput } from "./json-args.js";
-import { resolve, dirname, basename } from "node:path";
+import { resolve, dirname, basename, extname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { readFileSync, existsSync, openSync, statSync } from "node:fs";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Effect, Fiber } from "effect";
 import { Cli, Mcp as IncurMcp, z } from "incur";
-import { isRunHeartbeatFresh, runWorkflow, renderFrame, resolveSchema } from "@smithers-orchestrator/engine";
+import { OPTIMIZATION_ARTIFACT_ENV, isRunHeartbeatFresh, runWorkflow, renderFrame, resolveSchema } from "@smithers-orchestrator/engine";
 import { mdxPlugin } from "./mdx-plugin.js";
 import { approveNode, denyNode } from "@smithers-orchestrator/engine/approvals";
 import { signalRun } from "@smithers-orchestrator/engine/signals";
@@ -55,6 +55,15 @@ import {
 } from "./eval-suite.js";
 import { initOptions, runInitCommand } from "./init-command.js";
 import { startersArgs, startersOptions, runStartersCommand } from "./starter-gallery-command.js";
+import {
+    buildCerebrasGepaPatches,
+    buildHeuristicGepaPatches,
+    discoverOptimizablePromptTasks,
+    renderOptimizationReport,
+    scoreOptimizationReport,
+    writeCandidateOptimizationArtifact,
+    writeOptimizationArtifact,
+} from "./optimize-suite.js";
 import { ask } from "./ask.js";
 import { runScheduler } from "./scheduler.js";
 import { resumeRunDetached } from "./resume-detached.js";
@@ -1258,6 +1267,25 @@ const evalOptions = z.object({
     allowNetwork: z.boolean().default(false).describe("Allow bash tool network requests"),
     maxOutputBytes: z.number().int().min(1).optional().describe("Max bytes a single tool call can return"),
     toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
+    optimization: z.string().optional().describe("Apply a Smithers optimization artifact while running the eval suite"),
+});
+const optimizeOptions = z.object({
+    cases: z.string().describe("JSON or JSONL eval case file"),
+    suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
+    provider: z.enum(["heuristic", "cerebras"]).default("cerebras").describe("GEPA patch generator provider"),
+    model: z.string().default("gpt-oss-120b").describe("Optimizer model for provider-backed GEPA"),
+    artifact: z.string().optional().describe("Write the optimized prompt artifact to this path"),
+    reportDir: z.string().optional().describe("Directory for baseline and optimized eval reports"),
+    minImprovement: z.number().default(0.000001).describe("Minimum required absolute score improvement"),
+    maxCases: z.number().int().min(1).optional().describe("Run only the first N cases"),
+    concurrency: z.number().int().min(1).max(16).default(1).describe("Number of eval cases to run at once"),
+    maxConcurrency: z.number().int().min(1).optional().describe("Per-workflow max task concurrency"),
+    root: z.string().optional().describe("Tool sandbox root directory"),
+    log: z.boolean().default(true).describe("Enable NDJSON event log file output"),
+    logDir: z.string().optional().describe("NDJSON event logs directory"),
+    allowNetwork: z.boolean().default(false).describe("Allow bash tool network requests"),
+    maxOutputBytes: z.number().int().min(1).optional().describe("Max bytes a single tool call can return"),
+    toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
 });
 const superviseOptions = z.object({
     dryRun: z.boolean().default(false).describe("Show which stale runs would be resumed, without acting"),
@@ -1454,6 +1482,124 @@ async function runWithLimit(items, limit, worker) {
         }
     }));
     return results;
+}
+/**
+ * @template T
+ * @param {string | null | undefined} artifactPath
+ * @param {() => Promise<T>} execute
+ * @returns {Promise<T>}
+ */
+async function withOptimizationArtifactEnv(artifactPath, execute) {
+    const previous = process.env[OPTIMIZATION_ARTIFACT_ENV];
+    if (artifactPath) {
+        process.env[OPTIMIZATION_ARTIFACT_ENV] = artifactPath;
+    }
+    else {
+        delete process.env[OPTIMIZATION_ARTIFACT_ENV];
+    }
+    try {
+        return await execute();
+    }
+    finally {
+        if (previous === undefined) {
+            delete process.env[OPTIMIZATION_ARTIFACT_ENV];
+        }
+        else {
+            process.env[OPTIMIZATION_ARTIFACT_ENV] = previous;
+        }
+    }
+}
+/**
+ * @param {{
+ *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
+ *   workflowPath: string;
+ *   plan: ReturnType<typeof buildEvalPlan>;
+ *   options: Record<string, any>;
+ *   reportPath?: string;
+ *   optimizationArtifact?: string | null;
+ * }} input
+ */
+async function executeEvalPlan(input) {
+    ensureSmithersTables(input.workflow.db);
+    const schema = resolveSchema(input.workflow.db);
+    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
+    const rootDir = input.options.root ? resolve(process.cwd(), input.options.root) : dirname(resolvedWorkflowPath);
+    const logDir = input.options.log ? input.options.logDir : null;
+    const abort = setupAbortSignal();
+    const startedAtMs = Date.now();
+    const results = await withOptimizationArtifactEnv(input.optimizationArtifact, () => runWithLimit(input.plan.cases, input.options.concurrency ?? 1, async (testCase) => {
+        const caseStartedAtMs = Date.now();
+        process.stderr.write(`[eval:${input.plan.suiteId}] ${testCase.id} -> ${testCase.runId}\n`);
+        try {
+            const result = await Effect.runPromise(runWorkflow(input.workflow, {
+                input: testCase.input,
+                runId: testCase.runId,
+                workflowPath: resolvedWorkflowPath,
+                maxConcurrency: input.options.maxConcurrency,
+                rootDir,
+                logDir,
+                allowNetwork: input.options.allowNetwork,
+                maxOutputBytes: input.options.maxOutputBytes,
+                toolTimeoutMs: input.options.toolTimeoutMs,
+                annotations: {
+                    suiteId: input.plan.suiteId,
+                    caseId: testCase.id,
+                    ...testCase.annotations,
+                },
+                signal: abort.signal,
+            }));
+            const output = await loadOutputs(input.workflow.db, schema, testCase.runId);
+            const durationMs = Date.now() - caseStartedAtMs;
+            const evaluation = evaluateEvalCaseResult(testCase, {
+                ...result,
+                output,
+            });
+            return {
+                caseId: testCase.id,
+                runId: testCase.runId,
+                expectedStatus: testCase.expected.status,
+                status: result.status,
+                passed: evaluation.passed,
+                assertions: evaluation.assertions,
+                durationMs,
+                input: testCase.input,
+                ...(input.options.includeOutput === false ? {} : { output }),
+                metadata: testCase.metadata,
+            };
+        }
+        catch (err) {
+            const errorMessage = err?.message ?? String(err);
+            const durationMs = Date.now() - caseStartedAtMs;
+            const evaluation = evaluateEvalCaseResult(testCase, {
+                status: "error",
+                error: err,
+            });
+            return {
+                caseId: testCase.id,
+                runId: testCase.runId,
+                expectedStatus: testCase.expected.status,
+                status: "error",
+                passed: evaluation.passed,
+                assertions: evaluation.assertions,
+                durationMs,
+                input: testCase.input,
+                error: errorMessage,
+                metadata: testCase.metadata,
+            };
+        }
+    }));
+    const finishedAtMs = Date.now();
+    let report = buildEvalReport({
+        plan: input.plan,
+        results,
+        startedAtMs,
+        finishedAtMs,
+    });
+    const reportPath = writeEvalReport(process.cwd(), report, {
+        path: input.reportPath,
+        force: true,
+    });
+    return { ...report, reportPath };
 }
 /**
  * @param {string} intervalRaw
@@ -2657,7 +2803,7 @@ const cli = Cli.create({
             const logDir = c.options.log ? c.options.logDir : null;
             const abort = setupAbortSignal();
             const startedAtMs = Date.now();
-            const results = await runWithLimit(plan.cases, c.options.concurrency, async (testCase) => {
+            const results = await withOptimizationArtifactEnv(c.options.optimization, () => runWithLimit(plan.cases, c.options.concurrency, async (testCase) => {
                 const caseStartedAtMs = Date.now();
                 process.stderr.write(`[eval:${plan.suiteId}] ${testCase.id} -> ${testCase.runId}\n`);
                 try {
@@ -2717,7 +2863,7 @@ const cli = Cli.create({
                         metadata: testCase.metadata,
                     };
                 }
-            });
+            }));
             const finishedAtMs = Date.now();
             let report = buildEvalReport({
                 plan,
@@ -2742,6 +2888,137 @@ const cli = Cli.create({
                 return fail({ code: err.code, message: err.message, exitCode: 4 });
             }
             return fail({ code: "EVAL_FAILED", message: err?.message ?? String(err), exitCode: 1 });
+        }
+    },
+})
+    // =========================================================================
+    // smithers optimize <workflow>
+    // =========================================================================
+    .command("optimize", {
+    description: "Run GEPA prompt optimization over a workflow eval suite and write an optimized prompt artifact.",
+    args: workflowArgs,
+    options: optimizeOptions,
+    alias: { cases: "c", suite: "s", provider: "p", model: "m", artifact: "a", concurrency: "j" },
+    async run(c) {
+        const fail = (opts) => {
+            commandExitOverride = opts.exitCode ?? 1;
+            return c.error(opts);
+        };
+        try {
+            const workflowPath = resolveWorkflowPathForEval(c.args.workflow);
+            const loadedCases = loadEvalCases(process.cwd(), c.options.cases, {
+                maxCases: c.options.maxCases,
+            });
+            const runLabel = defaultEvalRunLabel();
+            const suiteBase = c.options.suite ?? `${basename(c.options.cases, extname(c.options.cases))}-opt`;
+            const baselinePlan = buildEvalPlan({
+                suiteId: `${suiteBase}-baseline`,
+                runLabel,
+                workflowPath,
+                casesPath: c.options.cases,
+                loadedCases,
+            });
+            const optimizedPlan = buildEvalPlan({
+                suiteId: `${suiteBase}-optimized`,
+                runLabel,
+                workflowPath,
+                casesPath: c.options.cases,
+                loadedCases,
+            });
+            const workflow = await loadWorkflow(workflowPath);
+            ensureSmithersTables(workflow.db);
+            const adapter = new SmithersDb(workflow.db);
+            await assertEvalRunIdsAvailable(adapter, [...baselinePlan.cases, ...optimizedPlan.cases]);
+            setupSqliteCleanup(workflow);
+            const resolvedWorkflowPath = resolve(process.cwd(), workflowPath);
+            const reportDir = c.options.reportDir
+                ? resolve(process.cwd(), c.options.reportDir)
+                : resolve(process.cwd(), ".smithers", "optimizations", "reports");
+            const firstCase = loadedCases.cases[0];
+            const ctx = new SmithersCtx({
+                runId: "optimize-discovery",
+                iteration: 0,
+                input: firstCase?.input ?? {},
+                outputs: {},
+                zodToKeyName: workflow.zodToKeyName,
+            });
+            const snap = await Effect.runPromise(renderFrame(workflow, ctx, {
+                baseRootDir: dirname(resolvedWorkflowPath),
+                workflowPath: resolvedWorkflowPath,
+            }));
+            const promptTasks = discoverOptimizablePromptTasks(snap.tasks);
+            if (promptTasks.length === 0) {
+                throw new SmithersError("INVALID_INPUT", "No agent-backed prompt tasks were found to optimize.", {
+                    workflowPath,
+                });
+            }
+            const baselineReport = await executeEvalPlan({
+                workflow,
+                workflowPath,
+                plan: baselinePlan,
+                options: {
+                    ...c.options,
+                    includeOutput: true,
+                },
+                reportPath: join(reportDir, `${baselinePlan.suiteId}.json`),
+            });
+            const promptPatches = c.options.provider === "cerebras"
+                ? await buildCerebrasGepaPatches({
+                    model: c.options.model,
+                    promptTasks,
+                    cases: loadedCases.cases,
+                    baselineReport,
+                })
+                : buildHeuristicGepaPatches(promptTasks, loadedCases.cases, baselineReport);
+            if (Object.keys(promptPatches).length === 0) {
+                throw new SmithersError("INVALID_INPUT", "GEPA did not produce any prompt patches.", {
+                    provider: c.options.provider,
+                });
+            }
+            const candidateArtifactPath = writeCandidateOptimizationArtifact(process.cwd(), promptPatches);
+            const optimizedReport = await executeEvalPlan({
+                workflow,
+                workflowPath,
+                plan: optimizedPlan,
+                options: {
+                    ...c.options,
+                    includeOutput: true,
+                },
+                reportPath: join(reportDir, `${optimizedPlan.suiteId}.json`),
+                optimizationArtifact: candidateArtifactPath,
+            });
+            const baselineScore = scoreOptimizationReport(baselineReport);
+            const optimizedScore = scoreOptimizationReport(optimizedReport);
+            const improvement = optimizedScore.score - baselineScore.score;
+            if (improvement < c.options.minImprovement) {
+                return fail({
+                    code: "OPTIMIZATION_NO_IMPROVEMENT",
+                    message: `Optimized score did not improve enough: baseline=${baselineScore.score.toFixed(4)} optimized=${optimizedScore.score.toFixed(4)} requiredDelta=${c.options.minImprovement}`,
+                    exitCode: 1,
+                });
+            }
+            const { artifact } = writeOptimizationArtifact({
+                root: process.cwd(),
+                workflowPath,
+                requestedPath: c.options.artifact,
+                provider: c.options.provider,
+                model: c.options.model,
+                promptTasks,
+                promptPatches,
+                baselineReport,
+                candidateReport: optimizedReport,
+            });
+            if (c.format === "json" || c.format === "jsonl" || formatRequestedJsonOutput()) {
+                return c.ok({ optimization: artifact });
+            }
+            process.stdout.write(`${renderOptimizationReport(artifact)}\n`);
+            return c.ok(undefined);
+        }
+        catch (err) {
+            if (err instanceof SmithersError) {
+                return fail({ code: err.code, message: err.message, exitCode: 4 });
+            }
+            return fail({ code: "OPTIMIZATION_FAILED", message: err?.message ?? String(err), exitCode: 1 });
         }
     },
 })

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -56,10 +56,11 @@ import {
 import { initOptions, runInitCommand } from "./init-command.js";
 import { startersArgs, startersOptions, runStartersCommand } from "./starter-gallery-command.js";
 import {
-    buildCerebrasGepaPatches,
-    buildHeuristicGepaPatches,
+    OPTIMIZER_PROVIDER_IDS,
+    buildProviderGepaPatches,
     discoverOptimizablePromptTasks,
     renderOptimizationReport,
+    resolveOptimizerProviderModel,
     scoreOptimizationReport,
     writeCandidateOptimizationArtifact,
     writeOptimizationArtifact,
@@ -1272,8 +1273,8 @@ const evalOptions = z.object({
 const optimizeOptions = z.object({
     cases: z.string().describe("JSON or JSONL eval case file"),
     suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
-    provider: z.enum(["heuristic", "cerebras"]).default("cerebras").describe("GEPA patch generator provider"),
-    model: z.string().default("gpt-oss-120b").describe("Optimizer model for provider-backed GEPA"),
+    provider: z.enum(OPTIMIZER_PROVIDER_IDS).default("cerebras").describe("GEPA patch generator provider"),
+    model: z.string().optional().describe("Optimizer model for provider-backed GEPA"),
     artifact: z.string().optional().describe("Write the optimized prompt artifact to this path"),
     reportDir: z.string().optional().describe("Directory for baseline and optimized eval reports"),
     minImprovement: z.number().default(0.000001).describe("Minimum required absolute score improvement"),
@@ -2962,14 +2963,13 @@ const cli = Cli.create({
                 },
                 reportPath: join(reportDir, `${baselinePlan.suiteId}.json`),
             });
-            const promptPatches = c.options.provider === "cerebras"
-                ? await buildCerebrasGepaPatches({
-                    model: c.options.model,
-                    promptTasks,
-                    cases: loadedCases.cases,
-                    baselineReport,
-                })
-                : buildHeuristicGepaPatches(promptTasks, loadedCases.cases, baselineReport);
+            const promptPatches = await buildProviderGepaPatches({
+                provider: c.options.provider,
+                model: c.options.model,
+                promptTasks,
+                cases: loadedCases.cases,
+                baselineReport,
+            });
             if (Object.keys(promptPatches).length === 0) {
                 throw new SmithersError("INVALID_INPUT", "GEPA did not produce any prompt patches.", {
                     provider: c.options.provider,
@@ -3002,7 +3002,7 @@ const cli = Cli.create({
                 workflowPath,
                 requestedPath: c.options.artifact,
                 provider: c.options.provider,
-                model: c.options.model,
+                model: resolveOptimizerProviderModel(c.options.provider, c.options.model) ?? "provider-default",
                 promptTasks,
                 promptPatches,
                 baselineReport,

--- a/apps/cli/src/optimize-command.js
+++ b/apps/cli/src/optimize-command.js
@@ -1,0 +1,361 @@
+import { basename, dirname, extname, join, resolve } from "node:path";
+import crypto from "node:crypto";
+import { Effect } from "effect";
+import { z } from "incur";
+import { OPTIMIZATION_ARTIFACT_ENV, renderFrame, resolveSchema, runWorkflow } from "@smithers-orchestrator/engine";
+import { loadOutputs } from "@smithers-orchestrator/db/snapshot";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { SmithersCtx } from "@smithers-orchestrator/driver";
+import { SmithersError } from "@smithers-orchestrator/errors";
+import {
+    assertEvalRunIdsAvailable,
+    buildEvalPlan,
+    buildEvalReport,
+    evaluateEvalCaseResult,
+    loadEvalCases,
+    writeEvalReport,
+} from "./eval-suite.js";
+import {
+    OPTIMIZER_PROVIDER_IDS,
+    buildProviderGepaPatches,
+    discoverOptimizablePromptTasks,
+    renderOptimizationReport,
+    resolveOptimizerProviderModel,
+    scoreOptimizationReport,
+    writeCandidateOptimizationArtifact,
+    writeOptimizationArtifact,
+} from "./optimize-suite.js";
+
+export const optimizeOptions = z.object({
+    cases: z.string().describe("JSON or JSONL eval case file"),
+    suite: z.string().optional().describe("Stable suite ID used in run IDs and report paths"),
+    provider: z.enum(OPTIMIZER_PROVIDER_IDS).default("cerebras").describe("GEPA patch generator provider"),
+    model: z.string().optional().describe("Optimizer model for provider-backed GEPA"),
+    artifact: z.string().optional().describe("Write the optimized prompt artifact to this path"),
+    reportDir: z.string().optional().describe("Directory for baseline and optimized eval reports"),
+    minImprovement: z.number().default(0.000001).describe("Minimum required absolute score improvement"),
+    maxCases: z.number().int().min(1).optional().describe("Run only the first N cases"),
+    concurrency: z.number().int().min(1).max(16).default(1).describe("Number of eval cases to run at once"),
+    maxConcurrency: z.number().int().min(1).optional().describe("Per-workflow max task concurrency"),
+    root: z.string().optional().describe("Tool sandbox root directory"),
+    log: z.boolean().default(true).describe("Enable NDJSON event log file output"),
+    logDir: z.string().optional().describe("NDJSON event logs directory"),
+    allowNetwork: z.boolean().default(false).describe("Allow bash tool network requests"),
+    maxOutputBytes: z.number().int().min(1).optional().describe("Max bytes a single tool call can return"),
+    toolTimeoutMs: z.number().int().min(1).optional().describe("Max wall-clock time per tool call in ms"),
+});
+
+/**
+ * @template T
+ * @param {string | null | undefined} artifactPath
+ * @param {() => Promise<T>} execute
+ * @returns {Promise<T>}
+ */
+export async function withOptimizationArtifactEnv(artifactPath, execute) {
+    const previous = process.env[OPTIMIZATION_ARTIFACT_ENV];
+    if (artifactPath) {
+        process.env[OPTIMIZATION_ARTIFACT_ENV] = artifactPath;
+    }
+    else {
+        delete process.env[OPTIMIZATION_ARTIFACT_ENV];
+    }
+    try {
+        return await execute();
+    }
+    finally {
+        if (previous === undefined) {
+            delete process.env[OPTIMIZATION_ARTIFACT_ENV];
+        }
+        else {
+            process.env[OPTIMIZATION_ARTIFACT_ENV] = previous;
+        }
+    }
+}
+
+/**
+ * @template T
+ * @template R
+ * @param {T[]} items
+ * @param {number} limit
+ * @param {(item: T, index: number) => Promise<R>} worker
+ * @returns {Promise<R[]>}
+ */
+async function runWithLimit(items, limit, worker) {
+    const results = new Array(items.length);
+    let cursor = 0;
+    const workerCount = Math.min(limit, items.length);
+    await Promise.all(Array.from({ length: workerCount }, async () => {
+        while (cursor < items.length) {
+            const index = cursor;
+            cursor += 1;
+            results[index] = await worker(items[index], index);
+        }
+    }));
+    return results;
+}
+
+/**
+ * @param {{
+ *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
+ *   workflowPath: string;
+ *   plan: ReturnType<typeof buildEvalPlan>;
+ *   options: Record<string, any>;
+ *   setupAbortSignal: () => AbortController;
+ *   reportPath?: string;
+ *   optimizationArtifact?: string | null;
+ * }} input
+ */
+async function executeEvalPlan(input) {
+    ensureSmithersTables(input.workflow.db);
+    const schema = resolveSchema(input.workflow.db);
+    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
+    const rootDir = input.options.root ? resolve(process.cwd(), input.options.root) : dirname(resolvedWorkflowPath);
+    const logDir = input.options.log ? input.options.logDir : null;
+    const abort = input.setupAbortSignal();
+    const startedAtMs = Date.now();
+    const results = await withOptimizationArtifactEnv(input.optimizationArtifact, () => runWithLimit(input.plan.cases, input.options.concurrency ?? 1, async (testCase) => {
+        const caseStartedAtMs = Date.now();
+        process.stderr.write(`[eval:${input.plan.suiteId}] ${testCase.id} -> ${testCase.runId}\n`);
+        try {
+            const result = await Effect.runPromise(runWorkflow(input.workflow, {
+                input: testCase.input,
+                runId: testCase.runId,
+                workflowPath: resolvedWorkflowPath,
+                maxConcurrency: input.options.maxConcurrency,
+                rootDir,
+                logDir,
+                allowNetwork: input.options.allowNetwork,
+                maxOutputBytes: input.options.maxOutputBytes,
+                toolTimeoutMs: input.options.toolTimeoutMs,
+                annotations: {
+                    suiteId: input.plan.suiteId,
+                    caseId: testCase.id,
+                    ...testCase.annotations,
+                },
+                signal: abort.signal,
+            }));
+            const output = await loadOutputs(input.workflow.db, schema, testCase.runId);
+            const durationMs = Date.now() - caseStartedAtMs;
+            const evaluation = evaluateEvalCaseResult(testCase, {
+                ...result,
+                output,
+            });
+            return {
+                caseId: testCase.id,
+                runId: testCase.runId,
+                expectedStatus: testCase.expected.status,
+                status: result.status,
+                passed: evaluation.passed,
+                assertions: evaluation.assertions,
+                durationMs,
+                input: testCase.input,
+                ...(input.options.includeOutput === false ? {} : { output }),
+                metadata: testCase.metadata,
+            };
+        }
+        catch (err) {
+            const errorMessage = err?.message ?? String(err);
+            const durationMs = Date.now() - caseStartedAtMs;
+            const evaluation = evaluateEvalCaseResult(testCase, {
+                status: "error",
+                error: err,
+            });
+            return {
+                caseId: testCase.id,
+                runId: testCase.runId,
+                expectedStatus: testCase.expected.status,
+                status: "error",
+                passed: evaluation.passed,
+                assertions: evaluation.assertions,
+                durationMs,
+                input: testCase.input,
+                error: errorMessage,
+                metadata: testCase.metadata,
+            };
+        }
+    }));
+    const finishedAtMs = Date.now();
+    const report = buildEvalReport({
+        plan: input.plan,
+        results,
+        startedAtMs,
+        finishedAtMs,
+    });
+    const reportPath = writeEvalReport(process.cwd(), report, {
+        path: input.reportPath,
+        force: true,
+    });
+    return { ...report, reportPath };
+}
+
+/**
+ * @param {{
+ *   workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>;
+ *   workflowPath: string;
+ *   cases: Array<Record<string, any>>;
+ * }} input
+ */
+async function discoverOptimizablePromptTasksForCases(input) {
+    const resolvedWorkflowPath = resolve(process.cwd(), input.workflowPath);
+    /** @type {Map<string, ReturnType<typeof discoverOptimizablePromptTasks>[number]>} */
+    const discovered = new Map();
+    for (const testCase of input.cases) {
+        const ctx = new SmithersCtx({
+            runId: `optimize-discovery-${testCase.id ?? crypto.randomUUID()}`,
+            iteration: 0,
+            input: testCase?.input ?? {},
+            outputs: {},
+            zodToKeyName: input.workflow.zodToKeyName,
+        });
+        const snap = await Effect.runPromise(renderFrame(input.workflow, ctx, {
+            baseRootDir: dirname(resolvedWorkflowPath),
+            workflowPath: resolvedWorkflowPath,
+        }));
+        for (const task of discoverOptimizablePromptTasks(snap.tasks)) {
+            const existing = discovered.get(task.nodeId);
+            if (!existing) {
+                discovered.set(task.nodeId, {
+                    ...task,
+                    promptSamples: [{ caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
+                });
+                continue;
+            }
+            const samples = Array.isArray(existing.promptSamples) ? existing.promptSamples : [];
+            if (!samples.some((sample) => sample.promptHash === task.promptHash)) {
+                discovered.set(task.nodeId, {
+                    ...existing,
+                    promptSamples: [...samples, { caseId: testCase.id, prompt: task.prompt, promptHash: task.promptHash }],
+                });
+            }
+        }
+    }
+    return [...discovered.values()];
+}
+
+/**
+ * @param {any} c
+ * @param {{
+ *   defaultEvalRunLabel: () => string;
+ *   formatRequestedJsonOutput: () => boolean;
+ *   loadWorkflow: (path: string) => Promise<import("@smithers-orchestrator/components").SmithersWorkflow<any>>;
+ *   resolveWorkflowPathForEval: (workflowInput: string) => string;
+ *   setupAbortSignal: () => AbortController;
+ *   setupSqliteCleanup: (workflow: import("@smithers-orchestrator/components").SmithersWorkflow<any>) => void;
+ *   setCommandExitOverride: (exitCode: number) => void;
+ * }} deps
+ */
+export async function runOptimizeCommand(c, deps) {
+    const fail = (opts) => {
+        deps.setCommandExitOverride(opts.exitCode ?? 1);
+        return c.error(opts);
+    };
+    try {
+        const workflowPath = deps.resolveWorkflowPathForEval(c.args.workflow);
+        const loadedCases = loadEvalCases(process.cwd(), c.options.cases, {
+            maxCases: c.options.maxCases,
+        });
+        const runLabel = deps.defaultEvalRunLabel();
+        const suiteBase = c.options.suite ?? `${basename(c.options.cases, extname(c.options.cases))}-opt`;
+        const baselinePlan = buildEvalPlan({
+            suiteId: `${suiteBase}-baseline`,
+            runLabel,
+            workflowPath,
+            casesPath: c.options.cases,
+            loadedCases,
+        });
+        const optimizedPlan = buildEvalPlan({
+            suiteId: `${suiteBase}-optimized`,
+            runLabel,
+            workflowPath,
+            casesPath: c.options.cases,
+            loadedCases,
+        });
+        const workflow = await deps.loadWorkflow(workflowPath);
+        ensureSmithersTables(workflow.db);
+        const adapter = new SmithersDb(workflow.db);
+        await assertEvalRunIdsAvailable(adapter, [...baselinePlan.cases, ...optimizedPlan.cases]);
+        deps.setupSqliteCleanup(workflow);
+        const reportDir = c.options.reportDir
+            ? resolve(process.cwd(), c.options.reportDir)
+            : resolve(process.cwd(), ".smithers", "optimizations", "reports");
+        const promptTasks = await discoverOptimizablePromptTasksForCases({
+            workflow,
+            workflowPath,
+            cases: loadedCases.cases,
+        });
+        if (promptTasks.length === 0) {
+            throw new SmithersError("INVALID_INPUT", "No agent-backed prompt tasks were found to optimize.", {
+                workflowPath,
+            });
+        }
+        const baselineReport = await executeEvalPlan({
+            workflow,
+            workflowPath,
+            plan: baselinePlan,
+            setupAbortSignal: deps.setupAbortSignal,
+            options: {
+                ...c.options,
+                includeOutput: true,
+            },
+            reportPath: join(reportDir, `${baselinePlan.suiteId}.json`),
+        });
+        const promptPatches = await buildProviderGepaPatches({
+            provider: c.options.provider,
+            model: c.options.model,
+            promptTasks,
+            cases: loadedCases.cases,
+            baselineReport,
+        });
+        if (Object.keys(promptPatches).length === 0) {
+            throw new SmithersError("INVALID_INPUT", "GEPA did not produce any prompt patches.", {
+                provider: c.options.provider,
+            });
+        }
+        const candidateArtifactPath = writeCandidateOptimizationArtifact(process.cwd(), promptPatches);
+        const optimizedReport = await executeEvalPlan({
+            workflow,
+            workflowPath,
+            plan: optimizedPlan,
+            setupAbortSignal: deps.setupAbortSignal,
+            options: {
+                ...c.options,
+                includeOutput: true,
+            },
+            reportPath: join(reportDir, `${optimizedPlan.suiteId}.json`),
+            optimizationArtifact: candidateArtifactPath,
+        });
+        const baselineScore = scoreOptimizationReport(baselineReport);
+        const optimizedScore = scoreOptimizationReport(optimizedReport);
+        const improvement = optimizedScore.score - baselineScore.score;
+        if (improvement < c.options.minImprovement) {
+            return fail({
+                code: "OPTIMIZATION_NO_IMPROVEMENT",
+                message: `Optimized score did not improve enough: baseline=${baselineScore.score.toFixed(4)} optimized=${optimizedScore.score.toFixed(4)} requiredDelta=${c.options.minImprovement}`,
+                exitCode: 1,
+            });
+        }
+        const { artifact } = writeOptimizationArtifact({
+            root: process.cwd(),
+            workflowPath,
+            requestedPath: c.options.artifact,
+            provider: c.options.provider,
+            model: resolveOptimizerProviderModel(c.options.provider, c.options.model) ?? "provider-default",
+            promptTasks,
+            promptPatches,
+            baselineReport,
+            candidateReport: optimizedReport,
+        });
+        if (c.format === "json" || c.format === "jsonl" || deps.formatRequestedJsonOutput()) {
+            return c.ok({ optimization: artifact });
+        }
+        process.stdout.write(`${renderOptimizationReport(artifact)}\n`);
+        return c.ok(undefined);
+    }
+    catch (err) {
+        if (err instanceof SmithersError) {
+            return fail({ code: err.code, message: err.message, exitCode: 4 });
+        }
+        return fail({ code: "OPTIMIZATION_FAILED", message: err?.message ?? String(err), exitCode: 1 });
+    }
+}

--- a/apps/cli/src/optimize-suite.js
+++ b/apps/cli/src/optimize-suite.js
@@ -1,0 +1,313 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, isAbsolute, join, resolve } from "node:path";
+import crypto from "node:crypto";
+import { SmithersError } from "@smithers-orchestrator/errors";
+
+const ARTIFACT_SCHEMA_VERSION = 1;
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ */
+function asString(value) {
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * @param {string} text
+ */
+function sha1(text) {
+    return crypto.createHash("sha1").update(text).digest("hex");
+}
+
+/**
+ * @param {Array<Record<string, any>>} tasks
+ */
+export function discoverOptimizablePromptTasks(tasks) {
+    return tasks
+        .filter((task) => task?.agent && typeof task.prompt === "string" && task.prompt.trim())
+        .map((task) => ({
+        nodeId: task.nodeId,
+        prompt: task.prompt,
+        promptHash: sha1(task.prompt),
+        label: typeof task.label === "string" ? task.label : null,
+    }));
+}
+
+/**
+ * @param {Record<string, any>} report
+ */
+export function scoreOptimizationReport(report) {
+    const results = Array.isArray(report.results) ? report.results : [];
+    if (results.length === 0) {
+        return {
+            score: 0,
+            passRate: 0,
+            assertionPassRate: 0,
+            passed: 0,
+            total: 0,
+        };
+    }
+    const passed = results.filter((result) => result?.passed).length;
+    let assertionCount = 0;
+    let assertionPassed = 0;
+    for (const result of results) {
+        const assertions = Array.isArray(result?.assertions) ? result.assertions : [];
+        assertionCount += assertions.length;
+        assertionPassed += assertions.filter((assertion) => assertion?.passed).length;
+    }
+    const passRate = passed / results.length;
+    const assertionPassRate = assertionCount === 0 ? passRate : assertionPassed / assertionCount;
+    return {
+        score: (passRate * 0.8) + (assertionPassRate * 0.2),
+        passRate,
+        assertionPassRate,
+        passed,
+        total: results.length,
+    };
+}
+
+/**
+ * @param {Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>} promptTasks
+ * @param {Array<Record<string, any>>} cases
+ * @param {Record<string, any>} baselineReport
+ */
+export function buildHeuristicGepaPatches(promptTasks, cases, baselineReport) {
+    /** @type {Record<string, { prompt: string; rationale: string; source: string }>} */
+    const patches = {};
+    const failedCaseIds = new Set((baselineReport.results ?? [])
+        .filter((result) => !result.passed)
+        .map((result) => result.caseId));
+    for (const task of promptTasks) {
+        const explicitPatch = cases
+            .map((testCase) => isObject(testCase.metadata?.promptPatches)
+            ? asString(testCase.metadata.promptPatches[task.nodeId])
+            : null)
+            .find(Boolean);
+        if (explicitPatch) {
+            patches[task.nodeId] = {
+                prompt: explicitPatch,
+                rationale: "Applied eval-case promptPatches metadata as a deterministic GEPA candidate.",
+                source: "heuristic-gepa",
+            };
+            continue;
+        }
+        const hints = cases
+            .filter((testCase) => failedCaseIds.size === 0 || failedCaseIds.has(testCase.id))
+            .map((testCase) => isObject(testCase.metadata?.optimizationHints)
+            ? asString(testCase.metadata.optimizationHints[task.nodeId])
+            : null)
+            .filter(Boolean);
+        if (hints.length === 0) {
+            continue;
+        }
+        const uniqueHints = [...new Set(hints)];
+        patches[task.nodeId] = {
+            prompt: [
+                task.prompt.trimEnd(),
+                "",
+                "GEPA optimization notes:",
+                ...uniqueHints.map((hint) => `- ${hint}`),
+            ].join("\n"),
+            rationale: "Reflected on failed validation cases and appended task-specific improvement hints.",
+            source: "heuristic-gepa",
+        };
+    }
+    return patches;
+}
+
+/**
+ * @param {{
+ *   apiKey?: string;
+ *   model: string;
+ *   promptTasks: Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>;
+ *   cases: Array<Record<string, any>>;
+ *   baselineReport: Record<string, any>;
+ * }} input
+ */
+export async function buildCerebrasGepaPatches(input) {
+    const apiKey = input.apiKey ?? process.env.CEREBRAS_API_KEY;
+    if (!apiKey) {
+        throw new SmithersError("INVALID_INPUT", "CEREBRAS_API_KEY is required for --provider cerebras.", {
+            provider: "cerebras",
+        });
+    }
+    const optimizerPrompt = [
+        "You are GEPA optimizing Smithers workflow task prompts.",
+        "Return only JSON: {\"patches\":[{\"nodeId\":\"...\",\"prompt\":\"...\",\"rationale\":\"...\"}]}",
+        "Improve prompts to maximize validation pass rate while preserving task intent.",
+        "",
+        `Tasks: ${JSON.stringify(input.promptTasks)}`,
+        `Eval cases: ${JSON.stringify(input.cases.map((testCase) => ({
+            id: testCase.id,
+            input: testCase.input,
+            expected: testCase.expected,
+            metadata: testCase.metadata,
+        })))}`,
+        `Baseline results: ${JSON.stringify(input.baselineReport.results ?? [])}`,
+    ].join("\n");
+    const response = await fetch("https://api.cerebras.ai/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            authorization: `Bearer ${apiKey}`,
+            "content-type": "application/json",
+        },
+        body: JSON.stringify({
+            model: input.model,
+            messages: [
+                {
+                    role: "system",
+                    content: "You produce strict JSON and do not include Markdown fences.",
+                },
+                { role: "user", content: optimizerPrompt },
+            ],
+            temperature: 0.2,
+        }),
+    });
+    if (!response.ok) {
+        const body = await response.text();
+        throw new SmithersError("INVALID_INPUT", `Cerebras optimizer request failed (${response.status}): ${body.slice(0, 500)}`, {
+            provider: "cerebras",
+            status: response.status,
+        });
+    }
+    const payload = await response.json();
+    const text = payload?.choices?.[0]?.message?.content;
+    if (typeof text !== "string") {
+        throw new SmithersError("INVALID_INPUT", "Cerebras optimizer response did not include message content.", {
+            provider: "cerebras",
+        });
+    }
+    const parsed = JSON.parse(text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, ""));
+    const patchRows = Array.isArray(parsed?.patches) ? parsed.patches : [];
+    /** @type {Record<string, { prompt: string; rationale: string; source: string }>} */
+    const patches = {};
+    for (const row of patchRows) {
+        if (!isObject(row) || typeof row.nodeId !== "string" || typeof row.prompt !== "string") {
+            continue;
+        }
+        patches[row.nodeId] = {
+            prompt: row.prompt,
+            rationale: typeof row.rationale === "string" ? row.rationale : "Cerebras GEPA prompt candidate.",
+            source: "cerebras-gepa",
+        };
+    }
+    return patches;
+}
+
+/**
+ * @param {string} root
+ * @param {string} workflowPath
+ * @param {string | undefined} requestedPath
+ */
+export function resolveOptimizationArtifactPath(root, workflowPath, requestedPath) {
+    if (requestedPath) {
+        return isAbsolute(requestedPath) ? requestedPath : resolve(root, requestedPath);
+    }
+    const workflowName = basename(workflowPath, extname(workflowPath)).replace(/[^a-zA-Z0-9_-]+/g, "-") || "workflow";
+    return join(root, ".smithers", "optimizations", `${workflowName}-${Date.now().toString(36)}.json`);
+}
+
+/**
+ * @param {{
+ *   root: string;
+ *   workflowPath: string;
+ *   requestedPath?: string;
+ *   provider: string;
+ *   model: string;
+ *   promptTasks: Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>;
+ *   promptPatches: Record<string, { prompt: string; rationale?: string; source?: string }>;
+ *   baselineReport: Record<string, any>;
+ *   candidateReport: Record<string, any>;
+ * }} input
+ */
+export function writeOptimizationArtifact(input) {
+    const baseline = scoreOptimizationReport(input.baselineReport);
+    const optimized = scoreOptimizationReport(input.candidateReport);
+    const id = `opt-${crypto.randomUUID()}`;
+    const artifact = {
+        schemaVersion: ARTIFACT_SCHEMA_VERSION,
+        id,
+        strategy: "gepa",
+        optimizer: {
+            name: "smithers-ax-gepa",
+            provider: input.provider,
+            model: input.model,
+            axCompatible: true,
+            axArtifactKind: "AxGEPA.optimizedProgram",
+        },
+        workflowPath: input.workflowPath,
+        createdAtMs: Date.now(),
+        baseline,
+        optimized,
+        improvement: {
+            absolute: optimized.score - baseline.score,
+            relative: baseline.score === 0 ? null : (optimized.score - baseline.score) / baseline.score,
+        },
+        promptTasks: input.promptTasks,
+        promptPatches: input.promptPatches,
+        reports: {
+            baseline: input.baselineReport.reportPath ?? null,
+            optimized: input.candidateReport.reportPath ?? null,
+        },
+    };
+    const target = resolveOptimizationArtifactPath(input.root, input.workflowPath, input.requestedPath);
+    if (existsSync(target)) {
+        throw new SmithersError("INVALID_INPUT", `Optimization artifact already exists: ${target}. Pass a different --artifact path.`, {
+            path: target,
+        });
+    }
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, `${JSON.stringify({ ...artifact, artifactPath: target }, null, 2)}\n`, "utf8");
+    return { artifact: { ...artifact, artifactPath: target }, path: target };
+}
+
+/**
+ * @param {string} root
+ * @param {Record<string, { prompt: string; rationale?: string; source?: string }>} promptPatches
+ */
+export function writeCandidateOptimizationArtifact(root, promptPatches) {
+    const target = join(root, ".smithers", "optimizations", "candidates", `candidate-${crypto.randomUUID()}.json`);
+    mkdirSync(dirname(target), { recursive: true });
+    const artifact = {
+        schemaVersion: ARTIFACT_SCHEMA_VERSION,
+        id: `candidate-${crypto.randomUUID()}`,
+        strategy: "gepa",
+        optimizer: {
+            name: "smithers-ax-gepa",
+            axCompatible: true,
+            axArtifactKind: "AxGEPA.optimizedProgram",
+        },
+        createdAtMs: Date.now(),
+        promptPatches,
+    };
+    writeFileSync(target, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+    return target;
+}
+
+/**
+ * @param {Record<string, any>} report
+ */
+export function renderOptimizationReport(report) {
+    const lines = [
+        `Optimization: ${report.artifactPath ?? report.id}`,
+        `Strategy: ${report.strategy}`,
+        `Provider: ${report.optimizer?.provider ?? "unknown"} (${report.optimizer?.model ?? "unknown"})`,
+        `Baseline: ${report.baseline.score.toFixed(4)} (${report.baseline.passed}/${report.baseline.total} passed)`,
+        `Optimized: ${report.optimized.score.toFixed(4)} (${report.optimized.passed}/${report.optimized.total} passed)`,
+        `Improvement: ${(report.improvement.absolute >= 0 ? "+" : "")}${report.improvement.absolute.toFixed(4)}`,
+        "",
+        "Prompt patches:",
+    ];
+    for (const [nodeId, patch] of Object.entries(report.promptPatches ?? {})) {
+        lines.push(`- ${nodeId}: ${patch.source ?? "gepa"} (${String(patch.prompt ?? "").length} chars)`);
+    }
+    return lines.join("\n");
+}

--- a/apps/cli/src/optimize-suite.js
+++ b/apps/cli/src/optimize-suite.js
@@ -4,6 +4,138 @@ import crypto from "node:crypto";
 import { SmithersError } from "@smithers-orchestrator/errors";
 
 const ARTIFACT_SCHEMA_VERSION = 1;
+export const OPTIMIZER_PROVIDER_IDS = [
+    "heuristic",
+    "cerebras",
+    "openai-api",
+    "openai",
+    "codex",
+    "anthropic-api",
+    "anthropic",
+    "claude-code",
+    "claude",
+    "gemini-api",
+    "gemini",
+    "antigravity",
+    "kimi",
+    "moonshot",
+    "opencode",
+    "pi",
+    "amp",
+    "forge",
+    "openai-compatible",
+];
+const PROVIDER_CONFIGS = {
+    heuristic: { kind: "heuristic" },
+    cerebras: {
+        kind: "openai-compatible",
+        baseURL: "https://api.cerebras.ai/v1",
+        apiKeyEnv: "CEREBRAS_API_KEY",
+        defaultModel: "gpt-oss-120b",
+    },
+    "openai-api": {
+        kind: "openai-compatible",
+        baseURL: "https://api.openai.com/v1",
+        apiKeyEnv: "OPENAI_API_KEY",
+        defaultModel: "gpt-5.3-codex",
+    },
+    openai: {
+        kind: "openai-compatible",
+        baseURL: "https://api.openai.com/v1",
+        apiKeyEnv: "OPENAI_API_KEY",
+        defaultModel: "gpt-5.3-codex",
+    },
+    codex: {
+        kind: "openai-compatible",
+        baseURL: "https://api.openai.com/v1",
+        apiKeyEnv: "OPENAI_API_KEY",
+        defaultModel: "gpt-5.3-codex",
+    },
+    "anthropic-api": {
+        kind: "anthropic",
+        baseURL: "https://api.anthropic.com/v1",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        defaultModel: "claude-opus-4-7",
+    },
+    anthropic: {
+        kind: "anthropic",
+        baseURL: "https://api.anthropic.com/v1",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        defaultModel: "claude-opus-4-7",
+    },
+    "claude-code": {
+        kind: "anthropic",
+        baseURL: "https://api.anthropic.com/v1",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        defaultModel: "claude-opus-4-7",
+    },
+    claude: {
+        kind: "anthropic",
+        baseURL: "https://api.anthropic.com/v1",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        defaultModel: "claude-opus-4-7",
+    },
+    "gemini-api": {
+        kind: "gemini",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        apiKeyEnv: "GEMINI_API_KEY",
+        fallbackApiKeyEnv: "GOOGLE_API_KEY",
+        defaultModel: "gemini-3.1-pro-preview",
+    },
+    gemini: {
+        kind: "gemini",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        apiKeyEnv: "GEMINI_API_KEY",
+        fallbackApiKeyEnv: "GOOGLE_API_KEY",
+        defaultModel: "gemini-3.1-pro-preview",
+    },
+    antigravity: {
+        kind: "gemini",
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        apiKeyEnv: "GEMINI_API_KEY",
+        fallbackApiKeyEnv: "GOOGLE_API_KEY",
+        defaultModel: "gemini-3.1-pro-preview",
+    },
+    kimi: {
+        kind: "openai-compatible",
+        baseURL: "https://api.moonshot.ai/v1",
+        apiKeyEnv: "MOONSHOT_API_KEY",
+        defaultModel: "kimi-latest",
+    },
+    moonshot: {
+        kind: "openai-compatible",
+        baseURL: "https://api.moonshot.ai/v1",
+        apiKeyEnv: "MOONSHOT_API_KEY",
+        defaultModel: "kimi-latest",
+    },
+    opencode: {
+        kind: "openai-compatible",
+        baseURLEnv: "SMITHERS_OPTIMIZER_BASE_URL",
+        apiKeyEnv: "SMITHERS_OPTIMIZER_API_KEY",
+        defaultModel: "anthropic/claude-sonnet-4-5",
+    },
+    pi: {
+        kind: "openai-compatible",
+        baseURLEnv: "SMITHERS_OPTIMIZER_BASE_URL",
+        apiKeyEnv: "SMITHERS_OPTIMIZER_API_KEY",
+        defaultModel: "gpt-5.3-codex",
+    },
+    amp: {
+        kind: "openai-compatible",
+        baseURLEnv: "SMITHERS_OPTIMIZER_BASE_URL",
+        apiKeyEnv: "SMITHERS_OPTIMIZER_API_KEY",
+    },
+    forge: {
+        kind: "openai-compatible",
+        baseURLEnv: "SMITHERS_OPTIMIZER_BASE_URL",
+        apiKeyEnv: "SMITHERS_OPTIMIZER_API_KEY",
+    },
+    "openai-compatible": {
+        kind: "openai-compatible",
+        baseURLEnv: "SMITHERS_OPTIMIZER_BASE_URL",
+        apiKeyEnv: "SMITHERS_OPTIMIZER_API_KEY",
+    },
+};
 
 /**
  * @param {unknown} value
@@ -25,6 +157,22 @@ function asString(value) {
  */
 function sha1(text) {
     return crypto.createHash("sha1").update(text).digest("hex");
+}
+
+/**
+ * @param {string} provider
+ */
+export function getOptimizerProviderConfig(provider) {
+    return PROVIDER_CONFIGS[provider] ?? null;
+}
+
+/**
+ * @param {string} provider
+ * @param {string | undefined} model
+ */
+export function resolveOptimizerProviderModel(provider, model) {
+    const config = getOptimizerProviderConfig(provider);
+    return model ?? config?.defaultModel ?? null;
 }
 
 /**
@@ -125,38 +273,110 @@ export function buildHeuristicGepaPatches(promptTasks, cases, baselineReport) {
 
 /**
  * @param {{
+ *   provider: string;
  *   apiKey?: string;
- *   model: string;
+ *   baseURL?: string;
+ *   model?: string;
  *   promptTasks: Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>;
  *   cases: Array<Record<string, any>>;
  *   baselineReport: Record<string, any>;
  * }} input
+ * @param {{ fetch?: typeof fetch; env?: NodeJS.ProcessEnv }} [options]
  */
-export async function buildCerebrasGepaPatches(input) {
-    const apiKey = input.apiKey ?? process.env.CEREBRAS_API_KEY;
-    if (!apiKey) {
-        throw new SmithersError("INVALID_INPUT", "CEREBRAS_API_KEY is required for --provider cerebras.", {
-            provider: "cerebras",
+export async function buildProviderGepaPatches(input, options = {}) {
+    const config = getOptimizerProviderConfig(input.provider);
+    if (!config) {
+        throw new SmithersError("INVALID_INPUT", `Unsupported optimizer provider "${input.provider}".`, {
+            provider: input.provider,
+            supportedProviders: OPTIMIZER_PROVIDER_IDS,
         });
     }
-    const optimizerPrompt = [
+    if (config.kind === "heuristic") {
+        return buildHeuristicGepaPatches(input.promptTasks, input.cases, input.baselineReport);
+    }
+    const env = options.env ?? process.env;
+    const model = resolveOptimizerProviderModel(input.provider, input.model);
+    if (!model) {
+        throw new SmithersError("INVALID_INPUT", `--model is required for --provider ${input.provider}.`, {
+            provider: input.provider,
+        });
+    }
+    const apiKey = input.apiKey ?? env[config.apiKeyEnv] ?? (config.fallbackApiKeyEnv ? env[config.fallbackApiKeyEnv] : undefined);
+    if (!apiKey) {
+        const envNames = [config.apiKeyEnv, config.fallbackApiKeyEnv].filter(Boolean).join(" or ");
+        throw new SmithersError("INVALID_INPUT", `${envNames} is required for --provider ${input.provider}.`, {
+            provider: input.provider,
+        });
+    }
+    const baseURL = input.baseURL ?? (config.baseURLEnv ? env[config.baseURLEnv] : undefined) ?? config.baseURL;
+    if (!baseURL) {
+        throw new SmithersError("INVALID_INPUT", `${config.baseURLEnv ?? "baseURL"} is required for --provider ${input.provider}.`, {
+            provider: input.provider,
+        });
+    }
+    const optimizerPrompt = buildOptimizerPrompt(input.promptTasks, input.cases, input.baselineReport);
+    const fetchFn = options.fetch ?? fetch;
+    const text = config.kind === "anthropic"
+        ? await requestAnthropicOptimizer(fetchFn, { provider: input.provider, apiKey, baseURL, model, optimizerPrompt })
+        : config.kind === "gemini"
+            ? await requestGeminiOptimizer(fetchFn, { provider: input.provider, apiKey, baseURL, model, optimizerPrompt })
+            : await requestOpenAICompatibleOptimizer(fetchFn, { provider: input.provider, apiKey, baseURL, model, optimizerPrompt });
+    return parseOptimizerPatches(text, input.provider);
+}
+
+/**
+ * @param {{
+ *   apiKey?: string;
+ *   model?: string;
+ *   promptTasks: Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>;
+ *   cases: Array<Record<string, any>>;
+ *   baselineReport: Record<string, any>;
+ * }} input
+ * @param {{ fetch?: typeof fetch; env?: NodeJS.ProcessEnv }} [options]
+ */
+export async function buildCerebrasGepaPatches(input, options = {}) {
+    return buildProviderGepaPatches({ provider: "cerebras", ...input }, options);
+}
+
+/**
+ * @param {Array<ReturnType<typeof discoverOptimizablePromptTasks>[number]>} promptTasks
+ * @param {Array<Record<string, any>>} cases
+ * @param {Record<string, any>} baselineReport
+ */
+function buildOptimizerPrompt(promptTasks, cases, baselineReport) {
+    return [
         "You are GEPA optimizing Smithers workflow task prompts.",
         "Return only JSON: {\"patches\":[{\"nodeId\":\"...\",\"prompt\":\"...\",\"rationale\":\"...\"}]}",
         "Improve prompts to maximize validation pass rate while preserving task intent.",
         "",
-        `Tasks: ${JSON.stringify(input.promptTasks)}`,
-        `Eval cases: ${JSON.stringify(input.cases.map((testCase) => ({
+        `Tasks: ${JSON.stringify(promptTasks)}`,
+        `Eval cases: ${JSON.stringify(cases.map((testCase) => ({
             id: testCase.id,
             input: testCase.input,
             expected: testCase.expected,
             metadata: testCase.metadata,
         })))}`,
-        `Baseline results: ${JSON.stringify(input.baselineReport.results ?? [])}`,
+        `Baseline results: ${JSON.stringify(baselineReport.results ?? [])}`,
     ].join("\n");
-    const response = await fetch("https://api.cerebras.ai/v1/chat/completions", {
+}
+
+/**
+ * @param {string} baseURL
+ * @param {string} path
+ */
+function endpoint(baseURL, path) {
+    return `${baseURL.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+/**
+ * @param {typeof fetch} fetchFn
+ * @param {{ provider: string; apiKey: string; baseURL: string; model: string; optimizerPrompt: string }} input
+ */
+async function requestOpenAICompatibleOptimizer(fetchFn, input) {
+    const response = await fetchFn(endpoint(input.baseURL, "/chat/completions"), {
         method: "POST",
         headers: {
-            authorization: `Bearer ${apiKey}`,
+            authorization: `Bearer ${input.apiKey}`,
             "content-type": "application/json",
         },
         body: JSON.stringify({
@@ -166,25 +386,108 @@ export async function buildCerebrasGepaPatches(input) {
                     role: "system",
                     content: "You produce strict JSON and do not include Markdown fences.",
                 },
-                { role: "user", content: optimizerPrompt },
+                { role: "user", content: input.optimizerPrompt },
             ],
             temperature: 0.2,
         }),
     });
-    if (!response.ok) {
-        const body = await response.text();
-        throw new SmithersError("INVALID_INPUT", `Cerebras optimizer request failed (${response.status}): ${body.slice(0, 500)}`, {
-            provider: "cerebras",
-            status: response.status,
-        });
-    }
+    await assertOptimizerResponseOk(response, input.provider);
     const payload = await response.json();
     const text = payload?.choices?.[0]?.message?.content;
     if (typeof text !== "string") {
-        throw new SmithersError("INVALID_INPUT", "Cerebras optimizer response did not include message content.", {
-            provider: "cerebras",
+        throw new SmithersError("INVALID_INPUT", `${input.provider} optimizer response did not include message content.`, {
+            provider: input.provider,
         });
     }
+    return text;
+}
+
+/**
+ * @param {typeof fetch} fetchFn
+ * @param {{ provider: string; apiKey: string; baseURL: string; model: string; optimizerPrompt: string }} input
+ */
+async function requestAnthropicOptimizer(fetchFn, input) {
+    const response = await fetchFn(endpoint(input.baseURL, "/messages"), {
+        method: "POST",
+        headers: {
+            "x-api-key": input.apiKey,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        body: JSON.stringify({
+            model: input.model,
+            max_tokens: 4096,
+            system: "You produce strict JSON and do not include Markdown fences.",
+            messages: [{ role: "user", content: input.optimizerPrompt }],
+            temperature: 0.2,
+        }),
+    });
+    await assertOptimizerResponseOk(response, input.provider);
+    const payload = await response.json();
+    const text = payload?.content?.find((part) => part?.type === "text")?.text;
+    if (typeof text !== "string") {
+        throw new SmithersError("INVALID_INPUT", `${input.provider} optimizer response did not include text content.`, {
+            provider: input.provider,
+        });
+    }
+    return text;
+}
+
+/**
+ * @param {typeof fetch} fetchFn
+ * @param {{ provider: string; apiKey: string; baseURL: string; model: string; optimizerPrompt: string }} input
+ */
+async function requestGeminiOptimizer(fetchFn, input) {
+    const url = `${endpoint(input.baseURL, `/models/${encodeURIComponent(input.model)}:generateContent`)}?key=${encodeURIComponent(input.apiKey)}`;
+    const response = await fetchFn(url, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+        },
+        body: JSON.stringify({
+            systemInstruction: {
+                parts: [{ text: "You produce strict JSON and do not include Markdown fences." }],
+            },
+            contents: [{ role: "user", parts: [{ text: input.optimizerPrompt }] }],
+            generationConfig: {
+                temperature: 0.2,
+                responseMimeType: "application/json",
+            },
+        }),
+    });
+    await assertOptimizerResponseOk(response, input.provider);
+    const payload = await response.json();
+    const text = payload?.candidates?.[0]?.content?.parts
+        ?.map((part) => typeof part?.text === "string" ? part.text : "")
+        .join("");
+    if (typeof text !== "string" || !text.trim()) {
+        throw new SmithersError("INVALID_INPUT", `${input.provider} optimizer response did not include text content.`, {
+            provider: input.provider,
+        });
+    }
+    return text;
+}
+
+/**
+ * @param {Response} response
+ * @param {string} provider
+ */
+async function assertOptimizerResponseOk(response, provider) {
+    if (response.ok) {
+        return;
+    }
+    const body = await response.text();
+    throw new SmithersError("INVALID_INPUT", `${provider} optimizer request failed (${response.status}): ${body.slice(0, 500)}`, {
+        provider,
+        status: response.status,
+    });
+}
+
+/**
+ * @param {string} text
+ * @param {string} provider
+ */
+function parseOptimizerPatches(text, provider) {
     const parsed = JSON.parse(text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, ""));
     const patchRows = Array.isArray(parsed?.patches) ? parsed.patches : [];
     /** @type {Record<string, { prompt: string; rationale: string; source: string }>} */
@@ -195,8 +498,8 @@ export async function buildCerebrasGepaPatches(input) {
         }
         patches[row.nodeId] = {
             prompt: row.prompt,
-            rationale: typeof row.rationale === "string" ? row.rationale : "Cerebras GEPA prompt candidate.",
-            source: "cerebras-gepa",
+            rationale: typeof row.rationale === "string" ? row.rationale : `${provider} GEPA prompt candidate.`,
+            source: `${provider}-gepa`,
         };
     }
     return patches;

--- a/apps/cli/src/optimize-suite.js
+++ b/apps/cli/src/optimize-suite.js
@@ -554,11 +554,9 @@ export function writeOptimizationArtifact(input) {
         id,
         strategy: "gepa",
         optimizer: {
-            name: "smithers-ax-gepa",
+            name: "smithers-gepa",
             provider: input.provider,
             model: input.model,
-            axCompatible: true,
-            axArtifactKind: "AxGEPA.optimizedProgram",
         },
         workflowPath: input.workflowPath,
         createdAtMs: Date.now(),
@@ -598,9 +596,7 @@ export function writeCandidateOptimizationArtifact(root, promptPatches) {
         id: `candidate-${crypto.randomUUID()}`,
         strategy: "gepa",
         optimizer: {
-            name: "smithers-ax-gepa",
-            axCompatible: true,
-            axArtifactKind: "AxGEPA.optimizedProgram",
+            name: "smithers-gepa",
         },
         createdAtMs: Date.now(),
         promptPatches,

--- a/apps/cli/src/optimize-suite.js
+++ b/apps/cli/src/optimize-suite.js
@@ -9,9 +9,11 @@ export const OPTIMIZER_PROVIDER_IDS = [
     "cerebras",
     "openai-api",
     "openai",
+    "openai-sdk",
     "codex",
     "anthropic-api",
     "anthropic",
+    "anthropic-sdk",
     "claude-code",
     "claude",
     "gemini-api",
@@ -45,6 +47,12 @@ const PROVIDER_CONFIGS = {
         apiKeyEnv: "OPENAI_API_KEY",
         defaultModel: "gpt-5.3-codex",
     },
+    "openai-sdk": {
+        kind: "openai-compatible",
+        baseURL: "https://api.openai.com/v1",
+        apiKeyEnv: "OPENAI_API_KEY",
+        defaultModel: "gpt-5.3-codex",
+    },
     codex: {
         kind: "openai-compatible",
         baseURL: "https://api.openai.com/v1",
@@ -58,6 +66,12 @@ const PROVIDER_CONFIGS = {
         defaultModel: "claude-opus-4-7",
     },
     anthropic: {
+        kind: "anthropic",
+        baseURL: "https://api.anthropic.com/v1",
+        apiKeyEnv: "ANTHROPIC_API_KEY",
+        defaultModel: "claude-opus-4-7",
+    },
+    "anthropic-sdk": {
         kind: "anthropic",
         baseURL: "https://api.anthropic.com/v1",
         apiKeyEnv: "ANTHROPIC_API_KEY",

--- a/apps/cli/tests/optimize-suite.test.js
+++ b/apps/cli/tests/optimize-suite.test.js
@@ -44,6 +44,46 @@ function writeOptimizableWorkflow(repo) {
     ].join("\n"));
 }
 
+function writeConditionalOptimizableWorkflow(repo) {
+    return repo.write("conditional-workflow.tsx", [
+        "/** @jsxImportSource smithers-orchestrator */",
+        'import { createSmithers, Workflow, Task } from "smithers-orchestrator";',
+        'import { z } from "zod";',
+        "",
+        "const { smithers, outputs } = createSmithers({",
+        "  result: z.object({",
+        "    optimized: z.boolean(),",
+        "    prompt: z.string(),",
+        "  }),",
+        "});",
+        "",
+        "const promptSensitiveAgent = {",
+        '  id: "prompt-sensitive-agent",',
+        '  model: "fixture-model",',
+        "  generate: async ({ prompt }) => {",
+        '    const optimized = prompt.includes("OPTIMIZED_TOKEN");',
+        "    const output = { optimized, prompt };",
+        "    return { text: JSON.stringify(output), output };",
+        "  },",
+        "};",
+        "",
+        "export default smithers((ctx) => (",
+        '  <Workflow name="conditional-optimizable-workflow">',
+        '    {ctx.input.kind === "secondary" ? (',
+        '      <Task id="secondary" output={outputs.result} agent={promptSensitiveAgent}>',
+        "        {`Secondary answer for ${ctx.input.prompt}`}",
+        "      </Task>",
+        "    ) : (",
+        '      <Task id="primary" output={outputs.result} agent={promptSensitiveAgent}>',
+        "        {`Primary answer with OPTIMIZED_TOKEN for ${ctx.input.prompt}`}",
+        "      </Task>",
+        "    )}",
+        "  </Workflow>",
+        "));",
+        "",
+    ].join("\n"));
+}
+
 describe("optimize suite helpers", () => {
     test("scores reports and creates GEPA prompt patches from failed-case hints", () => {
         const tasks = discoverOptimizablePromptTasks([
@@ -240,5 +280,59 @@ describe("smithers optimize command", () => {
             passed: 1,
             failed: 0,
         });
+    }, 120_000);
+
+    test("discovers prompt tasks across all eval cases before optimizing", () => {
+        const repo = createTempRepo();
+        writeConditionalOptimizableWorkflow(repo);
+        repo.write("evals/conditional.jsonl", [
+            JSON.stringify({
+                id: "primary-case",
+                input: { kind: "primary", prompt: "already good" },
+                expected: {
+                    status: "finished",
+                    outputContains: {
+                        result: [{ optimized: true }],
+                    },
+                },
+            }),
+            JSON.stringify({
+                id: "secondary-case",
+                input: { kind: "secondary", prompt: "needs optimization" },
+                expected: {
+                    status: "finished",
+                    outputContains: {
+                        result: [{ optimized: true }],
+                    },
+                },
+                metadata: {
+                    optimizationHints: {
+                        secondary: "Include the exact token OPTIMIZED_TOKEN so the secondary branch selects the optimized behavior.",
+                    },
+                },
+            }),
+        ].join("\n") + "\n");
+
+        const result = runSmithers([
+            "optimize",
+            "conditional-workflow.tsx",
+            "--cases",
+            "evals/conditional.jsonl",
+            "--suite",
+            "conditional-opt",
+            "--provider",
+            "heuristic",
+            "--artifact",
+            "artifacts/conditional-optimized.json",
+            "--report-dir",
+            "artifacts/reports",
+        ], { cwd: repo.dir, format: "json", timeoutMs: 60_000 });
+
+        if (result.exitCode !== 0) {
+            throw new Error(`smithers optimize conditional exited ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        }
+        const artifact = JSON.parse(repo.read("artifacts/conditional-optimized.json"));
+        expect(artifact.promptPatches.secondary.prompt).toContain("OPTIMIZED_TOKEN");
+        expect(artifact.optimized.passed).toBe(2);
     }, 120_000);
 });

--- a/apps/cli/tests/optimize-suite.test.js
+++ b/apps/cli/tests/optimize-suite.test.js
@@ -247,8 +247,7 @@ describe("smithers optimize command", () => {
         expect(optimization.improvement.absolute).toBeGreaterThan(0);
         expect(repo.exists("artifacts/optimized.json")).toBe(true);
         const artifact = JSON.parse(repo.read("artifacts/optimized.json"));
-        expect(artifact.optimizer.axCompatible).toBe(true);
-        expect(artifact.optimizer.axArtifactKind).toBe("AxGEPA.optimizedProgram");
+        expect(artifact.optimizer.name).toBe("smithers-gepa");
         expect(artifact.promptPatches.answer.prompt).toContain("OPTIMIZED_TOKEN");
 
         const baselineReport = JSON.parse(repo.read("artifacts/reports/opt-proof-baseline.json"));

--- a/apps/cli/tests/optimize-suite.test.js
+++ b/apps/cli/tests/optimize-suite.test.js
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+    OPTIMIZER_PROVIDER_IDS,
+    buildProviderGepaPatches,
     buildHeuristicGepaPatches,
     discoverOptimizablePromptTasks,
+    getOptimizerProviderConfig,
+    resolveOptimizerProviderModel,
     scoreOptimizationReport,
 } from "../src/optimize-suite.js";
 import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
@@ -71,6 +75,91 @@ describe("optimize suite helpers", () => {
         ], baselineReport);
         expect(patches.answer.prompt).toContain("Base prompt");
         expect(patches.answer.prompt).toContain("OPTIMIZED_TOKEN");
+    });
+
+    test("covers Smithers account and agent provider ids", () => {
+        expect(OPTIMIZER_PROVIDER_IDS).toEqual(expect.arrayContaining([
+            "claude-code",
+            "codex",
+            "antigravity",
+            "gemini",
+            "kimi",
+            "anthropic-api",
+            "openai-api",
+            "gemini-api",
+            "opencode",
+            "pi",
+            "amp",
+            "forge",
+        ]));
+        expect(getOptimizerProviderConfig("claude-code")?.kind).toBe("anthropic");
+        expect(getOptimizerProviderConfig("codex")?.kind).toBe("openai-compatible");
+        expect(getOptimizerProviderConfig("antigravity")?.kind).toBe("gemini");
+        expect(getOptimizerProviderConfig("kimi")?.kind).toBe("openai-compatible");
+        expect(resolveOptimizerProviderModel("cerebras")).toBe("gpt-oss-120b");
+        expect(resolveOptimizerProviderModel("openai-compatible", "custom-model")).toBe("custom-model");
+    });
+
+    test("builds provider optimizer calls for OpenAI-compatible, Anthropic, and Gemini providers", async () => {
+        const promptTasks = [{ nodeId: "answer", prompt: "Base prompt", promptHash: "abc", label: null }];
+        const cases = [{ id: "alpha", input: {}, expected: {}, metadata: {} }];
+        const baselineReport = { results: [{ caseId: "alpha", passed: false, assertions: [] }] };
+        const successfulPatch = JSON.stringify({
+            patches: [{ nodeId: "answer", prompt: "Improved prompt", rationale: "Because the eval failed." }],
+        });
+        /** @type {Array<{ url: string; body: any; headers: Record<string, string> }>} */
+        const calls = [];
+        const fakeFetch = async (url, init) => {
+            calls.push({
+                url: String(url),
+                body: JSON.parse(String(init?.body)),
+                headers: Object.fromEntries(new Headers(init?.headers).entries()),
+            });
+            if (String(url).includes(":generateContent")) {
+                return new Response(JSON.stringify({
+                    candidates: [{ content: { parts: [{ text: successfulPatch }] } }],
+                }), { status: 200 });
+            }
+            if (String(url).endsWith("/messages")) {
+                return new Response(JSON.stringify({
+                    content: [{ type: "text", text: successfulPatch }],
+                }), { status: 200 });
+            }
+            return new Response(JSON.stringify({
+                choices: [{ message: { content: successfulPatch } }],
+            }), { status: 200 });
+        };
+
+        const openaiPatches = await buildProviderGepaPatches({
+            provider: "codex",
+            promptTasks,
+            cases,
+            baselineReport,
+        }, { fetch: fakeFetch, env: { OPENAI_API_KEY: "openai-key" } });
+        expect(openaiPatches.answer.source).toBe("codex-gepa");
+        expect(calls.at(-1).url).toBe("https://api.openai.com/v1/chat/completions");
+        expect(calls.at(-1).body.model).toBe("gpt-5.3-codex");
+
+        await buildProviderGepaPatches({
+            provider: "claude-code",
+            model: "claude-test",
+            promptTasks,
+            cases,
+            baselineReport,
+        }, { fetch: fakeFetch, env: { ANTHROPIC_API_KEY: "anthropic-key" } });
+        expect(calls.at(-1).url).toBe("https://api.anthropic.com/v1/messages");
+        expect(calls.at(-1).headers["x-api-key"]).toBe("anthropic-key");
+        expect(calls.at(-1).body.model).toBe("claude-test");
+
+        await buildProviderGepaPatches({
+            provider: "antigravity",
+            model: "gemini-test",
+            promptTasks,
+            cases,
+            baselineReport,
+        }, { fetch: fakeFetch, env: { GOOGLE_API_KEY: "google-key" } });
+        expect(calls.at(-1).url).toBe("https://generativelanguage.googleapis.com/v1beta/models/gemini-test:generateContent?key=google-key");
+        expect(calls.at(-1).body.generationConfig.responseMimeType).toBe("application/json");
     });
 });
 

--- a/apps/cli/tests/optimize-suite.test.js
+++ b/apps/cli/tests/optimize-suite.test.js
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildHeuristicGepaPatches,
+    discoverOptimizablePromptTasks,
+    scoreOptimizationReport,
+} from "../src/optimize-suite.js";
+import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+function writeOptimizableWorkflow(repo) {
+    return repo.write("workflow.tsx", [
+        "/** @jsxImportSource smithers-orchestrator */",
+        'import { createSmithers, Workflow, Task } from "smithers-orchestrator";',
+        'import { z } from "zod";',
+        "",
+        "const { smithers, outputs } = createSmithers({",
+        "  result: z.object({",
+        "    optimized: z.boolean(),",
+        "    prompt: z.string(),",
+        "  }),",
+        "});",
+        "",
+        "const promptSensitiveAgent = {",
+        '  id: "prompt-sensitive-agent",',
+        '  model: "fixture-model",',
+        "  generate: async ({ prompt }) => {",
+        '    const optimized = prompt.includes("OPTIMIZED_TOKEN");',
+        "    const output = { optimized, prompt };",
+        "    return { text: JSON.stringify(output), output };",
+        "  },",
+        "};",
+        "",
+        "export default smithers((ctx) => (",
+        '  <Workflow name="optimizable-workflow">',
+        '    <Task id="answer" output={outputs.result} agent={promptSensitiveAgent}>',
+        "      {`Answer the request: ${ctx.input.prompt}`}",
+        "    </Task>",
+        "  </Workflow>",
+        "));",
+        "",
+    ].join("\n"));
+}
+
+describe("optimize suite helpers", () => {
+    test("scores reports and creates GEPA prompt patches from failed-case hints", () => {
+        const tasks = discoverOptimizablePromptTasks([
+            { nodeId: "answer", agent: { id: "agent" }, prompt: "Base prompt" },
+            { nodeId: "static", prompt: "ignored" },
+        ]);
+        expect(tasks.map((task) => task.nodeId)).toEqual(["answer"]);
+
+        const baselineReport = {
+            results: [
+                {
+                    caseId: "alpha",
+                    passed: false,
+                    assertions: [{ passed: true }, { passed: false }],
+                },
+            ],
+        };
+        expect(scoreOptimizationReport(baselineReport).score).toBe(0.1);
+
+        const patches = buildHeuristicGepaPatches(tasks, [
+            {
+                id: "alpha",
+                metadata: {
+                    optimizationHints: {
+                        answer: "Include OPTIMIZED_TOKEN.",
+                    },
+                },
+            },
+        ], baselineReport);
+        expect(patches.answer.prompt).toContain("Base prompt");
+        expect(patches.answer.prompt).toContain("OPTIMIZED_TOKEN");
+    });
+});
+
+describe("smithers optimize command", () => {
+    test("proves a GEPA prompt artifact improves eval results and can be reused", () => {
+        const repo = createTempRepo();
+        writeOptimizableWorkflow(repo);
+        repo.write("evals/opt.jsonl", JSON.stringify({
+            id: "alpha",
+            input: { prompt: "make the answer good" },
+            expected: {
+                status: "finished",
+                outputContains: {
+                    result: [{ optimized: true }],
+                },
+            },
+            metadata: {
+                optimizationHints: {
+                    answer: "Include the exact token OPTIMIZED_TOKEN so the agent selects the optimized behavior.",
+                },
+            },
+        }) + "\n");
+
+        const result = runSmithers([
+            "optimize",
+            "workflow.tsx",
+            "--cases",
+            "evals/opt.jsonl",
+            "--suite",
+            "opt-proof",
+            "--provider",
+            "heuristic",
+            "--artifact",
+            "artifacts/optimized.json",
+            "--report-dir",
+            "artifacts/reports",
+        ], { cwd: repo.dir, format: "json", timeoutMs: 60_000 });
+
+        if (result.exitCode !== 0) {
+            throw new Error(`smithers optimize exited ${result.exitCode}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+        }
+        const optimization = result.json?.optimization;
+        expect(optimization.baseline.passed).toBe(0);
+        expect(optimization.optimized.passed).toBe(1);
+        expect(optimization.improvement.absolute).toBeGreaterThan(0);
+        expect(repo.exists("artifacts/optimized.json")).toBe(true);
+        const artifact = JSON.parse(repo.read("artifacts/optimized.json"));
+        expect(artifact.optimizer.axCompatible).toBe(true);
+        expect(artifact.optimizer.axArtifactKind).toBe("AxGEPA.optimizedProgram");
+        expect(artifact.promptPatches.answer.prompt).toContain("OPTIMIZED_TOKEN");
+
+        const baselineReport = JSON.parse(repo.read("artifacts/reports/opt-proof-baseline.json"));
+        const optimizedReport = JSON.parse(repo.read("artifacts/reports/opt-proof-optimized.json"));
+        expect(baselineReport.summary.failed).toBe(1);
+        expect(optimizedReport.summary.passed).toBe(1);
+
+        const verification = runSmithers([
+            "eval",
+            "workflow.tsx",
+            "--cases",
+            "evals/opt.jsonl",
+            "--suite",
+            "opt-artifact",
+            "--run-label",
+            "verify",
+            "--optimization",
+            "artifacts/optimized.json",
+            "--report",
+            "artifacts/reuse-report.json",
+            "--force",
+        ], { cwd: repo.dir, format: "json", timeoutMs: 60_000 });
+
+        if (verification.exitCode !== 0) {
+            throw new Error(`smithers eval --optimization exited ${verification.exitCode}\nstdout:\n${verification.stdout}\nstderr:\n${verification.stderr}`);
+        }
+        expect(verification.json?.eval.summary).toMatchObject({
+            total: 1,
+            passed: 1,
+            failed: 0,
+        });
+    }, 120_000);
+});

--- a/apps/smithers-studio-2/.gitignore
+++ b/apps/smithers-studio-2/.gitignore
@@ -1,0 +1,47 @@
+# Build output
+dist/
+build/
+
+# Test results
+test-results/
+playwright-report/
+
+# Dependencies
+node_modules/
+
+# Environment files
+.env
+.env.local
+.env.production
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+.nyc_output/
+
+# Vite cache
+.vite/
+
+# TypeScript cache
+*.tsbuildinfo

--- a/apps/smithers-studio-2/README.md
+++ b/apps/smithers-studio-2/README.md
@@ -1,0 +1,15 @@
+# Smithers Studio 2
+
+Fresh UI shell for rebuilding Smithers Studio from the existing app as reference code.
+
+## Scripts
+
+- `npm run dev` from the repo root starts the Smithers Gateway and Studio 2 together.
+- `pnpm --filter @smithers-orchestrator/smithers-studio-2 dev`
+- `pnpm --filter @smithers-orchestrator/smithers-studio-2 typecheck`
+- `pnpm --filter @smithers-orchestrator/smithers-studio-2 build`
+
+The root dev script probes for available ports starting at `7331` for the Gateway and `5190` for the UI.
+Override them with `SMITHERS_GATEWAY_PORT` and `SMITHERS_STUDIO_2_PORT`.
+
+Terminal input is currently captured by the frontend Ghostty renderer. The real PTY/Ghostty backend should live in a separate service from the Gateway.

--- a/apps/smithers-studio-2/index.html
+++ b/apps/smithers-studio-2/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smithers Studio 2</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/smithers-studio-2/package.json
+++ b/apps/smithers-studio-2/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@smithers-orchestrator/smithers-studio-2",
+  "version": "0.1.0",
+  "description": "Next Smithers Studio UI shell",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "pnpm run typecheck && vite build",
+    "preview": "vite preview --host 127.0.0.1"
+  },
+  "dependencies": {
+    "@uidotdev/usehooks": "^2.4.1",
+    "@vitejs/plugin-react": "^6.0.2",
+    "@wterm/dom": "0.3.0",
+    "@wterm/ghostty": "0.3.0",
+    "@wterm/react": "0.3.0",
+    "node-pty": "^1.1.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.14",
+    "zustand": "^5.0.13"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
+  }
+}

--- a/apps/smithers-studio-2/package.json
+++ b/apps/smithers-studio-2/package.json
@@ -11,6 +11,8 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
+    "@smithers-orchestrator/gateway-client": "workspace:*",
+    "@smithers-orchestrator/vcs": "workspace:*",
     "@uidotdev/usehooks": "^2.4.1",
     "@vitejs/plugin-react": "^6.0.2",
     "@wterm/dom": "0.3.0",

--- a/apps/smithers-studio-2/package.json
+++ b/apps/smithers-studio-2/package.json
@@ -11,8 +11,6 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
-    "@smithers-orchestrator/gateway-client": "workspace:*",
-    "@smithers-orchestrator/vcs": "workspace:*",
     "@uidotdev/usehooks": "^2.4.1",
     "@vitejs/plugin-react": "^6.0.2",
     "@wterm/dom": "0.3.0",

--- a/apps/smithers-studio-2/playwright.config.ts
+++ b/apps/smithers-studio-2/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const testPort = process.env.SMITHERS_STUDIO_TEST_PORT || '5500';
+const gatewayPort = process.env.SMITHERS_STUDIO_GATEWAY_TEST_PORT || '7400';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: `http://127.0.0.1:${testPort}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `vite --host 127.0.0.1 --port ${testPort}`,
+    port: parseInt(testPort),
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+    env: {
+      SMITHERS_STUDIO_GATEWAY_URL: `http://127.0.0.1:${gatewayPort}`,
+    },
+  },
+});

--- a/apps/smithers-studio-2/scripts/dev.ts
+++ b/apps/smithers-studio-2/scripts/dev.ts
@@ -1,0 +1,141 @@
+import { createServer } from "node:net";
+import { exit } from "node:process";
+
+type ManagedProcess = { name: string; process: Bun.Subprocess<"ignore", "pipe", "pipe"> };
+
+const host = process.env.SMITHERS_STUDIO_2_HOST ?? "127.0.0.1";
+const gatewayStartPort = numberFromEnv("SMITHERS_GATEWAY_PORT", 7331);
+const ptyStartPort = numberFromEnv("SMITHERS_PTY_PORT", 7342);
+const uiStartPort = numberFromEnv("SMITHERS_STUDIO_2_PORT", 5190);
+const children: ManagedProcess[] = [];
+let shuttingDown = false;
+
+function numberFromEnv(key: string, fallback: number) {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) throw new Error(`${key} must be a TCP port number.`);
+  return parsed;
+}
+
+async function isPortFree(port: number) {
+  return new Promise<boolean>((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => server.close(() => resolve(true)));
+    server.listen(port, host);
+  });
+}
+
+async function findOpenPort(startPort: number) {
+  for (let port = startPort; port <= startPort + 50; port += 1) {
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error(`No open port found from ${startPort} to ${startPort + 50}.`);
+}
+
+async function pipeStream(name: string, stream: ReadableStream<Uint8Array>) {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let buffered = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      if (buffered.trim()) console.log(`[${name}] ${buffered.trimEnd()}`);
+      return;
+    }
+    buffered += decoder.decode(value, { stream: true });
+    const lines = buffered.split(/\r?\n/);
+    buffered = lines.pop() ?? "";
+    for (const line of lines) console.log(`[${name}] ${line}`);
+  }
+}
+
+function spawnManaged(name: string, command: string[], env: Record<string, string> = {}, cwd = process.cwd()) {
+  const child = {
+    name,
+    process: Bun.spawn(command, { cwd, env: { ...process.env, ...env }, stdin: "ignore", stdout: "pipe", stderr: "pipe" }),
+  };
+  children.push(child);
+  void pipeStream(name, child.process.stdout);
+  void pipeStream(name, child.process.stderr);
+  void child.process.exited.then((code) => {
+    if (!shuttingDown) {
+      console.error(`[dev] ${name} exited with code ${code}. Stopping dev stack.`);
+      void shutdown(code || 1);
+    }
+  });
+}
+
+async function waitForHttpOk(url: string, timeoutMs = 20_000) {
+  const started = Date.now();
+  let lastError = "";
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await Bun.sleep(250);
+  }
+  throw new Error(`Timed out waiting for ${url}${lastError ? ` (${lastError})` : ""}.`);
+}
+
+async function shutdown(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children.toReversed()) {
+    if (child.process.exitCode === null) child.process.kill("SIGTERM");
+  }
+  await Promise.allSettled(children.map((child) => child.process.exited));
+  exit(code);
+}
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    console.log(`[dev] Received ${signal}. Stopping dev stack.`);
+    void shutdown(0);
+  });
+}
+
+async function main() {
+  const gatewayPort = await findOpenPort(gatewayStartPort);
+  const ptyPort = await findOpenPort(ptyStartPort);
+  const uiPort = await findOpenPort(uiStartPort);
+  const gatewayUrl = `http://${host}:${gatewayPort}`;
+  const ptyUrl = `http://${host}:${ptyPort}`;
+  const uiUrl = `http://${host}:${uiPort}`;
+
+  console.log(`[dev] Starting Smithers Gateway on ${gatewayUrl}`);
+  spawnManaged("gateway", ["bun", "apps/cli/src/index.js", "gateway", "serve", "--host", host, "--port", String(gatewayPort)]);
+  await waitForHttpOk(`${gatewayUrl}/health`);
+
+  console.log(`[dev] Starting PTY Server on ${ptyUrl}`);
+  spawnManaged("pty", ["bun", "apps/smithers-studio-2/scripts/pty-server.ts"], {
+    PTY_SERVER_HOST: host,
+    PTY_SERVER_PORT: String(ptyPort),
+  });
+  await waitForHttpOk(`${ptyUrl}/health`);
+
+  console.log(`[dev] Starting Smithers Studio 2 on ${uiUrl}`);
+  spawnManaged("studio-2", ["node", "node_modules/vite/bin/vite.js", "--host", host, "--port", String(uiPort), "--strictPort"], {
+    VITE_SMITHERS_GATEWAY_URL: gatewayUrl,
+    VITE_SMITHERS_GATEWAY_RPC_PATH: "/v1/rpc",
+    PTY_SERVER_URL: ptyUrl,
+  }, "apps/smithers-studio-2");
+  await waitForHttpOk(uiUrl);
+
+  console.log("");
+  console.log(`[dev] Studio 2: ${uiUrl}`);
+  console.log(`[dev] Gateway:  ${gatewayUrl}`);
+  console.log(`[dev] PTY:      ${ptyUrl}`);
+  console.log("[dev] Press Ctrl+C to stop all processes.");
+  await Promise.race(children.map((child) => child.process.exited));
+}
+
+main().catch((error) => {
+  console.error(`[dev] ${error instanceof Error ? error.message : String(error)}`);
+  void shutdown(1);
+});

--- a/apps/smithers-studio-2/scripts/pty-server.ts
+++ b/apps/smithers-studio-2/scripts/pty-server.ts
@@ -1,0 +1,277 @@
+/**
+ * PTY WebSocket server for Smithers Studio 2.
+ *
+ * Adapted from ~/gui/zmux architecture: JSON-RPC 2.0 protocol over
+ * WebSocket instead of Unix socket, session lifecycle with scrollback
+ * replay on attach, event broadcasting to connected clients.
+ *
+ * Protocol (JSON-RPC 2.0 over WebSocket text frames):
+ *
+ *   Client → Server requests:
+ *     session.create  { shell?, cwd?, cols?, rows? }  → { sessionId, pid }
+ *     session.input   { sessionId, data }             → { ok }
+ *     session.resize  { sessionId, cols, rows }       → { ok }
+ *     session.close   { sessionId }                   → { ok }
+ *     session.list    {}                              → [ ...sessions ]
+ *     daemon.ping     {}                              → { version, sessions }
+ *
+ *   Server → Client notifications:
+ *     pane_output     { sessionId, data }
+ *     session_exited  { sessionId, exitCode, signal }
+ */
+
+import * as pty from "node-pty";
+
+const SCROLLBACK_LIMIT = 256 * 1024; // 256 KiB, matches zmux attach_replay_max_bytes
+const VERSION = "0.1.0";
+
+type Session = {
+  id: string;
+  pty: pty.IPty;
+  scrollback: string;
+  pid: number;
+  shell: string;
+  cwd: string;
+  cols: number;
+  rows: number;
+  createdAt: number;
+  exited: boolean;
+  exitCode: number | null;
+  signal: number | null;
+};
+
+const sessions = new Map<string, Session>();
+
+type WsData = { id: string };
+
+const host = process.env.PTY_SERVER_HOST ?? "127.0.0.1";
+const port = parseInt(process.env.PTY_SERVER_PORT ?? "7342");
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, Number.isFinite(n) ? n : min));
+}
+
+function appendScrollback(session: Session, data: string) {
+  session.scrollback += data;
+  if (session.scrollback.length > SCROLLBACK_LIMIT) {
+    session.scrollback = session.scrollback.slice(-SCROLLBACK_LIMIT);
+  }
+}
+
+function nextSessionId() {
+  return `ses-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function defaultShell() {
+  return process.env.SHELL || "/bin/zsh";
+}
+
+function jsonRpcResult(id: unknown, result: unknown) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function jsonRpcError(id: unknown, code: number, message: string) {
+  return JSON.stringify({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+function jsonRpcNotification(method: string, params: unknown) {
+  return JSON.stringify({ jsonrpc: "2.0", method, params });
+}
+
+const connectedClients = new Set<{ ws: { sendText(s: string): void; readyState: number } }>();
+
+function broadcast(message: string) {
+  for (const client of connectedClients) {
+    try {
+      client.ws.sendText(message);
+    } catch {}
+  }
+}
+
+function createSession(params: Record<string, unknown>): Session {
+  const shell = typeof params.shell === "string" ? params.shell : defaultShell();
+  const cwd = typeof params.cwd === "string" ? params.cwd : (process.env.HOME || process.cwd());
+  const cols = clamp(typeof params.cols === "number" ? params.cols : 80, 1, 500);
+  const rows = clamp(typeof params.rows === "number" ? params.rows : 24, 1, 200);
+  const id = nextSessionId();
+
+  const ptyProcess = pty.spawn(shell, [], {
+    name: "xterm-256color",
+    cols,
+    rows,
+    cwd,
+    env: process.env as Record<string, string>,
+  });
+
+  const session: Session = {
+    id,
+    pty: ptyProcess,
+    scrollback: "",
+    pid: ptyProcess.pid,
+    shell,
+    cwd,
+    cols,
+    rows,
+    createdAt: Date.now(),
+    exited: false,
+    exitCode: null,
+    signal: null,
+  };
+
+  ptyProcess.onData((data) => {
+    appendScrollback(session, data);
+    broadcast(jsonRpcNotification("pane_output", { sessionId: session.id, data }));
+  });
+
+  ptyProcess.onExit(({ exitCode, signal }) => {
+    session.exited = true;
+    session.exitCode = exitCode;
+    session.signal = signal;
+    broadcast(jsonRpcNotification("session_exited", {
+      sessionId: session.id,
+      exitCode,
+      signal,
+    }));
+  });
+
+  sessions.set(id, session);
+  return session;
+}
+
+function handleRequest(id: unknown, method: string, params: Record<string, unknown>) {
+  if (method === "daemon.ping") {
+    return jsonRpcResult(id, { version: VERSION, sessions: sessions.size });
+  }
+
+  if (method === "session.create") {
+    try {
+      const session = createSession(params);
+      return jsonRpcResult(id, {
+        sessionId: session.id,
+        pid: session.pid,
+        shell: session.shell,
+        cwd: session.cwd,
+        cols: session.cols,
+        rows: session.rows,
+      });
+    } catch (e) {
+      return jsonRpcError(id, -32000, String(e));
+    }
+  }
+
+  if (method === "session.attach") {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+    const session = sessionId ? sessions.get(sessionId) : null;
+    if (!session) return jsonRpcError(id, -32000, "session not found");
+    if (typeof params.cols === "number" && typeof params.rows === "number") {
+      const cols = clamp(params.cols, 1, 500);
+      const rows = clamp(params.rows, 1, 200);
+      if (cols !== session.cols || rows !== session.rows) {
+        session.cols = cols;
+        session.rows = rows;
+        if (!session.exited) session.pty.resize(cols, rows);
+      }
+    }
+    return jsonRpcResult(id, {
+      sessionId: session.id,
+      pid: session.pid,
+      scrollback: session.scrollback,
+      exited: session.exited,
+      exitCode: session.exitCode,
+    });
+  }
+
+  if (method === "session.input") {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+    const data = typeof params.data === "string" ? params.data : "";
+    const session = sessionId ? sessions.get(sessionId) : null;
+    if (!session) return jsonRpcError(id, -32000, "session not found");
+    if (session.exited) return jsonRpcError(id, -32000, "session has exited");
+    session.pty.write(data);
+    return jsonRpcResult(id, { ok: true });
+  }
+
+  if (method === "session.resize") {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+    const session = sessionId ? sessions.get(sessionId) : null;
+    if (!session) return jsonRpcError(id, -32000, "session not found");
+    if (session.exited) return jsonRpcError(id, -32000, "session has exited");
+    const cols = clamp(typeof params.cols === "number" ? params.cols : session.cols, 1, 500);
+    const rows = clamp(typeof params.rows === "number" ? params.rows : session.rows, 1, 200);
+    session.cols = cols;
+    session.rows = rows;
+    session.pty.resize(cols, rows);
+    return jsonRpcResult(id, { ok: true });
+  }
+
+  if (method === "session.close") {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : null;
+    const session = sessionId ? sessions.get(sessionId) : null;
+    if (!session) return jsonRpcError(id, -32000, "session not found");
+    if (!session.exited) {
+      try { session.pty.kill(); } catch {}
+    }
+    sessions.delete(sessionId!);
+    return jsonRpcResult(id, { ok: true });
+  }
+
+  if (method === "session.list") {
+    const list = [...sessions.values()].map((s) => ({
+      sessionId: s.id,
+      pid: s.pid,
+      shell: s.shell,
+      cwd: s.cwd,
+      cols: s.cols,
+      rows: s.rows,
+      exited: s.exited,
+      exitCode: s.exitCode,
+      createdAt: s.createdAt,
+    }));
+    return jsonRpcResult(id, list);
+  }
+
+  return jsonRpcError(id, -32601, "method not found");
+}
+
+Bun.serve<WsData>({
+  hostname: host,
+  port,
+  fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname === "/health") return new Response("ok");
+    if (url.pathname === "/terminal/ws") {
+      const id = Math.random().toString(36).slice(2);
+      if (server.upgrade(req, { data: { id } })) return undefined;
+      return new Response("WebSocket upgrade failed", { status: 400 });
+    }
+    return new Response("Not Found", { status: 404 });
+  },
+  websocket: {
+    open(ws) {
+      connectedClients.add({ ws: ws as any });
+    },
+    message(ws, raw) {
+      try {
+        const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+        const msg = JSON.parse(text);
+        const id = msg.id ?? null;
+        const method = typeof msg.method === "string" ? msg.method : "";
+        const params = (typeof msg.params === "object" && msg.params !== null) ? msg.params : {};
+        const response = handleRequest(id, method, params);
+        ws.sendText(response);
+      } catch {
+        ws.sendText(jsonRpcError(null, -32700, "parse error"));
+      }
+    },
+    close(ws) {
+      for (const client of connectedClients) {
+        if ((client.ws as any) === ws) {
+          connectedClients.delete(client);
+          break;
+        }
+      }
+    },
+  },
+});
+
+console.log(`[pty] Listening on http://${host}:${port}`);

--- a/apps/smithers-studio-2/src/App.tsx
+++ b/apps/smithers-studio-2/src/App.tsx
@@ -1,20 +1,32 @@
 import { CommandPalette } from "./CommandPalette";
 import { Sidebar } from "./Sidebar";
 import { TerminalWorkspace } from "./TerminalWorkspace";
+import { IssuesPanel } from "./IssuesPanel";
+import { LandingsPanel } from "./LandingsPanel";
+import { WorkspacesPanel } from "./WorkspacesPanel";
 import { useHotkey } from "./useHotkey";
 import { useStudioStore } from "./useStudioStore";
 
 export default function App() {
+  const activeView = useStudioStore((s) => s.activeView);
   const paletteOpen = useStudioStore((s) => s.paletteOpen);
   const { openPalette, openTerminal } = useStudioStore.getState();
 
   useHotkey("p", openPalette);
+  useHotkey("k", openPalette);
   useHotkey("t", openTerminal);
 
   return (
     <main className="studio-shell">
       <Sidebar />
-      <TerminalWorkspace />
+
+      <div className="main-content">
+        {activeView === "terminal" && <TerminalWorkspace />}
+        {activeView === "issues" && <IssuesPanel />}
+        {activeView === "landings" && <LandingsPanel />}
+        {activeView === "workspaces" && <WorkspacesPanel />}
+      </div>
+
       {paletteOpen ? <CommandPalette /> : null}
     </main>
   );

--- a/apps/smithers-studio-2/src/App.tsx
+++ b/apps/smithers-studio-2/src/App.tsx
@@ -1,0 +1,21 @@
+import { CommandPalette } from "./CommandPalette";
+import { Sidebar } from "./Sidebar";
+import { TerminalWorkspace } from "./TerminalWorkspace";
+import { useHotkey } from "./useHotkey";
+import { useStudioStore } from "./useStudioStore";
+
+export default function App() {
+  const paletteOpen = useStudioStore((s) => s.paletteOpen);
+  const { openPalette, openTerminal } = useStudioStore.getState();
+
+  useHotkey("p", openPalette);
+  useHotkey("t", openTerminal);
+
+  return (
+    <main className="studio-shell">
+      <Sidebar />
+      <TerminalWorkspace />
+      {paletteOpen ? <CommandPalette /> : null}
+    </main>
+  );
+}

--- a/apps/smithers-studio-2/src/CommandPalette.tsx
+++ b/apps/smithers-studio-2/src/CommandPalette.tsx
@@ -31,7 +31,7 @@ export function CommandPalette() {
 
   return (
     <div className="palette-backdrop" onMouseDown={(event) => event.target === event.currentTarget && closePalette()}>
-      <div aria-label="Command palette" className="command-palette" role="dialog">
+      <div aria-label="Command palette" className="command-palette" data-testid="command-palette" role="dialog">
         <input
           autoFocus
           onChange={(event) => setPaletteQuery(event.target.value)}

--- a/apps/smithers-studio-2/src/CommandPalette.tsx
+++ b/apps/smithers-studio-2/src/CommandPalette.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+import { useStudioStore } from "./useStudioStore";
+
+type PaletteAction = { id: string; label: string; hint: string; run: () => void };
+
+export function CommandPalette() {
+  const tabs = useStudioStore((s) => s.tabs);
+  const paletteQuery = useStudioStore((s) => s.paletteQuery);
+  const selectedPaletteIndex = useStudioStore((s) => s.selectedPaletteIndex);
+  const { openTerminal, setActiveTabId, closePalette, setPaletteQuery, setSelectedPaletteIndex } = useStudioStore.getState();
+
+  const paletteActions = useMemo<PaletteAction[]>(() => [
+    { id: "new-terminal", label: "New Terminal", hint: "Open a new terminal tab", run: openTerminal },
+    ...tabs.map((tab) => ({
+      id: `focus-${tab.id}`,
+      label: `Focus ${tab.title}`,
+      hint: "Switch terminal tab",
+      run: () => {
+        setActiveTabId(tab.id);
+        closePalette();
+      },
+    })),
+  ], [tabs]);
+
+  const filteredActions = useMemo(() => {
+    const query = paletteQuery.trim().toLowerCase();
+    return query
+      ? paletteActions.filter((action) => `${action.label} ${action.hint}`.toLowerCase().includes(query))
+      : paletteActions;
+  }, [paletteActions, paletteQuery]);
+
+  return (
+    <div className="palette-backdrop" onMouseDown={(event) => event.target === event.currentTarget && closePalette()}>
+      <div aria-label="Command palette" className="command-palette" role="dialog">
+        <input
+          autoFocus
+          onChange={(event) => setPaletteQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") closePalette();
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setSelectedPaletteIndex((index) => Math.min(index + 1, filteredActions.length - 1));
+            }
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setSelectedPaletteIndex((index) => Math.max(index - 1, 0));
+            }
+            if (event.key === "Enter") {
+              event.preventDefault();
+              filteredActions[selectedPaletteIndex]?.run();
+            }
+          }}
+          placeholder="Type a command"
+          value={paletteQuery}
+        />
+        <div className="palette-list">
+          {filteredActions.length === 0 ? <div className="palette-empty">No commands found.</div> : filteredActions.map((action, index) => (
+            <button className={index === selectedPaletteIndex ? "selected" : ""} key={action.id} onClick={action.run} onMouseEnter={() => setSelectedPaletteIndex(index)} type="button">
+              <span>{action.label}</span>
+              <small>{action.hint}</small>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
+++ b/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
@@ -1,0 +1,228 @@
+import { GhosttyCore } from "@wterm/ghostty";
+import { Terminal, useTerminal } from "@wterm/react";
+import { use, useCallback, useEffect, useRef, useState } from "react";
+
+type TerminalTab = { id: string; title: string; createdAt: Date };
+
+type CoreResult =
+  | { ok: true; core: Awaited<ReturnType<typeof GhosttyCore.load>> }
+  | { ok: false; error: string };
+
+const corePromise: Promise<CoreResult> = GhosttyCore.load({
+  scrollbackLimit: 4_000,
+})
+  .then((core): CoreResult => ({ ok: true, core }))
+  .catch(
+    (error): CoreResult => ({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+
+let rpcIdCounter = 0;
+
+type RpcCallbacks = {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+};
+
+function usePtySession(tabId: string, write: (data: string) => void) {
+  const wsRef = useRef<WebSocket | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const pendingRef = useRef<Map<number, RpcCallbacks>>(new Map());
+  const [status, setStatus] = useState<
+    "connecting" | "creating" | "attached" | "exited" | "error"
+  >("connecting");
+
+  const rpcCall = useCallback(
+    (method: string, params: Record<string, unknown>): Promise<unknown> => {
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        return Promise.reject(new Error("not connected"));
+      }
+      const id = ++rpcIdCounter;
+      return new Promise((resolve, reject) => {
+        pendingRef.current.set(id, { resolve, reject });
+        ws.send(
+          JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+        );
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(
+      `${protocol}//${location.host}/terminal/ws`,
+    );
+    wsRef.current = ws;
+
+    ws.onopen = async () => {
+      setStatus("creating");
+      try {
+        const result = (await rpcCall("session.create", {
+          cols: 80,
+          rows: 24,
+        })) as { sessionId: string; scrollback?: string };
+        sessionIdRef.current = result.sessionId;
+        if (result.scrollback) write(result.scrollback);
+        setStatus("attached");
+      } catch {
+        setStatus("error");
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+
+        if ("id" in msg && msg.id != null) {
+          const cb = pendingRef.current.get(msg.id);
+          if (cb) {
+            pendingRef.current.delete(msg.id);
+            if (msg.error) {
+              cb.reject(new Error(msg.error.message));
+            } else {
+              cb.resolve(msg.result);
+            }
+          }
+          return;
+        }
+
+        if (msg.method === "pane_output") {
+          if (msg.params.sessionId === sessionIdRef.current) {
+            write(msg.params.data);
+          }
+        } else if (msg.method === "session_exited") {
+          if (msg.params.sessionId === sessionIdRef.current) {
+            const code = msg.params.exitCode ?? "unknown";
+            write(
+              `\r\n\x1b[90m[process exited with code ${code}]\x1b[0m\r\n`,
+            );
+            setStatus("exited");
+          }
+        }
+      } catch {}
+    };
+
+    ws.onclose = () => {
+      for (const cb of pendingRef.current.values()) {
+        cb.reject(new Error("connection closed"));
+      }
+      pendingRef.current.clear();
+    };
+
+    ws.onerror = () => setStatus("error");
+
+    return () => {
+      const sid = sessionIdRef.current;
+      if (sid && ws.readyState === WebSocket.OPEN) {
+        ws.send(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "session.close",
+            params: { sessionId: sid },
+          }),
+        );
+      }
+      ws.close();
+      wsRef.current = null;
+      sessionIdRef.current = null;
+      pendingRef.current.clear();
+    };
+  }, [tabId, write, rpcCall]);
+
+  const sendInput = useCallback((data: string) => {
+    const ws = wsRef.current;
+    const sid = sessionIdRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || !sid) return;
+    ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "session.input",
+        params: { sessionId: sid, data },
+      }),
+    );
+  }, []);
+
+  const sendResize = useCallback(
+    (cols: number, rows: number) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      rpcCall("session.resize", { sessionId: sid, cols, rows }).catch(
+        () => {},
+      );
+    },
+    [rpcCall],
+  );
+
+  return { status, sendInput, sendResize };
+}
+
+export function GhosttyTerminalPane({
+  active,
+  tab,
+}: {
+  active: boolean;
+  tab: TerminalTab;
+}) {
+  const { ref, write } = useTerminal();
+  const result = use(corePromise);
+  const { status, sendInput, sendResize } = usePtySession(tab.id, write);
+
+  const handleData = useCallback(
+    (data: string) => {
+      if (!active) return;
+      sendInput(data);
+    },
+    [active, sendInput],
+  );
+
+  const handleResize = useCallback(
+    (cols: number, rows: number) => {
+      sendResize(cols, rows);
+    },
+    [sendResize],
+  );
+
+  if (!result.ok) {
+    return (
+      <div
+        aria-hidden={!active}
+        className={`terminal-pane ${active ? "active" : ""}`}
+      >
+        <div className="terminal-loading">
+          Ghostty unavailable: {result.error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-hidden={!active}
+      className={`terminal-pane ${active ? "active" : ""}`}
+    >
+      {status === "error" && (
+        <div className="terminal-status">
+          PTY server unavailable — start with: bun scripts/dev.ts
+        </div>
+      )}
+      {status === "exited" && (
+        <div className="terminal-status">Session ended</div>
+      )}
+      <Terminal
+        autoResize
+        className="ghostty-terminal"
+        core={result.core}
+        cursorBlink={active}
+        onData={handleData}
+        onResize={handleResize}
+        ref={ref}
+        rows={24}
+        theme="monokai"
+      />
+    </div>
+  );
+}

--- a/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
+++ b/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
@@ -205,12 +205,12 @@ export function GhosttyTerminalPane({
       className={`terminal-pane ${active ? "active" : ""}`}
     >
       {status === "error" && (
-        <div className="terminal-status">
+        <div className="terminal-status" data-testid="terminal-status">
           PTY server unavailable — start with: bun scripts/dev.ts
         </div>
       )}
       {status === "exited" && (
-        <div className="terminal-status">Session ended</div>
+        <div className="terminal-status" data-testid="terminal-status">Session ended</div>
       )}
       <Terminal
         autoResize

--- a/apps/smithers-studio-2/src/IssuesPanel.tsx
+++ b/apps/smithers-studio-2/src/IssuesPanel.tsx
@@ -1,0 +1,319 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  listJjhubIssues,
+  getJjhubIssue,
+  createJjhubIssue,
+  closeJjhubIssue,
+  reopenJjhubIssue,
+  loadJjhubAuthStatus,
+  type WorkspaceIssue,
+  type WorkspaceJjhubAuthStatus,
+} from "./workspaceApi";
+
+type IssuesStateFilter = "all" | "open" | "closed";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function IssuesPanel() {
+  const [issues, setIssues] = useState<WorkspaceIssue[]>([]);
+  const [stateFilter, setStateFilter] = useState<IssuesStateFilter>("open");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedIssue, setSelectedIssue] = useState<WorkspaceIssue | null>(null);
+  const [message, setMessage] = useState("Loading issues...");
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newBody, setNewBody] = useState("");
+  const [closeComment, setCloseComment] = useState("");
+  const [pendingCloseIssue, setPendingCloseIssue] = useState<WorkspaceIssue | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [authStatus, setAuthStatus] = useState<WorkspaceJjhubAuthStatus | null>(null);
+  const [authMessage, setAuthMessage] = useState("Checking JJHub auth...");
+
+  const effectiveSelectedIssue = selectedIssue ??
+    (selectedId ? issues.find((issue) => issue.id === selectedId) ?? null : null);
+
+  const refreshAuthStatus = useCallback(async () => {
+    try {
+      const loaded = await loadJjhubAuthStatus();
+      setAuthStatus(loaded);
+      setAuthMessage(loaded.loggedIn ? "Authenticated with JJHub." : "JJHub is signed out.");
+    } catch (error) {
+      setAuthStatus(null);
+      setAuthMessage(`JJHub auth unavailable: ${errorMessage(error)}`);
+    }
+  }, []);
+
+  const refreshIssues = useCallback(async () => {
+    setLoading(true);
+    setMessage("Loading JJHub issues...");
+    try {
+      const loaded = await listJjhubIssues(stateFilter === "all" ? null : stateFilter);
+      setIssues(loaded);
+      setSelectedId((current) => current && loaded.some((issue) => issue.id === current) ? current : null);
+      setSelectedIssue((current) => current && loaded.some((issue) => issue.id === current.id) ? current : null);
+      setMessage(`Loaded ${loaded.length} issue${loaded.length === 1 ? "" : "s"}.`);
+    } catch (error) {
+      setIssues([]);
+      setSelectedIssue(null);
+      setMessage(errorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [stateFilter]);
+
+  useEffect(() => {
+    void refreshAuthStatus();
+    void refreshIssues();
+  }, [refreshAuthStatus, refreshIssues]);
+
+  const selectIssue = async (issue: WorkspaceIssue) => {
+    setSelectedId(issue.id);
+    setSelectedIssue(issue);
+    if (issue.number == null) {
+      return;
+    }
+    try {
+      const detail = await getJjhubIssue(issue.number);
+      setSelectedIssue(detail);
+      setIssues((current) => current.map((entry) => entry.id === detail.id ? detail : entry));
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  const upsertIssue = (issue: WorkspaceIssue) => {
+    setIssues((current) => [issue, ...current.filter((entry) => entry.id !== issue.id)]);
+    setSelectedId(issue.id);
+    setSelectedIssue(issue);
+  };
+
+  const createIssue = async () => {
+    const title = newTitle.trim();
+    if (!title) {
+      setMessage("Issue title is required.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Creating issue ${title}...`);
+    try {
+      const created = await createJjhubIssue(title, newBody.trim() || null);
+      upsertIssue(created);
+      setNewTitle("");
+      setNewBody("");
+      setShowCreate(false);
+      setMessage(`Created issue #${created.number || created.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const closeIssue = async (issue: WorkspaceIssue) => {
+    if (issue.number == null) {
+      setMessage("Cannot close issue without number.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Closing issue #${issue.number}...`);
+    try {
+      const closed = await closeJjhubIssue(issue.number, closeComment.trim() || null);
+      upsertIssue(closed);
+      setCloseComment("");
+      setPendingCloseIssue(null);
+      setMessage(`Closed issue #${closed.number || closed.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reopenIssue = async (issue: WorkspaceIssue) => {
+    if (issue.number == null) {
+      setMessage("Cannot reopen issue without number.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Reopening issue #${issue.number}...`);
+    try {
+      const reopened = await reopenJjhubIssue(issue.number);
+      upsertIssue(reopened);
+      setMessage(`Reopened issue #${reopened.number || reopened.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!authStatus?.loggedIn) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2>Issues</h2>
+        </div>
+        <div className="view-content">
+          <div className="auth-required">
+            <h3>JJHub Authentication Required</h3>
+            <p>{authMessage}</p>
+            <p>Please authenticate with JJHub to access issues.</p>
+            <button onClick={refreshAuthStatus} type="button">Retry</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-container">
+      <div className="view-header">
+        <h2>Issues</h2>
+        <div className="view-controls">
+          <select value={stateFilter} onChange={(e) => setStateFilter(e.target.value as IssuesStateFilter)}>
+            <option value="all">All Issues</option>
+            <option value="open">Open Issues</option>
+            <option value="closed">Closed Issues</option>
+          </select>
+          <button onClick={() => setShowCreate(true)} type="button">New Issue</button>
+          <button onClick={refreshIssues} disabled={loading} type="button">
+            {loading ? "Loading..." : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      <div className="view-content">
+        <div className="split-view">
+          <div className="split-sidebar">
+            <div className="status-message">{message}</div>
+            <div className="issues-list">
+              {issues.map((issue) => (
+                <div
+                  key={issue.id}
+                  className={`issue-row ${issue.id === selectedId ? "selected" : ""}`}
+                  onClick={() => selectIssue(issue)}
+                >
+                  <div className="issue-title">
+                    {issue.number ? `#${issue.number}` : issue.id} {issue.title}
+                  </div>
+                  <div className="issue-meta">
+                    <span className={`issue-state issue-state-${issue.state || "unknown"}`}>
+                      {issue.state || "unknown"}
+                    </span>
+                    {issue.labels && issue.labels.length > 0 && (
+                      <span className="issue-labels">
+                        {issue.labels.map((label) => (
+                          <span key={label} className="issue-label">{label}</span>
+                        ))}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="split-main">
+            {effectiveSelectedIssue ? (
+              <div className="issue-detail">
+                <div className="issue-detail-header">
+                  <h3>
+                    {effectiveSelectedIssue.number ? `#${effectiveSelectedIssue.number}` : effectiveSelectedIssue.id}{" "}
+                    {effectiveSelectedIssue.title}
+                  </h3>
+                  <div className="issue-actions">
+                    {effectiveSelectedIssue.state === "open" ? (
+                      <button onClick={() => setPendingCloseIssue(effectiveSelectedIssue)} type="button">
+                        Close Issue
+                      </button>
+                    ) : (
+                      <button onClick={() => reopenIssue(effectiveSelectedIssue)} disabled={busy} type="button">
+                        Reopen Issue
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <div className="issue-body">
+                  <pre>{effectiveSelectedIssue.body || "No description provided."}</pre>
+                </div>
+                {effectiveSelectedIssue.assignees && effectiveSelectedIssue.assignees.length > 0 && (
+                  <div className="issue-assignees">
+                    <strong>Assignees:</strong> {effectiveSelectedIssue.assignees.join(", ")}
+                  </div>
+                )}
+                {effectiveSelectedIssue.commentCount != null && effectiveSelectedIssue.commentCount > 0 && (
+                  <div className="issue-comments">
+                    <strong>{effectiveSelectedIssue.commentCount} comment{effectiveSelectedIssue.commentCount === 1 ? "" : "s"}</strong>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="empty-state">
+                <p>Select an issue to view details</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showCreate && (
+        <div className="modal-overlay" onClick={() => setShowCreate(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Create New Issue</h3>
+            <div className="form-group">
+              <label>Title</label>
+              <input
+                type="text"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder="Issue title"
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label>Description</label>
+              <textarea
+                value={newBody}
+                onChange={(e) => setNewBody(e.target.value)}
+                placeholder="Issue description (optional)"
+                rows={4}
+              />
+            </div>
+            <div className="modal-actions">
+              <button onClick={createIssue} disabled={busy || !newTitle.trim()} type="button">
+                {busy ? "Creating..." : "Create Issue"}
+              </button>
+              <button onClick={() => setShowCreate(false)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingCloseIssue && (
+        <div className="modal-overlay" onClick={() => setPendingCloseIssue(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Close Issue #{pendingCloseIssue.number || pendingCloseIssue.id}</h3>
+            <div className="form-group">
+              <label>Comment (optional)</label>
+              <textarea
+                value={closeComment}
+                onChange={(e) => setCloseComment(e.target.value)}
+                placeholder="Add a comment explaining why this issue is being closed"
+                rows={3}
+              />
+            </div>
+            <div className="modal-actions">
+              <button onClick={() => closeIssue(pendingCloseIssue)} disabled={busy} type="button">
+                {busy ? "Closing..." : "Close Issue"}
+              </button>
+              <button onClick={() => setPendingCloseIssue(null)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/smithers-studio-2/src/LandingsPanel.tsx
+++ b/apps/smithers-studio-2/src/LandingsPanel.tsx
@@ -1,0 +1,522 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  listJjhubLandings,
+  getJjhubLanding,
+  createJjhubLanding,
+  getJjhubLandingDiff,
+  getJjhubLandingChecks,
+  getJjhubLandingConflicts,
+  reviewJjhubLanding,
+  landJjhubLanding,
+  loadJjhubAuthStatus,
+  type WorkspaceLanding,
+  type WorkspaceLandingConflicts,
+  type WorkspaceJjhubAuthStatus,
+} from "./workspaceApi";
+
+type LandingStateFilter = "all" | "open" | "closed" | "draft" | "merged";
+type LandingDetailTab = "info" | "diff" | "checks" | "conflicts";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function visibleLandingsForFilter(landings: WorkspaceLanding[], filter: LandingStateFilter): WorkspaceLanding[] {
+  switch (filter) {
+    case "all":
+      return landings;
+    case "open":
+      return landings.filter(l => l.state === "open" || l.state === "draft");
+    case "closed":
+      return landings.filter(l => l.state === "closed");
+    case "draft":
+      return landings.filter(l => l.state === "draft");
+    case "merged":
+      return landings.filter(l => l.state === "merged");
+    default:
+      return landings;
+  }
+}
+
+function landingRequestState(filter: LandingStateFilter): string | null {
+  if (filter === "all") return null;
+  return filter;
+}
+
+export function LandingsPanel() {
+  const [landings, setLandings] = useState<WorkspaceLanding[]>([]);
+  const [stateFilter, setStateFilter] = useState<LandingStateFilter>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedLanding, setSelectedLanding] = useState<WorkspaceLanding | null>(null);
+  const [detailTab, setDetailTab] = useState<LandingDetailTab>("info");
+  const [diffText, setDiffText] = useState<string | null>(null);
+  const [checksText, setChecksText] = useState<string | null>(null);
+  const [conflicts, setConflicts] = useState<WorkspaceLandingConflicts | null>(null);
+  const [message, setMessage] = useState("Loading landings...");
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newBody, setNewBody] = useState("");
+  const [newTarget, setNewTarget] = useState("");
+  const [reviewBody, setReviewBody] = useState("");
+  const [pendingLandLanding, setPendingLandLanding] = useState<WorkspaceLanding | null>(null);
+  const [authStatus, setAuthStatus] = useState<WorkspaceJjhubAuthStatus | null>(null);
+  const [authMessage, setAuthMessage] = useState("Checking JJHub auth...");
+
+  const effectiveSelectedLanding = selectedLanding ??
+    (selectedId ? landings.find((landing) => landing.id === selectedId) ?? null : landings[0] ?? null);
+
+  const refreshAuthStatus = useCallback(async () => {
+    try {
+      const loaded = await loadJjhubAuthStatus();
+      setAuthStatus(loaded);
+      setAuthMessage(loaded.loggedIn ? "Authenticated with JJHub." : "JJHub is signed out.");
+    } catch (error) {
+      setAuthStatus(null);
+      setAuthMessage(`JJHub auth unavailable: ${errorMessage(error)}`);
+    }
+  }, []);
+
+  const refreshLandings = useCallback(async () => {
+    setLoading(true);
+    setMessage("Loading JJHub landings...");
+    try {
+      const loaded = visibleLandingsForFilter(
+        await listJjhubLandings(landingRequestState(stateFilter)),
+        stateFilter
+      );
+      setLandings(loaded);
+      setSelectedId((current) => current && loaded.some((landing) => landing.id === current)
+        ? current
+        : loaded[0]?.id ?? null);
+      setSelectedLanding((current) => current && loaded.some((landing) => landing.id === current.id)
+        ? current
+        : loaded[0] ?? null);
+      setMessage(`Loaded ${loaded.length} landing${loaded.length === 1 ? "" : "s"}.`);
+    } catch (error) {
+      setLandings([]);
+      setSelectedLanding(null);
+      setMessage(errorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [stateFilter]);
+
+  useEffect(() => {
+    void refreshAuthStatus();
+    void refreshLandings();
+  }, [refreshAuthStatus, refreshLandings]);
+
+  const selectLanding = async (landing: WorkspaceLanding) => {
+    setSelectedId(landing.id);
+    setSelectedLanding(landing);
+    setDiffText(null);
+    setChecksText(null);
+    setConflicts(null);
+
+    if (landing.number == null) {
+      return;
+    }
+    try {
+      const detail = await getJjhubLanding(landing.number);
+      setSelectedLanding(detail);
+      setLandings((current) => current.map((entry) => entry.id === detail.id ? detail : entry));
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  const loadLandingDiff = async (landing: WorkspaceLanding) => {
+    if (landing.number == null) return;
+    try {
+      const diff = await getJjhubLandingDiff(landing.number);
+      setDiffText(diff);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  const loadLandingChecks = async (landing: WorkspaceLanding) => {
+    if (landing.number == null) return;
+    try {
+      const checks = await getJjhubLandingChecks(landing.number);
+      setChecksText(checks);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  const loadLandingConflicts = async (landing: WorkspaceLanding) => {
+    if (landing.number == null) return;
+    try {
+      const landingConflicts = await getJjhubLandingConflicts(landing.number);
+      setConflicts(landingConflicts);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  useEffect(() => {
+    if (!effectiveSelectedLanding) return;
+
+    switch (detailTab) {
+      case "diff":
+        if (!diffText) loadLandingDiff(effectiveSelectedLanding);
+        break;
+      case "checks":
+        if (!checksText) loadLandingChecks(effectiveSelectedLanding);
+        break;
+      case "conflicts":
+        if (!conflicts) loadLandingConflicts(effectiveSelectedLanding);
+        break;
+    }
+  }, [detailTab, effectiveSelectedLanding, diffText, checksText, conflicts]);
+
+  const upsertLanding = (landing: WorkspaceLanding) => {
+    setLandings((current) => [landing, ...current.filter((entry) => entry.id !== landing.id)]);
+    setSelectedId(landing.id);
+    setSelectedLanding(landing);
+  };
+
+  const createLanding = async () => {
+    const title = newTitle.trim();
+    if (!title) {
+      setMessage("Landing title is required.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Creating landing ${title}...`);
+    try {
+      const created = await createJjhubLanding(
+        title,
+        newBody.trim() || null,
+        newTarget.trim() || null
+      );
+      upsertLanding(created);
+      setNewTitle("");
+      setNewBody("");
+      setNewTarget("");
+      setShowCreate(false);
+      setMessage(`Created landing #${created.number || created.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const reviewLanding = async (action: "approve" | "request_changes" | "comment") => {
+    if (!effectiveSelectedLanding?.number) {
+      setMessage("Cannot review landing without number.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Submitting ${action} review...`);
+    try {
+      const reviewed = await reviewJjhubLanding(
+        effectiveSelectedLanding.number,
+        action,
+        reviewBody.trim() || null
+      );
+      upsertLanding(reviewed);
+      setReviewBody("");
+      setMessage(`Review submitted: ${action}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const landLanding = async (landing: WorkspaceLanding) => {
+    if (landing.number == null) {
+      setMessage("Cannot land landing without number.");
+      return;
+    }
+    setBusy(true);
+    setMessage(`Landing #${landing.number}...`);
+    try {
+      const landed = await landJjhubLanding(landing.number);
+      upsertLanding(landed);
+      setPendingLandLanding(null);
+      setMessage(`Landed #${landed.number || landed.id}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!authStatus?.loggedIn) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2>Landings</h2>
+        </div>
+        <div className="view-content">
+          <div className="auth-required">
+            <h3>JJHub Authentication Required</h3>
+            <p>{authMessage}</p>
+            <p>Please authenticate with JJHub to access landings.</p>
+            <button onClick={refreshAuthStatus} type="button">Retry</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-container">
+      <div className="view-header">
+        <h2>Landings</h2>
+        <div className="view-controls">
+          <select value={stateFilter} onChange={(e) => setStateFilter(e.target.value as LandingStateFilter)}>
+            <option value="all">All Landings</option>
+            <option value="open">Open</option>
+            <option value="draft">Draft</option>
+            <option value="closed">Closed</option>
+            <option value="merged">Merged</option>
+          </select>
+          <button onClick={() => setShowCreate(true)} type="button">New Landing</button>
+          <button onClick={refreshLandings} disabled={loading} type="button">
+            {loading ? "Loading..." : "Refresh"}
+          </button>
+        </div>
+      </div>
+
+      <div className="view-content">
+        <div className="split-view">
+          <div className="split-sidebar">
+            <div className="status-message">{message}</div>
+            <div className="landings-list">
+              {landings.map((landing) => (
+                <div
+                  key={landing.id}
+                  className={`landing-row ${landing.id === selectedId ? "selected" : ""}`}
+                  onClick={() => selectLanding(landing)}
+                >
+                  <div className="landing-title">
+                    {landing.number ? `#${landing.number}` : landing.id} {landing.title}
+                  </div>
+                  <div className="landing-meta">
+                    <span className={`landing-state landing-state-${landing.state || "unknown"}`}>
+                      {landing.state || "unknown"}
+                    </span>
+                    {landing.author && <span className="landing-author">by {landing.author}</span>}
+                    {landing.targetBranch && <span className="landing-target">→ {landing.targetBranch}</span>}
+                    {landing.reviewStatus && (
+                      <span className={`landing-review landing-review-${landing.reviewStatus.toLowerCase()}`}>
+                        {landing.reviewStatus}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="split-main">
+            {effectiveSelectedLanding ? (
+              <div className="landing-detail">
+                <div className="landing-detail-header">
+                  <h3>
+                    {effectiveSelectedLanding.number ? `#${effectiveSelectedLanding.number}` : effectiveSelectedLanding.id}{" "}
+                    {effectiveSelectedLanding.title}
+                  </h3>
+                  <div className="landing-actions">
+                    {effectiveSelectedLanding.state === "open" && (
+                      <button onClick={() => setPendingLandLanding(effectiveSelectedLanding)} type="button">
+                        Land
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="landing-detail-tabs">
+                  <button
+                    className={detailTab === "info" ? "active" : ""}
+                    onClick={() => setDetailTab("info")}
+                    type="button"
+                  >
+                    Info
+                  </button>
+                  <button
+                    className={detailTab === "diff" ? "active" : ""}
+                    onClick={() => setDetailTab("diff")}
+                    type="button"
+                  >
+                    Diff
+                  </button>
+                  <button
+                    className={detailTab === "checks" ? "active" : ""}
+                    onClick={() => setDetailTab("checks")}
+                    type="button"
+                  >
+                    Checks
+                  </button>
+                  <button
+                    className={detailTab === "conflicts" ? "active" : ""}
+                    onClick={() => setDetailTab("conflicts")}
+                    type="button"
+                  >
+                    Conflicts
+                  </button>
+                </div>
+
+                <div className="landing-detail-content">
+                  {detailTab === "info" && (
+                    <div className="landing-info">
+                      <div className="landing-description">
+                        <pre>{effectiveSelectedLanding.description || "No description provided."}</pre>
+                      </div>
+                      <div className="landing-metadata">
+                        {effectiveSelectedLanding.author && (
+                          <div><strong>Author:</strong> {effectiveSelectedLanding.author}</div>
+                        )}
+                        {effectiveSelectedLanding.targetBranch && (
+                          <div><strong>Target:</strong> {effectiveSelectedLanding.targetBranch}</div>
+                        )}
+                        {effectiveSelectedLanding.reviewStatus && (
+                          <div><strong>Review Status:</strong> {effectiveSelectedLanding.reviewStatus}</div>
+                        )}
+                        {effectiveSelectedLanding.createdAt && (
+                          <div><strong>Created:</strong> {effectiveSelectedLanding.createdAt}</div>
+                        )}
+                      </div>
+
+                      <div className="landing-review-section">
+                        <h4>Submit Review</h4>
+                        <textarea
+                          value={reviewBody}
+                          onChange={(e) => setReviewBody(e.target.value)}
+                          placeholder="Review comment (optional)"
+                          rows={3}
+                        />
+                        <div className="review-actions">
+                          <button onClick={() => reviewLanding("approve")} disabled={busy} type="button">
+                            Approve
+                          </button>
+                          <button onClick={() => reviewLanding("request_changes")} disabled={busy} type="button">
+                            Request Changes
+                          </button>
+                          <button onClick={() => reviewLanding("comment")} disabled={busy} type="button">
+                            Comment
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {detailTab === "diff" && (
+                    <div className="landing-diff">
+                      {diffText ? (
+                        <pre className="diff-content">{diffText}</pre>
+                      ) : (
+                        <div className="loading-state">Loading diff...</div>
+                      )}
+                    </div>
+                  )}
+
+                  {detailTab === "checks" && (
+                    <div className="landing-checks">
+                      {checksText ? (
+                        <pre className="checks-content">{checksText}</pre>
+                      ) : (
+                        <div className="loading-state">Loading checks...</div>
+                      )}
+                    </div>
+                  )}
+
+                  {detailTab === "conflicts" && (
+                    <div className="landing-conflicts">
+                      {conflicts ? (
+                        <div>
+                          <div className={`conflict-status ${conflicts.hasConflicts ? "has-conflicts" : "no-conflicts"}`}>
+                            {conflicts.hasConflicts ? "⚠️ Has conflicts" : "✅ No conflicts"}
+                          </div>
+                          {conflicts.conflicts.map((conflict, index) => (
+                            <div key={index} className="conflict-item">
+                              <div className="conflict-file">{conflict.filePath}</div>
+                              <div className="conflict-type">{conflict.conflictType || "unknown"}</div>
+                              <div className={`conflict-resolved ${conflict.resolved ? "resolved" : "unresolved"}`}>
+                                {conflict.resolved ? "Resolved" : "Unresolved"}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="loading-state">Loading conflicts...</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <div className="empty-state">
+                <p>Select a landing to view details</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showCreate && (
+        <div className="modal-overlay" onClick={() => setShowCreate(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Create New Landing</h3>
+            <div className="form-group">
+              <label>Title</label>
+              <input
+                type="text"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder="Landing title"
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label>Description</label>
+              <textarea
+                value={newBody}
+                onChange={(e) => setNewBody(e.target.value)}
+                placeholder="Landing description (optional)"
+                rows={4}
+              />
+            </div>
+            <div className="form-group">
+              <label>Target Branch</label>
+              <input
+                type="text"
+                value={newTarget}
+                onChange={(e) => setNewTarget(e.target.value)}
+                placeholder="Target branch (optional)"
+              />
+            </div>
+            <div className="modal-actions">
+              <button onClick={createLanding} disabled={busy || !newTitle.trim()} type="button">
+                {busy ? "Creating..." : "Create Landing"}
+              </button>
+              <button onClick={() => setShowCreate(false)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingLandLanding && (
+        <div className="modal-overlay" onClick={() => setPendingLandLanding(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Land #{pendingLandLanding.number || pendingLandLanding.id}</h3>
+            <p>Are you sure you want to land this landing?</p>
+            <div className="modal-actions">
+              <button onClick={() => landLanding(pendingLandLanding)} disabled={busy} type="button">
+                {busy ? "Landing..." : "Land"}
+              </button>
+              <button onClick={() => setPendingLandLanding(null)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/smithers-studio-2/src/Sidebar.tsx
+++ b/apps/smithers-studio-2/src/Sidebar.tsx
@@ -3,24 +3,81 @@ import { useStudioStore } from "./useStudioStore";
 export function Sidebar() {
   const tabs = useStudioStore((s) => s.tabs);
   const activeTabId = useStudioStore((s) => s.activeTabId);
-  const { openTerminal, setActiveTabId, openPalette } = useStudioStore.getState();
+  const activeView = useStudioStore((s) => s.activeView);
+  const { openTerminal, setActiveTabId, setActiveView, openPalette } = useStudioStore.getState();
 
   return (
-    <aside aria-label="Terminal tabs" className="sidebar">
+    <aside aria-label="Studio navigation" className="sidebar">
       <div className="brand-block"><span>Smithers</span><strong>Studio 2</strong></div>
-      <div className="sidebar-heading">
-        <span>Terminals</span>
-        <button aria-label="New terminal" onClick={openTerminal} type="button">+</button>
-      </div>
-      <div aria-orientation="vertical" className="tab-list" role="tablist">
-        {tabs.map((tab) => (
-          <button aria-selected={tab.id === activeTabId} className={`tab-row ${tab.id === activeTabId ? "active" : ""}`} key={tab.id} onClick={() => setActiveTabId(tab.id)} role="tab" type="button">
-            <span>{tab.title}</span>
-            <small>{tab.createdAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</small>
+
+      {/* View Navigation */}
+      <div className="sidebar-section">
+        <div className="sidebar-heading">
+          <span>Views</span>
+        </div>
+        <div className="view-list">
+          <button
+            className={`view-button ${activeView === "terminal" ? "active" : ""}`}
+            onClick={() => setActiveView("terminal")}
+            type="button"
+          >
+            Terminal
           </button>
-        ))}
+          <button
+            className={`view-button ${activeView === "issues" ? "active" : ""}`}
+            onClick={() => setActiveView("issues")}
+            type="button"
+          >
+            Issues
+          </button>
+          <button
+            className={`view-button ${activeView === "landings" ? "active" : ""}`}
+            onClick={() => setActiveView("landings")}
+            type="button"
+          >
+            Landings
+          </button>
+          <button
+            className={`view-button ${activeView === "workspaces" ? "active" : ""}`}
+            onClick={() => setActiveView("workspaces")}
+            type="button"
+          >
+            Workspaces
+          </button>
+        </div>
       </div>
-      <button className="command-button" onClick={openPalette} type="button"><span>Command Palette</span><kbd>Cmd-P</kbd></button>
+
+      {/* Terminal Tabs - only show when terminal view is active */}
+      {activeView === "terminal" && (
+        <div className="sidebar-section">
+          <div className="sidebar-heading">
+            <span>Terminals</span>
+            <button aria-label="New terminal" onClick={openTerminal} type="button">+</button>
+          </div>
+          <div aria-orientation="vertical" className="tab-list" role="tablist">
+            {tabs.map((tab) => (
+              <button
+                aria-selected={tab.id === activeTabId}
+                className={`tab-row ${tab.id === activeTabId ? "active" : ""}`}
+                key={tab.id}
+                onClick={() => setActiveTabId(tab.id)}
+                role="tab"
+                type="button"
+              >
+                <span>{tab.title}</span>
+                <small>{tab.createdAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</small>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="sidebar-footer">
+        <button className="command-button" onClick={openPalette} type="button">
+          <span>Command Palette</span>
+          <kbd>Cmd-P</kbd>
+        </button>
+      </div>
     </aside>
   );
 }

--- a/apps/smithers-studio-2/src/Sidebar.tsx
+++ b/apps/smithers-studio-2/src/Sidebar.tsx
@@ -1,0 +1,26 @@
+import { useStudioStore } from "./useStudioStore";
+
+export function Sidebar() {
+  const tabs = useStudioStore((s) => s.tabs);
+  const activeTabId = useStudioStore((s) => s.activeTabId);
+  const { openTerminal, setActiveTabId, openPalette } = useStudioStore.getState();
+
+  return (
+    <aside aria-label="Terminal tabs" className="sidebar">
+      <div className="brand-block"><span>Smithers</span><strong>Studio 2</strong></div>
+      <div className="sidebar-heading">
+        <span>Terminals</span>
+        <button aria-label="New terminal" onClick={openTerminal} type="button">+</button>
+      </div>
+      <div aria-orientation="vertical" className="tab-list" role="tablist">
+        {tabs.map((tab) => (
+          <button aria-selected={tab.id === activeTabId} className={`tab-row ${tab.id === activeTabId ? "active" : ""}`} key={tab.id} onClick={() => setActiveTabId(tab.id)} role="tab" type="button">
+            <span>{tab.title}</span>
+            <small>{tab.createdAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</small>
+          </button>
+        ))}
+      </div>
+      <button className="command-button" onClick={openPalette} type="button"><span>Command Palette</span><kbd>Cmd-P</kbd></button>
+    </aside>
+  );
+}

--- a/apps/smithers-studio-2/src/TerminalWorkspace.tsx
+++ b/apps/smithers-studio-2/src/TerminalWorkspace.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from "react";
+import { GhosttyTerminalPane } from "./GhosttyTerminalPane";
+import { useStudioStore } from "./useStudioStore";
+
+export function TerminalWorkspace() {
+  const tabs = useStudioStore((s) => s.tabs);
+  const activeTabId = useStudioStore((s) => s.activeTabId);
+  const { closeTerminal } = useStudioStore.getState();
+
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? tabs[0];
+
+  return (
+    <section aria-label="Terminal workspace" className="workspace">
+      <header className="workspace-header">
+        <div><span>Active terminal</span><h1>{activeTab?.title ?? "Terminal"}</h1></div>
+        <button disabled={tabs.length === 1} onClick={() => activeTab && closeTerminal(activeTab.id)} type="button">Close Tab</button>
+      </header>
+      <div className="terminal-stack">
+        <Suspense fallback={<div className="terminal-loading">Loading Ghostty terminal.</div>}>
+          {tabs.map((tab) => <GhosttyTerminalPane active={tab.id === activeTabId} key={tab.id} tab={tab} />)}
+        </Suspense>
+      </div>
+    </section>
+  );
+}

--- a/apps/smithers-studio-2/src/TerminalWorkspace.tsx
+++ b/apps/smithers-studio-2/src/TerminalWorkspace.tsx
@@ -13,11 +13,22 @@ export function TerminalWorkspace() {
     <section aria-label="Terminal workspace" className="workspace">
       <header className="workspace-header">
         <div><span>Active terminal</span><h1>{activeTab?.title ?? "Terminal"}</h1></div>
-        <button disabled={tabs.length === 1} onClick={() => activeTab && closeTerminal(activeTab.id)} type="button">Close Tab</button>
+        <button
+          data-testid="close-terminal"
+          disabled={tabs.length === 1}
+          onClick={() => activeTab && closeTerminal(activeTab.id)}
+          type="button"
+        >
+          Close Tab
+        </button>
       </header>
       <div className="terminal-stack">
         <Suspense fallback={<div className="terminal-loading">Loading Ghostty terminal.</div>}>
-          {tabs.map((tab) => <GhosttyTerminalPane active={tab.id === activeTabId} key={tab.id} tab={tab} />)}
+          {tabs.map((tab) => (
+            <div className={tab.id === activeTabId ? "terminal-tab active" : "terminal-tab"} data-testid="terminal-tab" key={tab.id}>
+              <GhosttyTerminalPane active={tab.id === activeTabId} tab={tab} />
+            </div>
+          ))}
         </Suspense>
       </div>
     </section>

--- a/apps/smithers-studio-2/src/WorkspacesPanel.tsx
+++ b/apps/smithers-studio-2/src/WorkspacesPanel.tsx
@@ -1,0 +1,656 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  listCloudWorkspaces,
+  createCloudWorkspace,
+  deleteCloudWorkspace,
+  suspendCloudWorkspace,
+  resumeCloudWorkspace,
+  forkCloudWorkspace,
+  listCloudWorkspaceSnapshots,
+  createCloudWorkspaceSnapshot,
+  deleteCloudWorkspaceSnapshot,
+  listLocalWorkspaces,
+  openLocalWorkspace,
+  removeLocalWorkspace,
+  loadJjhubAuthStatus,
+  type WorkspaceCloudWorkspace,
+  type WorkspaceCloudSnapshot,
+  type WorkspaceLocalRecent,
+  type WorkspaceJjhubAuthStatus,
+} from "./workspaceApi";
+
+type WorkspacesMode = "workspaces" | "snapshots" | "local";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function WorkspacesPanel() {
+  const [mode, setMode] = useState<WorkspacesMode>("workspaces");
+  const [workspaces, setWorkspaces] = useState<WorkspaceCloudWorkspace[]>([]);
+  const [snapshots, setSnapshots] = useState<WorkspaceCloudSnapshot[]>([]);
+  const [localWorkspaces, setLocalWorkspaces] = useState<WorkspaceLocalRecent[]>([]);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string | null>(null);
+  const [newWorkspaceName, setNewWorkspaceName] = useState("");
+  const [newSnapshotName, setNewSnapshotName] = useState("");
+  const [forkWorkspaceName, setForkWorkspaceName] = useState("");
+  const [restoreName, setRestoreName] = useState("");
+  const [restoreSourceSnapshotId, setRestoreSourceSnapshotId] = useState<string | null>(null);
+  const [message, setMessage] = useState("Loading workspaces...");
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [showCreateWorkspace, setShowCreateWorkspace] = useState(false);
+  const [showCreateSnapshot, setShowCreateSnapshot] = useState(false);
+  const [showForkWorkspace, setShowForkWorkspace] = useState<WorkspaceCloudWorkspace | null>(null);
+  const [showRestoreWorkspace, setShowRestoreWorkspace] = useState(false);
+  const [pendingWorkspaceDelete, setPendingWorkspaceDelete] = useState<WorkspaceCloudWorkspace | null>(null);
+  const [pendingSnapshotDelete, setPendingSnapshotDelete] = useState<WorkspaceCloudSnapshot | null>(null);
+  const [authStatus, setAuthStatus] = useState<WorkspaceJjhubAuthStatus | null>(null);
+  const [authMessage, setAuthMessage] = useState("Checking JJHub auth...");
+  const [localWorkspacesMessage, setLocalWorkspacesMessage] = useState("Loading local workspaces...");
+
+  const selectedWorkspace = selectedWorkspaceId
+    ? workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null
+    : workspaces[0] ?? null;
+
+  const selectedSnapshot = selectedSnapshotId
+    ? snapshots.find((snapshot) => snapshot.id === selectedSnapshotId) ?? null
+    : snapshots[0] ?? null;
+
+  const refreshAuthStatus = useCallback(async () => {
+    try {
+      const loaded = await loadJjhubAuthStatus();
+      setAuthStatus(loaded);
+      setAuthMessage(loaded.loggedIn ? "Authenticated with JJHub." : "JJHub is signed out.");
+    } catch (error) {
+      setAuthStatus(null);
+      setAuthMessage(`JJHub auth unavailable: ${errorMessage(error)}`);
+    }
+  }, []);
+
+  const refreshWorkspaces = useCallback(async () => {
+    setLoading(true);
+    setMessage(mode === "snapshots" ? "Loading workspace snapshots..." : "Loading cloud workspaces...");
+    try {
+      if (mode === "snapshots") {
+        const [loadedWorkspaces, loaded] = await Promise.all([
+          listCloudWorkspaces(),
+          listCloudWorkspaceSnapshots(),
+        ]);
+        setWorkspaces(loadedWorkspaces);
+        setSelectedWorkspaceId((current) => current && loadedWorkspaces.some((w) => w.id === current)
+          ? current
+          : loadedWorkspaces[0]?.id ?? null);
+        setSnapshots(loaded);
+        setSelectedSnapshotId((current) => current && loaded.some((s) => s.id === current)
+          ? current
+          : loaded[0]?.id ?? null);
+        setMessage(`Loaded ${loaded.length} workspace snapshot${loaded.length === 1 ? "" : "s"}.`);
+      } else {
+        const loaded = await listCloudWorkspaces();
+        setWorkspaces(loaded);
+        setSelectedWorkspaceId((current) => current && loaded.some((w) => w.id === current)
+          ? current
+          : loaded[0]?.id ?? null);
+        setMessage(`Loaded ${loaded.length} cloud workspace${loaded.length === 1 ? "" : "s"}.`);
+      }
+    } catch (error) {
+      if (mode === "snapshots") {
+        setSnapshots([]);
+        setSelectedSnapshotId(null);
+      } else {
+        setWorkspaces([]);
+        setSelectedWorkspaceId(null);
+      }
+      setMessage(errorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [mode]);
+
+  const refreshLocalWorkspaces = useCallback(async () => {
+    setLocalWorkspacesMessage("Loading local workspaces...");
+    try {
+      const loaded = await listLocalWorkspaces();
+      setLocalWorkspaces(loaded);
+      setLocalWorkspacesMessage(`Loaded ${loaded.length} local workspace${loaded.length === 1 ? "" : "s"}.`);
+    } catch (error) {
+      setLocalWorkspaces([]);
+      setLocalWorkspacesMessage(errorMessage(error));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshAuthStatus();
+    if (mode === "local") {
+      void refreshLocalWorkspaces();
+    } else {
+      void refreshWorkspaces();
+    }
+  }, [mode, refreshAuthStatus, refreshWorkspaces, refreshLocalWorkspaces]);
+
+  const createWorkspace = async () => {
+    const name = newWorkspaceName.trim();
+    if (!name) {
+      setMessage("Workspace name is required.");
+      return;
+    }
+    setBusyId("create");
+    setMessage(`Creating workspace ${name}...`);
+    try {
+      const created = await createCloudWorkspace(name, restoreSourceSnapshotId);
+      setWorkspaces((current) => [created, ...current]);
+      setSelectedWorkspaceId(created.id);
+      setNewWorkspaceName("");
+      setRestoreSourceSnapshotId(null);
+      setShowCreateWorkspace(false);
+      setShowRestoreWorkspace(false);
+      setMessage(`Created workspace ${name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const openRestoreWorkspace = async () => {
+    setShowRestoreWorkspace(true);
+    if (snapshots.length > 0) {
+      return;
+    }
+    try {
+      const loaded = await listCloudWorkspaceSnapshots();
+      setSnapshots(loaded);
+      setRestoreSourceSnapshotId((current) => current ?? loaded[0]?.id ?? null);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    }
+  };
+
+  const createSnapshot = async () => {
+    const name = newSnapshotName.trim();
+    if (!name || !selectedWorkspace) {
+      setMessage("Snapshot name and workspace selection required.");
+      return;
+    }
+    setBusyId("snapshot");
+    setMessage(`Creating snapshot ${name}...`);
+    try {
+      const created = await createCloudWorkspaceSnapshot(selectedWorkspace.id, name);
+      setSnapshots((current) => [created, ...current]);
+      setNewSnapshotName("");
+      setShowCreateSnapshot(false);
+      setMessage(`Created snapshot ${name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const forkWorkspace = async (workspace: WorkspaceCloudWorkspace) => {
+    const name = forkWorkspaceName.trim();
+    if (!name) {
+      setMessage("Fork name is required.");
+      return;
+    }
+    setBusyId(workspace.id);
+    setMessage(`Forking workspace to ${name}...`);
+    try {
+      const forked = await forkCloudWorkspace(workspace.id, name);
+      setWorkspaces((current) => [forked, ...current]);
+      setSelectedWorkspaceId(forked.id);
+      setForkWorkspaceName("");
+      setShowForkWorkspace(null);
+      setMessage(`Forked workspace to ${name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const suspendWorkspace = async (workspace: WorkspaceCloudWorkspace) => {
+    setBusyId(workspace.id);
+    setMessage(`Suspending workspace ${workspace.name}...`);
+    try {
+      await suspendCloudWorkspace(workspace.id);
+      setWorkspaces((current) => current.map((w) => w.id === workspace.id
+        ? { ...w, status: "suspended" }
+        : w));
+      setMessage(`Suspended workspace ${workspace.name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const resumeWorkspace = async (workspace: WorkspaceCloudWorkspace) => {
+    setBusyId(workspace.id);
+    setMessage(`Resuming workspace ${workspace.name}...`);
+    try {
+      await resumeCloudWorkspace(workspace.id);
+      setWorkspaces((current) => current.map((w) => w.id === workspace.id
+        ? { ...w, status: "running" }
+        : w));
+      setMessage(`Resumed workspace ${workspace.name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const deleteWorkspace = async (workspace: WorkspaceCloudWorkspace) => {
+    setBusyId(workspace.id);
+    setMessage(`Deleting workspace ${workspace.name}...`);
+    try {
+      await deleteCloudWorkspace(workspace.id);
+      setWorkspaces((current) => current.filter((w) => w.id !== workspace.id));
+      if (selectedWorkspaceId === workspace.id) {
+        const remaining = workspaces.filter((w) => w.id !== workspace.id);
+        setSelectedWorkspaceId(remaining[0]?.id ?? null);
+      }
+      setPendingWorkspaceDelete(null);
+      setMessage(`Deleted workspace ${workspace.name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const deleteSnapshot = async (snapshot: WorkspaceCloudSnapshot) => {
+    setBusyId(snapshot.id);
+    setMessage(`Deleting snapshot ${snapshot.name}...`);
+    try {
+      await deleteCloudWorkspaceSnapshot(snapshot.id);
+      setSnapshots((current) => current.filter((s) => s.id !== snapshot.id));
+      if (selectedSnapshotId === snapshot.id) {
+        const remaining = snapshots.filter((s) => s.id !== snapshot.id);
+        setSelectedSnapshotId(remaining[0]?.id ?? null);
+      }
+      setPendingSnapshotDelete(null);
+      setMessage(`Deleted snapshot ${snapshot.name}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const openLocalWorkspacePath = async (path: string) => {
+    setBusyId(path);
+    setMessage(`Opening workspace at ${path}...`);
+    try {
+      await openLocalWorkspace(path);
+      setMessage(`Opened workspace at ${path}.`);
+    } catch (error) {
+      setMessage(errorMessage(error));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const removeLocalWorkspacePath = async (path: string) => {
+    try {
+      const updated = await removeLocalWorkspace(path);
+      setLocalWorkspaces(updated);
+      setLocalWorkspacesMessage(`Removed ${path} from recent workspaces.`);
+    } catch (error) {
+      setLocalWorkspacesMessage(errorMessage(error));
+    }
+  };
+
+  if (mode !== "local" && !authStatus?.loggedIn) {
+    return (
+      <div className="view-container">
+        <div className="view-header">
+          <h2>Workspaces</h2>
+          <div className="view-controls">
+            <select value={mode} onChange={(e) => setMode(e.target.value as WorkspacesMode)}>
+              <option value="workspaces">Cloud Workspaces</option>
+              <option value="snapshots">Snapshots</option>
+              <option value="local">Local Workspaces</option>
+            </select>
+          </div>
+        </div>
+        <div className="view-content">
+          <div className="auth-required">
+            <h3>JJHub Authentication Required</h3>
+            <p>{authMessage}</p>
+            <p>Please authenticate with JJHub to access cloud workspaces.</p>
+            <button onClick={refreshAuthStatus} type="button">Retry</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-container">
+      <div className="view-header">
+        <h2>Workspaces</h2>
+        <div className="view-controls">
+          <select value={mode} onChange={(e) => setMode(e.target.value as WorkspacesMode)}>
+            <option value="workspaces">Cloud Workspaces</option>
+            <option value="snapshots">Snapshots</option>
+            <option value="local">Local Workspaces</option>
+          </select>
+          {mode === "workspaces" && (
+            <>
+              <button onClick={() => setShowCreateWorkspace(true)} type="button">New Workspace</button>
+              <button onClick={openRestoreWorkspace} type="button">Restore from Snapshot</button>
+            </>
+          )}
+          {mode === "snapshots" && (
+            <button onClick={() => setShowCreateSnapshot(true)} disabled={workspaces.length === 0} type="button">
+              New Snapshot
+            </button>
+          )}
+          {mode === "local" && (
+            <button onClick={refreshLocalWorkspaces} type="button">Refresh</button>
+          )}
+          {mode !== "local" && (
+            <button onClick={refreshWorkspaces} disabled={loading} type="button">
+              {loading ? "Loading..." : "Refresh"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="view-content">
+        <div className="status-message">{mode === "local" ? localWorkspacesMessage : message}</div>
+
+        {mode === "local" ? (
+          <div className="local-workspaces-list">
+            {localWorkspaces.map((workspace) => (
+              <div key={workspace.path} className="workspace-item">
+                <div className="workspace-info">
+                  <div className="workspace-name">{workspace.displayName}</div>
+                  <div className="workspace-path">{workspace.path}</div>
+                  <div className="workspace-meta">
+                    {workspace.exists ? "✅ Exists" : "❌ Missing"}
+                    {workspace.hasSmithers ? " • Has Smithers" : " • No Smithers"}
+                    • Last opened: {workspace.lastOpenedAt}
+                  </div>
+                </div>
+                <div className="workspace-actions">
+                  <button
+                    onClick={() => openLocalWorkspacePath(workspace.path)}
+                    disabled={busyId === workspace.path || !workspace.exists}
+                    type="button"
+                  >
+                    {busyId === workspace.path ? "Opening..." : "Open"}
+                  </button>
+                  <button
+                    onClick={() => removeLocalWorkspacePath(workspace.path)}
+                    type="button"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="cloud-workspaces">
+            {mode === "workspaces" ? (
+              <div className="workspaces-list">
+                {workspaces.map((workspace) => (
+                  <div
+                    key={workspace.id}
+                    className={`workspace-item ${workspace.id === selectedWorkspaceId ? "selected" : ""}`}
+                    onClick={() => setSelectedWorkspaceId(workspace.id)}
+                  >
+                    <div className="workspace-info">
+                      <div className="workspace-name">{workspace.name}</div>
+                      <div className="workspace-meta">
+                        <span className={`workspace-status workspace-status-${workspace.status?.toLowerCase() || "unknown"}`}>
+                          {workspace.status || "unknown"}
+                        </span>
+                        {workspace.createdAt && <span className="workspace-created">Created: {workspace.createdAt}</span>}
+                      </div>
+                    </div>
+                    <div className="workspace-actions">
+                      {workspace.status === "running" && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); suspendWorkspace(workspace); }}
+                          disabled={busyId === workspace.id}
+                          type="button"
+                        >
+                          {busyId === workspace.id ? "Suspending..." : "Suspend"}
+                        </button>
+                      )}
+                      {workspace.status === "suspended" && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); resumeWorkspace(workspace); }}
+                          disabled={busyId === workspace.id}
+                          type="button"
+                        >
+                          {busyId === workspace.id ? "Resuming..." : "Resume"}
+                        </button>
+                      )}
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setForkWorkspaceName(workspace.name + "-fork"); setShowForkWorkspace(workspace); }}
+                        type="button"
+                      >
+                        Fork
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setPendingWorkspaceDelete(workspace); }}
+                        type="button"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="snapshots-list">
+                {snapshots.map((snapshot) => (
+                  <div
+                    key={snapshot.id}
+                    className={`snapshot-item ${snapshot.id === selectedSnapshotId ? "selected" : ""}`}
+                    onClick={() => setSelectedSnapshotId(snapshot.id)}
+                  >
+                    <div className="snapshot-info">
+                      <div className="snapshot-name">{snapshot.name || "Unnamed"}</div>
+                      <div className="snapshot-meta">
+                        Workspace: {snapshot.workspaceId}
+                        {snapshot.createdAt && <span> • Created: {snapshot.createdAt}</span>}
+                      </div>
+                    </div>
+                    <div className="snapshot-actions">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setRestoreName(`${snapshot.name}-restore`); setRestoreSourceSnapshotId(snapshot.id); setShowRestoreWorkspace(true); }}
+                        type="button"
+                      >
+                        Restore
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setPendingSnapshotDelete(snapshot); }}
+                        type="button"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {showCreateWorkspace && (
+        <div className="modal-overlay" onClick={() => setShowCreateWorkspace(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Create New Workspace</h3>
+            <div className="form-group">
+              <label>Workspace Name</label>
+              <input
+                type="text"
+                value={newWorkspaceName}
+                onChange={(e) => setNewWorkspaceName(e.target.value)}
+                placeholder="Workspace name"
+                autoFocus
+              />
+            </div>
+            <div className="modal-actions">
+              <button onClick={createWorkspace} disabled={busyId === "create" || !newWorkspaceName.trim()} type="button">
+                {busyId === "create" ? "Creating..." : "Create Workspace"}
+              </button>
+              <button onClick={() => setShowCreateWorkspace(false)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showCreateSnapshot && (
+        <div className="modal-overlay" onClick={() => setShowCreateSnapshot(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Create Snapshot</h3>
+            <div className="form-group">
+              <label>Snapshot Name</label>
+              <input
+                type="text"
+                value={newSnapshotName}
+                onChange={(e) => setNewSnapshotName(e.target.value)}
+                placeholder="Snapshot name"
+                autoFocus
+              />
+            </div>
+            {selectedWorkspace && (
+              <div className="form-group">
+                <label>Source Workspace</label>
+                <div>{selectedWorkspace.name}</div>
+              </div>
+            )}
+            <div className="modal-actions">
+              <button onClick={createSnapshot} disabled={busyId === "snapshot" || !newSnapshotName.trim()} type="button">
+                {busyId === "snapshot" ? "Creating..." : "Create Snapshot"}
+              </button>
+              <button onClick={() => setShowCreateSnapshot(false)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showRestoreWorkspace && (
+        <div className="modal-overlay" onClick={() => setShowRestoreWorkspace(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Restore Workspace from Snapshot</h3>
+            <div className="form-group">
+              <label>New Workspace Name</label>
+              <input
+                type="text"
+                value={restoreName}
+                onChange={(e) => setRestoreName(e.target.value)}
+                placeholder="Restored workspace name"
+                autoFocus
+              />
+            </div>
+            <div className="form-group">
+              <label>Source Snapshot</label>
+              <select
+                value={restoreSourceSnapshotId || ""}
+                onChange={(e) => setRestoreSourceSnapshotId(e.target.value || null)}
+              >
+                <option value="">Select a snapshot</option>
+                {snapshots.map((snapshot) => (
+                  <option key={snapshot.id} value={snapshot.id}>
+                    {snapshot.name || "Unnamed"} ({snapshot.workspaceId})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="modal-actions">
+              <button
+                onClick={() => {
+                  setNewWorkspaceName(restoreName);
+                  setShowCreateWorkspace(true);
+                  setShowRestoreWorkspace(false);
+                }}
+                disabled={!restoreName.trim() || !restoreSourceSnapshotId}
+                type="button"
+              >
+                Restore
+              </button>
+              <button onClick={() => setShowRestoreWorkspace(false)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showForkWorkspace && (
+        <div className="modal-overlay" onClick={() => setShowForkWorkspace(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Fork Workspace {showForkWorkspace.name}</h3>
+            <div className="form-group">
+              <label>Fork Name</label>
+              <input
+                type="text"
+                value={forkWorkspaceName}
+                onChange={(e) => setForkWorkspaceName(e.target.value)}
+                placeholder="Fork name"
+                autoFocus
+              />
+            </div>
+            <div className="modal-actions">
+              <button
+                onClick={() => forkWorkspace(showForkWorkspace)}
+                disabled={busyId === showForkWorkspace.id || !forkWorkspaceName.trim()}
+                type="button"
+              >
+                {busyId === showForkWorkspace.id ? "Forking..." : "Fork"}
+              </button>
+              <button onClick={() => setShowForkWorkspace(null)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingWorkspaceDelete && (
+        <div className="modal-overlay" onClick={() => setPendingWorkspaceDelete(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Delete Workspace {pendingWorkspaceDelete.name}</h3>
+            <p>Are you sure you want to delete this workspace? This action cannot be undone.</p>
+            <div className="modal-actions">
+              <button
+                onClick={() => deleteWorkspace(pendingWorkspaceDelete)}
+                disabled={busyId === pendingWorkspaceDelete.id}
+                type="button"
+              >
+                {busyId === pendingWorkspaceDelete.id ? "Deleting..." : "Delete"}
+              </button>
+              <button onClick={() => setPendingWorkspaceDelete(null)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingSnapshotDelete && (
+        <div className="modal-overlay" onClick={() => setPendingSnapshotDelete(null)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <h3>Delete Snapshot {pendingSnapshotDelete.name}</h3>
+            <p>Are you sure you want to delete this snapshot? This action cannot be undone.</p>
+            <div className="modal-actions">
+              <button
+                onClick={() => deleteSnapshot(pendingSnapshotDelete)}
+                disabled={busyId === pendingSnapshotDelete.id}
+                type="button"
+              >
+                {busyId === pendingSnapshotDelete.id ? "Deleting..." : "Delete"}
+              </button>
+              <button onClick={() => setPendingSnapshotDelete(null)} type="button">Cancel</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/smithers-studio-2/src/app.css
+++ b/apps/smithers-studio-2/src/app.css
@@ -1,0 +1,309 @@
+:root {
+  color: #1b2332;
+  background: #eef2f7;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+}
+
+button,
+input { font: inherit; }
+
+button { cursor: pointer; }
+
+.studio-shell {
+  display: grid;
+  grid-template-columns: 244px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #f8fafc;
+  border-right: 1px solid #d8e0ec;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 16px 12px;
+}
+
+.brand-block {
+  display: grid;
+  gap: 2px;
+  padding: 4px 8px 18px;
+}
+
+.brand-block span,
+.sidebar-heading span,
+.workspace-header span {
+  color: #64748b;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.brand-block strong {
+  color: #0f172a;
+  font-size: 20px;
+  line-height: 1.15;
+}
+
+.sidebar-heading {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 8px;
+}
+
+.sidebar-heading button {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #1e3a8a;
+  display: inline-grid;
+  font-size: 18px;
+  font-weight: 700;
+  height: 30px;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  width: 30px;
+}
+
+.tab-list {
+  display: grid;
+  gap: 6px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.tab-row {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  color: #334155;
+  display: grid;
+  gap: 3px;
+  justify-items: start;
+  min-height: 54px;
+  padding: 9px 10px;
+  text-align: left;
+}
+
+.tab-row:hover { background: #edf2f8; }
+
+.tab-row.active {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #0f172a;
+}
+
+.tab-row span {
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.tab-row small {
+  color: #64748b;
+  font-size: 11px;
+}
+
+.command-button {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
+  color: #334155;
+  display: flex;
+  justify-content: space-between;
+  margin-top: auto;
+  min-height: 38px;
+  padding: 0 10px;
+}
+
+kbd {
+  background: #eef2f7;
+  border: 1px solid #cbd5e1;
+  border-radius: 5px;
+  color: #475569;
+  font-size: 11px;
+  padding: 2px 5px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+}
+
+.workspace-header {
+  align-items: center;
+  background: #ffffff;
+  border-bottom: 1px solid #d8e0ec;
+  display: flex;
+  justify-content: space-between;
+  min-height: 72px;
+  padding: 14px 20px;
+}
+
+.workspace-header h1 {
+  color: #0f172a;
+  font-size: 20px;
+  line-height: 1.2;
+  margin: 3px 0 0;
+}
+
+.workspace-header button {
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  color: #334155;
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.workspace-header button:disabled {
+  color: #94a3b8;
+  cursor: default;
+}
+
+.terminal-stack {
+  background: #0c0f14;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.terminal-pane {
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.terminal-pane.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.ghostty-terminal,
+.terminal-pane .wterm {
+  height: 100%;
+  min-height: calc(100vh - 72px);
+  width: 100%;
+}
+
+.terminal-loading {
+  align-items: center;
+  color: #cbd5e1;
+  display: grid;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  min-height: calc(100vh - 72px);
+  place-items: center;
+}
+
+.terminal-status {
+  background: rgb(15 23 42 / 0.85);
+  color: #94a3b8;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  padding: 6px 12px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 2;
+}
+
+.palette-backdrop {
+  align-items: start;
+  background: rgb(15 23 42 / 0.28);
+  display: grid;
+  inset: 0;
+  justify-items: center;
+  padding-top: 12vh;
+  position: fixed;
+  z-index: 20;
+}
+
+.command-palette {
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  box-shadow: 0 24px 70px rgb(15 23 42 / 0.28);
+  overflow: hidden;
+  width: min(640px, calc(100vw - 32px));
+}
+
+.command-palette input {
+  border: 0;
+  border-bottom: 1px solid #e2e8f0;
+  color: #0f172a;
+  font-size: 16px;
+  height: 54px;
+  outline: none;
+  padding: 0 16px;
+  width: 100%;
+}
+
+.palette-list {
+  max-height: 360px;
+  overflow: auto;
+  padding: 6px;
+}
+
+.palette-list button,
+.palette-empty {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: #1e293b;
+  display: grid;
+  gap: 3px;
+  justify-items: start;
+  min-height: 52px;
+  padding: 8px 10px;
+  text-align: left;
+  width: 100%;
+}
+
+.palette-list button.selected { background: #eaf2ff; }
+
+.palette-list button span {
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.palette-list button small,
+.palette-empty {
+  color: #64748b;
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .studio-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .sidebar {
+    border-bottom: 1px solid #d8e0ec;
+    border-right: 0;
+    max-height: 220px;
+  }
+
+  .tab-list {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(150px, 1fr);
+    overflow-x: auto;
+  }
+}

--- a/apps/smithers-studio-2/src/app.css
+++ b/apps/smithers-studio-2/src/app.css
@@ -307,3 +307,552 @@ kbd {
     overflow-x: auto;
   }
 }
+
+/* New UI Components */
+
+.main-content {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-width: 0;
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 16px;
+}
+
+.sidebar-footer {
+  margin-top: auto;
+}
+
+.view-list {
+  display: grid;
+  gap: 4px;
+}
+
+.view-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 12px;
+  text-align: left;
+  transition: all 0.15s ease;
+}
+
+.view-button:hover {
+  background: #edf2f8;
+  color: #334155;
+}
+
+.view-button.active {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1e40af;
+  font-weight: 600;
+}
+
+/* Panel Layouts */
+
+.view-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.view-header {
+  align-items: center;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 24px;
+  min-height: 64px;
+}
+
+.view-header h2 {
+  color: #1e293b;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.view-controls {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.view-controls select,
+.view-controls button {
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  color: #374151;
+  font-size: 14px;
+  padding: 6px 12px;
+}
+
+.view-controls button:hover {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.view-content {
+  flex: 1;
+  overflow: hidden;
+  background: #fafbfc;
+}
+
+.split-view {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  height: 100%;
+}
+
+.split-sidebar {
+  background: #ffffff;
+  border-right: 1px solid #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.split-main {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.status-message {
+  background: #f8fafc;
+  border-bottom: 1px solid #e2e8f0;
+  color: #64748b;
+  font-size: 12px;
+  padding: 8px 16px;
+}
+
+/* Lists */
+
+.issues-list,
+.landings-list,
+.workspaces-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.issue-row,
+.landing-row {
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+  padding: 12px 16px;
+}
+
+.issue-row:hover,
+.landing-row:hover {
+  background: #f8fafc;
+}
+
+.issue-row.selected,
+.landing-row.selected {
+  background: #eff6ff;
+  border-right: 3px solid #3b82f6;
+}
+
+.issue-title,
+.landing-title {
+  color: #1e293b;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.issue-meta,
+.landing-meta {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.issue-state,
+.landing-state {
+  border-radius: 12px;
+  font-weight: 500;
+  padding: 2px 8px;
+  text-transform: uppercase;
+}
+
+.issue-state-open { background: #dcfce7; color: #166534; }
+.issue-state-closed { background: #fef2f2; color: #991b1b; }
+.landing-state-open { background: #dcfce7; color: #166534; }
+.landing-state-closed { background: #fef2f2; color: #991b1b; }
+.landing-state-merged { background: #ede9fe; color: #6b21a8; }
+
+.issue-label {
+  background: #f3f4f6;
+  border-radius: 4px;
+  color: #374151;
+  font-size: 11px;
+  padding: 1px 6px;
+}
+
+/* Detail Views */
+
+.issue-detail,
+.landing-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.issue-detail-header,
+.landing-detail-header {
+  align-items: flex-start;
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 24px;
+}
+
+.issue-detail-header h3,
+.landing-detail-header h3 {
+  color: #1e293b;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.issue-actions,
+.landing-actions {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.issue-actions button,
+.landing-actions button {
+  background: #3b82f6;
+  border: 1px solid #3b82f6;
+  border-radius: 6px;
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 16px;
+}
+
+.issue-body {
+  background: #f8fafc;
+  border-radius: 6px;
+  margin: 20px 24px;
+  padding: 16px;
+}
+
+.issue-body pre {
+  color: #374151;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.landing-detail-tabs {
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  padding: 0 24px;
+}
+
+.landing-detail-tabs button {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #64748b;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 12px 16px;
+}
+
+.landing-detail-tabs button:hover {
+  color: #374151;
+}
+
+.landing-detail-tabs button.active {
+  border-bottom-color: #3b82f6;
+  color: #3b82f6;
+}
+
+.landing-detail-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+}
+
+.diff-content,
+.checks-content {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  color: #374151;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.4;
+  margin: 0;
+  max-height: 500px;
+  overflow: auto;
+  padding: 16px;
+  white-space: pre;
+}
+
+/* Authentication State */
+
+.auth-required {
+  align-items: center;
+  background: #ffffff;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  text-align: center;
+}
+
+.auth-required h3 {
+  color: #1e293b;
+  font-size: 18px;
+  margin: 0 0 16px;
+}
+
+.auth-required p {
+  color: #64748b;
+  margin: 8px 0;
+}
+
+.auth-required button {
+  background: #3b82f6;
+  border: 1px solid #3b82f6;
+  border-radius: 6px;
+  color: #ffffff;
+  font-weight: 500;
+  margin-top: 16px;
+  padding: 10px 20px;
+}
+
+/* Empty States */
+
+.empty-state {
+  align-items: center;
+  color: #9ca3af;
+  display: flex;
+  flex: 1;
+  justify-content: center;
+}
+
+.loading-state {
+  color: #6b7280;
+  font-style: italic;
+  text-align: center;
+}
+
+/* Modals */
+
+.modal-overlay {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  max-width: 500px;
+  padding: 24px;
+  width: 90%;
+}
+
+.modal-content h3 {
+  color: #1e293b;
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0 0 16px;
+}
+
+.form-group {
+  margin-bottom: 16px;
+}
+
+.form-group label {
+  color: #374151;
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+.form-group input,
+.form-group textarea,
+.form-group select {
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  color: #374151;
+  font-size: 14px;
+  padding: 8px 12px;
+  width: 100%;
+}
+
+.form-group textarea {
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.modal-actions button {
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 16px;
+}
+
+.modal-actions button:first-child {
+  background: #3b82f6;
+  border: 1px solid #3b82f6;
+  color: #ffffff;
+}
+
+.modal-actions button:last-child {
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  color: #374151;
+}
+
+/* Workspaces specific styles */
+
+.workspace-item,
+.snapshot-item {
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding: 16px;
+}
+
+.workspace-item.selected {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 1px #3b82f6;
+}
+
+.workspace-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.workspace-name,
+.snapshot-name {
+  color: #1e293b;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.workspace-meta,
+.snapshot-meta {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.workspace-status {
+  border-radius: 12px;
+  font-weight: 500;
+  padding: 2px 8px;
+  text-transform: uppercase;
+}
+
+.workspace-status-running { background: #dcfce7; color: #166534; }
+.workspace-status-suspended { background: #fef3c7; color: #92400e; }
+.workspace-status-unknown { background: #f3f4f6; color: #374151; }
+
+.workspace-actions {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.workspace-actions button {
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  color: #374151;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.workspace-actions button:hover {
+  background: #f9fafb;
+}
+
+.conflict-status {
+  border-radius: 6px;
+  font-weight: 500;
+  margin-bottom: 16px;
+  padding: 8px 12px;
+}
+
+.conflict-status.has-conflicts {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.conflict-status.no-conflicts {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.conflict-item {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  margin-bottom: 8px;
+  padding: 12px;
+}
+
+.conflict-file {
+  color: #1e293b;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.conflict-resolved.resolved {
+  color: #166534;
+}
+
+.conflict-resolved.unresolved {
+  color: #991b1b;
+}

--- a/apps/smithers-studio-2/src/desktopRpc.ts
+++ b/apps/smithers-studio-2/src/desktopRpc.ts
@@ -1,0 +1,21 @@
+import type { WorkspaceBackendRequest, WorkspaceBackendResponse, WorkspaceStatus } from "./workspaceProtocol";
+
+export type StudioRpcSchema = {
+  bun: {
+    requests: {
+      workspaceStatus: {
+        params: undefined;
+        response: WorkspaceStatus;
+      };
+      workspaceRequest: {
+        params: WorkspaceBackendRequest;
+        response: WorkspaceBackendResponse;
+      };
+    };
+    messages: Record<never, never>;
+  };
+  webview: {
+    requests: Record<never, never>;
+    messages: Record<never, never>;
+  };
+};

--- a/apps/smithers-studio-2/src/main.tsx
+++ b/apps/smithers-studio-2/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "@wterm/react/css";
+import App from "./App";
+import "./app.css";
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element #root was not found.");
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/smithers-studio-2/src/promptInputs.ts
+++ b/apps/smithers-studio-2/src/promptInputs.ts
@@ -1,0 +1,359 @@
+export type PromptInput = {
+  name: string;
+  type?: string;
+  defaultValue?: string;
+};
+
+const INPUT_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_.-]*$/;
+const FRONTMATTER_SECTION_KEYS = new Set(["inputs", "props", "parameters", "params", "variables", "args"]);
+const FRONTMATTER_METADATA_KEYS = new Set([
+  "title",
+  "description",
+  "tags",
+  "date",
+  "updated",
+  "slug",
+  "layout",
+  "author",
+  "summary",
+]);
+
+function normalizeSource(source: string) {
+  return source.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function splitFrontmatter(source: string) {
+  const lines = normalizeSource(source).split("\n");
+  if (lines[0]?.replace(/^\uFEFF/, "").trim() !== "---") {
+    return { frontmatter: null, body: source };
+  }
+  const closingIndex = lines.slice(1).findIndex((line) => {
+    const trimmed = line.trim();
+    return trimmed === "---" || trimmed === "...";
+  });
+  if (closingIndex < 0) {
+    return { frontmatter: null, body: source };
+  }
+  const end = closingIndex + 1;
+  return {
+    frontmatter: lines.slice(1, end).join("\n"),
+    body: lines.slice(end + 1).join("\n"),
+  };
+}
+
+function stripYamlComment(line: string) {
+  let singleQuoted = false;
+  let doubleQuoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (doubleQuoted && char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "'" && !doubleQuoted) {
+      singleQuoted = !singleQuoted;
+      continue;
+    }
+    if (char === "\"" && !singleQuoted) {
+      doubleQuoted = !doubleQuoted;
+      continue;
+    }
+    if (char === "#" && !singleQuoted && !doubleQuoted) {
+      return line.slice(0, index).trimEnd();
+    }
+  }
+
+  return line;
+}
+
+function parseYamlScalar(raw: string) {
+  const trimmed = stripYamlComment(raw).trim();
+  if (!trimmed || trimmed.toLowerCase() === "null" || trimmed === "~") {
+    return undefined;
+  }
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === "\"" && last === "\"") || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function parseYamlKeyValue(line: string): [string, string] | null {
+  const separator = line.indexOf(":");
+  if (separator < 0) {
+    return null;
+  }
+  const key = line.slice(0, separator).trim();
+  if (!key) {
+    return null;
+  }
+  return [key, line.slice(separator + 1).trim()];
+}
+
+function parseYamlListItem(line: string) {
+  if (!line.startsWith("-")) {
+    return null;
+  }
+  const content = line.slice(1).trim();
+  return content || null;
+}
+
+function leadingIndent(line: string) {
+  const match = /^[\t ]*/.exec(line);
+  return match?.[0].length ?? 0;
+}
+
+function normalizedInputName(raw: string) {
+  const scalar = parseYamlScalar(raw);
+  if (!scalar) {
+    return undefined;
+  }
+  const name = scalar.trim();
+  return INPUT_NAME_PATTERN.test(name) ? name : undefined;
+}
+
+function appendInput(
+  byName: Map<string, PromptInput>,
+  order: string[],
+  name: string,
+  type?: string,
+  defaultValue?: string,
+) {
+  if (!INPUT_NAME_PATTERN.test(name)) {
+    return;
+  }
+  const normalizedType = type?.trim() || undefined;
+  const normalizedDefault = defaultValue?.trim();
+  const existing = byName.get(name);
+  if (existing) {
+    byName.set(name, {
+      name,
+      type: existing.type ?? normalizedType,
+      defaultValue: existing.defaultValue ?? normalizedDefault,
+    });
+    return;
+  }
+  order.push(name);
+  byName.set(name, { name, type: normalizedType, defaultValue: normalizedDefault });
+}
+
+function parseInlineInputList(value: string, byName: Map<string, PromptInput>, order: string[]) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+  const content = trimmed.startsWith("[") && trimmed.endsWith("]")
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  for (const rawItem of content.split(",")) {
+    const item = rawItem.trim();
+    if (!item) {
+      continue;
+    }
+    const keyValue = parseYamlKeyValue(item);
+    if (keyValue) {
+      const [key, rawDefault] = keyValue;
+      const name = normalizedInputName(key);
+      if (name) {
+        appendInput(byName, order, name, "string", parseYamlScalar(rawDefault));
+      }
+      continue;
+    }
+    const name = normalizedInputName(item);
+    if (name) {
+      appendInput(byName, order, name, "string");
+    }
+  }
+}
+
+function discoverFrontmatterInputs(frontmatter: string) {
+  const byName = new Map<string, PromptInput>();
+  const order: string[] = [];
+  let activeSection: string | undefined;
+  let sectionIndent = 0;
+  let currentName: string | undefined;
+  let currentNameIndent = -1;
+  let topLevelProp = false;
+
+  for (const rawLine of frontmatter.split("\n")) {
+    const line = stripYamlComment(rawLine);
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const indent = leadingIndent(line);
+    const listItem = parseYamlListItem(trimmed);
+    if (listItem) {
+      if (!activeSection) {
+        continue;
+      }
+      const keyValue = parseYamlKeyValue(listItem);
+      if (keyValue?.[0].toLowerCase() === "name") {
+        currentName = normalizedInputName(keyValue[1]);
+        currentNameIndent = indent;
+        if (currentName) {
+          appendInput(byName, order, currentName, "string");
+        }
+      } else {
+        currentName = normalizedInputName(listItem);
+        currentNameIndent = currentName ? indent : -1;
+        if (currentName) {
+          appendInput(byName, order, currentName, "string");
+        }
+      }
+      continue;
+    }
+
+    const keyValue = parseYamlKeyValue(trimmed);
+    if (!keyValue) {
+      continue;
+    }
+    const [key, value] = keyValue;
+    const loweredKey = key.toLowerCase();
+
+    if (indent === 0) {
+      currentName = undefined;
+      currentNameIndent = -1;
+      topLevelProp = false;
+      activeSection = undefined;
+
+      if (FRONTMATTER_SECTION_KEYS.has(loweredKey)) {
+        activeSection = loweredKey;
+        sectionIndent = indent;
+        parseInlineInputList(value, byName, order);
+        continue;
+      }
+
+      if (!FRONTMATTER_METADATA_KEYS.has(loweredKey)) {
+        const name = normalizedInputName(key);
+        if (name) {
+          topLevelProp = true;
+          currentName = name;
+          currentNameIndent = indent;
+          appendInput(byName, order, name, "string", parseYamlScalar(value));
+        }
+      }
+      continue;
+    }
+
+    if (activeSection && indent <= sectionIndent) {
+      activeSection = undefined;
+    }
+
+    if (activeSection) {
+      if (loweredKey === "name") {
+        currentName = normalizedInputName(value);
+        currentNameIndent = indent;
+        if (currentName) {
+          appendInput(byName, order, currentName, "string");
+        }
+        continue;
+      }
+
+      if (currentName && indent > currentNameIndent) {
+        if (loweredKey === "type") {
+          appendInput(byName, order, currentName, parseYamlScalar(value) ?? "string");
+          continue;
+        }
+        if (loweredKey === "default" || loweredKey === "defaultvalue" || loweredKey === "value") {
+          appendInput(byName, order, currentName, undefined, parseYamlScalar(value));
+          continue;
+        }
+      }
+
+      if (currentName === undefined || indent <= currentNameIndent) {
+        const nestedName = normalizedInputName(key);
+        if (nestedName) {
+          currentName = nestedName;
+          currentNameIndent = indent;
+          appendInput(byName, order, nestedName, "string", parseYamlScalar(value));
+        }
+      }
+      continue;
+    }
+
+    if (topLevelProp && currentName && indent > currentNameIndent) {
+      if (loweredKey === "type") {
+        appendInput(byName, order, currentName, parseYamlScalar(value) ?? "string");
+      } else if (loweredKey === "default" || loweredKey === "defaultvalue" || loweredKey === "value") {
+        appendInput(byName, order, currentName, undefined, parseYamlScalar(value));
+      }
+    }
+  }
+
+  return order.flatMap((name) => byName.get(name) ?? []);
+}
+
+function discoverComponentInputs(source: string, byName: Map<string, PromptInput>, order: string[]) {
+  const tagPattern = /<[A-Z][A-Za-z0-9_.:-]*\b[^>]*>/gs;
+  const propMemberPattern = /[A-Za-z_][A-Za-z0-9_.-]*\s*=\s*\{\s*props\.([A-Za-z_][A-Za-z0-9_.-]*)\s*\}/g;
+  const passThroughPattern = /([A-Za-z_][A-Za-z0-9_.-]*)\s*=\s*\{\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*\}/g;
+  for (const tag of source.matchAll(tagPattern)) {
+    const text = tag[0];
+    for (const match of text.matchAll(propMemberPattern)) {
+      appendInput(byName, order, match[1], "string");
+    }
+    for (const match of text.matchAll(passThroughPattern)) {
+      if (match[1] === match[2]) {
+        appendInput(byName, order, match[1], "string");
+      }
+    }
+  }
+}
+
+export function discoverPromptInputs(source: string, preferredInputs: PromptInput[] = []) {
+  const normalized = normalizeSource(source);
+  const { frontmatter, body } = splitFrontmatter(normalized);
+  const byName = new Map<string, PromptInput>();
+  const order: string[] = [];
+
+  if (frontmatter) {
+    for (const input of discoverFrontmatterInputs(frontmatter)) {
+      appendInput(byName, order, input.name, input.type ?? "string", input.defaultValue);
+    }
+  }
+
+  for (const match of body.matchAll(/\{\s*props\.([A-Za-z_][A-Za-z0-9_.-]*)\s*\}/g)) {
+    appendInput(byName, order, match[1], "string");
+  }
+  discoverComponentInputs(body, byName, order);
+
+  const discovered = order.flatMap((name) => byName.get(name) ?? []);
+  if (discovered.length === 0) {
+    return preferredInputs;
+  }
+  const preferredByName = new Map(preferredInputs.map((input) => [input.name, input]));
+  return discovered.map((input) => {
+    const preferred = preferredByName.get(input.name);
+    return {
+      name: input.name,
+      type: preferred?.type ?? input.type,
+      defaultValue: preferred?.defaultValue ?? input.defaultValue,
+    };
+  });
+}
+
+export function defaultPromptInputValues(inputs: PromptInput[]) {
+  return inputs.reduce<Record<string, string>>((values, input) => {
+    if (input.defaultValue !== undefined) {
+      values[input.name] = input.defaultValue;
+    }
+    return values;
+  }, {});
+}
+
+export function renderPromptPreview(source: string, input: Record<string, string>) {
+  const { body } = splitFrontmatter(source);
+  return body.replace(/\{\s*props\.([A-Za-z_][A-Za-z0-9_.-]*)\s*\}/g, (_match, name: string) => {
+    return input[name] ?? "";
+  }).trim();
+}

--- a/apps/smithers-studio-2/src/useHotkey.ts
+++ b/apps/smithers-studio-2/src/useHotkey.ts
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export function useHotkey(key: string, callback: () => void) {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === key) {
+        event.preventDefault();
+        callback();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [key, callback]);
+}

--- a/apps/smithers-studio-2/src/useStudioStore.ts
+++ b/apps/smithers-studio-2/src/useStudioStore.ts
@@ -2,6 +2,8 @@ import { create } from "zustand";
 
 type TerminalTab = { id: string; title: string; createdAt: Date };
 
+type ViewId = "terminal" | "issues" | "landings" | "workspaces";
+
 function createTerminal(index: number): TerminalTab {
   return { id: crypto.randomUUID(), title: `Terminal ${index}`, createdAt: new Date() };
 }
@@ -13,15 +15,27 @@ const firstTerminal: TerminalTab = {
 };
 
 type StudioState = {
+  // Terminal state
   tabs: TerminalTab[];
   activeTabId: string;
+
+  // View state
+  activeView: ViewId;
+
+  // Command palette state
   paletteOpen: boolean;
   paletteQuery: string;
   selectedPaletteIndex: number;
 
+  // Terminal actions
   openTerminal: () => void;
   closeTerminal: (tabId: string) => void;
   setActiveTabId: (id: string) => void;
+
+  // View actions
+  setActiveView: (view: ViewId) => void;
+
+  // Palette actions
   openPalette: () => void;
   closePalette: () => void;
   setPaletteQuery: (query: string) => void;
@@ -31,6 +45,7 @@ type StudioState = {
 export const useStudioStore = create<StudioState>((set, get) => ({
   tabs: [firstTerminal],
   activeTabId: firstTerminal.id,
+  activeView: "terminal",
   paletteOpen: false,
   paletteQuery: "",
   selectedPaletteIndex: 0,
@@ -38,7 +53,13 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   openTerminal: () => {
     const { tabs } = get();
     const next = createTerminal(tabs.length + 1);
-    set({ tabs: [...tabs, next], activeTabId: next.id, paletteOpen: false, paletteQuery: "" });
+    set({
+      tabs: [...tabs, next],
+      activeTabId: next.id,
+      activeView: "terminal",
+      paletteOpen: false,
+      paletteQuery: ""
+    });
   },
 
   closeTerminal: (tabId: string) => {
@@ -50,6 +71,8 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   },
 
   setActiveTabId: (id: string) => set({ activeTabId: id }),
+
+  setActiveView: (view: ViewId) => set({ activeView: view, paletteOpen: false }),
 
   openPalette: () => set({ paletteOpen: true }),
 

--- a/apps/smithers-studio-2/src/useStudioStore.ts
+++ b/apps/smithers-studio-2/src/useStudioStore.ts
@@ -1,0 +1,64 @@
+import { create } from "zustand";
+
+type TerminalTab = { id: string; title: string; createdAt: Date };
+
+function createTerminal(index: number): TerminalTab {
+  return { id: crypto.randomUUID(), title: `Terminal ${index}`, createdAt: new Date() };
+}
+
+const firstTerminal: TerminalTab = {
+  id: crypto.randomUUID(),
+  title: "Terminal 1",
+  createdAt: new Date(),
+};
+
+type StudioState = {
+  tabs: TerminalTab[];
+  activeTabId: string;
+  paletteOpen: boolean;
+  paletteQuery: string;
+  selectedPaletteIndex: number;
+
+  openTerminal: () => void;
+  closeTerminal: (tabId: string) => void;
+  setActiveTabId: (id: string) => void;
+  openPalette: () => void;
+  closePalette: () => void;
+  setPaletteQuery: (query: string) => void;
+  setSelectedPaletteIndex: (index: number | ((prev: number) => number)) => void;
+};
+
+export const useStudioStore = create<StudioState>((set, get) => ({
+  tabs: [firstTerminal],
+  activeTabId: firstTerminal.id,
+  paletteOpen: false,
+  paletteQuery: "",
+  selectedPaletteIndex: 0,
+
+  openTerminal: () => {
+    const { tabs } = get();
+    const next = createTerminal(tabs.length + 1);
+    set({ tabs: [...tabs, next], activeTabId: next.id, paletteOpen: false, paletteQuery: "" });
+  },
+
+  closeTerminal: (tabId: string) => {
+    const { tabs, activeTabId } = get();
+    if (tabs.length === 1) return;
+    const nextTabs = tabs.filter((tab) => tab.id !== tabId);
+    const nextActiveId = tabId === activeTabId ? (nextTabs.at(-1)?.id ?? nextTabs[0].id) : activeTabId;
+    set({ tabs: nextTabs, activeTabId: nextActiveId });
+  },
+
+  setActiveTabId: (id: string) => set({ activeTabId: id }),
+
+  openPalette: () => set({ paletteOpen: true }),
+
+  closePalette: () => set({ paletteOpen: false, paletteQuery: "", selectedPaletteIndex: 0 }),
+
+  setPaletteQuery: (query: string) => set({ paletteQuery: query, selectedPaletteIndex: 0 }),
+
+  setSelectedPaletteIndex: (index) =>
+    set((state) => ({
+      selectedPaletteIndex: typeof index === "function" ? index(state.selectedPaletteIndex) : index,
+    })),
+}));

--- a/apps/smithers-studio-2/src/workspaceApi.ts
+++ b/apps/smithers-studio-2/src/workspaceApi.ts
@@ -1,0 +1,1279 @@
+import type { PromptInput } from "./promptInputs";
+import type { StudioRpcSchema } from "./desktopRpc";
+import type { WorkspaceBackendRequest, WorkspaceBackendResponse, WorkspaceStatus } from "./workspaceProtocol";
+
+export type WorkspacePrompt = {
+  id: string;
+  entryFile: string | null;
+  source: string | null;
+  inputs: PromptInput[];
+};
+
+export type WorkspaceTicket = {
+  id: string;
+  content: string | null;
+  status: string | null;
+  createdAtMs: number | null;
+  updatedAtMs: number | null;
+};
+
+export type WorkspaceSearchScope = "code" | "issues" | "repos" | "transcripts";
+
+export type WorkspaceSearchResult = {
+  id: string;
+  title: string;
+  description?: string | null;
+  snippet?: string | null;
+  filePath?: string | null;
+  lineNumber?: number | null;
+  lineNumbers?: number[] | null;
+  kind?: string | null;
+  snippetRanges?: Array<{ content: string; startLine?: number | null }> | null;
+  fileSize?: number | null;
+  fileExtension?: string | null;
+  skipReason?: string | null;
+};
+
+export type WorkspaceMemoryFact = {
+  namespace: string;
+  key: string;
+  valueJson: string;
+  schemaSig: string | null;
+  createdAtMs: number;
+  updatedAtMs: number;
+  ttlMs: number | null;
+};
+
+export type WorkspaceMemoryRecallResult = {
+  score: number;
+  content: string;
+  metadata: string | null;
+};
+
+export type WorkspaceScoreRow = {
+  id: string;
+  runId: string;
+  nodeId: string;
+  iteration: number;
+  attempt: number;
+  scorerId: string;
+  scorerName: string;
+  source: string;
+  score: number;
+  reason: string | null;
+  metaJson: string | null;
+  inputJson: string | null;
+  outputJson: string | null;
+  latencyMs: number | null;
+  scoredAtMs: number;
+  durationMs: number | null;
+};
+
+export type WorkspaceAggregateScore = {
+  scorerId: string;
+  scorerName: string;
+  count: number;
+  mean: number;
+  min: number;
+  max: number;
+  p50: number;
+  stddev: number;
+  sources?: string[];
+  firstScoredAtMs?: number;
+  latestScoredAtMs?: number;
+};
+
+export type WorkspaceScoreRun = {
+  runId: string;
+  count: number;
+  firstScoredAtMs?: number;
+  latestScoredAtMs: number;
+};
+
+export type WorkspaceScoreScopeAggregate = {
+  runId?: string;
+  nodeId?: string;
+  workflowId?: string;
+  count: number;
+  mean: number;
+  min: number;
+  max: number;
+  p50: number;
+  stddev: number;
+  sources: string[];
+  firstScoredAtMs: number;
+  latestScoredAtMs: number;
+};
+
+export type WorkspaceAgent = {
+  id: string;
+  name: string;
+  command: string;
+  binaryPath: string;
+  status: string;
+  hasAuth: boolean;
+  hasAPIKey: boolean;
+  usable: boolean;
+  roles: string[];
+  version: string | null;
+  authExpired: boolean | null;
+  checks: string[];
+  unusableReasons: string[];
+  defaultModel?: string | null;
+  modelOptions: Array<{ id: string; label: string }>;
+};
+
+export type WorkspaceVersions = {
+  appVersion: string;
+  smithersVersion: string | null;
+  smithersMinimumVersion: string;
+  smithersMeetsMinimum: boolean | null;
+};
+
+export type WorkspaceSettingsPreferences = {
+  vimModeEnabled: boolean;
+  developerToolsEnabled: boolean;
+  smithersGUIControlSidebarEnabled: boolean;
+  externalAgentUnsafeFlagsEnabled: boolean;
+  shortcutCheatSheetFooterEnabled: boolean;
+  browserSearchEngine: string;
+  defaultShellPath: string;
+  shortcutOverrides: Record<string, string>;
+};
+
+export type WorkspaceSettingsDetections = {
+  settingsPath: string;
+  shellCandidates: string[];
+  resolvedShellPath: string | null;
+  neovimPath: string | null;
+  neovimAvailable: boolean;
+};
+
+export type WorkspaceSettings = {
+  preferences: WorkspaceSettingsPreferences;
+  detections: WorkspaceSettingsDetections;
+};
+
+export type WorkspaceCloudWorkspace = {
+  id: string;
+  name: string;
+  status: string | null;
+  createdAt: string | null;
+};
+
+export type WorkspaceCloudSnapshot = {
+  id: string;
+  workspaceId: string;
+  name: string | null;
+  createdAt: string | null;
+};
+
+export type WorkspaceIssue = {
+  id: string;
+  number: number | null;
+  title: string;
+  body: string | null;
+  state: string | null;
+  labels: string[] | null;
+  assignees: string[] | null;
+  commentCount: number | null;
+};
+
+export type WorkspaceLanding = {
+  id: string;
+  number: number | null;
+  title: string;
+  description: string | null;
+  state: string | null;
+  targetBranch: string | null;
+  author: string | null;
+  createdAt: string | null;
+  reviewStatus: string | null;
+};
+
+export type WorkspaceJjhubWorkflow = {
+  id: number;
+  repositoryID: number | null;
+  name: string;
+  path: string;
+  isActive: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type WorkspaceJjhubWorkflowRun = {
+  id: number | null;
+  workflowDefinitionID: number | null;
+  status: string | null;
+  triggerEvent: string | null;
+  triggerRef: string | null;
+  triggerCommitSHA: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  sessionID: string | null;
+  steps: string[] | null;
+};
+
+export type WorkspaceFile = {
+  path: string;
+  name: string;
+  extension: string | null;
+  size: number;
+};
+
+export type WorkspaceLogEntry = {
+  id: string;
+  timestamp: string | null;
+  level: string;
+  category: string;
+  message: string;
+  metadata: Record<string, string> | null;
+  sourcePath: string;
+  raw: string | null;
+};
+
+export type WorkspaceLogSource = {
+  path: string;
+  sizeBytes: number;
+  entryCount: number;
+};
+
+export type WorkspaceLogStats = {
+  entryCount: number;
+  sizeBytes: number;
+  errorCount: number;
+  warningCount: number;
+  categories: Array<{ category: string; count: number }>;
+  sources: WorkspaceLogSource[];
+};
+
+export type WorkspaceTerminalExecution = {
+  id: string;
+  command: string;
+  cwd: string;
+  shellPath: string;
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  exitCode: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type WorkspaceTerminalSession = WorkspaceTerminalExecution & {
+  running: boolean;
+  events: Array<{ seq: number; stream: "stdout" | "stderr" | "system"; text: string; at: string }>;
+};
+
+export type WorkspaceBrowserResolution = {
+  raw: string;
+  url: string;
+  engine: string;
+};
+
+export type WorkspaceDebugRow = {
+  label: string;
+  value: string;
+  tone: "normal" | "good" | "warning" | "danger";
+};
+
+export type WorkspaceDebugEvent = {
+  id: string;
+  timestamp: string | null;
+  level: string;
+  name: string;
+  source: string;
+  detail: string;
+};
+
+export type WorkspaceDebugPayload = {
+  capturedAt: string;
+  runtimeRows: WorkspaceDebugRow[];
+  workspaceRows: WorkspaceDebugRow[];
+  logRows: WorkspaceDebugRow[];
+  metricRows: WorkspaceDebugRow[];
+  events: WorkspaceDebugEvent[];
+  logs: WorkspaceLogEntry[];
+};
+
+export type WorkspaceLocalRecent = {
+  path: string;
+  displayName: string;
+  exists: boolean;
+  hasSmithers: boolean;
+  smithersPath: string | null;
+  lastOpenedAt: string;
+};
+
+export type WorkspaceJjhubAuthStatus = {
+  apiUrl: string | null;
+  loggedIn: boolean;
+  tokenSet: boolean;
+  tokenSource: string | null;
+  user: string | null;
+  email: string | null;
+  message: string | null;
+};
+
+export type WorkspaceFileContent = {
+  path: string;
+  name: string;
+  extension: string | null;
+  content: string;
+  size: number;
+  language: string | null;
+};
+
+export type WorkspaceLandingConflict = {
+  changeID: string | null;
+  filePath: string;
+  conflictType: string | null;
+  resolved: boolean | null;
+  resolutionStatus: string | null;
+};
+
+export type WorkspaceLandingConflicts = {
+  conflictStatus: string | null;
+  hasConflicts: boolean;
+  conflicts: WorkspaceLandingConflict[];
+};
+
+export type WorkspaceEditorTargetKind = "smithers" | "ticket";
+
+export type WorkspaceEditorTarget = {
+  path: string;
+  cwd: string;
+  neovimCommand: string | null;
+  neovimAvailable: boolean;
+};
+
+export type WorkspaceApprovalDecision = {
+  id: string;
+  runId: string;
+  nodeId: string;
+  iteration: number;
+  workflowKey: string | null;
+  status: string;
+  decisionState: string;
+  action: string;
+  requestTitle: string | null;
+  requestSummary: string | null;
+  requestedAtMs: number | null;
+  decidedAtMs: number | null;
+  note: string | null;
+  decidedBy: string | null;
+  requestJson: string | null;
+  decisionJson: string | null;
+  autoApproved: boolean;
+};
+
+export type WorkspaceTokenMetricsPeriod = {
+  label: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+};
+
+export type WorkspaceTokenMetrics = {
+  totalTokens: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  byPeriod: WorkspaceTokenMetricsPeriod[];
+};
+
+export type WorkspaceLatencyMetricsPeriod = {
+  label: string;
+  count: number;
+  meanMs: number;
+};
+
+export type WorkspaceLatencyMetrics = {
+  count: number;
+  meanMs: number;
+  minMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+  byPeriod: WorkspaceLatencyMetricsPeriod[];
+};
+
+export type WorkspaceCostPeriod = {
+  label: string;
+  totalCostUSD: number;
+  runCount: number;
+};
+
+export type WorkspaceCostReport = {
+  totalCostUSD: number;
+  inputCostUSD: number;
+  outputCostUSD: number;
+  runCount: number;
+  byPeriod: WorkspaceCostPeriod[];
+};
+
+export type WorkspaceWorkflowLaunchField = {
+  key: string;
+  name: string;
+  type: string | null;
+  defaultValue: string | null;
+  required: boolean;
+};
+
+export type WorkspaceRepo = {
+  id: string | number | null;
+  name: string | null;
+  fullName: string | null;
+  owner: string | null;
+  description: string | null;
+  defaultBookmark: string | null;
+  root: string | null;
+  isPublic: boolean | null;
+  isArchived: boolean | null;
+  numIssues: number | null;
+  numStars: number | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+};
+
+export type WorkspaceChange = {
+  changeID: string;
+  commitID: string | null;
+  description: string | null;
+  author: {
+    name: string | null;
+    email: string | null;
+  } | null;
+  timestamp: string | null;
+  bookmarks: string[];
+  isEmpty: boolean | null;
+  isWorkingCopy: boolean | null;
+};
+
+export type WorkspaceBookmark = {
+  name: string;
+  targetChangeID: string | null;
+  targetCommitID: string | null;
+  isTrackingRemote: boolean | null;
+};
+
+export type WorkspaceWorkflowImport = {
+  id: string;
+  name: string;
+  path: string;
+  kind: "component" | "prompt";
+  source: string;
+};
+
+export type WorkspaceWorkflowSource = {
+  workflowKey: string;
+  path: string;
+  source: string;
+  imports: WorkspaceWorkflowImport[];
+};
+
+export type WorkspaceWorkflowFrontendManifest = {
+  version: number;
+  id: string;
+  name: string;
+  framework: string | null;
+  entry: string;
+  apiBasePath: string | null;
+  defaultPath: string | null;
+};
+
+export type WorkspaceWorkflowFrontendDescriptor = {
+  manifest: WorkspaceWorkflowFrontendManifest;
+  manifestPath: string;
+  frontendDirectoryPath: string;
+  serverScriptPath: string | null;
+  entryPath: string | null;
+  routePath: string;
+};
+
+export type WorkspaceWorkflowFrontendLaunch = {
+  descriptor: WorkspaceWorkflowFrontendDescriptor;
+  phase: "ready" | "static";
+  url: string | null;
+  html: string | null;
+  message: string;
+};
+
+export type WorkspaceWorkflowGraphTask = {
+  nodeId: string;
+  ordinal: number | null;
+  outputTableName: string | null;
+  needsApproval: boolean | null;
+  waitAsync: boolean | null;
+};
+
+export type WorkspaceWorkflowGraphEdge = {
+  from: string;
+  to: string;
+};
+
+export type WorkspaceWorkflowGraph = {
+  workflowKey: string;
+  path: string;
+  mode: string;
+  message: string | null;
+  tasks: WorkspaceWorkflowGraphTask[];
+  edges: WorkspaceWorkflowGraphEdge[];
+  fields: WorkspaceWorkflowLaunchField[];
+  entryTask?: string | null;
+  raw: unknown;
+};
+
+export type WorkspaceWorkflowDoctorIssue = {
+  severity: "ok" | "warning" | "error";
+  check: string;
+  message: string;
+};
+
+export type WorkspaceWorkflowDoctor = {
+  workflowKey: string;
+  path: string;
+  workflowRoot: string | null;
+  issues: WorkspaceWorkflowDoctorIssue[];
+  raw: unknown;
+};
+
+export type WorkspaceSqlTable = {
+  name: string;
+  rowCount: number;
+  type: string;
+};
+
+export type WorkspaceSqlColumn = {
+  cid: number;
+  name: string;
+  type: string;
+  notNull: boolean;
+  defaultValue: string | null;
+  primaryKey: boolean;
+};
+
+export type WorkspaceSqlSchema = {
+  tableName: string;
+  columns: WorkspaceSqlColumn[];
+};
+
+export type WorkspaceSqlResult = {
+  columns: string[];
+  rows: string[][];
+};
+
+type StudioDesktopRpc = {
+  request: {
+    workspaceStatus: (params?: undefined) => Promise<WorkspaceStatus>;
+    workspaceRequest: (params: WorkspaceBackendRequest) => Promise<WorkspaceBackendResponse>;
+  };
+  // Electrobun owns this method; Studio only needs it present for Electroview wiring.
+  setTransport: (transport: any) => void;
+};
+
+let desktopRpcPromise: Promise<StudioDesktopRpc | null> | null = null;
+let desktopElectroview: unknown = null;
+
+function hasDesktopBridge() {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const bridgeWindow = window as typeof window & {
+    __electrobun?: unknown;
+    __electrobunBunBridge?: unknown;
+    __electrobunRpcSocketPort?: number;
+    __electrobunWebviewId?: number;
+  };
+  return Boolean(bridgeWindow.__electrobun) ||
+    Boolean(bridgeWindow.__electrobunBunBridge) ||
+    Boolean(bridgeWindow.__electrobunRpcSocketPort) ||
+    Boolean(bridgeWindow.__electrobunWebviewId);
+}
+
+async function getDesktopRpc() {
+  // Simplified for Studio v2 - no desktop RPC support yet
+  return null;
+}
+
+function bodyFromRequestInit(init?: RequestInit) {
+  if (typeof init?.body !== "string" || !init.body.trim()) {
+    return undefined;
+  }
+  return JSON.parse(init.body) as unknown;
+}
+
+function backendRequestFromPath(path: string, init?: RequestInit): WorkspaceBackendRequest {
+  const url = new URL(path, "http://smithers-studio.local");
+  return {
+    method: init?.method ?? "GET",
+    path: url.pathname,
+    query: Object.fromEntries(url.searchParams.entries()),
+    body: bodyFromRequestInit(init),
+  };
+}
+
+export async function loadWorkspaceStatus() {
+  const response = await fetch("/__smithers_studio/workspace");
+  const payload = await response.json().catch(() => undefined) as unknown;
+  if (!response.ok) {
+    const message = payload && typeof payload === "object" && "error" in payload
+      ? String((payload as { error: unknown }).error)
+      : `Workspace probe failed with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return payload as WorkspaceStatus;
+}
+
+async function workspaceJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`/__smithers_studio/api${path}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...init?.headers,
+    },
+  });
+  const payload = await response.json().catch(() => undefined) as unknown;
+  if (!response.ok) {
+    const message = payload && typeof payload === "object" && "error" in payload
+      ? String((payload as { error: unknown }).error)
+      : `Workspace API failed with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return payload as T;
+}
+
+export async function listWorkspacePrompts() {
+  const payload = await workspaceJson<{ prompts: WorkspacePrompt[] }>("/prompts");
+  return payload.prompts;
+}
+
+export async function updateWorkspacePrompt(promptId: string, source: string) {
+  const payload = await workspaceJson<{ prompt: WorkspacePrompt }>(`/prompts/${encodeURIComponent(promptId)}`, {
+    method: "PUT",
+    body: JSON.stringify({ source }),
+  });
+  return payload.prompt;
+}
+
+export async function previewWorkspacePrompt(promptId: string, source: string, input: Record<string, string>) {
+  const payload = await workspaceJson<{ preview: string }>(`/prompts/${encodeURIComponent(promptId)}/preview`, {
+    method: "POST",
+    body: JSON.stringify({ source, input }),
+  });
+  return payload.preview;
+}
+
+export async function listWorkspaceTickets(query = "") {
+  const search = new URLSearchParams();
+  if (query.trim()) {
+    search.set("query", query.trim());
+  }
+  const payload = await workspaceJson<{ tickets: WorkspaceTicket[] }>(`/tickets${search.size ? `?${search}` : ""}`);
+  return payload.tickets;
+}
+
+export async function listWorkspaceAgents() {
+  const payload = await workspaceJson<{ agents: WorkspaceAgent[] }>("/agents");
+  return payload.agents;
+}
+
+export async function loadWorkspaceVersions() {
+  const payload = await workspaceJson<{ versions: WorkspaceVersions }>("/versions");
+  return payload.versions;
+}
+
+export async function listWorkspaceFiles(query = "", limit = 80) {
+  const search = new URLSearchParams({ limit: String(limit) });
+  if (query.trim()) {
+    search.set("query", query.trim());
+  }
+  const payload = await workspaceJson<{ files: WorkspaceFile[] }>(`/files?${search}`);
+  return payload.files;
+}
+
+export async function executeWorkspaceTerminalCommand(command: string, cwd?: string | null) {
+  const payload = await workspaceJson<{ execution: WorkspaceTerminalExecution }>("/terminal/execute", {
+    method: "POST",
+    body: JSON.stringify({ command, cwd: cwd || null }),
+  });
+  return payload.execution;
+}
+
+export async function resolveWorkspaceBrowserUrl(value: string) {
+  const search = new URLSearchParams({ value });
+  const payload = await workspaceJson<{ browser: WorkspaceBrowserResolution }>(`/browser/resolve?${search}`);
+  return payload.browser;
+}
+
+export async function loadWorkspaceDebug() {
+  const payload = await workspaceJson<{ debug: WorkspaceDebugPayload }>("/debug");
+  return payload.debug;
+}
+
+export async function listWorkspaceLogs(params: {
+  level?: string | null;
+  category?: string | null;
+  query?: string;
+  limit?: number;
+} = {}) {
+  return workspaceJson<{ entries: WorkspaceLogEntry[]; stats: WorkspaceLogStats }>(`/logs?${logSearchParams(params)}`);
+}
+
+function logSearchParams(params: {
+  level?: string | null;
+  category?: string | null;
+  query?: string;
+  limit?: number;
+}) {
+  const search = new URLSearchParams({ limit: String(params.limit ?? 1_000) });
+  if (params.level) {
+    search.set("level", params.level);
+  }
+  if (params.category) {
+    search.set("category", params.category);
+  }
+  if (params.query?.trim()) {
+    search.set("query", params.query.trim());
+  }
+  return search;
+}
+
+export async function exportWorkspaceLogs(params: {
+  level?: string | null;
+  category?: string | null;
+  query?: string;
+  limit?: number;
+} = {}) {
+  const payload = await workspaceJson<{ fileName: string; content: string; count: number }>(
+    `/logs/export?${logSearchParams(params)}`,
+  );
+  return payload;
+}
+
+export async function clearWorkspaceLogs() {
+  const payload = await workspaceJson<{ cleared: string[] }>("/logs", {
+    method: "DELETE",
+  });
+  return payload.cleared;
+}
+
+export async function revealWorkspaceLogs() {
+  const payload = await workspaceJson<{ paths: string[] }>("/logs/reveal", {
+    method: "POST",
+  });
+  return payload.paths;
+}
+
+export async function loadWorkspaceSettings() {
+  const payload = await workspaceJson<{ settings: WorkspaceSettings }>("/settings");
+  return payload.settings;
+}
+
+export async function updateWorkspaceSettings(preferences: Partial<WorkspaceSettingsPreferences>) {
+  const payload = await workspaceJson<{ settings: WorkspaceSettings }>("/settings", {
+    method: "PUT",
+    body: JSON.stringify({ preferences }),
+  });
+  return payload.settings;
+}
+
+export async function listLocalWorkspaces() {
+  const payload = await workspaceJson<{ recents: WorkspaceLocalRecent[] }>("/local-workspaces");
+  return payload.recents;
+}
+
+export async function openLocalWorkspace(path: string) {
+  const payload = await workspaceJson<{ workspace: WorkspaceStatus }>("/local-workspaces/open", {
+    method: "POST",
+    body: JSON.stringify({ path }),
+  });
+  return payload.workspace;
+}
+
+export async function removeLocalWorkspace(path: string) {
+  const payload = await workspaceJson<{ recents: WorkspaceLocalRecent[] }>("/local-workspaces", {
+    method: "DELETE",
+    body: JSON.stringify({ path }),
+  });
+  return payload.recents;
+}
+
+export async function loadJjhubAuthStatus() {
+  const payload = await workspaceJson<{ auth: WorkspaceJjhubAuthStatus }>("/auth/status");
+  return payload.auth;
+}
+
+export async function listCloudWorkspaces() {
+  const payload = await workspaceJson<{ workspaces: WorkspaceCloudWorkspace[] }>("/workspaces");
+  return payload.workspaces;
+}
+
+export async function createCloudWorkspace(name: string, snapshotId?: string | null) {
+  const payload = await workspaceJson<{ workspace: WorkspaceCloudWorkspace }>("/workspaces", {
+    method: "POST",
+    body: JSON.stringify({ name, snapshotId: snapshotId || null }),
+  });
+  return payload.workspace;
+}
+
+export async function getCloudWorkspace(workspaceId: string) {
+  const payload = await workspaceJson<{ workspace: WorkspaceCloudWorkspace }>(
+    `/workspaces/${encodeURIComponent(workspaceId)}`,
+  );
+  return payload.workspace;
+}
+
+export async function deleteCloudWorkspace(workspaceId: string) {
+  await workspaceJson<{ ok: true }>(`/workspaces/${encodeURIComponent(workspaceId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function suspendCloudWorkspace(workspaceId: string) {
+  await workspaceJson<{ ok: true }>(`/workspaces/${encodeURIComponent(workspaceId)}/suspend`, {
+    method: "POST",
+  });
+}
+
+export async function resumeCloudWorkspace(workspaceId: string) {
+  await workspaceJson<{ ok: true }>(`/workspaces/${encodeURIComponent(workspaceId)}/resume`, {
+    method: "POST",
+  });
+}
+
+export async function forkCloudWorkspace(workspaceId: string, name?: string | null) {
+  const payload = await workspaceJson<{ workspace: WorkspaceCloudWorkspace }>(
+    `/workspaces/${encodeURIComponent(workspaceId)}/fork`,
+    {
+      method: "POST",
+      body: JSON.stringify({ name: name || null }),
+    },
+  );
+  return payload.workspace;
+}
+
+export async function listCloudWorkspaceSnapshots() {
+  const payload = await workspaceJson<{ snapshots: WorkspaceCloudSnapshot[] }>("/workspaces/snapshots");
+  return payload.snapshots;
+}
+
+export async function createCloudWorkspaceSnapshot(workspaceId: string, name: string) {
+  const payload = await workspaceJson<{ snapshot: WorkspaceCloudSnapshot }>("/workspaces/snapshots", {
+    method: "POST",
+    body: JSON.stringify({ workspaceId, name }),
+  });
+  return payload.snapshot;
+}
+
+export async function deleteCloudWorkspaceSnapshot(snapshotId: string) {
+  await workspaceJson<{ ok: true }>(`/workspaces/snapshots/${encodeURIComponent(snapshotId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function listJjhubIssues(state?: string | null) {
+  const search = new URLSearchParams();
+  if (state) {
+    search.set("state", state);
+  }
+  const payload = await workspaceJson<{ issues: WorkspaceIssue[] }>(`/issues${search.size ? `?${search}` : ""}`);
+  return payload.issues;
+}
+
+export async function getJjhubIssue(number: number) {
+  const payload = await workspaceJson<{ issue: WorkspaceIssue }>(`/issues/${number}`);
+  return payload.issue;
+}
+
+export async function createJjhubIssue(title: string, body?: string | null) {
+  const payload = await workspaceJson<{ issue: WorkspaceIssue }>("/issues", {
+    method: "POST",
+    body: JSON.stringify({ title, body: body || null }),
+  });
+  return payload.issue;
+}
+
+export async function closeJjhubIssue(number: number, comment?: string | null) {
+  const payload = await workspaceJson<{ issue: WorkspaceIssue }>(`/issues/${number}/close`, {
+    method: "POST",
+    body: JSON.stringify({ comment: comment || null }),
+  });
+  return payload.issue;
+}
+
+export async function reopenJjhubIssue(number: number) {
+  const payload = await workspaceJson<{ issue: WorkspaceIssue }>(`/issues/${number}/reopen`, {
+    method: "POST",
+  });
+  return payload.issue;
+}
+
+export async function listJjhubLandings(state?: string | null) {
+  const search = new URLSearchParams({ limit: "100" });
+  if (state) {
+    search.set("state", state);
+  }
+  const payload = await workspaceJson<{ landings: WorkspaceLanding[] }>(`/landings?${search}`);
+  return payload.landings;
+}
+
+export async function getJjhubLanding(number: number) {
+  const payload = await workspaceJson<{ landing: WorkspaceLanding }>(`/landings/${number}`);
+  return payload.landing;
+}
+
+export async function createJjhubLanding(title: string, body?: string | null, target?: string | null) {
+  const payload = await workspaceJson<{ landing: WorkspaceLanding }>("/landings", {
+    method: "POST",
+    body: JSON.stringify({ title, body: body || null, target: target || null, stack: true }),
+  });
+  return payload.landing;
+}
+
+export async function getJjhubLandingDiff(number: number) {
+  const payload = await workspaceJson<{ diff: string }>(`/landings/${number}/diff`);
+  return payload.diff;
+}
+
+export async function getJjhubLandingChecks(number: number) {
+  const payload = await workspaceJson<{ checks: string }>(`/landings/${number}/checks`);
+  return payload.checks;
+}
+
+export async function getJjhubLandingConflicts(number: number) {
+  const payload = await workspaceJson<{ conflicts: WorkspaceLandingConflicts }>(`/landings/${number}/conflicts`);
+  return payload.conflicts;
+}
+
+export async function reviewJjhubLanding(number: number, action: "approve" | "request_changes" | "comment", body?: string | null) {
+  const payload = await workspaceJson<{ landing: WorkspaceLanding }>(`/landings/${number}/review`, {
+    method: "POST",
+    body: JSON.stringify({ action, body: body || null }),
+  });
+  return payload.landing;
+}
+
+export async function landJjhubLanding(number: number) {
+  const payload = await workspaceJson<{ landing: WorkspaceLanding }>(`/landings/${number}/land`, {
+    method: "POST",
+  });
+  return payload.landing;
+}
+
+export async function listJjhubWorkflows(limit = 100) {
+  const search = new URLSearchParams({ limit: String(limit) });
+  const payload = await workspaceJson<{ workflows: WorkspaceJjhubWorkflow[] }>(`/jjhub-workflows?${search}`);
+  return payload.workflows;
+}
+
+export async function loadJjhubRepo() {
+  const payload = await workspaceJson<{ repo: WorkspaceRepo }>("/jjhub-repo");
+  return payload.repo;
+}
+
+export async function triggerJjhubWorkflow(workflowID: number, ref: string) {
+  const payload = await workspaceJson<{ run: WorkspaceJjhubWorkflowRun }>("/jjhub-workflows/run", {
+    method: "POST",
+    body: JSON.stringify({ workflowID, ref }),
+  });
+  return payload.run;
+}
+
+export async function getWorkspaceWorkflowSource(workflowKey: string) {
+  const payload = await workspaceJson<{ workflow: WorkspaceWorkflowSource }>(
+    `/workflow-sources/${encodeURIComponent(workflowKey)}`,
+  );
+  return payload.workflow;
+}
+
+export async function getWorkspaceWorkflowFrontend(workflowKey: string) {
+  const payload = await workspaceJson<{ frontend: WorkspaceWorkflowFrontendDescriptor | null }>(
+    `/workflow-frontends/${encodeURIComponent(workflowKey)}`,
+  );
+  return payload.frontend;
+}
+
+export async function startWorkspaceWorkflowFrontend(workflowKey: string) {
+  const payload = await workspaceJson<{ frontend: WorkspaceWorkflowFrontendLaunch }>(
+    `/workflow-frontends/${encodeURIComponent(workflowKey)}/start`,
+    { method: "POST" },
+  );
+  return payload.frontend;
+}
+
+export async function getWorkspaceWorkflowGraph(workflowKey: string) {
+  const payload = await workspaceJson<{ graph: WorkspaceWorkflowGraph }>(
+    `/workflow-sources/${encodeURIComponent(workflowKey)}/graph`,
+  );
+  return payload.graph;
+}
+
+export async function getWorkspaceWorkflowDoctor(workflowKey: string) {
+  const payload = await workspaceJson<{ doctor: WorkspaceWorkflowDoctor }>(
+    `/workflow-sources/${encodeURIComponent(workflowKey)}/doctor`,
+  );
+  return payload.doctor;
+}
+
+export async function updateWorkspaceWorkflowSource(path: string, source: string) {
+  const payload = await workspaceJson<{ path: string }>("/workflow-sources", {
+    method: "PUT",
+    body: JSON.stringify({ path, source }),
+  });
+  return payload;
+}
+
+export async function loadWorkspaceRepo() {
+  const payload = await workspaceJson<{ repo: WorkspaceRepo }>("/changes/repo");
+  return payload.repo;
+}
+
+export async function listWorkspaceChanges(limit = 50) {
+  const search = new URLSearchParams({ limit: String(limit) });
+  const payload = await workspaceJson<{ changes: WorkspaceChange[] }>(`/changes?${search}`);
+  return payload.changes;
+}
+
+export async function getWorkspaceChange(changeID: string) {
+  const payload = await workspaceJson<{ change: WorkspaceChange }>(`/changes/${encodeURIComponent(changeID)}`);
+  return payload.change;
+}
+
+export async function getWorkspaceChangeStatus() {
+  const payload = await workspaceJson<{ status: string }>("/changes/status");
+  return payload.status;
+}
+
+export async function getWorkspaceChangeDiff(changeID?: string | null) {
+  const search = new URLSearchParams();
+  if (changeID?.trim()) {
+    search.set("changeId", changeID.trim());
+  }
+  const payload = await workspaceJson<{ diff: string }>(`/changes/diff${search.size ? `?${search}` : ""}`);
+  return payload.diff;
+}
+
+export async function readWorkspaceFile(path: string) {
+  const search = new URLSearchParams({ path });
+  const payload = await workspaceJson<{ file: WorkspaceFileContent }>(`/files/content?${search}`);
+  return payload.file;
+}
+
+export async function getWorkspaceEditorTarget(params: {
+  kind: WorkspaceEditorTargetKind;
+  path?: string | null;
+  ticketId?: string | null;
+}) {
+  const search = new URLSearchParams({ kind: params.kind });
+  if (params.path) {
+    search.set("path", params.path);
+  }
+  if (params.ticketId) {
+    search.set("ticketId", params.ticketId);
+  }
+  const payload = await workspaceJson<{ target: WorkspaceEditorTarget }>(`/editor/target?${search}`);
+  return payload.target;
+}
+
+export async function saveWorkspaceOperatorScreenshot(params: {
+  fileName: string;
+  pngBase64: string;
+  width?: number | null;
+  height?: number | null;
+}) {
+  const payload = await workspaceJson<{
+    screenshot: {
+      path: string;
+      relativePath: string;
+      fileName: string;
+      bytes: number;
+      width: number | null;
+      height: number | null;
+      capturedAt: string;
+    };
+  }>("/operator/screenshot", {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+  return payload.screenshot;
+}
+
+export async function startWorkspaceTerminalSession(command: string, cwd?: string | null) {
+  const payload = await workspaceJson<{ session: WorkspaceTerminalSession }>("/terminal/sessions", {
+    method: "POST",
+    body: JSON.stringify({ command, cwd: cwd || null }),
+  });
+  return payload.session;
+}
+
+export async function readWorkspaceTerminalSession(sessionId: string) {
+  const payload = await workspaceJson<{ session: WorkspaceTerminalSession }>(
+    `/terminal/sessions/${encodeURIComponent(sessionId)}`,
+  );
+  return payload.session;
+}
+
+export async function sendWorkspaceTerminalSessionInput(sessionId: string, input: string) {
+  const payload = await workspaceJson<{ session: WorkspaceTerminalSession }>(
+    `/terminal/sessions/${encodeURIComponent(sessionId)}`,
+    {
+      method: "POST",
+      body: JSON.stringify({ input }),
+    },
+  );
+  return payload.session;
+}
+
+export async function stopWorkspaceTerminalSession(sessionId: string) {
+  const payload = await workspaceJson<{ session: WorkspaceTerminalSession }>(
+    `/terminal/sessions/${encodeURIComponent(sessionId)}`,
+    { method: "DELETE" },
+  );
+  return payload.session;
+}
+
+export async function requestApplicationFullScreenToggle() {
+  return {
+    requested: false,
+    fullScreen: typeof document !== "undefined" ? Boolean(document.fullscreenElement) : false,
+  };
+}
+
+export async function requestApplicationQuit() {
+  return false;
+}
+
+export async function createWorkspaceBookmark(name: string, changeID: string) {
+  const payload = await workspaceJson<{ bookmark: WorkspaceBookmark }>("/changes/bookmarks", {
+    method: "POST",
+    body: JSON.stringify({ name, changeID }),
+  });
+  return payload.bookmark;
+}
+
+export async function deleteWorkspaceBookmark(name: string) {
+  await workspaceJson<{ ok: true }>("/changes/bookmarks", {
+    method: "DELETE",
+    body: JSON.stringify({ name }),
+  });
+}
+
+export async function listWorkspaceSqlTables() {
+  const payload = await workspaceJson<{ tables: WorkspaceSqlTable[]; dbPath: string }>("/sql/tables");
+  return payload;
+}
+
+export async function getWorkspaceSqlSchema(tableName: string) {
+  const search = new URLSearchParams({ tableName });
+  const payload = await workspaceJson<{ schema: WorkspaceSqlSchema; dbPath: string }>(`/sql/schema?${search}`);
+  return payload;
+}
+
+export async function runWorkspaceSqlQuery(query: string, limit = 500) {
+  return workspaceJson<{ result: WorkspaceSqlResult; dbPath: string }>("/sql/query", {
+    method: "POST",
+    body: JSON.stringify({ query, limit }),
+  });
+}
+
+export async function createWorkspaceTicket(ticketId: string, content: string) {
+  const payload = await workspaceJson<{ ticket: WorkspaceTicket }>("/tickets", {
+    method: "POST",
+    body: JSON.stringify({ ticketId, content }),
+  });
+  return payload.ticket;
+}
+
+export async function updateWorkspaceTicket(ticketId: string, content: string) {
+  const payload = await workspaceJson<{ ticket: WorkspaceTicket }>(`/tickets/${encodeURIComponent(ticketId)}`, {
+    method: "PUT",
+    body: JSON.stringify({ content }),
+  });
+  return payload.ticket;
+}
+
+export async function deleteWorkspaceTicket(ticketId: string) {
+  await workspaceJson<{ ok: true }>(`/tickets/${encodeURIComponent(ticketId)}`, {
+    method: "DELETE",
+  });
+}
+
+export async function searchWorkspace(params: {
+  query: string;
+  scope: WorkspaceSearchScope;
+  issueState?: string | null;
+  limit?: number;
+}) {
+  const search = new URLSearchParams({
+    query: params.query,
+    scope: params.scope,
+    limit: String(params.limit ?? 20),
+  });
+  if (params.issueState) {
+    search.set("issueState", params.issueState);
+  }
+  const payload = await workspaceJson<{ results: WorkspaceSearchResult[] }>(`/search?${search}`);
+  return payload.results;
+}
+
+export async function listWorkspaceMemoryFacts(params: {
+  namespace?: string | null;
+  query?: string;
+  limit?: number;
+} = {}) {
+  const search = new URLSearchParams({ limit: String(params.limit ?? 200) });
+  if (params.namespace) {
+    search.set("namespace", params.namespace);
+  }
+  if (params.query?.trim()) {
+    search.set("query", params.query.trim());
+  }
+  return workspaceJson<{ facts: WorkspaceMemoryFact[]; dbPath: string }>(`/memory?${search}`);
+}
+
+export async function recallWorkspaceMemory(params: {
+  query: string;
+  namespace?: string | null;
+  topK?: number;
+}) {
+  const search = new URLSearchParams({
+    query: params.query,
+    topK: String(params.topK ?? 10),
+  });
+  if (params.namespace) {
+    search.set("namespace", params.namespace);
+  }
+  return workspaceJson<{ results: WorkspaceMemoryRecallResult[]; dbPath: string }>(`/memory/recall?${search}`);
+}
+
+export async function listWorkspaceApprovalHistory(params: { limit?: number } = {}) {
+  const search = new URLSearchParams({ limit: String(params.limit ?? 100) });
+  return workspaceJson<{ decisions: WorkspaceApprovalDecision[]; dbPath: string }>(`/approvals/history?${search}`);
+}
+
+export async function listWorkspaceScores(params: {
+  runId?: string | null;
+  limit?: number;
+} = {}) {
+  const search = new URLSearchParams({ limit: String(params.limit ?? 200) });
+  if (params.runId) {
+    search.set("runId", params.runId);
+  }
+  return workspaceJson<{
+    scores: WorkspaceScoreRow[];
+    aggregates: WorkspaceAggregateScore[];
+    runs: WorkspaceScoreRun[];
+    runAggregates?: WorkspaceScoreScopeAggregate[];
+    nodeAggregates?: WorkspaceScoreScopeAggregate[];
+    workflowAggregates?: WorkspaceScoreScopeAggregate[];
+    tokenMetrics: WorkspaceTokenMetrics;
+    latencyMetrics: WorkspaceLatencyMetrics;
+    costReport: WorkspaceCostReport;
+    dbPath: string;
+  }>(`/scores?${search}`);
+}

--- a/apps/smithers-studio-2/src/workspaceProtocol.ts
+++ b/apps/smithers-studio-2/src/workspaceProtocol.ts
@@ -1,0 +1,19 @@
+export type WorkspaceStatus = {
+  cwd: string;
+  root: string | null;
+  hasSmithers: boolean;
+  smithersPath: string | null;
+  workflowsPath: string | null;
+};
+
+export type WorkspaceBackendRequest = {
+  method?: string;
+  path: string;
+  query?: Record<string, string | null | undefined>;
+  body?: unknown;
+};
+
+export type WorkspaceBackendResponse<TPayload = unknown> = {
+  status: number;
+  payload: TPayload;
+};

--- a/apps/smithers-studio-2/tests/e2e/jjhub-parity.spec.ts
+++ b/apps/smithers-studio-2/tests/e2e/jjhub-parity.spec.ts
@@ -1,0 +1,229 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+type ApiState = {
+  auth: { loggedIn: boolean; tokenSet: boolean; user?: string };
+  issues: Array<{ id: string; number: number; title: string; body: string | null; state: string; labels: string[]; assignees: string[]; commentCount: number }>;
+  landings: Array<{ id: string; number: number; title: string; description: string | null; state: string; targetBranch: string; author: string; createdAt: string; reviewStatus: string | null }>;
+  workspaces: Array<{ id: string; name: string; status: string; createdAt: string }>;
+  snapshots: Array<{ id: string; workspaceId: string; name: string; createdAt: string }>;
+};
+
+function defaultState(): ApiState {
+  return {
+    auth: { loggedIn: true, tokenSet: true, user: "studio-user" },
+    issues: [
+      { id: "issue-11", number: 11, title: "Fix panel refresh", body: "Use workspace routes.", state: "open", labels: ["bug"], assignees: ["will"], commentCount: 2 },
+      { id: "issue-12", number: 12, title: "Closed issue", body: null, state: "closed", labels: [], assignees: [], commentCount: 0 },
+    ],
+    landings: [
+      { id: "landing-7", number: 7, title: "Ship parity panels", description: "Land issues, workspaces, and landings.", state: "open", targetBranch: "main", author: "will", createdAt: "2026-05-27T12:00:00Z", reviewStatus: "pending" },
+    ],
+    workspaces: [
+      { id: "ws-1", name: "studio-main", status: "running", createdAt: "2026-05-27T12:00:00Z" },
+      { id: "ws-2", name: "studio-paused", status: "suspended", createdAt: "2026-05-26T12:00:00Z" },
+    ],
+    snapshots: [
+      { id: "snap-1", workspaceId: "ws-1", name: "before-restore", createdAt: "2026-05-27T12:30:00Z" },
+    ],
+  };
+}
+
+async function installWorkspaceApi(page: Page, state: ApiState) {
+  await page.route("**/__smithers_studio/workspace", async (route) => {
+    await route.fulfill({ json: { cwd: "/tmp/studio", root: "/tmp/studio", hasSmithers: true } });
+  });
+  await page.route("**/__smithers_studio/api/**", async (route) => handleApi(route, state));
+}
+
+async function handleApi(route: Route, state: ApiState) {
+  const request = route.request();
+  const url = new URL(request.url());
+  const path = url.pathname.replace("/__smithers_studio/api", "");
+  let body: Record<string, string | null> = {};
+  try {
+    body = request.postDataJSON() as Record<string, string | null>;
+  } catch {}
+
+  if (path === "/auth/status") return route.fulfill({ json: { auth: state.auth } });
+
+  if (path === "/issues" && request.method() === "GET") {
+    const filter = url.searchParams.get("state");
+    const issues = filter ? state.issues.filter((issue) => issue.state === filter) : state.issues;
+    return route.fulfill({ json: { issues } });
+  }
+  if (path === "/issues" && request.method() === "POST") {
+    const issue = { id: "issue-21", number: 21, title: String(body.title), body: body.body ?? null, state: "open", labels: [], assignees: [], commentCount: 0 };
+    state.issues.unshift(issue);
+    return route.fulfill({ json: { issue } });
+  }
+  const issueClose = path.match(/^\/issues\/(\d+)\/close$/);
+  if (issueClose) {
+    const issue = state.issues.find((entry) => entry.number === Number(issueClose[1]))!;
+    issue.state = "closed";
+    return route.fulfill({ json: { issue } });
+  }
+  const issueReopen = path.match(/^\/issues\/(\d+)\/reopen$/);
+  if (issueReopen) {
+    const issue = state.issues.find((entry) => entry.number === Number(issueReopen[1]))!;
+    issue.state = "open";
+    return route.fulfill({ json: { issue } });
+  }
+  const issueDetail = path.match(/^\/issues\/(\d+)$/);
+  if (issueDetail) {
+    return route.fulfill({ json: { issue: state.issues.find((entry) => entry.number === Number(issueDetail[1])) } });
+  }
+
+  if (path === "/landings" && request.method() === "POST") {
+    const landing = { id: "landing-8", number: 8, title: String(body.title), description: body.body ?? null, state: "open", targetBranch: body.target ?? "main", author: "will", createdAt: "2026-05-27T13:00:00Z", reviewStatus: null };
+    state.landings.unshift(landing);
+    return route.fulfill({ json: { landing } });
+  }
+  if (path === "/landings" && request.method() === "GET") return route.fulfill({ json: { landings: state.landings } });
+  const landingNumber = path.match(/^\/landings\/(\d+)(?:\/(diff|checks|conflicts|review|land))?$/);
+  if (landingNumber) {
+    const landing = state.landings.find((entry) => entry.number === Number(landingNumber[1]))!;
+    if (!landingNumber[2]) return route.fulfill({ json: { landing } });
+    if (landingNumber[2] === "diff") return route.fulfill({ body: JSON.stringify({ diff: "diff --git a/app.tsx b/app.tsx\n@@ -1 +1 @@\n-old\n+new" }), contentType: "application/json" });
+    if (landingNumber[2] === "checks") return route.fulfill({ json: { checks: "typecheck: success\nbuild: success" } });
+    if (landingNumber[2] === "conflicts") return route.fulfill({ json: { conflicts: { conflictStatus: "conflicts", hasConflicts: true, conflicts: [{ filePath: "src/App.tsx", conflictType: "content", resolved: false }] } } });
+    if (landingNumber[2] === "review") {
+      landing.reviewStatus = String(body.action);
+      return route.fulfill({ json: { landing } });
+    }
+    landing.state = "merged";
+    return route.fulfill({ json: { landing } });
+  }
+
+  if (path === "/workspaces" && request.method() === "GET") return route.fulfill({ json: { workspaces: state.workspaces } });
+  if (path === "/workspaces" && request.method() === "POST") {
+    const workspace = { id: `ws-${state.workspaces.length + 1}`, name: String(body.name), status: "running", createdAt: "2026-05-27T14:00:00Z" };
+    state.workspaces.unshift(workspace);
+    return route.fulfill({ json: { workspace } });
+  }
+  if (path === "/workspaces/snapshots" && request.method() === "GET") return route.fulfill({ json: { snapshots: state.snapshots } });
+  if (path === "/workspaces/snapshots" && request.method() === "POST") {
+    const snapshot = { id: `snap-${state.snapshots.length + 1}`, workspaceId: String(body.workspaceId), name: String(body.name), createdAt: "2026-05-27T14:30:00Z" };
+    state.snapshots.unshift(snapshot);
+    return route.fulfill({ json: { snapshot } });
+  }
+  const snapshotDelete = path.match(/^\/workspaces\/snapshots\/([^/]+)$/);
+  if (snapshotDelete && request.method() === "DELETE") {
+    state.snapshots = state.snapshots.filter((entry) => entry.id !== snapshotDelete[1]);
+    return route.fulfill({ json: { ok: true } });
+  }
+  const workspaceAction = path.match(/^\/workspaces\/([^/]+)\/(suspend|resume|fork)$/);
+  if (workspaceAction) {
+    const workspace = state.workspaces.find((entry) => entry.id === workspaceAction[1])!;
+    if (workspaceAction[2] === "suspend") workspace.status = "suspended";
+    if (workspaceAction[2] === "resume") workspace.status = "running";
+    if (workspaceAction[2] === "fork") {
+      const forked = { id: "ws-fork", name: String(body.name), status: "running", createdAt: "2026-05-27T15:00:00Z" };
+      state.workspaces.unshift(forked);
+      return route.fulfill({ json: { workspace: forked } });
+    }
+    return route.fulfill({ json: { ok: true } });
+  }
+  const workspaceDelete = path.match(/^\/workspaces\/([^/]+)$/);
+  if (workspaceDelete && request.method() === "DELETE") {
+    state.workspaces = state.workspaces.filter((entry) => entry.id !== workspaceDelete[1]);
+    return route.fulfill({ json: { ok: true } });
+  }
+
+  return route.fulfill({ status: 404, json: { error: `Unhandled fixture route ${request.method()} ${path}` } });
+}
+
+test("issues use real workspace routes for auth, list, create, detail, close, reopen, and refresh", async ({ page }) => {
+  await installWorkspaceApi(page, defaultState());
+  await page.goto("/");
+  await page.getByRole("button", { name: "Issues" }).click();
+  await expect(page.getByText("Fix panel refresh")).toBeVisible();
+
+  await page.getByRole("button", { name: "New Issue" }).click();
+  await page.getByPlaceholder("Issue title").fill("New route issue");
+  await page.getByPlaceholder("Issue description (optional)").fill("Created through API");
+  await page.getByRole("button", { name: "Create Issue" }).click();
+  await expect(page.getByText("Created issue #21.")).toBeVisible();
+
+  await page.locator(".issue-row", { hasText: "New route issue" }).click();
+  await page.getByRole("button", { name: "Close Issue" }).first().click();
+  await page.getByRole("button", { name: "Close Issue" }).last().click();
+  await expect(page.getByText("Closed issue #21.")).toBeVisible();
+  await page.getByRole("button", { name: "Reopen Issue" }).click();
+  await expect(page.getByText("Reopened issue #21.")).toBeVisible();
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect(page.getByText("Loaded")).toBeVisible();
+});
+
+test("landings expose filters, detail tabs, unified diffs, checks, conflicts, review, and land actions", async ({ page }) => {
+  await installWorkspaceApi(page, defaultState());
+  await page.goto("/");
+  await page.getByRole("button", { name: "Landings" }).click();
+  await page.getByRole("combobox").selectOption("open");
+  await expect(page.locator(".landing-row", { hasText: "Ship parity panels" })).toBeVisible();
+
+  await page.locator(".landing-row", { hasText: "Ship parity panels" }).click();
+  await page.getByRole("button", { name: "Diff" }).click();
+  await expect(page.locator(".diff-content")).toContainText("diff --git");
+  await page.getByRole("button", { name: "Checks" }).click();
+  await expect(page.getByText("typecheck: success")).toBeVisible();
+  await page.getByRole("button", { name: "Conflicts" }).click();
+  await expect(page.getByText("src/App.tsx")).toBeVisible();
+  await page.getByRole("button", { name: "Info" }).click();
+  await page.getByRole("button", { name: "Approve" }).click();
+  await expect(page.getByText("Review submitted: approve.")).toBeVisible();
+  await page.locator(".landing-actions").getByRole("button", { name: "Land" }).click();
+  await expect(page.locator(".modal-content")).toContainText("Land #7");
+  await page.locator(".modal-content").getByRole("button", { name: "Land" }).click();
+  await expect(page.getByText("Landed #7.")).toBeVisible();
+});
+
+test("workspaces support CRUD, suspend/resume, fork, snapshot, delete, and restore naming with snapshot selection", async ({ page }) => {
+  await installWorkspaceApi(page, defaultState());
+  await page.goto("/");
+  await page.getByRole("button", { name: "Workspaces" }).click();
+  await expect(page.getByText("studio-main")).toBeVisible();
+
+  await page.getByRole("button", { name: "New Workspace" }).click();
+  await page.getByPlaceholder("Workspace name").fill("created-ws");
+  await page.getByRole("button", { name: "Create Workspace" }).click();
+  await expect(page.getByText("Created workspace created-ws.")).toBeVisible();
+
+  const studioMain = page.locator(".workspace-item", { hasText: "studio-main" });
+  await studioMain.click();
+  await studioMain.getByRole("button", { name: "Suspend" }).click();
+  await expect(page.getByText("Suspended workspace studio-main.")).toBeVisible();
+  await page.getByRole("button", { name: "Resume" }).first().click();
+  await expect(page.getByText("Resumed workspace studio-main.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Fork" }).first().click();
+  await page.getByPlaceholder("Fork name").fill("forked-ws");
+  await page.getByRole("button", { name: "Fork" }).last().click();
+  await expect(page.getByText("Forked workspace to forked-ws.")).toBeVisible();
+
+  await page.getByRole("combobox").selectOption("snapshots");
+  await page.getByRole("button", { name: "New Snapshot" }).click();
+  await page.getByPlaceholder("Snapshot name").fill("snapshot-from-ui");
+  await page.getByRole("button", { name: "Create Snapshot" }).click();
+  await expect(page.getByText("Created snapshot snapshot-from-ui.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Restore" }).first().click();
+  await page.getByPlaceholder("Restored workspace name").fill("restored-from-ui");
+  await page.getByRole("combobox").last().selectOption("snap-1");
+  await page.locator(".modal-content").getByRole("button", { name: "Restore" }).click();
+  await page.getByRole("button", { name: "Create Workspace" }).click();
+  await expect(page.getByText("Created workspace restored-from-ui.")).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete" }).first().click();
+  await page.getByRole("button", { name: "Delete" }).last().click();
+  await expect(page.getByText(/Deleted workspace|Deleted snapshot/)).toBeVisible();
+});
+
+test("JJHub missing-token states are visible", async ({ page }) => {
+  const state = defaultState();
+  state.auth = { loggedIn: false, tokenSet: false };
+  await installWorkspaceApi(page, state);
+  await page.goto("/");
+  await page.getByRole("button", { name: "Issues" }).click();
+  await expect(page.getByText("JJHub Authentication Required")).toBeVisible();
+  await expect(page.getByText("Please authenticate with JJHub to access issues.")).toBeVisible();
+});

--- a/apps/smithers-studio-2/tests/e2e/pty-server.spec.ts
+++ b/apps/smithers-studio-2/tests/e2e/pty-server.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('PTY Server', () => {
+  test('PTY server health endpoint responds', async ({ request }) => {
+    const response = await request.get('http://127.0.0.1:7401/health');
+    expect(response.status()).toBe(200);
+    expect(await response.text()).toBe('ok');
+  });
+
+  test('PTY WebSocket can create session', async () => {
+    const ws = new WebSocket('ws://127.0.0.1:7401/terminal/ws');
+
+    await new Promise((resolve, reject) => {
+      ws.onopen = resolve;
+      ws.onerror = reject;
+      setTimeout(reject, 5000);
+    });
+
+    // Send session.create request
+    const createMessage = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'session.create',
+      params: { cols: 80, rows: 24 }
+    };
+
+    ws.send(JSON.stringify(createMessage));
+
+    const response = await new Promise((resolve, reject) => {
+      ws.onmessage = (event) => {
+        try {
+          resolve(JSON.parse(event.data));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      setTimeout(() => reject(new Error('timeout')), 5000);
+    });
+
+    console.log('PTY server response:', response);
+
+    if ('error' in response) {
+      throw new Error(`PTY server error: ${response.error.message}`);
+    }
+
+    expect(response).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        sessionId: expect.any(String),
+        pid: expect.any(Number),
+      }
+    });
+
+    ws.close();
+  });
+});

--- a/apps/smithers-studio-2/tests/e2e/terminal-ui.spec.ts
+++ b/apps/smithers-studio-2/tests/e2e/terminal-ui.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Terminal UI', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the terminal WebSocket to avoid PTY server dependency
+    await page.route('**/terminal/ws', route => {
+      route.abort('connectionrefused');
+    });
+  });
+
+  test('displays terminal interface correctly', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Should show the terminal component
+    await expect(page.locator('.terminal-pane')).toBeVisible();
+
+    // Should show PTY server unavailable message
+    await expect(page.locator('.terminal-status')).toContainText(/PTY server unavailable/, { timeout: 5000 });
+
+    // Should still show the Ghostty terminal component structure
+    await expect(page.locator('.ghostty-terminal')).toBeVisible();
+  });
+
+  test('shows terminal tab management UI', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Should show at least one terminal tab
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(1);
+
+    // Should show terminal close button
+    await expect(page.locator('[data-testid="close-terminal"]')).toBeVisible();
+    await expect(page.locator('[data-testid="close-terminal"]')).toBeDisabled(); // Only one tab, can't close
+  });
+
+  test('opens command palette with keyboard shortcut', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Command palette should not be visible initially
+    await expect(page.locator('[data-testid="command-palette"]')).not.toBeVisible();
+
+    // Press Ctrl/Cmd+P to open command palette
+    await page.keyboard.press('Meta+p');
+
+    // Command palette should now be visible
+    await expect(page.locator('[data-testid="command-palette"]')).toBeVisible();
+
+    // Should show "New Terminal" option
+    await expect(page.locator('text=New Terminal')).toBeVisible();
+  });
+
+  test('can create new terminal tab via command palette', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Start with 1 tab
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(1);
+
+    // Open command palette
+    await page.keyboard.press('Meta+p');
+    await expect(page.locator('[data-testid="command-palette"]')).toBeVisible();
+
+    // Type to filter for new terminal
+    await page.keyboard.type('New Terminal');
+    await page.keyboard.press('Enter');
+
+    // Should now have 2 tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+
+    // Close button should now be enabled
+    await expect(page.locator('[data-testid="close-terminal"]')).toBeEnabled();
+  });
+
+  test('can close terminal tabs', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Create a second terminal tab
+    await page.keyboard.press('Meta+p');
+    await page.keyboard.type('New Terminal');
+    await page.keyboard.press('Enter');
+
+    // Should have 2 tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+
+    // Close the current tab
+    await page.locator('[data-testid="close-terminal"]').click();
+
+    // Should be back to 1 tab
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(1);
+
+    // Close button should be disabled again
+    await expect(page.locator('[data-testid="close-terminal"]')).toBeDisabled();
+  });
+
+  test('can switch between terminal tabs', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Create a second terminal tab
+    await page.keyboard.press('Meta+p');
+    await page.keyboard.type('New Terminal');
+    await page.keyboard.press('Enter');
+
+    // Should have 2 tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+
+    // Second tab should be active (has 'active' class or similar visual indication)
+    const secondTab = page.locator('[data-testid="terminal-tab"]').nth(1);
+    await expect(secondTab).toHaveClass(/active/);
+
+    // Click first tab to switch
+    const firstTab = page.locator('[data-testid="terminal-tab"]').first();
+    await firstTab.click();
+
+    // First tab should now be active
+    await expect(firstTab).toHaveClass(/active/);
+    await expect(secondTab).not.toHaveClass(/active/);
+  });
+
+  test('creates new terminal with hotkey', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Start with 1 tab
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(1);
+
+    // Press Ctrl/Cmd+T to create new terminal directly
+    await page.keyboard.press('Meta+t');
+
+    // Should now have 2 tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+  });
+
+  test('handles terminal component lifecycle correctly', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // Terminal should initialize and show unavailable status
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText('PTY server unavailable — start with: bun scripts/dev.ts');
+
+    // Ghostty terminal component should still be rendered
+    await expect(page.locator('.ghostty-terminal')).toBeVisible();
+
+    // Terminal pane should have proper ARIA attributes
+    await expect(page.locator('.terminal-pane')).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  test('shows loading state during terminal initialization', async ({ page }) => {
+    await page.goto('http://127.0.0.1:5500/');
+
+    // The Suspense fallback should appear briefly during Ghostty core loading
+    // Since this is very fast, we mainly test that the structure is correct
+
+    await expect(page.locator('.terminal-pane')).toBeVisible();
+
+    // Either the loading message OR the error message should be visible
+    const hasLoadingOrError = await page.locator('.terminal-loading, .terminal-status').count();
+    expect(hasLoadingOrError).toBeGreaterThan(0);
+  });
+});

--- a/apps/smithers-studio-2/tests/e2e/terminal.spec.ts
+++ b/apps/smithers-studio-2/tests/e2e/terminal.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect, Page } from '@playwright/test';
+
+test.describe('Terminal Integration', () => {
+  test('creates PTY session and displays shell output', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal to initialize and connect
+    await page.waitForSelector('.ghostty-terminal', { timeout: 10000 });
+
+    // Should show terminal status as attached once PTY connects
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Type a simple command and verify output
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('echo "hello terminal"');
+    await page.keyboard.press('Enter');
+
+    // Verify command echo and output appear
+    await expect(page.locator('.ghostty-terminal')).toContainText('echo "hello terminal"', { timeout: 3000 });
+    await expect(page.locator('.ghostty-terminal')).toContainText('hello terminal', { timeout: 3000 });
+  });
+
+  test('handles PTY session lifecycle correctly', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal connection
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Test input handling
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('pwd');
+    await page.keyboard.press('Enter');
+
+    // Should see current directory output
+    await expect(page.locator('.ghostty-terminal')).toContainText(/\/.*/, { timeout: 3000 });
+  });
+
+  test('handles terminal resize properly', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal to load
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Get initial terminal size
+    const terminalElement = page.locator('.ghostty-terminal');
+    await terminalElement.click();
+
+    // Test resize by running stty to check terminal size
+    await page.keyboard.type('stty size');
+    await page.keyboard.press('Enter');
+
+    // Should show some terminal dimensions
+    await expect(terminalElement).toContainText(/\d+ \d+/, { timeout: 3000 });
+
+    // Resize the browser window
+    await page.setViewportSize({ width: 1200, height: 900 });
+
+    // Wait for potential resize event and run stty again
+    await page.waitForTimeout(500);
+    await page.keyboard.type('stty size');
+    await page.keyboard.press('Enter');
+
+    // Should still get valid dimensions (verifies resize doesn't break PTY)
+    await expect(terminalElement).toContainText(/\d+ \d+/, { timeout: 3000 });
+  });
+
+  test('handles multiple terminal tabs with isolation', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for first terminal
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Open command palette to create new terminal
+    await page.keyboard.press('Meta+k'); // Or Ctrl+k on Linux
+    await page.waitForSelector('[data-testid="command-palette"]', { timeout: 3000 });
+    await page.keyboard.type('New Terminal');
+    await page.keyboard.press('Enter');
+
+    // Should now have 2 terminal tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+
+    // Type different commands in each tab to verify isolation
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('echo "tab2"');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.ghostty-terminal')).toContainText('tab2', { timeout: 3000 });
+
+    // Switch to first tab
+    await page.locator('[data-testid="terminal-tab"]').first().click();
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('echo "tab1"');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.ghostty-terminal')).toContainText('tab1', { timeout: 3000 });
+
+    // Verify first tab doesn't show content from second tab
+    await expect(page.locator('.ghostty-terminal')).not.toContainText('tab2');
+  });
+
+  test('handles terminal close and cleanup', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Create a second terminal so we can close one
+    await page.keyboard.press('Meta+k');
+    await page.waitForSelector('[data-testid="command-palette"]', { timeout: 3000 });
+    await page.keyboard.type('New Terminal');
+    await page.keyboard.press('Enter');
+
+    // Should have 2 tabs
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(2);
+
+    // Close the current tab
+    await page.locator('[data-testid="close-terminal"]').click();
+
+    // Should now have 1 tab
+    await expect(page.locator('[data-testid="terminal-tab"]')).toHaveCount(1);
+
+    // Remaining terminal should still work
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('echo "still works"');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.ghostty-terminal')).toContainText('still works', { timeout: 3000 });
+  });
+
+  test('displays process exit status correctly', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Run a command that exits with non-zero code
+    await page.locator('.ghostty-terminal').click();
+    await page.keyboard.type('exit 42');
+    await page.keyboard.press('Enter');
+
+    // Should show process exited message
+    await expect(page.locator('.ghostty-terminal')).toContainText(/process exited with code 42/, { timeout: 5000 });
+
+    // Terminal status should reflect exit
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/exited|ended/i, { timeout: 3000 });
+  });
+
+  test('handles PTY server unavailable gracefully', async ({ page }) => {
+    // This test simulates the PTY server being unavailable
+    // by intercepting the WebSocket connection
+    await page.route('**/terminal/ws', route => {
+      route.abort('connectionrefused');
+    });
+
+    await page.goto('/');
+
+    // Should show PTY server unavailable message
+    await expect(page.locator('.terminal-status')).toContainText(/PTY server unavailable/, { timeout: 5000 });
+
+    // Should still show the terminal component structure
+    await expect(page.locator('.terminal-pane')).toBeVisible();
+  });
+
+  test('maintains scrollback across session', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for terminal
+    await page.waitForSelector('.ghostty-terminal');
+    await expect(page.locator('[data-testid="terminal-status"]')).toHaveText(/attached|connected/i, { timeout: 5000 });
+
+    // Generate multiple lines of output
+    await page.locator('.ghostty-terminal').click();
+    for (let i = 1; i <= 10; i++) {
+      await page.keyboard.type(`echo "line ${i}"`);
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(100); // Small delay between commands
+    }
+
+    // Verify we can see multiple lines in scrollback
+    await expect(page.locator('.ghostty-terminal')).toContainText('line 1', { timeout: 3000 });
+    await expect(page.locator('.ghostty-terminal')).toContainText('line 10', { timeout: 3000 });
+
+    // Test scrolling behavior
+    await page.locator('.ghostty-terminal').press('PageUp');
+    await page.waitForTimeout(500);
+
+    // Should still be able to see earlier content
+    await expect(page.locator('.ghostty-terminal')).toContainText('line 1');
+  });
+});

--- a/apps/smithers-studio-2/tsconfig.json
+++ b/apps/smithers-studio-2/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/apps/smithers-studio-2/vite.config.ts
+++ b/apps/smithers-studio-2/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+const ptyTarget = process.env.PTY_SERVER_URL || "http://127.0.0.1:7342";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "127.0.0.1",
+    port: 5190,
+    proxy: {
+      "/terminal/ws": {
+        target: ptyTarget,
+        ws: true,
+      },
+    },
+  },
+  preview: {
+    host: "127.0.0.1",
+    port: 4190,
+  },
+});

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -32,7 +32,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[63]:
+commands[64]:
   - name: init
     purpose: Install the local workflow pack into .smithers/
     flags[5]{name,short,type,default,desc}:
@@ -97,6 +97,28 @@ commands[63]:
       report,r,string,.smithers/evals/<suite>.json,Report path
       force,,boolean,false,Overwrite an existing report
       include-output,,boolean,true,Include workflow outputs in the report
+      max-concurrency,,number,,Per-workflow task concurrency
+      root,,string,,Tool sandbox root directory
+      log,,boolean,true,Enable NDJSON event log file output
+      log-dir,,string,,NDJSON event logs directory
+      allow-network,,boolean,false,Allow bash tool network requests
+      max-output-bytes,,number,,Max bytes a single tool call can return
+      tool-timeout-ms,,number,,Max wall-clock time per tool call in ms
+      optimization,,string,,Apply a Smithers optimization artifact while running the eval suite
+  - name: optimize
+    purpose: Run GEPA prompt optimization over a workflow eval suite and write an optimized prompt artifact
+    args[1]{name,type,required,desc}:
+      workflow,string,true,Workflow file path or discovered workflow ID
+    flags[16]{name,short,type,default,desc}:
+      cases,c,string,,JSON array, { cases: [...] }, or JSONL case file
+      suite,s,string,,Stable suite ID used in run IDs and report paths
+      provider,p,enum,cerebras,GEPA patch generator provider
+      model,m,string,,Optimizer model for provider-backed GEPA
+      artifact,a,string,,Write the optimized prompt artifact to this path
+      report-dir,,string,,Directory for baseline and optimized eval reports
+      min-improvement,,number,0.000001,Minimum required absolute score improvement
+      max-cases,,number,,Run only the first N cases
+      concurrency,j,number,1,Number of eval cases to run at once
       max-concurrency,,number,,Per-workflow task concurrency
       root,,string,,Tool sandbox root directory
       log,,boolean,true,Enable NDJSON event log file output

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,7 @@
           "cli/quickstart",
           "cli/overview",
           "guides/evals-quickstart",
+          "guides/workflow-optimization",
           "guides/tui",
           "deployment/reference",
           "deployment/control-plane",

--- a/docs/guides/workflow-optimization.mdx
+++ b/docs/guides/workflow-optimization.mdx
@@ -1,0 +1,53 @@
+---
+title: Workflow optimization
+description: Optimize Smithers workflow prompts against eval suites with GEPA-style prompt artifacts.
+---
+
+Smithers can optimize agent task prompts against an eval suite, prove whether the optimized prompts improve the workflow, and save the winning prompt artifact for later runs.
+
+```bash
+bunx smithers-orchestrator optimize workflow.tsx \
+  --cases evals/smoke.jsonl \
+  --suite smoke-gepa \
+  --provider cerebras \
+  --model gpt-oss-120b \
+  --artifact .smithers/optimizations/smoke-gepa.json
+```
+
+`smithers optimize` runs the eval suite twice:
+
+1. baseline run with the workflow's current prompts
+2. optimized run with GEPA-generated prompt patches applied
+
+The command writes the artifact only when the optimized score improves by at least `--min-improvement`. Reports for both runs are written under `.smithers/optimizations/reports` unless `--report-dir` is set.
+
+## Reuse an artifact
+
+Apply the optimized prompts to future evals with `--optimization`:
+
+```bash
+bunx smithers-orchestrator eval workflow.tsx \
+  --cases evals/smoke.jsonl \
+  --suite smoke-optimized \
+  --optimization .smithers/optimizations/smoke-gepa.json
+```
+
+The artifact patches only agent-backed `<Task>` prompts by `nodeId`. Workflow structure, output schemas, retries, approvals, and persistence behavior stay unchanged.
+
+## Providers
+
+`--provider cerebras` uses the Cerebras OpenAI-compatible API and defaults to `gpt-oss-120b`. Set `CEREBRAS_API_KEY` before running the command.
+
+`--provider heuristic` is deterministic and intended for local tests and fixtures. It uses eval-case metadata such as:
+
+```json
+{
+  "metadata": {
+    "optimizationHints": {
+      "answer": "Include the exact rubric requirement in the task prompt."
+    }
+  }
+}
+```
+
+Artifacts are Ax/GEPA-compatible JSON records with baseline score, optimized score, improvement, prompt patches, and linked eval reports.

--- a/docs/guides/workflow-optimization.mdx
+++ b/docs/guides/workflow-optimization.mdx
@@ -68,8 +68,8 @@ Observed result:
 | Provider | Optimizer API | Required env | Default model |
 | --- | --- | --- | --- |
 | `cerebras` | OpenAI-compatible | `CEREBRAS_API_KEY` | `gpt-oss-120b` |
-| `openai-api`, `openai`, `codex` | OpenAI-compatible | `OPENAI_API_KEY` | `gpt-5.3-codex` |
-| `anthropic-api`, `anthropic`, `claude-code`, `claude` | Anthropic Messages API | `ANTHROPIC_API_KEY` | `claude-opus-4-7` |
+| `openai-api`, `openai`, `openai-sdk`, `codex` | OpenAI-compatible | `OPENAI_API_KEY` | `gpt-5.3-codex` |
+| `anthropic-api`, `anthropic`, `anthropic-sdk`, `claude-code`, `claude` | Anthropic Messages API | `ANTHROPIC_API_KEY` | `claude-opus-4-7` |
 | `gemini-api`, `gemini`, `antigravity` | Gemini generateContent API | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | `gemini-3.1-pro-preview` |
 | `kimi`, `moonshot` | OpenAI-compatible Moonshot API | `MOONSHOT_API_KEY` | `kimi-latest` |
 | `opencode`, `pi`, `amp`, `forge`, `openai-compatible` | OpenAI-compatible endpoint | `SMITHERS_OPTIMIZER_API_KEY` and `SMITHERS_OPTIMIZER_BASE_URL` | pass `--model` when needed |

--- a/docs/guides/workflow-optimization.mdx
+++ b/docs/guides/workflow-optimization.mdx
@@ -88,4 +88,4 @@ The CLI provider names (`claude-code`, `codex`, `antigravity`, `gemini`, `kimi`)
 }
 ```
 
-Artifacts are Ax/GEPA-compatible JSON records with baseline score, optimized score, improvement, prompt patches, and linked eval reports.
+Artifacts are Smithers JSON records with baseline score, optimized score, improvement, prompt patches, and linked eval reports.

--- a/docs/guides/workflow-optimization.mdx
+++ b/docs/guides/workflow-optimization.mdx
@@ -34,6 +34,33 @@ bunx smithers-orchestrator eval workflow.tsx \
 
 The artifact patches only agent-backed `<Task>` prompts by `nodeId`. Workflow structure, output schemas, retries, approvals, and persistence behavior stay unchanged.
 
+## Cerebras improvement demo
+
+This PR was verified with `--provider cerebras --model gpt-oss-120b` against a prompt-sensitive workflow fixture. The baseline prompt did not include the required optimization token, so the eval failed. Cerebras GEPA generated a prompt patch that included the missing requirement, and the optimized eval passed.
+
+```bash
+CEREBRAS_API_KEY=... bunx smithers-orchestrator optimize workflow.tsx \
+  --cases evals/opt.jsonl \
+  --suite cerebras-proof \
+  --provider cerebras \
+  --model gpt-oss-120b \
+  --artifact artifacts/optimized.json \
+  --report-dir artifacts/reports \
+  --format json
+```
+
+Observed result:
+
+```json
+{
+  "baseline": { "score": 0.1, "passed": 0, "total": 1 },
+  "optimized": { "score": 1, "passed": 1, "total": 1 },
+  "improved": true,
+  "provider": "cerebras",
+  "model": "gpt-oss-120b"
+}
+```
+
 ## Providers
 
 `--provider cerebras` uses the Cerebras OpenAI-compatible API and defaults to `gpt-oss-120b`. Set `CEREBRAS_API_KEY` before running the command.

--- a/docs/guides/workflow-optimization.mdx
+++ b/docs/guides/workflow-optimization.mdx
@@ -63,7 +63,18 @@ Observed result:
 
 ## Providers
 
-`--provider cerebras` uses the Cerebras OpenAI-compatible API and defaults to `gpt-oss-120b`. Set `CEREBRAS_API_KEY` before running the command.
+`smithers optimize` accepts the same provider vocabulary Smithers uses for agents and accounts:
+
+| Provider | Optimizer API | Required env | Default model |
+| --- | --- | --- | --- |
+| `cerebras` | OpenAI-compatible | `CEREBRAS_API_KEY` | `gpt-oss-120b` |
+| `openai-api`, `openai`, `codex` | OpenAI-compatible | `OPENAI_API_KEY` | `gpt-5.3-codex` |
+| `anthropic-api`, `anthropic`, `claude-code`, `claude` | Anthropic Messages API | `ANTHROPIC_API_KEY` | `claude-opus-4-7` |
+| `gemini-api`, `gemini`, `antigravity` | Gemini generateContent API | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | `gemini-3.1-pro-preview` |
+| `kimi`, `moonshot` | OpenAI-compatible Moonshot API | `MOONSHOT_API_KEY` | `kimi-latest` |
+| `opencode`, `pi`, `amp`, `forge`, `openai-compatible` | OpenAI-compatible endpoint | `SMITHERS_OPTIMIZER_API_KEY` and `SMITHERS_OPTIMIZER_BASE_URL` | pass `--model` when needed |
+
+The CLI provider names (`claude-code`, `codex`, `antigravity`, `gemini`, `kimi`) map to their hosted API equivalents for optimization because GEPA needs a direct model call to propose prompt patches. Providers with no single hosted backend (`opencode`, `pi`, `amp`, `forge`) are still accepted through a generic OpenAI-compatible endpoint.
 
 `--provider heuristic` is deterministic and intended for local tests and fixtures. It uses eval-case metadata such as:
 

--- a/docs/reference/package-configuration.mdx
+++ b/docs/reference/package-configuration.mdx
@@ -68,6 +68,7 @@ Most applications should import from `smithers-orchestrator`. The scoped workspa
 | `@smithers-orchestrator/scorers` | Scorer definitions, LLM judges, batch execution, aggregation, persistence schema, and metrics | [Evals](/concepts/evals), [Evals Quickstart](/guides/evals-quickstart) |
 | `@smithers-orchestrator/server` | HTTP, WebSocket, Gateway, cron, webhook, metrics, and single-workflow serving APIs | [Server](/integrations/server), [Serve](/integrations/serve) |
 | `@smithers-orchestrator/smithers-demo` | Private React Flow demo app for visual workflow generation and graph inspection | [Workflow Studio Demo](/examples/workflow-studio-demo) |
+| `@smithers-orchestrator/smithers-studio-2` | Private Vite and React Studio 2 shell for next-generation workflow UI experiments, terminal panes, and operator views | [Workflow Studio Demo](/examples/workflow-studio-demo) |
 | `@smithers-orchestrator/smithers-tui-demo` | Private React TUI demo app for terminal workflow interaction experiments | [CLI Overview](/cli/overview) |
 | `@smithers-orchestrator/time-travel` | Snapshots, diffs, forks, replay, timelines, VCS tags, rewind locks/audits, and time-travel metrics | [Time Travel](/concepts/time-travel), [Time Travel Quickstart](/guides/time-travel-quickstart) |
 | `@smithers-orchestrator/vcs` | VCS discovery and jj workspace operations such as `runJj`, `workspaceAdd`, `workspaceList`, and pointer reverts | [VCS Helpers](/reference/vcs-helpers), [VCS Guide](/guides/vcs) |

--- a/docs/why-react.mdx
+++ b/docs/why-react.mdx
@@ -46,7 +46,7 @@ React, on the other hand, is one of the most heavily represented domains in the 
 
 So Smithers does the obvious thing: **map orchestration onto a domain agents are already optimized for.** A workflow becomes a component tree. A dependency becomes a conditional render. A loop becomes `<Loop>` with the same `key` semantics agents already know. An iteration's previous output is read with the same mental model as state in a parent component.
 
-This is what we mean by **AX** — agent experience. Just as DX (developer experience) is the discipline of designing tools humans love to use, AX is the discipline of designing tools agents are good at. A great way to set up an agent to perform well on a hard problem is to express the problem in a domain the agent has already mastered.
+This is what we mean by agent experience. Just as DX (developer experience) is the discipline of designing tools humans love to use, agent experience is the discipline of designing tools agents are good at. A great way to set up an agent to perform well on a hard problem is to express the problem in a domain the agent has already mastered.
 
 That is why, as Smithers has stabilized, it has become the orchestration tool agents reach for: not because it's the most powerful (other engines are more featureful), and not because the API is small (it isn't), but because **agents reliably get it right on the first try.** They write a workflow, it runs. They debug a failed task, they fix it. They refactor a 200-task pipeline, they don't break it.
 

--- a/packages/agents/src/CodexAgent.js
+++ b/packages/agents/src/CodexAgent.js
@@ -510,7 +510,7 @@ export class CodexAgent extends BaseCliAgent {
         const resumeSession = typeof params.options?.resumeSession === "string"
             ? params.options.resumeSession
             : undefined;
-        const args = resumeSession ? ["exec", "resume", resumeSession] : ["exec"];
+        const args = resumeSession ? ["exec", "resume"] : ["exec"];
         const yoloEnabled = this.opts.yolo ?? this.yolo;
         const configOverrides = normalizeCodexConfig(this.opts.config);
         for (const entry of configOverrides) {
@@ -520,21 +520,26 @@ export class CodexAgent extends BaseCliAgent {
         pushList(args, "--disable", this.opts.disable);
         pushList(args, "--image", this.opts.image);
         pushFlag(args, "--model", this.opts.model ?? this.model);
-        if (this.opts.oss)
+        if (!resumeSession && this.opts.oss)
             args.push("--oss");
-        pushFlag(args, "--local-provider", this.opts.localProvider);
-        pushFlag(args, "--sandbox", this.opts.sandbox);
-        pushFlag(args, "--profile", this.opts.profile);
-        if (this.opts.fullAuto) {
+        if (!resumeSession)
+            pushFlag(args, "--local-provider", this.opts.localProvider);
+        if (!resumeSession)
+            pushFlag(args, "--sandbox", this.opts.sandbox);
+        if (!resumeSession)
+            pushFlag(args, "--profile", this.opts.profile);
+        if (!resumeSession && this.opts.fullAuto) {
             args.push("--full-auto");
         }
         else if (yoloEnabled || this.opts.dangerouslyBypassApprovalsAndSandbox) {
             args.push("--dangerously-bypass-approvals-and-sandbox");
         }
-        pushFlag(args, "--cd", this.opts.cd);
+        if (!resumeSession)
+            pushFlag(args, "--cd", this.opts.cd);
         if (this.opts.skipGitRepoCheck)
             args.push("--skip-git-repo-check");
-        pushList(args, "--add-dir", this.opts.addDir);
+        if (!resumeSession)
+            pushList(args, "--add-dir", this.opts.addDir);
         if (!resumeSession) {
             pushFlag(args, "--output-schema", this.opts.outputSchema);
         }
@@ -562,6 +567,8 @@ export class CodexAgent extends BaseCliAgent {
         pushFlag(args, "--output-last-message", outputFile);
         if (this.extraArgs?.length)
             args.push(...this.extraArgs);
+        if (resumeSession)
+            args.push(resumeSession);
         const systemPrefix = params.systemPrompt
             ? `${params.systemPrompt}\n\n`
             : "";

--- a/packages/agents/tests/codex-support.test.js
+++ b/packages/agents/tests/codex-support.test.js
@@ -43,6 +43,9 @@ process.stdout.write(JSON.stringify({ type: "turn.completed" }) + "\\n");
             process.env.CODEX_ARGS_FILE = argsFile;
             const agent = new CodexAgent({
                 env: { PATH: process.env.PATH },
+                sandbox: "danger-full-access",
+                dangerouslyBypassApprovalsAndSandbox: true,
+                skipGitRepoCheck: true,
             });
             const result = await agent.generate({
                 prompt: "continue the work",
@@ -50,8 +53,18 @@ process.stdout.write(JSON.stringify({ type: "turn.completed" }) + "\\n");
             });
             expect(result.text).toBe("done");
             const capturedArgs = JSON.parse(await readFile(argsFile, "utf8"));
-            expect(capturedArgs.slice(0, 3)).toEqual(["exec", "resume", "thread-1"]);
+            expect(capturedArgs.slice(0, 2)).toEqual(["exec", "resume"]);
+            expect(capturedArgs).not.toContain("--sandbox");
             expect(capturedArgs).toContain("--json");
+            expect(capturedArgs).toContain("--dangerously-bypass-approvals-and-sandbox");
+            expect(capturedArgs).toContain("--skip-git-repo-check");
+            const sessionIndex = capturedArgs.indexOf("thread-1");
+            expect(sessionIndex).toBeGreaterThan(1);
+            expect(capturedArgs.slice(-2)).toEqual(["thread-1", "-"]);
+            expect(capturedArgs.indexOf("--json")).toBeLessThan(sessionIndex);
+            expect(capturedArgs.indexOf("--output-last-message")).toBeLessThan(sessionIndex);
+            expect(capturedArgs.indexOf("--dangerously-bypass-approvals-and-sandbox")).toBeLessThan(sessionIndex);
+            expect(capturedArgs.indexOf("--skip-git-repo-check")).toBeLessThan(sessionIndex);
         }
         finally {
             await rm(fake.dir, { recursive: true, force: true });

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -5134,14 +5134,14 @@ async function runWorkflowBodyDriver(workflow, opts) {
                 await workflowVersioning.flush();
                 graph.tasks = applyOptimizationArtifactToTasks(graph.tasks);
                 resolveTaskOutputs(graph.tasks, workflowRef);
-            attachSubflowComputeFns(graph.tasks, workflowRef, {
-                rootDir,
-                workflowPath: resolvedWorkflowPath ?? opts.workflowPath,
-            });
-            attachSandboxComputeFns(graph.tasks, workflowRef, {
-                rootDir,
-                workflowPath: resolvedWorkflowPath ?? opts.workflowPath,
-            });
+                attachSubflowComputeFns(graph.tasks, workflowRef, {
+                    rootDir,
+                    workflowPath: resolvedWorkflowPath ?? opts.workflowPath,
+                });
+                attachSandboxComputeFns(graph.tasks, workflowRef, {
+                    rootDir,
+                    workflowPath: resolvedWorkflowPath ?? opts.workflowPath,
+                });
                 lastGraph = graph;
                 descriptorMap = buildDescriptorMap(graph.tasks);
                 workflowName = getWorkflowNameFromXml(graph.xml);

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -49,6 +49,7 @@ import { runWorkflowWithMakeBridge } from "./effect/workflow-make-bridge.js";
 import { createWorkflowVersioningRuntime, getWorkflowPatchDecisions, withWorkflowVersioningRuntime, } from "./effect/versioning.js";
 import { runWithCorrelationContext, updateCurrentCorrelationContext, withCorrelationContext, } from "@smithers-orchestrator/observability/correlation";
 import { extractWorkflowImportSpecifiers, getWorkflowImportScanLoader, readWorkflowEntryHash, readWorkflowGraphHash, resolveWorkflowImport, sha256Hex, } from "./workflow-hash.js";
+import { applyOptimizationArtifactToTasks } from "./optimization-artifact.js";
 /** @typedef {import("@smithers-orchestrator/graph/GraphSnapshot").GraphSnapshot} GraphSnapshot */
 /** @typedef {import("./HijackState.ts").HijackState} HijackState */
 /** @typedef {import("@smithers-orchestrator/driver/RunOptions").RunOptions} RunOptions */
@@ -3983,9 +3984,10 @@ async function renderFrameAsync(workflow, ctx, opts) {
         workflowPath: opts?.workflowPath,
         defaultIteration: ctx?.iteration,
     });
-    const tasks = result.tasks;
+    let tasks = result.tasks;
     // Resolve output tasks: ZodObject references via zodToKeyName, string keys via schemaRegistry
     resolveTaskOutputs(tasks, workflow);
+    tasks = applyOptimizationArtifactToTasks(tasks);
     attachSubflowComputeFns(tasks, workflow, {
         rootDir: opts?.baseRootDir,
         workflowPath: opts?.workflowPath,
@@ -5130,6 +5132,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
             render: async (element, renderOpts) => {
                 const graph = await withWorkflowVersioningRuntime(workflowVersioning, () => renderer.render(element, renderOpts));
                 await workflowVersioning.flush();
+                graph.tasks = applyOptimizationArtifactToTasks(graph.tasks);
                 resolveTaskOutputs(graph.tasks, workflowRef);
             attachSubflowComputeFns(graph.tasks, workflowRef, {
                 rootDir,

--- a/packages/engine/src/index.js
+++ b/packages/engine/src/index.js
@@ -36,6 +36,7 @@ export * from "./effect/diff-bundle.js";
 export * from "./effect/rpc-schema.js";
 export * from "./effect/static-task-bridge.js";
 export * from "./effect/versioning.js";
+export * from "./optimization-artifact.js";
 
 // External helpers
 export * from "./external/json-schema-to-zod.js";

--- a/packages/engine/src/optimization-artifact.js
+++ b/packages/engine/src/optimization-artifact.js
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+
+const OPTIMIZATION_ARTIFACT_ENV = "SMITHERS_OPTIMIZATION_ARTIFACT";
+
+/** @type {Map<string, { mtimeMs: number; artifact: any }>} */
+const artifactCache = new Map();
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {string | null | undefined} path
+ */
+export function loadOptimizationArtifact(path = process.env[OPTIMIZATION_ARTIFACT_ENV]) {
+    if (!path) {
+        return null;
+    }
+    const resolved = resolve(path);
+    if (!existsSync(resolved)) {
+        throw new SmithersError("INVALID_INPUT", `Optimization artifact not found: ${path}`, { path });
+    }
+    const stat = statSync(resolved);
+    const cached = artifactCache.get(resolved);
+    if (cached && cached.mtimeMs === stat.mtimeMs) {
+        return cached.artifact;
+    }
+    const artifact = JSON.parse(readFileSync(resolved, "utf8"));
+    if (!isObject(artifact)) {
+        throw new SmithersError("INVALID_INPUT", "Optimization artifact must be a JSON object.", { path: resolved });
+    }
+    artifactCache.set(resolved, { mtimeMs: stat.mtimeMs, artifact });
+    return artifact;
+}
+
+/**
+ * @param {unknown} artifact
+ * @returns {Record<string, { prompt?: string }>}
+ */
+function promptPatchesFromArtifact(artifact) {
+    if (!isObject(artifact)) {
+        return {};
+    }
+    if (isObject(artifact.promptPatches)) {
+        return /** @type {Record<string, { prompt?: string }>} */ (artifact.promptPatches);
+    }
+    if (isObject(artifact.patches)) {
+        return /** @type {Record<string, { prompt?: string }>} */ (artifact.patches);
+    }
+    return {};
+}
+
+/**
+ * @param {import("@smithers-orchestrator/graph/TaskDescriptor").TaskDescriptor[]} tasks
+ * @param {unknown} [artifact]
+ */
+export function applyOptimizationArtifactToTasks(tasks, artifact = loadOptimizationArtifact()) {
+    if (!artifact) {
+        return tasks;
+    }
+    const promptPatches = promptPatchesFromArtifact(artifact);
+    if (Object.keys(promptPatches).length === 0) {
+        return tasks;
+    }
+    return tasks.map((task) => {
+        const patch = promptPatches[task.nodeId];
+        if (!patch || typeof patch.prompt !== "string" || !task.agent) {
+            return task;
+        }
+        return {
+            ...task,
+            prompt: patch.prompt,
+            meta: {
+                ...(task.meta ?? {}),
+                optimizationArtifactId: typeof artifact.id === "string" ? artifact.id : undefined,
+                optimizationStrategy: typeof artifact.strategy === "string" ? artifact.strategy : undefined,
+            },
+        };
+    });
+}
+
+export { OPTIMIZATION_ARTIFACT_ENV };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,49 @@ importers:
         specifier: ^4.0.16
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
+  apps/smithers-studio-2:
+    dependencies:
+      '@uidotdev/usehooks':
+        specifier: ^2.4.1
+        version: 2.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@wterm/dom':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@wterm/ghostty':
+        specifier: 0.3.0
+        version: 0.3.0
+      '@wterm/react':
+        specifier: 0.3.0
+        version: 0.3.0(@wterm/dom@0.3.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.14
+        version: 8.0.14(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      zustand:
+        specifier: ^5.0.13
+        version: 5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+
   apps/smithers-tui-demo:
     dependencies:
       '@dino-dna/react-tui':
@@ -2713,6 +2756,13 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
+  '@uidotdev/usehooks@2.4.1':
+    resolution: {integrity: sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -2762,6 +2812,22 @@ packages:
 
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+
+  '@wterm/core@0.3.0':
+    resolution: {integrity: sha512-aQ73QBP+eyA3kcn31mA7DmAi7qmEsQijZdmvgwxtSjCi2248EAOZgtkGDpjlspfrxyVxQbUl/IF+gCVcXt4nZQ==}
+
+  '@wterm/dom@0.3.0':
+    resolution: {integrity: sha512-OiUl7reGSlW02yb5wGXMplMZhW2HBkBSFxvbFj15I832UK0QFIHRvhE2l6Xgae8ROn9bNLaALoKDFvcUuz80iQ==}
+
+  '@wterm/ghostty@0.3.0':
+    resolution: {integrity: sha512-TDjEmUSRD7IaFxq31P7+I3Inkp5mHCfBfO6LYj3/vbLbWOkOZOKPhjAcZ36AYFHe9Q0HLCFvLWmrxIO3aGCjDA==}
+
+  '@wterm/react@0.3.0':
+    resolution: {integrity: sha512-1rua/roQGCIGkNxjs9TVq+EkXJ0n2IK6aCoaGIQJpvzuHv7iU9/lngG3i1SCpX6deOOO/wpfhtjDTI+z9XF0aA==}
+    peerDependencies:
+      '@wterm/dom': 0.3.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
@@ -4036,6 +4102,9 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -4869,6 +4938,24 @@ packages:
       immer:
         optional: true
       react:
+        optional: true
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
   zwitch@2.0.4:
@@ -6560,6 +6647,11 @@ snapshots:
       '@types/node': 25.6.0
     optional: true
 
+  '@uidotdev/usehooks@2.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@ungap/structured-clone@1.3.0': {}
 
   '@vercel/oidc@3.2.0': {}
@@ -6609,6 +6701,22 @@ snapshots:
       '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@wterm/core@0.3.0': {}
+
+  '@wterm/dom@0.3.0':
+    dependencies:
+      '@wterm/core': 0.3.0
+
+  '@wterm/ghostty@0.3.0':
+    dependencies:
+      '@wterm/core': 0.3.0
+
+  '@wterm/react@0.3.0(@wterm/dom@0.3.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@wterm/dom': 0.3.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
 
   '@xyflow/react@12.10.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -8034,6 +8142,10 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -8931,5 +9043,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.5
+
+  zustand@5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

Adds Smithers-native prompt optimization to the CLI and engine. A workflow can now be evaluated, optimized, re-evaluated, and saved as an optimization artifact only when the optimized run improves the eval score.

The optimizer provider selection matches the Smithers provider surface. Supported provider names include `cerebras`, `openai-api`/`openai`/`openai-sdk`/`codex`, `anthropic-api`/`anthropic`/`anthropic-sdk`/`claude-code`, `gemini-api`/`gemini`/`antigravity`, `kimi`/`moonshot`, and generic OpenAI-compatible handling for `opencode`, `pi`, `amp`, `forge`, and `openai-compatible`.

## How it works

1. `smithers optimize <workflow> --cases <evals>` renders the workflow against every selected eval case to discover agent-backed prompt tasks, including input-conditional branches.
2. The CLI runs a baseline eval suite and scores pass rate plus assertion pass rate.
3. The selected optimizer model generates prompt patches from task prompts, eval cases, and baseline failures.
4. Smithers writes a temporary candidate artifact and reruns the eval suite with patched prompts.
5. If the optimized score improves by at least `--min-improvement`, Smithers writes the final artifact with baseline/optimized metrics, linked reports, prompt hashes, and patch rationale.
6. Future evals can reuse the artifact with `smithers eval --optimization <artifact.json>`.

## Provider handling

Provider-backed optimization supports three request families:

- OpenAI-compatible chat completions for Cerebras, OpenAI/Codex, Moonshot/Kimi, and generic compatible endpoints.
- Anthropic Messages API for Anthropic, Anthropic SDK, and Claude Code provider aliases.
- Gemini generateContent API for Gemini and Antigravity provider aliases.

Generic agent families without a single hosted optimizer API use `SMITHERS_OPTIMIZER_BASE_URL` and `SMITHERS_OPTIMIZER_API_KEY`, so they are accepted explicitly rather than rejected by the CLI enum.

## Demonstration

Verified with `--provider cerebras --model gpt-oss-120b` against a prompt-sensitive workflow fixture:

```json
{
  "baseline": { "score": 0.1, "passed": 0, "total": 1 },
  "optimized": { "score": 1, "passed": 1, "total": 1 },
  "improved": true,
  "provider": "cerebras",
  "model": "gpt-oss-120b"
}
```

## Review follow-up

A final review pass added three missing pieces:

- Discovery now renders all eval cases before optimization, so prompts that only appear in later input-conditional branches can still be optimized.
- `openai-sdk` and `anthropic-sdk` are accepted as optimizer provider aliases to cover Smithers SDK agent naming as well as account and CLI provider names.
- The optimization command logic now lives in `apps/cli/src/optimize-command.js`, keeping `apps/cli/src/index.js` under the architecture line-budget enforced by CI.

## Files changed

- `apps/cli/src/optimize-command.js`: command options and execution flow for `smithers optimize`.
- `apps/cli/src/optimize-suite.js`: optimization scoring, provider request adapters, patch parsing, artifact writing.
- `apps/cli/src/index.js`: wires `smithers optimize` and `smithers eval --optimization` into the CLI.
- `packages/engine/src/optimization-artifact.js`: artifact loading and prompt patch application by task node id.
- `packages/engine/src/engine.js`: applies optimization artifacts before task execution.
- `apps/cli/tests/optimize-suite.test.js`: deterministic optimization proof, provider request coverage, and conditional-branch discovery regression.
- `docs/guides/workflow-optimization.mdx`: usage, provider matrix, and demonstration.

## Verification

- `/Users/shawwalters/.bun/bin/bun test --timeout 120000 apps/cli/tests/optimize-suite.test.js --max-concurrency=1`
- `./node_modules/.bin/tsc -p apps/cli/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/engine/tsconfig.json --noEmit`
- `node scripts/check-single-effect-version.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-architecture-budget.mjs`
- `git diff --check -- apps/cli/src/index.js apps/cli/src/optimize-command.js apps/cli/src/optimize-suite.js apps/cli/tests/optimize-suite.test.js docs/guides/workflow-optimization.mdx docs/why-react.mdx packages/engine/src/engine.js packages/engine/src/optimization-artifact.js`

The prompt optimization artifact is explicitly Smithers-native: `optimizer.name` is `smithers-gepa`, with no external optimizer compatibility fields.