### PR TITLE
fix(gateway-react): discard stale RPC responses in useGatewayRpc

### DIFF
--- a/packages/gateway-react/src/useGatewayRpc.ts
+++ b/packages/gateway-react/src/useGatewayRpc.ts
@@ -21,6 +21,7 @@ export function useGatewayRpc<Method extends GatewayRpcMethod>(
     deps: readonly unknown[];
   } | undefined>(undefined);
   paramsRef.current = params;
+  const generationRef = useRef(0);
   const [data, setData] = useState<GatewayRpcPayload<Method>>();
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState(enabled);
@@ -29,14 +30,22 @@ export function useGatewayRpc<Method extends GatewayRpcMethod>(
     if (!enabled) {
       return;
     }
+    const generation = ++generationRef.current;
     setLoading(true);
     setError(undefined);
     try {
-      setData(await client.rpc(method, paramsRef.current));
+      const payload = await client.rpc(method, paramsRef.current);
+      if (generation === generationRef.current) {
+        setData(payload);
+      }
     } catch (cause) {
-      setError(cause instanceof Error ? cause : new Error(String(cause)));
+      if (generation === generationRef.current) {
+        setError(cause instanceof Error ? cause : new Error(String(cause)));
+      }
     } finally {
-      setLoading(false);
+      if (generation === generationRef.current) {
+        setLoading(false);
+      }
     }
   }, [client, enabled, method]);
 
@@ -53,6 +62,12 @@ export function useGatewayRpc<Method extends GatewayRpcMethod>(
       void refetch();
     }
   });
+
+  useEffect(() => {
+    return () => {
+      generationRef.current += 1;
+    };
+  }, []);
 
   return { data, error, loading, refetch };
 }


### PR DESCRIPTION
## Bug

`useGatewayRpc` (`packages/gateway-react/src/useGatewayRpc.ts`) ran `refetch`, awaited `client.rpc(...)`, and then unconditionally called `setData`/`setError`/`setLoading`.

## Failure scenario

When `params`/`deps` change quickly, the effect fires `refetch` again before the previous request resolves. If an earlier, slower request resolves after a newer one, its result clobbers the fresher data (a classic stale-response race). The same problem applies after unmount, where a late response would attempt to update state on a torn-down component.

## Fix

Added a per-request generation counter (`generationRef`) that is incremented at the start of every `refetch`. Each invocation captures its own generation and only applies `setData`/`setError`/`setLoading` when its generation still matches the latest one. A cleanup effect bumps the generation on unmount so any in-flight request is invalidated. Only the latest request can update state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)