### PR TITLE
fix(driver): handle EPIPE on child stdin to avoid crashing the process

### DIFF
--- a/packages/driver/src/child-process.js
+++ b/packages/driver/src/child-process.js
@@ -199,6 +199,12 @@ export function spawnCaptureEffect(command, args, options) {
         child.on("close", (code) => {
             finalize({ stdout, stderr, exitCode: code ?? null });
         });
+        child.stdin?.on("error", (error) => {
+            logWarning("child process stdin error", {
+                ...logAnnotations,
+                error: error instanceof Error ? error.message : String(error),
+            }, span);
+        });
         if (input) {
             child.stdin?.write(input);
         }

--- a/packages/driver/tests/spawnCaptureEffect.test.js
+++ b/packages/driver/tests/spawnCaptureEffect.test.js
@@ -297,6 +297,40 @@ describe("spawnCaptureEffect — external kill / spawn errors", () => {
   });
 });
 
+describe("spawnCaptureEffect — stdin EPIPE handling", () => {
+  test("large input to a child that closes stdin and exits does not crash with uncaught EPIPE", async () => {
+    // Child immediately closes its stdin and exits. Writing a large payload
+    // into the pipe after the reader is gone triggers an EPIPE error event on
+    // the parent's child.stdin stream. Without an "error" listener on stdin,
+    // that becomes an uncaught exception and crashes the process. The effect
+    // must instead settle (succeed/fail with a handled error).
+    let unhandled = null;
+    const onUnhandled = (err) => {
+      unhandled = err;
+    };
+    process.on("uncaughtException", onUnhandled);
+    try {
+      // ~1 MB payload, well over a pipe buffer, so the write cannot fully
+      // flush before the child has gone away.
+      const bigInput = "x".repeat(1_000_000);
+      const result = await run(
+        "node",
+        ["-e", "process.stdin.destroy(); process.exit(0)"],
+        { input: bigInput },
+      );
+      // The task settled cleanly rather than crashing.
+      expect(typeof result.exitCode === "number" || result.exitCode === null).toBe(
+        true,
+      );
+    } finally {
+      // Give any deferred error event a tick to land before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      process.removeListener("uncaughtException", onUnhandled);
+    }
+    expect(unhandled).toBeNull();
+  });
+});
+
 describe("spawnCaptureEffect — concurrency / fd hygiene", () => {
   test("spawns 20 cheap processes concurrently without leaking", async () => {
     const N = 20;


### PR DESCRIPTION
## Bug

In `packages/driver/src/child-process.js`, the `input` is written to `child.stdin` with no `"error"` listener attached to the stdin stream:

```js
if (input) {
    child.stdin?.write(input);
}
child.stdin?.end();
```

## Failure scenario

If the child process closes its stdin or exits before draining a large input, the write emits an `EPIPE` error on the stdin stream. Because there is no `error` listener, this becomes an unhandled stream error and crashes the entire driver process instead of failing only the single task that owns this child.

## Fix

Attach an `error` handler to `child.stdin` before writing/ending. Pipe errors (EPIPE and similar) are now logged via `logWarning` (matching the existing logging style in this file) rather than surfacing as an uncaught exception. The existing write/end logic is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)