### PR TITLE
fix(time-travel): record added/removed Ralph loops in snapshot diff

### DIFF
--- a/packages/time-travel/src/SnapshotDiff.ts
+++ b/packages/time-travel/src/SnapshotDiff.ts
@@ -12,6 +12,8 @@ export type SnapshotDiff = {
   outputsAdded: string[];
   outputsRemoved: string[];
   outputsChanged: OutputChange[];
+  ralphAdded: string[];
+  ralphRemoved: string[];
   ralphChanged: RalphChange[];
   inputChanged: boolean;
   vcsPointerChanged: boolean;

--- a/packages/time-travel/src/diff.js
+++ b/packages/time-travel/src/diff.js
@@ -69,6 +69,8 @@ export function diffSnapshots(a, b) {
         }
     }
     // Ralph
+    const ralphAdded = [];
+    const ralphRemoved = [];
     const ralphChanged = [];
     const allRalphKeys = new Set([
         ...Object.keys(a.ralph),
@@ -78,9 +80,12 @@ export function diffSnapshots(a, b) {
         const aR = a.ralph[key];
         const bR = b.ralph[key];
         if (!aR || !bR) {
-            // One side missing — treat as changed if both exist
-            if (aR && bR) {
-                ralphChanged.push({ ralphId: key, from: aR, to: bR });
+            // One side missing — loop was added or removed between snapshots
+            if (!aR) {
+                ralphAdded.push(key);
+            }
+            else {
+                ralphRemoved.push(key);
             }
             continue;
         }
@@ -99,6 +104,8 @@ export function diffSnapshots(a, b) {
         outputsAdded,
         outputsRemoved,
         outputsChanged,
+        ralphAdded,
+        ralphRemoved,
         ralphChanged,
         inputChanged,
         vcsPointerChanged,
@@ -159,6 +166,18 @@ export function formatDiffForTui(diff) {
         lines.push(pc.bold("Outputs changed:"));
         for (const o of diff.outputsChanged) {
             lines.push(pc.yellow(`  ~ ${o.key}`));
+        }
+    }
+    if (diff.ralphAdded.length > 0) {
+        lines.push(pc.bold("Ralph (loops) added:"));
+        for (const r of diff.ralphAdded) {
+            lines.push(pc.green(`  + ${r}`));
+        }
+    }
+    if (diff.ralphRemoved.length > 0) {
+        lines.push(pc.bold("Ralph (loops) removed:"));
+        for (const r of diff.ralphRemoved) {
+            lines.push(pc.red(`  - ${r}`));
         }
     }
     if (diff.ralphChanged.length > 0) {

--- a/packages/time-travel/tests/diff.test.js
+++ b/packages/time-travel/tests/diff.test.js
@@ -106,6 +106,26 @@ describe("diffSnapshots", () => {
         expect(diff.ralphChanged[0].from.iteration).toBe(0);
         expect(diff.ralphChanged[0].to.iteration).toBe(1);
     });
+    test("detects added ralph loop (present only in b)", () => {
+        const a = makeParsed({ ralph: {} });
+        const b = makeParsed({
+            ralph: { "main-loop": { ralphId: "main-loop", iteration: 0, done: false } },
+        });
+        const diff = diffSnapshots(a, b);
+        expect(diff.ralphAdded).toEqual(["main-loop"]);
+        expect(diff.ralphRemoved).toEqual([]);
+        expect(diff.ralphChanged).toEqual([]);
+    });
+    test("detects removed ralph loop (present only in a)", () => {
+        const a = makeParsed({
+            ralph: { "main-loop": { ralphId: "main-loop", iteration: 0, done: false } },
+        });
+        const b = makeParsed({ ralph: {} });
+        const diff = diffSnapshots(a, b);
+        expect(diff.ralphRemoved).toEqual(["main-loop"]);
+        expect(diff.ralphAdded).toEqual([]);
+        expect(diff.ralphChanged).toEqual([]);
+    });
     test("detects input changes", () => {
         const a = makeParsed();
         const b = makeParsed({ input: { prompt: "different" } });
@@ -165,6 +185,26 @@ describe("formatDiffForTui", () => {
         expect(output).toContain("implement::0");
         expect(output).toContain("pending");
         expect(output).toContain("running");
+    });
+    test("surfaces added ralph loop", () => {
+        const a = makeParsed({ ralph: {} });
+        const b = makeParsed({
+            ralph: { "main-loop": { ralphId: "main-loop", iteration: 0, done: false } },
+        });
+        const diff = diffSnapshots(a, b);
+        const output = formatDiffForTui(diff);
+        expect(output).toContain("Ralph (loops) added:");
+        expect(output).toContain("main-loop");
+    });
+    test("surfaces removed ralph loop", () => {
+        const a = makeParsed({
+            ralph: { "main-loop": { ralphId: "main-loop", iteration: 0, done: false } },
+        });
+        const b = makeParsed({ ralph: {} });
+        const diff = diffSnapshots(a, b);
+        const output = formatDiffForTui(diff);
+        expect(output).toContain("Ralph (loops) removed:");
+        expect(output).toContain("main-loop");
     });
 });
 describe("formatDiffAsJson", () => {


### PR DESCRIPTION
## Bug

In `packages/time-travel/src/diff.js`, the Ralph diff loop handled a loop that exists on only one snapshot like this:

```js
if (!aR || !bR) {
    // One side missing — treat as changed if both exist
    if (aR && bR) {
        ralphChanged.push({ ralphId: key, from: aR, to: bR });
    }
    continue;
}
```

The inner `if (aR && bR)` can never be true inside the `if (!aR || !bR)` branch (at least one of them is falsy). So a Ralph loop that was **added** or **removed** between two snapshots produced no diff entry at all — `diffSnapshots` silently dropped it.

## Failure scenario

Snapshot A has Ralph loop `loop-1`; snapshot B does not (or vice versa). `diffSnapshots(A, B)` reports no Ralph difference, so `formatDiffForTui` / `formatDiffAsJson` never surface that a loop appeared or disappeared.

## Fix

- Add `ralphAdded: string[]` and `ralphRemoved: string[]` to the `SnapshotDiff` type (consistent with the existing `nodesAdded`/`nodesRemoved`/`outputsAdded`/`outputsRemoved` string arrays).
- In the diff loop, push the key onto `ralphAdded` when the loop only exists on side B and `ralphRemoved` when it only exists on side A.
- Render the new arrays in `formatDiffForTui` (green `+` for added, red `-` for removed). `formatDiffAsJson` picks them up automatically via the spread.
- The both-sides "changed" case is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)