### PR TITLE
fix(agents): stop double-counting Claude stream-json tokens from the result event

### DIFF
--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -458,6 +458,7 @@ export function extractUsageFromOutput(raw) {
     const lines = stripOscSequences(raw).split(/\r?\n/).filter(Boolean);
     const usage = {};
     let found = false;
+    let countedIncremental = false;
     for (const line of lines) {
         let parsed;
         try {
@@ -480,6 +481,7 @@ export function extractUsageFromOutput(raw) {
                     (usage.cacheWriteTokens ?? 0) + u.cache_creation_input_tokens;
             }
             found = true;
+            countedIncremental = true;
             continue;
         }
         if (parsed.type === "message_delta" && parsed.usage) {
@@ -488,7 +490,18 @@ export function extractUsageFromOutput(raw) {
                     (usage.outputTokens ?? 0) + parsed.usage.output_tokens;
             }
             found = true;
+            countedIncremental = true;
             continue;
+        }
+        if (parsed.type === "result") {
+            // Claude Code stream-json emits a terminal "result" event whose
+            // top-level usage summarizes tokens already accumulated from the
+            // per-message message_start/message_delta events. If we counted
+            // those incrementally, skip this event to avoid double-counting.
+            // Otherwise fall through so the usage is still captured.
+            if (countedIncremental) {
+                continue;
+            }
         }
         if (parsed.type === "turn.completed" && parsed.usage) {
             const u = parsed.usage;

--- a/packages/agents/tests/extract-usage.test.js
+++ b/packages/agents/tests/extract-usage.test.js
@@ -21,6 +21,32 @@ describe("extractUsageFromOutput", () => {
     expect(usage.cacheWriteTokens).toBe(200);
   });
 
+  test("does not double-count Claude stream-json terminal result event", () => {
+    const lines = [
+      JSON.stringify({ type: "message_start", message: { usage: { input_tokens: 1523, cache_creation_input_tokens: 200, cache_read_input_tokens: 50, output_tokens: 1 } } }),
+      JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } }),
+      JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 42 } }),
+      JSON.stringify({ type: "message_stop" }),
+      JSON.stringify({ type: "result", subtype: "success", usage: { input_tokens: 1523, output_tokens: 42, cache_creation_input_tokens: 200, cache_read_input_tokens: 50 } }),
+    ];
+    const raw = lines.join("\n");
+    const usage = extractUsageFromOutput(raw);
+    expect(usage).toBeDefined();
+    expect(usage.inputTokens).toBe(1523);
+    expect(usage.outputTokens).toBe(42);
+    expect(usage.cacheReadTokens).toBe(50);
+    expect(usage.cacheWriteTokens).toBe(200);
+  });
+
+  test("falls back to result usage when no incremental events were seen", () => {
+    const raw = JSON.stringify({ type: "result", subtype: "success", usage: { input_tokens: 800, output_tokens: 90, cache_read_input_tokens: 30 } });
+    const usage = extractUsageFromOutput(raw);
+    expect(usage).toBeDefined();
+    expect(usage.inputTokens).toBe(800);
+    expect(usage.outputTokens).toBe(90);
+    expect(usage.cacheReadTokens).toBe(30);
+  });
+
   test("extracts tokens from Codex --json JSONL with turn.completed", () => {
     const lines = [
       JSON.stringify({ type: "turn.started", session_id: "sess-1" }),


### PR DESCRIPTION
## Bug

In `packages/agents/src/BaseCliAgent/BaseCliAgent.js`, `extractUsageFromOutput` parses Claude Code `stream-json` NDJSON and accumulates usage incrementally:

- `message_start` adds input tokens (and cache read/write).
- `message_delta` adds output tokens.

Claude Code's stream-json output ends with a terminal `{"type":"result",...}` event whose top-level `usage` object is a **summary** of the tokens already counted from those incremental events. That `result` event had no dedicated branch, so it fell through to the generic `parsed.usage` accumulation branch and added the same input/output tokens a second time.

### Failure scenario

For a normal Claude stream-json run, `agentTokensTotal` and the reported usage were inflated by roughly 2x (the per-message totals plus the result-event summary of those same totals).

## Fix

`extractUsageFromOutput` now tracks whether incremental usage was counted (`countedIncremental`) from `message_start`/`message_delta`. When a `type === "result"` event is encountered:

- If incremental usage was already counted, the event is skipped (no double count).
- Otherwise it falls through to the generic branch so result usage is still captured.

Non-stream-json formats (`turn.completed`, `step_finish`, Gemini `stats.models`, generic `usage`) are unchanged.

Added two regression tests in `packages/agents/tests/extract-usage.test.js`:
- A full stream-json sequence ending in a `result` event asserts no double counting.
- A standalone `result` event asserts fallback capture still works.

All 9 tests in that file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)