### PR TITLE
fix(components): populate Approval decidedAt and evaluate autoApprove callbacks once

### DIFF
--- a/packages/components/src/components/Approval.js
+++ b/packages/components/src/components/Approval.js
@@ -123,16 +123,18 @@ export function Approval(props) {
     if ((mode === "select" || mode === "rank") && (!options || options.length === 0)) {
         throw new SmithersError("APPROVAL_OPTIONS_REQUIRED", `Approval ${props.id} requires options when mode="${mode}".`);
     }
+    const conditionMet = props.autoApprove
+        ? evaluateBooleanCallback(props.autoApprove.condition, ctx)
+        : undefined;
+    const revertOnMet = props.autoApprove
+        ? evaluateBooleanCallback(props.autoApprove.revertOn, ctx)
+        : undefined;
     const autoApprove = props.autoApprove
         ? {
             ...(typeof props.autoApprove.after === "number" ? { after: props.autoApprove.after } : {}),
             audit: props.autoApprove.audit !== false,
-            ...(evaluateBooleanCallback(props.autoApprove.condition, ctx) !== undefined
-                ? { conditionMet: evaluateBooleanCallback(props.autoApprove.condition, ctx) }
-                : {}),
-            ...(evaluateBooleanCallback(props.autoApprove.revertOn, ctx) !== undefined
-                ? { revertOnMet: evaluateBooleanCallback(props.autoApprove.revertOn, ctx) }
-                : {}),
+            ...(conditionMet !== undefined ? { conditionMet } : {}),
+            ...(revertOnMet !== undefined ? { revertOnMet } : {}),
         }
         : undefined;
     const requestMeta = {
@@ -177,7 +179,7 @@ export function Approval(props) {
             approved: approval?.status === "approved",
             note: approval?.note ?? null,
             decidedBy: approval?.decidedBy ?? null,
-            decidedAt: null,
+            decidedAt: approval?.decidedAtMs != null ? new Date(approval.decidedAtMs).toISOString() : null,
         };
     };
     return React.createElement("smithers:task", {

--- a/packages/components/tests/approval-decided-at.test.jsx
+++ b/packages/components/tests/approval-decided-at.test.jsx
@@ -1,0 +1,131 @@
+/** @jsxImportSource smithers-orchestrator */
+import { describe, expect, test } from "bun:test";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { withTaskRuntime } from "@smithers-orchestrator/driver/task-runtime";
+import { SmithersRenderer } from "@smithers-orchestrator/react-reconciler/dom/renderer";
+import { Approval } from "../src/components/index.js";
+import { createTestSmithers } from "./helpers.js";
+
+async function render(el) {
+    const renderer = new SmithersRenderer();
+    return renderer.render(el);
+}
+
+function runtimeFor(db, runId, nodeId, iteration = 0) {
+    return { db, runId, nodeId, iteration };
+}
+
+describe("Approval regression: decidedAt and autoApprove callback evaluation", () => {
+    test("decision output decidedAt reflects decidedAtMs as an ISO string", async () => {
+        const decidedAtMs = 1_716_000_000_000;
+        const { db, cleanup } = createTestSmithers({});
+        ensureSmithersTables(db);
+        const adapter = new SmithersDb(db);
+        try {
+            await adapter.insertOrUpdateApproval({
+                runId: "run",
+                nodeId: "approval-decided-at",
+                iteration: 0,
+                status: "approved",
+                requestedAtMs: 1,
+                decidedAtMs,
+                note: "looks good",
+                decidedBy: "alice",
+                requestJson: null,
+                decisionJson: null,
+                autoApproved: false,
+            });
+
+            const rendered = await render(
+                <Approval id="approval-decided-at" output="out" request={{ title: "Approve" }} />,
+            );
+
+            const decision = await withTaskRuntime(
+                runtimeFor(db, "run", "approval-decided-at"),
+                () => rendered.tasks[0].computeFn(),
+            );
+
+            // Pre-fix this was hardcoded to null. It must reflect the stored decidedAtMs.
+            expect(decision.decidedAt).not.toBeNull();
+            expect(decision.decidedAt).toBe(new Date(decidedAtMs).toISOString());
+            expect(decision).toEqual({
+                approved: true,
+                note: "looks good",
+                decidedBy: "alice",
+                decidedAt: new Date(decidedAtMs).toISOString(),
+            });
+        }
+        finally {
+            cleanup();
+        }
+    });
+
+    test("decision output decidedAt stays null when decidedAtMs is unset", async () => {
+        const { db, cleanup } = createTestSmithers({});
+        ensureSmithersTables(db);
+        const adapter = new SmithersDb(db);
+        try {
+            await adapter.insertOrUpdateApproval({
+                runId: "run",
+                nodeId: "approval-no-decided-at",
+                iteration: 0,
+                status: "approved",
+                requestedAtMs: 1,
+                decidedAtMs: null,
+                note: null,
+                decidedBy: null,
+                requestJson: null,
+                decisionJson: null,
+                autoApproved: false,
+            });
+
+            const rendered = await render(
+                <Approval id="approval-no-decided-at" output="out" request={{ title: "Approve" }} />,
+            );
+
+            const decision = await withTaskRuntime(
+                runtimeFor(db, "run", "approval-no-decided-at"),
+                () => rendered.tasks[0].computeFn(),
+            );
+
+            expect(decision.decidedAt).toBeNull();
+        }
+        finally {
+            cleanup();
+        }
+    });
+
+    test("autoApprove.condition callback is invoked exactly once per render", async () => {
+        let conditionCalls = 0;
+        let revertOnCalls = 0;
+
+        const rendered = await render(
+            <Approval
+                id="approval-once"
+                output="out"
+                request={{ title: "Auto" }}
+                autoApprove={{
+                    condition: () => {
+                        conditionCalls += 1;
+                        return true;
+                    },
+                    revertOn: () => {
+                        revertOnCalls += 1;
+                        return false;
+                    },
+                }}
+            />,
+        );
+
+        // Pre-fix the callbacks were evaluated twice (once in the guard, once in
+        // the spread). Each callback must run exactly once per render.
+        expect(conditionCalls).toBe(1);
+        expect(revertOnCalls).toBe(1);
+        expect(rendered.tasks[0].approvalAutoApprove).toEqual({
+            audit: true,
+            conditionMet: true,
+            revertOnMet: false,
+        });
+    });
+});

--- a/packages/components/tests/remaining-coverage.test.jsx
+++ b/packages/components/tests/remaining-coverage.test.jsx
@@ -207,7 +207,7 @@ describe("remaining component branch coverage", () => {
                 approved: true,
                 note: "approved note",
                 decidedBy: "carol",
-                decidedAt: null,
+                decidedAt: new Date(2).toISOString(),
             });
             await expect(
                 withTaskRuntime(runtimeFor(db, "run", "approval-invalid-json"), () => invalidJson.tasks[0].computeFn()),

--- a/packages/engine/tests/approval-component.test.jsx
+++ b/packages/engine/tests/approval-component.test.jsx
@@ -137,7 +137,9 @@ describe("<Approval>", () => {
         expect(approvalRows[0]?.approved).toBe(false);
         expect(approvalRows[0]?.note).toBe("Needs another review");
         expect(approvalRows[0]?.decidedBy).toBe("qa-user");
-        expect(approvalRows[0]?.decidedAt).toBeNull();
+        const approvalRecord = await Effect.runPromise(adapter.getApproval(first.runId, "publish-gate", 0));
+        expect(approvalRecord?.decidedAtMs).not.toBeNull();
+        expect(approvalRows[0]?.decidedAt).toBe(new Date(approvalRecord.decidedAtMs).toISOString());
         const resultRows = await db.select().from(tables.result);
         expect(resultRows).toHaveLength(1);
         expect(resultRows[0]?.status).toBe("denied");


### PR DESCRIPTION
## Bug

`packages/components/src/components/Approval.js` had two defects:

1. **Lost decision timestamp.** In the `decision` branch of `computeDecision`, the returned object hardcoded `decidedAt: null` even though the underlying `approval` row carries `decidedAtMs` (`number | null`). The timestamp at which a human approved/denied was silently dropped, despite the `approvalDecisionSchema` declaring `decidedAt: z.string().datetime().nullable()`.

2. **Callbacks evaluated twice.** `autoApprove.condition` and `autoApprove.revertOn` were each invoked twice — once for the `!== undefined` guard and again for the stored `conditionMet` / `revertOnMet` value. Since these are user-supplied callbacks, calling them twice risks divergent return values and double side-effects.

## Failure scenario

- A reviewer approves an Approval node; the resolved decision output reports `decidedAt: null`, so any downstream consumer (audit log, UI timeline, eval) cannot recover when the decision was made.
- An `autoApprove.condition` callback that mutates state or reads a changing value (e.g. a counter, clock, or DB lookup) is run twice per render, producing inconsistent `conditionMet` and duplicated effects.

## Fix

1. Populate `decidedAt` from `approval.decidedAtMs`: `approval?.decidedAtMs != null ? new Date(approval.decidedAtMs).toISOString() : null`, matching the schema and mirroring `HumanTask.js`'s use of `approval.decidedAtMs`.
2. Evaluate each `evaluateBooleanCallback(...)` once into a local (`conditionMet`, `revertOnMet`) and reuse it for both the guard and the stored value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)