### PR TITLE
fix(driver): remove abort listener on normal completion in withAbort

### DIFF
--- a/packages/driver/src/withAbort.js
+++ b/packages/driver/src/withAbort.js
@@ -16,18 +16,23 @@ function throwIfAborted(signal) {
 }
 /**
  * @param {AbortSignal} [signal]
- * @returns {Promise<never> | null}
+ * @returns {{ promise: Promise<never>, cleanup: () => void } | null}
  */
 function abortPromise(signal) {
     if (!signal)
         return null;
     if (signal.aborted)
-        return Promise.reject(makeAbortError());
-    return new Promise((_, reject) => {
-        signal.addEventListener("abort", () => reject(makeAbortError()), {
-            once: true,
-        });
+        return { promise: Promise.reject(makeAbortError()), cleanup: () => {} };
+    /** @type {() => void} */
+    let cleanup = () => {};
+    const promise = new Promise((_, reject) => {
+        function onAbort() {
+            reject(makeAbortError());
+        }
+        signal.addEventListener("abort", onAbort, { once: true });
+        cleanup = () => signal.removeEventListener("abort", onAbort);
     });
+    return { promise, cleanup };
 }
 /**
  * @template T
@@ -39,5 +44,12 @@ export async function withAbort(value, signal) {
     throwIfAborted(signal);
     const abort = abortPromise(signal);
     const promise = Promise.resolve(value);
-    return abort ? Promise.race([promise, abort]) : promise;
+    if (!abort)
+        return promise;
+    try {
+        return await Promise.race([promise, abort.promise]);
+    }
+    finally {
+        abort.cleanup();
+    }
 }

--- a/packages/driver/tests/withAbort.test.js
+++ b/packages/driver/tests/withAbort.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { withAbort } from "../src/withAbort.js";
+
+/**
+ * Wrap an AbortSignal so we can count how many "abort" listeners are added and
+ * removed. The net count (added - removed) reveals listeners that leak when
+ * `withAbort` resolves normally without cleaning up after itself.
+ *
+ * @param {AbortSignal} signal
+ */
+function trackAbortListeners(signal) {
+  const counts = { added: 0, removed: 0 };
+  const originalAdd = signal.addEventListener.bind(signal);
+  const originalRemove = signal.removeEventListener.bind(signal);
+  signal.addEventListener = (type, ...rest) => {
+    if (type === "abort") counts.added += 1;
+    // @ts-expect-error - forwarding variadic args to the original method
+    return originalAdd(type, ...rest);
+  };
+  signal.removeEventListener = (type, ...rest) => {
+    if (type === "abort") counts.removed += 1;
+    // @ts-expect-error - forwarding variadic args to the original method
+    return originalRemove(type, ...rest);
+  };
+  return counts;
+}
+
+describe("withAbort — listener cleanup", () => {
+  test("removes the abort listener after normal completion", async () => {
+    const controller = new AbortController();
+    const counts = trackAbortListeners(controller.signal);
+
+    await withAbort("done", controller.signal);
+
+    // Whatever listener was attached must be removed on normal completion.
+    expect(counts.added).toBe(counts.removed);
+    expect(counts.added - counts.removed).toBe(0);
+  });
+
+  test("does not accumulate listeners across many normal completions", async () => {
+    const controller = new AbortController();
+    const counts = trackAbortListeners(controller.signal);
+
+    for (let i = 0; i < 1000; i++) {
+      await withAbort(i, controller.signal);
+    }
+
+    // Net lingering listeners after 1000 normal completions must be zero.
+    expect(counts.added - counts.removed).toBe(0);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  test("still resolves with the underlying value", async () => {
+    const controller = new AbortController();
+    const result = await withAbort(Promise.resolve(42), controller.signal);
+    expect(result).toBe(42);
+  });
+});


### PR DESCRIPTION
## Bug

`packages/driver/src/withAbort.js` `abortPromise` adds an `"abort"` event listener (with `{ once: true }`) to the provided `AbortSignal`. The `{ once: true }` option only removes the listener if the abort event actually fires. When the wrapped value settles normally (the common case), `Promise.race` resolves with that value but the listener stays attached to the signal.

## Failure scenario

A run uses a single long-lived `AbortSignal` for its entire lifetime. Every task and every poll wraps work in `withAbort`, and the vast majority complete normally without ever aborting. Each of those calls leaves a dangling `"abort"` listener on the shared signal. Over a run this accumulates into:

- `MaxListenersExceededWarning` on the signal/emitter, and
- steady memory growth from the retained listener closures.

## Fix

`abortPromise` now captures the listener in a named `onAbort` function and returns the race promise alongside a `cleanup` function that calls `signal.removeEventListener("abort", onAbort)`. `withAbort` awaits `Promise.race(...)` inside a `try { ... } finally { abort.cleanup(); }`, so the listener is removed on both the resolve and the reject paths. This mirrors the `removeEventListener` cleanup pattern already used in `packages/agents/src/BaseCliAgent/runRpcCommandEffect.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)