### PR TITLE
fix(components): EscalationChain must only run a level when the prior level escalated

### DIFF
--- a/packages/components/src/components/EscalationChain.js
+++ b/packages/components/src/components/EscalationChain.js
@@ -4,10 +4,42 @@
 // @smithers-type-exports-end
 
 import React from "react";
+import { SmithersContext } from "@smithers-orchestrator/react-reconciler/context";
 import { Sequence } from "./Sequence.js";
 import { Branch } from "./Branch.js";
 import { Task } from "./Task.js";
 import { Approval } from "./Approval.js";
+/**
+ * Default escalation predicate: escalate when the previous level has no result
+ * yet, or its result signals a failure (`error`/`failed` truthy or `ok === false`).
+ * @param {unknown} result
+ * @returns {boolean}
+ */
+function defaultEscalateIf(result) {
+    if (result == null)
+        return true;
+    if (typeof result === "object") {
+        const row = /** @type {Record<string, unknown>} */ (result);
+        if (row.error != null && row.error !== false)
+            return true;
+        if (row.failed === true)
+            return true;
+        if (row.ok === false)
+            return true;
+    }
+    return false;
+}
+/**
+ * Resolve whether the previous level escalated by invoking its `escalateIf`
+ * predicate (or the default) against its actual result.
+ * @param {EscalationLevel} prevLevel
+ * @param {unknown} prevResult
+ * @returns {boolean}
+ */
+function didEscalate(prevLevel, prevResult) {
+    const predicate = prevLevel.escalateIf ?? defaultEscalateIf;
+    return Boolean(predicate(prevResult));
+}
 /**
  * Escalation chain: tries agents in order, escalating on failure or when
  * `escalateIf` returns `true`. Optionally ends with a human approval fallback.
@@ -18,6 +50,7 @@ import { Approval } from "./Approval.js";
 export function EscalationChain(props) {
     if (props.skipIf)
         return null;
+    const ctx = React.useContext(SmithersContext);
     const prefix = props.id ?? "escalation";
     const { levels, children, humanFallback, humanRequest, escalationOutput } = props;
     // Build the chain from the last level forward, nesting each level inside a
@@ -43,14 +76,14 @@ export function EscalationChain(props) {
         }
         else {
             // Subsequent levels are gated by a Branch that checks whether the
-            // previous level needs escalation. The `if` condition is `true` at
-            // render time when the previous level's `escalateIf` would trigger,
-            // but since we cannot evaluate the runtime result at component-render
-            // time, we rely on `continueOnFail` and use a compute Task to check
-            // the escalation predicate, then Branch on its output.
-            //
-            // For the composite pattern we wrap each subsequent level so it only
-            // mounts when the prior level signals escalation.
+            // previous level needs escalation. The chain re-renders reactively as
+            // outputs become available, so we read the previous level's actual
+            // result from the workflow context and run its `escalateIf` predicate
+            // (or the default failure predicate) to decide whether this level runs.
+            const prevLevel = levels[i - 1];
+            const prevLevelId = `${prefix}-level-${i - 1}`;
+            const prevResult = ctx?.outputMaybe(prevLevel.output, { nodeId: prevLevelId });
+            const escalated = didEscalate(prevLevel, prevResult);
             const checkId = `${prefix}-check-${i - 1}`;
             const checkTask = React.createElement(Task, {
                 id: checkId,
@@ -58,40 +91,47 @@ export function EscalationChain(props) {
                 continueOnFail: true,
                 label: `Check escalation from level ${i - 1}`,
                 children: () => {
-                    // This compute function runs at task execution time.
-                    // It evaluates the previous level's escalateIf predicate.
+                    // Record the escalation decision for the prior level so it is
+                    // visible in the escalation output stream.
                     return {
-                        escalated: true,
+                        escalated,
                         fromLevel: i - 1,
                         toLevel: i,
                     };
                 },
             });
-            // Gate the current level: it always mounts when we reach this point
-            // in the sequence because the previous level had continueOnFail.
-            // The Branch uses `true` here because the sequence only reaches this
-            // point if the previous task failed or escalateIf was configured.
+            // Gate the current level on the previous level's escalation decision:
+            // it only mounts when the prior level actually escalated.
             const gatedLevel = React.createElement(Branch, {
-                if: true,
+                if: escalated,
                 then: taskEl,
             });
             levelElements.push(checkTask);
             levelElements.push(gatedLevel);
         }
     }
-    // Append human fallback if requested.
-    if (humanFallback) {
+    // Append human fallback if requested. It only mounts when the final
+    // automated level escalated (i.e. all automated levels were exhausted).
+    if (humanFallback && levels.length > 0) {
         const humanId = `${prefix}-human-fallback`;
         const request = humanRequest ?? {
             title: "Escalation requires human review",
             summary: `All ${levels.length} automated levels have been exhausted.`,
         };
-        levelElements.push(React.createElement(Approval, {
+        const lastLevel = levels[levels.length - 1];
+        const lastLevelId = `${prefix}-level-${levels.length - 1}`;
+        const lastResult = ctx?.outputMaybe(lastLevel.output, { nodeId: lastLevelId });
+        const lastEscalated = didEscalate(lastLevel, lastResult);
+        const approvalEl = React.createElement(Approval, {
             id: humanId,
             output: escalationOutput,
             request,
             continueOnFail: true,
             label: request.title,
+        });
+        levelElements.push(React.createElement(Branch, {
+            if: lastEscalated,
+            then: approvalEl,
         }));
     }
     return React.createElement(Sequence, {}, ...levelElements);

--- a/packages/components/src/components/EscalationChain.js
+++ b/packages/components/src/components/EscalationChain.js
@@ -110,18 +110,22 @@ export function EscalationChain(props) {
             levelElements.push(gatedLevel);
         }
     }
-    // Append human fallback if requested. It only mounts when the final
-    // automated level escalated (i.e. all automated levels were exhausted).
+    // Append human fallback if requested. It only mounts when every automated
+    // level escalated (i.e. all automated levels were exhausted). A single
+    // level resolving without escalation stops the chain and the fallback, even
+    // if later levels never ran and therefore have no recorded result.
     if (humanFallback && levels.length > 0) {
         const humanId = `${prefix}-human-fallback`;
         const request = humanRequest ?? {
             title: "Escalation requires human review",
             summary: `All ${levels.length} automated levels have been exhausted.`,
         };
-        const lastLevel = levels[levels.length - 1];
-        const lastLevelId = `${prefix}-level-${levels.length - 1}`;
-        const lastResult = ctx?.outputMaybe(lastLevel.output, { nodeId: lastLevelId });
-        const lastEscalated = didEscalate(lastLevel, lastResult);
+        const allEscalated = levels.every((level, idx) => {
+            const levelResult = ctx?.outputMaybe(level.output, {
+                nodeId: `${prefix}-level-${idx}`,
+            });
+            return didEscalate(level, levelResult);
+        });
         const approvalEl = React.createElement(Approval, {
             id: humanId,
             output: escalationOutput,
@@ -130,7 +134,7 @@ export function EscalationChain(props) {
             label: request.title,
         });
         levelElements.push(React.createElement(Branch, {
-            if: lastEscalated,
+            if: allEscalated,
             then: approvalEl,
         }));
     }

--- a/packages/components/tests/escalation-chain-gating.test.jsx
+++ b/packages/components/tests/escalation-chain-gating.test.jsx
@@ -1,0 +1,181 @@
+/** @jsxImportSource smithers-orchestrator */
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import {
+    SmithersContext,
+    SmithersCtx,
+} from "@smithers-orchestrator/react-reconciler/context";
+import { SmithersRenderer } from "@smithers-orchestrator/react-reconciler/dom/renderer";
+import { EscalationChain } from "../src/components/index.js";
+
+const agent = { id: "agent", generate: async () => ({ text: "ok" }) };
+const otherAgent = { id: "other", generate: async () => ({ text: "ok" }) };
+
+/**
+ * Render an element inside a SmithersContext provider seeded with the given
+ * output rows, mirroring how the runtime exposes prior level results to the
+ * escalation chain.
+ * @param {React.ReactElement} el
+ * @param {Record<string, Array<Record<string, unknown>>>} outputs
+ */
+async function renderWithOutputs(el, outputs) {
+    const ctx = new SmithersCtx({
+        runId: "test-run",
+        iteration: 0,
+        input: {},
+        outputs,
+    });
+    const renderer = new SmithersRenderer();
+    return renderer.render(
+        <SmithersContext.Provider value={ctx}>{el}</SmithersContext.Provider>,
+    );
+}
+
+describe("EscalationChain gates levels on the real escalation decision", () => {
+    test("does NOT mount the next level or the human fallback when the previous level succeeded (escalateIf false)", async () => {
+        // Level 0 produced a result that escalateIf considers a success.
+        const result = await renderWithOutputs(
+            <EscalationChain
+                id="incident"
+                levels={[
+                    {
+                        agent,
+                        output: "level_out",
+                        label: "First",
+                        escalateIf: (r) => r?.success !== true,
+                    },
+                    { agent: otherAgent, output: "level_out", label: "Second" },
+                ]}
+                escalationOutput="escalation_out"
+                humanFallback
+                humanRequest={{ title: "Human review", summary: "Escalate" }}
+            >
+                triage incident
+            </EscalationChain>,
+            {
+                level_out: [
+                    { nodeId: "incident-level-0", iteration: 0, success: true },
+                ],
+            },
+        );
+
+        const ids = result.tasks.map((task) => task.nodeId);
+        // The check task always records the decision, but the gated second
+        // level and the human fallback Approval must NOT be mounted.
+        expect(ids).toContain("incident-level-0");
+        expect(ids).toContain("incident-check-0");
+        expect(ids).not.toContain("incident-level-1");
+        expect(ids).not.toContain("incident-human-fallback");
+
+        // The recorded decision reflects no escalation.
+        const checkTask = result.tasks.find(
+            (task) => task.nodeId === "incident-check-0",
+        );
+        expect(checkTask.computeFn()).toEqual({
+            escalated: false,
+            fromLevel: 0,
+            toLevel: 1,
+        });
+    });
+
+    test("DOES mount the next level and human fallback when the previous level escalates (escalateIf true)", async () => {
+        const result = await renderWithOutputs(
+            <EscalationChain
+                id="incident"
+                levels={[
+                    {
+                        agent,
+                        output: "level_out",
+                        label: "First",
+                        escalateIf: (r) => r?.success !== true,
+                    },
+                    {
+                        agent: otherAgent,
+                        output: "level_out",
+                        label: "Second",
+                        escalateIf: (r) => r?.success !== true,
+                    },
+                ]}
+                escalationOutput="escalation_out"
+                humanFallback
+                humanRequest={{ title: "Human review", summary: "Escalate" }}
+            >
+                triage incident
+            </EscalationChain>,
+            {
+                // Both automated levels report failure, so escalation continues
+                // through the chain and into the human fallback.
+                level_out: [
+                    { nodeId: "incident-level-0", iteration: 0, success: false },
+                    { nodeId: "incident-level-1", iteration: 0, success: false },
+                ],
+            },
+        );
+
+        const ids = result.tasks.map((task) => task.nodeId);
+        expect(ids).toEqual([
+            "incident-level-0",
+            "incident-check-0",
+            "incident-level-1",
+            "incident-human-fallback",
+        ]);
+
+        const checkTask = result.tasks.find(
+            (task) => task.nodeId === "incident-check-0",
+        );
+        expect(checkTask.computeFn()).toEqual({
+            escalated: true,
+            fromLevel: 0,
+            toLevel: 1,
+        });
+        const fallback = result.tasks.find(
+            (task) => task.nodeId === "incident-human-fallback",
+        );
+        expect(fallback.needsApproval).toBe(true);
+    });
+
+    test("default failure predicate gates on the prior result when no escalateIf is provided", async () => {
+        // No escalateIf on level 0 -> defaultEscalateIf is used. A successful
+        // result (no error/failed/ok=false) must NOT escalate.
+        const success = await renderWithOutputs(
+            <EscalationChain
+                id="incident"
+                levels={[
+                    { agent, output: "level_out", label: "First" },
+                    { agent: otherAgent, output: "level_out", label: "Second" },
+                ]}
+                escalationOutput="escalation_out"
+            >
+                triage incident
+            </EscalationChain>,
+            {
+                level_out: [
+                    { nodeId: "incident-level-0", iteration: 0, ok: true },
+                ],
+            },
+        );
+        expect(success.tasks.map((t) => t.nodeId)).not.toContain(
+            "incident-level-1",
+        );
+
+        // A failing result (ok === false) escalates under the default predicate.
+        const failure = await renderWithOutputs(
+            <EscalationChain
+                id="incident"
+                levels={[
+                    { agent, output: "level_out", label: "First" },
+                    { agent: otherAgent, output: "level_out", label: "Second" },
+                ]}
+                escalationOutput="escalation_out"
+            >
+                triage incident
+            </EscalationChain>,
+            {
+                level_out: [
+                    { nodeId: "incident-level-0", iteration: 0, ok: false },
+                ],
+            },
+        );
+        expect(failure.tasks.map((t) => t.nodeId)).toContain("incident-level-1");
+    });
+});


### PR DESCRIPTION
## Bug

`packages/components/src/components/EscalationChain.js` gated every subsequent escalation level behind `Branch({ if: true })` (hardcoded), and the per-level check Task returned `{ escalated: true, ... }` unconditionally. As a result:

- Every escalation level ran on every execution, even when an earlier level already succeeded.
- The human-fallback `Approval` always mounted regardless of whether the automated levels were exhausted.
- Each level's `escalateIf` predicate was never invoked.

### Failure scenario

Given an `EscalationChain` with levels `[A, B]` and `humanFallback`: if level A succeeds (or A's `escalateIf` returns `false`), level B and the human approval should be skipped. With the old code, B's gating Branch was `if: true` and the human Approval was unconditional, so B and the human review both ran anyway — defeating the entire purpose of the escalation ladder.

## Fix

Wire the gating to the actual escalation decision of the previous level using the workflow context's reactive output mechanism:

- Read the previous level's real result from `ctx.outputMaybe(prevLevel.output, { nodeId: prevLevelId })` (the chain re-renders reactively as outputs land).
- Run `prevLevel.escalateIf(result)` to compute escalation, falling back to a default failure predicate (escalate when the prior result is missing or signals failure via `error` / `failed` / `ok === false`).
- The check Task records that real decision (`{ escalated, fromLevel, toLevel }`) instead of a hardcoded `true`, preserving the existing escalation output schema.
- The gating `Branch` for each level now uses `if: escalated` instead of `if: true`, and the human-fallback `Approval` is wrapped in a `Branch` gated on the final level's escalation decision.

Existing `EscalationChain` coverage in `packages/components/tests/composite-coverage.test.jsx` still passes (node ids, the check `computeFn` output, and the fallback approval metadata are all preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)