### PR TITLE
fix(server): runRegistry cleanup, prototype-safe token lookup, JWT exp required, WS error frame id

### DIFF
--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -939,7 +939,10 @@ function verifyJwtToken(token, config) {
     if (!audiences.some((audience) => tokenAudiences.includes(audience))) {
         return { ok: false, message: "JWT audience did not match" };
     }
-    if (typeof exp === "number" && now - skew >= exp) {
+    if (typeof exp !== "number") {
+        return { ok: false, message: "JWT is missing a valid exp claim" };
+    }
+    if (now - skew >= exp) {
         return { ok: false, message: "JWT has expired" };
     }
     if (typeof nbf === "number" && now + skew < nbf) {
@@ -2490,6 +2493,7 @@ export class Gateway {
             }
         })
             .finally(() => {
+            this.runRegistry.delete(runId);
             this.activeRuns.delete(runId);
             this.inflightRuns.delete(runId);
         });
@@ -2555,8 +2559,10 @@ export class Gateway {
         });
         ws.on("message", async (raw) => {
             this.recordMessageReceived("ws", "request");
+            /** @type {RequestFrame | undefined} */
+            let frame;
             try {
-                const frame = parseGatewayRequestFrame(raw, this.maxPayload);
+                frame = parseGatewayRequestFrame(raw, this.maxPayload);
                 const response = await this.executeRpc(connection, frame, async () => {
                     if (!connection.authenticated && frame.method !== "connect") {
                         return responseError(frame.id, "UNAUTHORIZED", "Connect first");
@@ -2582,10 +2588,10 @@ export class Gateway {
                     ...gatewayErrorAnnotations(error),
                 }, "gateway:rpc:invalid");
                 if (isSmithersError(error)) {
-                    this.sendResponse(connection, responseError("invalid", error.code, error.summary));
+                    this.sendResponse(connection, responseError(frame?.id ?? "invalid", error.code, error.summary));
                     return;
                 }
-                this.sendResponse(connection, responseError("server", "SERVER_ERROR", error?.message ?? "Gateway request failed"));
+                this.sendResponse(connection, responseError(frame?.id ?? "server", "SERVER_ERROR", error?.message ?? "Gateway request failed"));
             }
         });
         let cleanedUp = false;
@@ -2750,7 +2756,7 @@ export class Gateway {
                     message: "A bearer token is required",
                 };
             }
-            const grant = this.auth.tokens[token];
+            const grant = Object.hasOwn(this.auth.tokens, token) ? this.auth.tokens[token] : undefined;
             if (!grant) {
                 return {
                     ok: false,

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -939,12 +939,8 @@ function verifyJwtToken(token, config) {
     if (!audiences.some((audience) => tokenAudiences.includes(audience))) {
         return { ok: false, message: "JWT audience did not match" };
     }
-    if (typeof exp !== "number") {
-        return { ok: false, message: "JWT is missing a valid exp claim" };
-    }
-    if (now - skew >= exp) {
-        return { ok: false, message: "JWT has expired" };
-    }
+    if (typeof exp !== "number") return { ok: false, message: "JWT is missing a valid exp claim" };
+    if (now - skew >= exp) return { ok: false, message: "JWT has expired" };
     if (typeof nbf === "number" && now + skew < nbf) {
         return { ok: false, message: "JWT is not active yet" };
     }
@@ -2493,9 +2489,7 @@ export class Gateway {
             }
         })
             .finally(() => {
-            this.runRegistry.delete(runId);
-            this.activeRuns.delete(runId);
-            this.inflightRuns.delete(runId);
+            for (const m of [this.runRegistry, this.activeRuns, this.inflightRuns]) m.delete(runId);
         });
         this.inflightRuns.set(runId, runPromise.then(() => undefined, () => undefined));
         return { runId, workflow: workflowKey };
@@ -2559,8 +2553,7 @@ export class Gateway {
         });
         ws.on("message", async (raw) => {
             this.recordMessageReceived("ws", "request");
-            /** @type {RequestFrame | undefined} */
-            let frame;
+            /** @type {RequestFrame | undefined} */ let frame;
             try {
                 frame = parseGatewayRequestFrame(raw, this.maxPayload);
                 const response = await this.executeRpc(connection, frame, async () => {

--- a/packages/server/tests/gateway.test.jsx
+++ b/packages/server/tests/gateway.test.jsx
@@ -763,4 +763,140 @@ describe("Gateway", () => {
         ]);
         await client.close();
     });
+    test("rejects token-mode bearer tokens that collide with Object prototype keys", async () => {
+        const dbPath = makeDbPath("proto-token");
+        dbPaths.push(dbPath);
+        gateway = new Gateway({
+            protocol: 1,
+            features: ["runs"],
+            heartbeatMs: 100,
+            auth: {
+                mode: "token",
+                tokens: {
+                    "op-token": {
+                        role: "operator",
+                        scopes: ["*"],
+                        userId: "user:will",
+                    },
+                },
+            },
+        });
+        gateway.register("basic", createValueWorkflow(dbPath));
+        server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+        const port = getPort(server);
+        // Magic prototype keys resolve to truthy inherited members on a plain
+        // object, so a direct `tokens[token]` lookup would treat them as valid
+        // grants. They must be rejected as unauthorized instead.
+        for (const magicToken of ["toString", "__proto__", "constructor", "hasOwnProperty"]) {
+            const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+            await new Promise((resolve, reject) => {
+                ws.once("open", () => resolve());
+                ws.once("error", reject);
+            });
+            const attacker = new GatewayClient(ws);
+            await attacker.waitFor((message) => message.type === "event" && message.event === "connect.challenge");
+            const hello = await attacker.request("connect", {
+                minProtocol: 1,
+                maxProtocol: 1,
+                client: {
+                    id: "proto-client",
+                    version: "1.0.0",
+                    platform: "bun-test",
+                },
+                auth: { token: magicToken },
+            });
+            expect(hello.ok).toBe(false);
+            expect(hello.error.code).toBe("UNAUTHORIZED");
+            await attacker.close();
+        }
+    });
+    test("rejects validly-signed JWTs that omit the exp claim", async () => {
+        const dbPath = makeDbPath("jwt-no-exp");
+        dbPaths.push(dbPath);
+        const secret = "super-secret";
+        gateway = new Gateway({
+            protocol: 1,
+            features: ["runs"],
+            heartbeatMs: 100,
+            auth: {
+                mode: "jwt",
+                issuer: "https://auth.example.com",
+                audience: "smithers",
+                secret,
+                scopesClaim: "permissions",
+            },
+        });
+        gateway.register("basic", createValueWorkflow(dbPath));
+        server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+        const port = getPort(server);
+        // Same issuer/audience/signature as a valid token, but with no exp claim.
+        // Such a token would never expire, so it must be rejected outright.
+        const noExpToken = createJwtToken({
+            iss: "https://auth.example.com",
+            aud: "smithers",
+            sub: "user:jwt",
+            role: "operator",
+            permissions: ["runs.create", "runs.get"],
+        }, secret);
+        const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+        await new Promise((resolve, reject) => {
+            ws.once("open", () => resolve());
+            ws.once("error", reject);
+        });
+        const rejected = new GatewayClient(ws);
+        await rejected.waitFor((message) => message.type === "event" && message.event === "connect.challenge");
+        const hello = await rejected.request("connect", {
+            minProtocol: 1,
+            maxProtocol: 1,
+            client: {
+                id: "jwt-client",
+                version: "1.0.0",
+                platform: "bun-test",
+            },
+            auth: { token: noExpToken },
+        });
+        expect(hello.ok).toBe(false);
+        expect(hello.error.code).toBe("UNAUTHORIZED");
+        await rejected.close();
+    });
+    test("removes the runRegistry entry after a run completes", async () => {
+        const dbPath = makeDbPath("run-registry");
+        dbPaths.push(dbPath);
+        gateway = new Gateway({
+            protocol: 1,
+            features: ["streaming", "runs"],
+            heartbeatMs: 100,
+            auth: {
+                mode: "token",
+                tokens: {
+                    "op-token": {
+                        role: "operator",
+                        scopes: ["*"],
+                        userId: "user:will",
+                    },
+                },
+            },
+        });
+        gateway.register("basic", createValueWorkflow(dbPath));
+        server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+        const port = getPort(server);
+        const { client } = await connectGateway(port, "op-token");
+        const created = await client.request("runs.create", {
+            workflow: "basic",
+            input: { value: 3 },
+        });
+        expect(created.ok).toBe(true);
+        const runId = created.payload.runId;
+        // The registry holds the run while it is active.
+        expect(gateway.runRegistry.has(runId)).toBe(true);
+        await waitForRunStatus(client, runId, ["finished"]);
+        // The entry is deleted in the run promise's .finally(), which runs just
+        // after the run.completed broadcast, so poll briefly for the cleanup.
+        const started = Date.now();
+        while (gateway.runRegistry.has(runId) && Date.now() - started < 5_000) {
+            await sleep(10);
+        }
+        expect(gateway.runRegistry.has(runId)).toBe(false);
+        await client.close();
+    });
 });


### PR DESCRIPTION
## Summary

Four surgical hardening fixes in `packages/server/src/gateway.js`.

### 1. runRegistry leak
`startRun` registered each run in `this.runRegistry` but the run promise's `.finally()` only cleared `activeRuns` and `inflightRuns`, never `runRegistry`. Every run leaked one record for the lifetime of the gateway process (unbounded memory growth). Fix: also `this.runRegistry.delete(runId)` in the same `.finally()`.

### 2. Prototype-pollution-prone token lookup
Token-mode auth read `this.auth.tokens[token]` directly. Magic keys like `__proto__`, `toString`, or `constructor` resolve to truthy inherited prototype members, so such a "token" passed the `if (!grant)` check and then crashed dereferencing `grant.role`/`grant.scopes` — a 500 where a 401 was expected. Fix: guard with `Object.hasOwn(this.auth.tokens, token)` before treating the grant as valid.

### 3. JWT with no exp never expired
`verifyJwtToken` only enforced expiry when `typeof exp === "number"`, so a token omitting the `exp` claim was accepted forever. Fix: reject a missing or non-numeric `exp` as unauthorized; the existing clock-skew comparison is preserved for tokens that do carry `exp`.

### 4. WS failure responses used hardcoded ids
In the WebSocket message handler, `frame` was declared inside the `try`, so the `catch` could only send `responseError("invalid", ...)` / `responseError("server", ...)` with fabricated ids. Clients could not correlate the error with their request. Fix: hoist the `frame` declaration outside the `try` and echo `frame?.id ?? "invalid"` / `frame?.id ?? "server"` so the real id is used whenever parsing succeeded.

## Testing
- `node --check packages/server/src/gateway.js` passes.
- Existing JWT gateway tests already supply an `exp` claim, so fix (3) does not regress them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)