### PR TITLE
fix(scorers): robustly parse judge JSON so a brace in the reason no longer scores 0

### DIFF
--- a/packages/scorers/src/llmJudge.js
+++ b/packages/scorers/src/llmJudge.js
@@ -4,6 +4,69 @@
 /** @typedef {import("./types.js").ScoreResult} ScoreResult */
 
 /**
+ * Extracts and parses a JSON object from a judge's free-form text response.
+ *
+ * First tries `JSON.parse` on the trimmed text. If that fails, scans for the
+ * first `{` and walks forward tracking brace depth while respecting string
+ * literals and escape sequences, so braces inside string values (e.g. a brace
+ * in the `reason`) do not prematurely close the object.
+ *
+ * @param {string} text
+ * @returns {Record<string, unknown> | undefined}
+ */
+function parseJudgeJson(text) {
+    const trimmed = text.trim();
+    try {
+        return JSON.parse(trimmed);
+    }
+    catch {
+        // fall through to balanced-brace extraction
+    }
+    const start = trimmed.indexOf("{");
+    if (start === -1) {
+        return undefined;
+    }
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < trimmed.length; i++) {
+        const char = trimmed[i];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (char === "\\") {
+            if (inString) {
+                escaped = true;
+            }
+            continue;
+        }
+        if (char === '"') {
+            inString = !inString;
+            continue;
+        }
+        if (inString) {
+            continue;
+        }
+        if (char === "{") {
+            depth++;
+        }
+        else if (char === "}") {
+            depth--;
+            if (depth === 0) {
+                try {
+                    return JSON.parse(trimmed.slice(start, i + 1));
+                }
+                catch {
+                    return undefined;
+                }
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
  * Creates an LLM-as-judge scorer that delegates evaluation to an AI agent.
  *
  * The judge agent receives a prompt constructed from `promptTemplate` and is
@@ -41,23 +104,19 @@ export function llmJudge(config) {
             : typeof response?.text === "string"
                 ? response.text
                 : JSON.stringify(response);
-        // Try to parse JSON from the response
-        const jsonMatch = text.match(/\{[\s\S]*?"score"\s*:\s*[\d.]+[\s\S]*?\}/);
-        if (jsonMatch) {
-            try {
-                const parsed = JSON.parse(jsonMatch[0]);
-                const rawScore = Number(parsed.score);
-                return {
-                    score: Number.isFinite(rawScore)
-                        ? Math.max(0, Math.min(1, rawScore))
-                        : 0,
-                    reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
-                    meta: { raw: text },
-                };
-            }
-            catch {
-                // fall through to default
-            }
+        // Try to parse JSON from the response. First attempt the whole trimmed
+        // text, then fall back to the outermost balanced-brace object so that a
+        // brace inside the judge's `reason` string does not truncate the match.
+        const parsed = parseJudgeJson(text);
+        if (parsed && typeof parsed === "object") {
+            const rawScore = Number(parsed.score);
+            return {
+                score: Number.isFinite(rawScore)
+                    ? Math.max(0, Math.min(1, rawScore))
+                    : 0,
+                reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+                meta: { raw: text },
+            };
         }
         // If we can't parse JSON, return a low-confidence score
         return {

--- a/packages/scorers/tests/scorers-llm-judge-parse.test.js
+++ b/packages/scorers/tests/scorers-llm-judge-parse.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { llmJudge } from "../src/index.js";
+
+/**
+ * Builds a mock judge agent that always responds with the given text, so the
+ * tests can exercise the response-parsing logic in isolation.
+ *
+ * @param {string} responseText
+ */
+function mockJudge(responseText) {
+    return {
+        generate: async () => ({ text: responseText }),
+    };
+}
+
+/**
+ * @param {string} responseText
+ */
+function makeScorer(responseText) {
+    return llmJudge({
+        id: "parse-test",
+        name: "Parse Test",
+        description: "Exercises judge response parsing",
+        judge: mockJudge(responseText),
+        instructions: "You are a judge.",
+        promptTemplate: ({ output }) => `Rate: ${String(output)}`,
+    });
+}
+
+const input = { input: "q", output: "a" };
+
+describe("llmJudge response parsing (regression: brace in reason)", () => {
+    test("KEY REGRESSION: a brace in the reason still yields the real score, not 0", async () => {
+        // Pre-fix, the regex /\{[\s\S]*?"score"\s*:\s*[\d.]+[\s\S]*?\}/ stopped at
+        // the first `}` (inside the reason), producing invalid JSON -> score 0.
+        const scorer = makeScorer('{ "score": 0.8, "reason": "nested {obj} here" }');
+        const result = await scorer.score(input);
+        expect(result.score).toBe(0.8);
+        expect(result.reason).toBe("nested {obj} here");
+    });
+
+    test("JSON wrapped in surrounding prose preserves the real score", async () => {
+        const scorer = makeScorer(
+            'Here is my evaluation:\n{"score": 0.7, "reason": "good answer"}\nThanks!',
+        );
+        const result = await scorer.score(input);
+        expect(result.score).toBe(0.7);
+        expect(result.reason).toBe("good answer");
+    });
+
+    test("nested objects in the JSON do not truncate the parse", async () => {
+        const scorer = makeScorer(
+            '{"score": 0.6, "reason": "ok", "details": {"a": 1, "b": {"c": 2}}}',
+        );
+        const result = await scorer.score(input);
+        expect(result.score).toBe(0.6);
+        expect(result.reason).toBe("ok");
+    });
+
+    test("escaped quotes inside the reason are preserved", async () => {
+        const scorer = makeScorer(
+            '{"score": 0.9, "reason": "the model said \\"hi {x}\\" exactly"}',
+        );
+        const result = await scorer.score(input);
+        expect(result.score).toBe(0.9);
+        expect(result.reason).toBe('the model said "hi {x}" exactly');
+    });
+
+    test("well-formed JSON with no braces in reason still works", async () => {
+        const scorer = makeScorer('{"score": 1, "reason": "perfect"}');
+        const result = await scorer.score(input);
+        expect(result.score).toBe(1);
+        expect(result.reason).toBe("perfect");
+    });
+
+    test("genuinely unparseable output falls back to score 0", async () => {
+        const scorer = makeScorer("I cannot produce JSON for this, sorry.");
+        const result = await scorer.score(input);
+        expect(result.score).toBe(0);
+        expect(result.reason).toBe("Failed to parse judge response as JSON");
+    });
+});


### PR DESCRIPTION
## Bug

`packages/scorers/src/llmJudge.js` extracted the judge's JSON using a non-greedy regex:

```js
const jsonMatch = text.match(/\{[\s\S]*?"score"\s*:\s*[\d.]+[\s\S]*?\}/);
```

The trailing `[\s\S]*?\}` stops at the **first** `}` after the score. So whenever the judge's `reason` contains a `{` or `}` (very common when the judge is evaluating structured/JSON-ish content), the captured substring is cut off mid-object. `JSON.parse` then throws, the `catch` falls through, and the scorer silently returns **score 0** with `reason: "Failed to parse judge response as JSON"`.

### Failure scenario

A perfectly valid judge response like:

```json
{"score": 0.9, "reason": "the snippet {foo: 1} looks correct"}
```

gets truncated to `{"score": 0.9, "reason": "the snippet {foo: 1}` (or earlier), fails to parse, and is scored 0 — penalizing good outputs purely because the reason mentions a brace.

## Fix

Replace the brittle regex with a `parseJudgeJson` helper that:

1. First tries `JSON.parse` on the trimmed full text (handles clean responses with no surrounding prose).
2. On failure, scans from the first `{` and walks forward tracking brace depth, **respecting string literals and escape sequences**, returning the outermost balanced-brace object.

This correctly handles braces inside string values, nested objects, escaped quotes, and prose wrapped around the JSON. Behavior is identical for well-formed responses, and the fallback-to-0 is preserved only for truly unparseable output.

Verified against well-formed, brace-in-reason, surrounding-prose, nested-object, escaped-quote, and unparseable cases — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)