### PR TITLE
fix(openapi): preserve server base-path when building request URLs

### DIFF
--- a/packages/openapi/src/tool-factory/_helpers.js
+++ b/packages/openapi/src/tool-factory/_helpers.js
@@ -57,7 +57,13 @@ export function buildUrl(baseUrl, path, pathParams, queryParams, options) {
     for (const [key, value] of Object.entries(pathParams)) {
         url = url.replace(`{${key}}`, encodeURIComponent(value));
     }
-    const fullUrl = new URL(url, baseUrl);
+    // Join the server base path with the operation path so a base URL with a
+    // path component (e.g. https://api.example.com/v2) is preserved. Passing an
+    // absolute path to `new URL` would otherwise discard the base path.
+    const fullUrl = new URL(baseUrl);
+    const basePath = fullUrl.pathname.replace(/\/+$/, "");
+    const opPath = url.replace(/^\/+/, "");
+    fullUrl.pathname = opPath ? `${basePath}/${opPath}` : basePath || "/";
     // Add query parameters
     for (const [key, value] of Object.entries(queryParams)) {
         fullUrl.searchParams.set(key, value);

--- a/packages/openapi/tests/build-url-base-path.test.js
+++ b/packages/openapi/tests/build-url-base-path.test.js
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------
+// Regression: buildUrl must preserve the server base path
+//
+// `new URL("/users/5", "https://api.example.com/v2")` discards the base
+// path ("/v2") because the operation path is absolute. buildUrl now joins
+// the server base path with the operation path so specs whose server URL
+// carries a base path hit the correct endpoint instead of a 404.
+// ---------------------------------------------------------------------------
+import { describe, test, expect } from "bun:test";
+import { buildUrl } from "../src/tool-factory/_helpers.js";
+
+const noOptions = {};
+
+describe("buildUrl preserves server base path", () => {
+    test("base with path component is retained (no trailing slash)", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2",
+            "/users/{id}",
+            { id: "5" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/v2/users/5");
+    });
+
+    test("base with path component is retained (trailing slash)", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2/",
+            "/users/{id}",
+            { id: "5" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/v2/users/5");
+    });
+
+    test("multi-segment base path is retained", () => {
+        const url = buildUrl(
+            "https://api.example.com/api/v3",
+            "/users/{id}",
+            { id: "5" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/api/v3/users/5");
+    });
+
+    test("base without a path component still works", () => {
+        const url = buildUrl(
+            "https://api.example.com",
+            "/users/{id}",
+            { id: "5" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/users/5");
+    });
+
+    test("query params are appended after the base path is preserved", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2",
+            "/users",
+            {},
+            { limit: "10", tag: "dog" },
+            noOptions,
+        );
+        const parsed = new URL(url);
+        expect(parsed.origin + parsed.pathname).toBe("https://api.example.com/v2/users");
+        expect(parsed.searchParams.get("limit")).toBe("10");
+        expect(parsed.searchParams.get("tag")).toBe("dog");
+    });
+
+    test("path params are substituted within a preserved base path", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2",
+            "/orgs/{org}/users/{id}",
+            { org: "acme", id: "5" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/v2/orgs/acme/users/5");
+    });
+
+    test("apiKey-in-query auth still appends to a preserved base path", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2",
+            "/users/{id}",
+            { id: "5" },
+            {},
+            { auth: { type: "apiKey", name: "api_key", value: "key123", in: "query" } },
+        );
+        const parsed = new URL(url);
+        expect(parsed.origin + parsed.pathname).toBe("https://api.example.com/v2/users/5");
+        expect(parsed.searchParams.get("api_key")).toBe("key123");
+    });
+});


### PR DESCRIPTION
## Bug

`packages/openapi/src/tool-factory/_helpers.js` — `buildUrl` built request URLs with `new URL(path, baseUrl)`. Because operation paths from an OpenAPI spec always start with `/` (e.g. `/users/{id}`), the WHATWG `URL` constructor treats them as absolute and discards the path component of the server base URL.

### Failure scenario

For a spec whose server URL has a base path, e.g. `https://api.example.com/v2`:

```
new URL("/users/5", "https://api.example.com/v2")
// => https://api.example.com/users/5   (the /v2 base path is dropped)
```

Every request then hits the wrong endpoint, typically returning 404. Any OpenAPI spec with a non-root server base path was affected.

## Fix

Join the server base path and the operation path instead of relying on `new URL(path, baseUrl)`:

- Construct the URL from `baseUrl` alone.
- Strip a trailing slash from the base path and a leading slash from the operation path.
- Set `pathname` to `${basePath}/${opPath}` so the base path (e.g. `/v2`) is preserved.

Handles base URLs with and without a trailing slash. Query-string building and path-parameter substitution are unchanged.

Verified results:

```
https://api.example.com/v2  + /users/{id}=5            -> https://api.example.com/v2/users/5
https://api.example.com/v2/ + /users/{id}=5 ?limit=10  -> https://api.example.com/v2/users/5?limit=10
https://api.example.com     + /users/5                 -> https://api.example.com/users/5
https://api.example.com/v2  + /users/5 (apiKey query)  -> https://api.example.com/v2/users/5?k=abc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)