### PR TITLE
fix(smithers): use token matching in bash network guard to stop over-blocking

### DIFF
--- a/packages/smithers/src/tools/bash.js
+++ b/packages/smithers/src/tools/bash.js
@@ -100,29 +100,36 @@ function validateBashInvocation(cmd, args, opts, ctx) {
   }
 }
 
+function tokenExecutableName(token) {
+  const stripped = token.split(/[/\\]/).pop() ?? token;
+  return stripped;
+}
+
 function assertNetworkAllowed(cmd, args, allowNetwork) {
   if (allowNetwork) {
     return;
   }
-  const hay = [cmd, ...(args ?? [])].join(" ");
-  const networkCommands = [
-    "curl",
-    "wget",
-    "http://",
-    "https://",
-    "npm",
-    "bun",
-    "pip",
-  ];
-  if (networkCommands.some((fragment) => hay.includes(fragment))) {
+  const tokens = [cmd, ...(args ?? [])].flatMap((part) =>
+    String(part).split(/\s+/).filter(Boolean),
+  );
+  const executables = new Set(tokens.map(tokenExecutableName));
+  const networkExecutables = ["curl", "wget", "npm", "bun", "pip"];
+  const hasNetworkExecutable = networkExecutables.some((name) =>
+    executables.has(name),
+  );
+  const urlSchemes = ["http://", "https://"];
+  const hasUrlToken = tokens.some((token) =>
+    urlSchemes.some((scheme) => token.startsWith(scheme)),
+  );
+  if (hasNetworkExecutable || hasUrlToken) {
     throw new SmithersError(
       "TOOL_NETWORK_DISABLED",
       "Network access is disabled for bash tool",
     );
   }
-  if (hay.includes("git")) {
-    const gitRemoteOps = ["push", "pull", "fetch", "clone", "remote"];
-    if (gitRemoteOps.some((op) => hay.includes(op))) {
+  if (executables.has("git")) {
+    const gitRemoteOps = new Set(["push", "pull", "fetch", "clone", "remote"]);
+    if (tokens.some((token) => gitRemoteOps.has(token))) {
       throw new SmithersError(
         "TOOL_GIT_REMOTE_DISABLED",
         "Git remote operations are disabled for bash tool",

--- a/packages/smithers/tests/tools-unit.test.js
+++ b/packages/smithers/tests/tools-unit.test.js
@@ -404,6 +404,43 @@ describe("process helpers and bash tool", () => {
     );
   });
 
+  test("network guard matches whole tokens, not substrings", async () => {
+    const root = await makeRoot();
+
+    await withToolCtx(root, { allowNetwork: false }, async () => {
+      // Benign commands whose args merely contain a blocked substring
+      // ("bundle" contains "bun", "pipeline" contains "pip") must run.
+      expect((await bashTool("/bin/echo", ["bundle.js"])).trim()).toBe(
+        "bundle.js",
+      );
+      expect((await bashTool("/bin/echo", ["pipeline.txt"])).trim()).toBe(
+        "pipeline.txt",
+      );
+
+      // Real network commands must still be blocked.
+      await expectSmithersCode(
+        bashTool("curl", ["http://x"]),
+        "TOOL_NETWORK_DISABLED",
+      );
+      await expectSmithersCode(
+        bashTool("wget", ["http://x"]),
+        "TOOL_NETWORK_DISABLED",
+      );
+      await expectSmithersCode(
+        bashTool("npm", ["install"]),
+        "TOOL_NETWORK_DISABLED",
+      );
+      await expectSmithersCode(
+        bashTool("bun", ["add", "left-pad"]),
+        "TOOL_NETWORK_DISABLED",
+      );
+      await expectSmithersCode(
+        bashTool("pip", ["install", "requests"]),
+        "TOOL_NETWORK_DISABLED",
+      );
+    });
+  });
+
   test("resolves an explicit working directory inside the root", async () => {
     const root = await makeRoot();
     mkdirSync(join(root, "subdir"));


### PR DESCRIPTION
## Bug

`assertNetworkAllowed` in `packages/smithers/src/tools/bash.js` joined `cmd` + `args` into a single string and used substring `.includes()` against fragments like `"bun"`, `"npm"`, `"pip"`, `"git"`, and the url schemes. Because these are matched as raw substrings, benign commands were wrongly rejected.

### Failure scenario

When network access is disabled (the default), commands whose tokens merely *contain* a blocked fragment as a substring were rejected with `TOOL_NETWORK_DISABLED`:

- `echo bundle.js` -> `bun` is a substring of `bundle.js`
- `cat pipeline.txt` -> `pip` is a substring of `pipeline.txt`

Similarly any token containing `git` would enter the git-remote branch and could trip on substrings like `push`/`pull` inside unrelated arguments.

## Fix

Tokenize the command (split each part on whitespace) and match:

- network executables (`curl`, `wget`, `npm`, `bun`, `pip`) against the basename of each token as whole executable names, so `/usr/bin/curl` still matches but `bundle.js` does not;
- url schemes (`http://`, `https://`) as actual prefixes of a token rather than substrings anywhere;
- git remote ops (`push`, `pull`, `fetch`, `clone`, `remote`) as whole tokens, only when `git` is an invoked executable.

The blocked tool set and the `allowNetwork` bypass are unchanged; only the matching is tightened to remove false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)