### PR TITLE
fix(engine): read binary file content as raw bytes in historical diff bundle

### DIFF
--- a/packages/engine/src/effect/diff-bundle.js
+++ b/packages/engine/src/effect/diff-bundle.js
@@ -44,6 +44,40 @@ async function runGit(cwd, args, options) {
     });
 }
 /**
+ * @param {string} cwd
+ * @param {string[]} args
+ * @param {{ allowExitCodes?: ReadonlySet<number>; }} [options]
+ * @returns {Promise<Buffer>}
+ */
+async function runGitRaw(cwd, args, options) {
+    return new Promise((resolve, reject) => {
+        const child = spawn("git", args, {
+            cwd,
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        /** @type {Buffer[]} */
+        const stdoutChunks = [];
+        let stderr = "";
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => {
+            stdoutChunks.push(chunk);
+        });
+        child.stderr.on("data", (chunk) => {
+            stderr += chunk;
+        });
+        child.once("error", reject);
+        child.once("close", (code) => {
+            const allowExitCodes = options?.allowExitCodes;
+            if (code === 0 || (typeof code === "number" && allowExitCodes?.has(code))) {
+                resolve(Buffer.concat(stdoutChunks));
+                return;
+            }
+            reject(new SmithersError("INVALID_INPUT", `git ${args.join(" ")} failed`, { cwd, args, code, stderr: stderr.trim() }));
+        });
+        child.stdin.end();
+    });
+}
+/**
  * @param {string} diff
  * @returns {string[]}
  */
@@ -179,11 +213,11 @@ async function computeUntrackedDiffs(currentDir) {
  */
 async function readBinaryContentAtRef(currentDir, targetRef, path) {
     try {
-        const { stdout } = await runGit(currentDir, [
+        const stdout = await runGitRaw(currentDir, [
             "show",
             `${targetRef}:${path}`,
         ]);
-        return Buffer.from(stdout, "binary").toString("base64");
+        return stdout.toString("base64");
     }
     catch {
         return undefined;

--- a/packages/engine/tests/diff-bundle.test.js
+++ b/packages/engine/tests/diff-bundle.test.js
@@ -120,6 +120,50 @@ describe("diff bundle", () => {
         }
     });
 
+    test("reproduces exact binary bytes from a ref without UTF-8 corruption", async () => {
+        const repo = makeRepo();
+        try {
+            // Bytes that are NOT valid UTF-8: lone continuation bytes (0x80-0xBF),
+            // 0xFF/0xFE (never valid UTF-8), an overlong/truncated multibyte lead
+            // byte (0xC0 with no continuation), plus NUL. Decoding this as UTF-8
+            // (the old bug) replaces invalid sequences with U+FFFD, mangling the
+            // bytes; reading raw Buffers preserves them exactly.
+            const original = Buffer.from([
+                0x00, 0xff, 0xfe, 0x80, 0x81, 0xbf, 0xc0, 0xc1,
+                0xe2, 0x28, 0xa1, 0xf0, 0x28, 0x8c, 0x28, 0x7f,
+            ]);
+            writeFileSync(join(repo, "payload.bin"), original);
+            commitAll(repo, "add binary payload");
+
+            const base64 = await __diffBundleInternals.readBinaryContentAtRef(repo, "HEAD", "payload.bin");
+            expect(base64).toBe(original.toString("base64"));
+            // Round-trip the embedded content back to bytes and compare exactly.
+            expect(Buffer.from(base64 ?? "", "base64").equals(original)).toBe(true);
+
+            // The ref-based diff bundle must embed the same exact bytes.
+            const empty = await computeDiffBundleBetweenRefs("HEAD", "HEAD", repo, 1);
+            expect(empty.patches).toEqual([]);
+
+            // Modify the binary so the bundle includes a patch for it.
+            const modified = Buffer.from([
+                0x00, 0xff, 0xfe, 0x80, 0x90, 0xbf, 0xc0, 0xc1,
+                0xed, 0xa0, 0x80, 0xf4, 0x90, 0x80, 0x80, 0x00,
+            ]);
+            writeFileSync(join(repo, "payload.bin"), modified);
+            commitAll(repo, "modify binary payload");
+
+            const bundle = await computeDiffBundleBetweenRefs("HEAD~1", "HEAD", repo, 2);
+            const patch = bundle.patches.find((p) => p.path === "payload.bin");
+            expect(patch).toBeDefined();
+            expect(patch?.operation).toBe("modify");
+            expect(patch?.binaryContent).toBe(modified.toString("base64"));
+            expect(Buffer.from(patch?.binaryContent ?? "", "base64").equals(modified)).toBe(true);
+        }
+        finally {
+            cleanup(repo);
+        }
+    });
+
     test("exposes guarded internals for malformed diff and missing binary refs", async () => {
         const repo = makeRepo();
         try {


### PR DESCRIPTION
## Bug

In `packages/engine/src/effect/diff-bundle.js`, `readBinaryContentAtRef` reconstructs binary bytes from a string that `runGit` has already decoded as UTF-8. `runGit` calls `child.stdout.setEncoding("utf8")`, so its `stdout` is a JS string whose non-ASCII bytes have been lossily UTF-8 decoded. Passing that string through `Buffer.from(stdout, "binary").toString("base64")` cannot recover the original bytes.

### Failure scenario

On the `computeDiffBundleBetweenRefs` / `getNodeDiff` (historical, ref-based) path, any binary file present in the diff (images, wasm, etc.) gets its content captured as corrupt base64. When that diff bundle is later applied via `applyPatchFallback`, the decoded bytes do not match the original file, producing a broken artifact.

The sibling `computeDiffBundle` does not have this problem because it reads the binary directly off disk via `readFile` (which returns a `Buffer`).

## Fix

Add a `runGitRaw` variant that collects raw `Buffer` chunks (no `setEncoding("utf8")` on stdout) and returns `Buffer.concat(chunks)`. `readBinaryContentAtRef` now uses `runGitRaw` for `git show <ref>:<path>` and base64-encodes the resulting `Buffer` directly. The text/diff path is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)