### PR TITLE
fix(gateway-react): reset events when runId changes in useGatewayRunEvents

### DIFF
--- a/packages/gateway-react/src/useGatewayRunEvents.ts
+++ b/packages/gateway-react/src/useGatewayRunEvents.ts
@@ -14,6 +14,7 @@ export function useGatewayRunEvents(runId: string | undefined, options: { afterS
       return;
     }
     const abort = new AbortController();
+    setEvents([]);
     setStreaming(true);
     setError(undefined);
     void (async () => {


### PR DESCRIPTION
## Bug

`packages/gateway-react/src/useGatewayRunEvents.ts` accumulates events from the gateway run-event stream into a `useState` array. The streaming effect re-runs whenever `runId` changes, restarting the subscription against the new run — but it never clears the existing `events` array.

## Failure scenario

A component that switches from run A to run B keeps the events already collected for run A and then appends run B's events on top, so the consumer sees A's events followed by B's instead of just B's. The same stale-data problem applies to any re-subscription triggered by a `runId` (or `afterSeq`) change.

## Fix

Call `setEvents([])` at the start of the effect, before subscribing to the new stream, so events from the previous run are not retained. `error` is already reset via `setError(undefined)` and `streaming` is set in the same block, so only the events array needed clearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)