### PR TITLE
fix(studio): clear restore snapshot id so New Workspace does not silently restore

### DIFF
--- a/apps/smithers-studio-2/package.json
+++ b/apps/smithers-studio-2/package.json
@@ -8,6 +8,7 @@
     "dev": "vite --host 127.0.0.1",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "pnpm run typecheck && vite build",
+    "e2e": "playwright test",
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
@@ -24,6 +25,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3"
   }

--- a/apps/smithers-studio-2/src/WorkspacesPanel.tsx
+++ b/apps/smithers-studio-2/src/WorkspacesPanel.tsx
@@ -341,7 +341,7 @@ export function WorkspacesPanel() {
           </select>
           {mode === "workspaces" && (
             <>
-              <button onClick={() => setShowCreateWorkspace(true)} type="button">New Workspace</button>
+              <button onClick={() => { setRestoreSourceSnapshotId(null); setShowCreateWorkspace(true); }} type="button">New Workspace</button>
               <button onClick={openRestoreWorkspace} type="button">Restore from Snapshot</button>
             </>
           )}
@@ -541,7 +541,7 @@ export function WorkspacesPanel() {
       )}
 
       {showRestoreWorkspace && (
-        <div className="modal-overlay" onClick={() => setShowRestoreWorkspace(false)}>
+        <div className="modal-overlay" onClick={() => { setRestoreSourceSnapshotId(null); setShowRestoreWorkspace(false); }}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <h3>Restore Workspace from Snapshot</h3>
             <div className="form-group">
@@ -580,7 +580,7 @@ export function WorkspacesPanel() {
               >
                 Restore
               </button>
-              <button onClick={() => setShowRestoreWorkspace(false)} type="button">Cancel</button>
+              <button onClick={() => { setRestoreSourceSnapshotId(null); setShowRestoreWorkspace(false); }} type="button">Cancel</button>
             </div>
           </div>
         </div>

--- a/apps/smithers-studio-2/tests/e2e/jjhub-parity.spec.ts
+++ b/apps/smithers-studio-2/tests/e2e/jjhub-parity.spec.ts
@@ -218,6 +218,47 @@ test("workspaces support CRUD, suspend/resume, fork, snapshot, delete, and resto
   await expect(page.getByText(/Deleted workspace|Deleted snapshot/)).toBeVisible();
 });
 
+test("New Workspace after cancelling Restore does not pass a stale snapshotId", async ({ page }) => {
+  await installWorkspaceApi(page, defaultState());
+
+  // Record the snapshotId sent on each workspace-create POST so we can assert
+  // the intended-empty workspace is not silently created from a snapshot.
+  const createSnapshotIds: Array<string | null> = [];
+  await page.route("**/__smithers_studio/api/workspaces", async (route) => {
+    const request = route.request();
+    if (request.method() === "POST") {
+      const body = request.postDataJSON() as { name: string; snapshotId: string | null };
+      createSnapshotIds.push(body.snapshotId ?? null);
+      const workspace = { id: "ws-new", name: String(body.name), status: "running", createdAt: "2026-05-27T16:00:00Z" };
+      return route.fulfill({ json: { workspace } });
+    }
+    return route.fulfill({ json: { workspaces: defaultState().workspaces } });
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Workspaces" }).click();
+  await expect(page.getByText("studio-main")).toBeVisible();
+
+  // Open the Restore modal from a snapshot (this sets restoreSourceSnapshotId).
+  await page.getByRole("combobox").selectOption("snapshots");
+  await page.getByRole("button", { name: "Restore" }).first().click();
+  await expect(page.getByText("Restore Workspace from Snapshot")).toBeVisible();
+
+  // Cancel/dismiss the Restore modal instead of completing the restore.
+  await page.locator(".modal-content").getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByText("Restore Workspace from Snapshot")).toHaveCount(0);
+
+  // Now create a plain New Workspace.
+  await page.getByRole("combobox").first().selectOption("workspaces");
+  await page.getByRole("button", { name: "New Workspace" }).click();
+  await page.getByPlaceholder("Workspace name").fill("empty-ws");
+  await page.getByRole("button", { name: "Create Workspace" }).click();
+  await expect(page.getByText("Created workspace empty-ws.")).toBeVisible();
+
+  // The create must not carry the snapshotId left over from the cancelled restore.
+  expect(createSnapshotIds).toEqual([null]);
+});
+
 test("JJHub missing-token states are visible", async ({ page }) => {
   const state = defaultState();
   state.auth = { loggedIn: false, tokenSet: false };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14


### PR DESCRIPTION
## Bug

In `apps/smithers-studio-2/src/WorkspacesPanel.tsx`, `restoreSourceSnapshotId` is set when the user clicks **Restore** on a snapshot, but it is only cleared on the successful create path (`createWorkspace`).

## Failure scenario

1. User clicks **Restore** on a snapshot → `restoreSourceSnapshotId` is set, the Restore modal opens.
2. User **Cancels** the Restore modal (or dismisses it via the overlay). The stale `restoreSourceSnapshotId` remains in state.
3. User clicks **New Workspace** to create an empty workspace, fills in a name, and clicks **Create**.
4. `createCloudWorkspace(name, restoreSourceSnapshotId)` is called with the leftover snapshot id, silently turning the intended-empty workspace into a restore-from-snapshot.

## Fix

Reset `restoreSourceSnapshotId` back to `null` in:
- the Restore modal **Cancel** handler,
- the Restore modal overlay/dismiss handler,
- the **New Workspace** button `onClick` that opens the create modal.

The successful-restore flow (the Restore button that pre-fills the create modal with the chosen snapshot) is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)