### PR TITLE
fix(smithers): separate stdout/stderr capture budgets and avoid UTF-8 truncation corruption

### DIFF
--- a/packages/smithers/src/tools/utils.js
+++ b/packages/smithers/src/tools/utils.js
@@ -27,12 +27,25 @@ export function sha256Hex(value) {
   return createHash("sha256").update(value).digest("hex");
 }
 
+function utf8BoundaryLength(buf, byteLength) {
+  let end = Math.min(byteLength, buf.length);
+  if (end >= buf.length) {
+    return buf.length;
+  }
+  // If the cut lands on a continuation byte, back up to the lead byte of the
+  // partial sequence so we never decode an incomplete codepoint.
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) {
+    end -= 1;
+  }
+  return end;
+}
+
 export function truncateToBytes(text, maxBytes) {
   const buf = Buffer.from(text, "utf8");
   if (buf.length <= maxBytes) {
     return text;
   }
-  return buf.subarray(0, maxBytes).toString("utf8");
+  return buf.subarray(0, utf8BoundaryLength(buf, maxBytes)).toString("utf8");
 }
 
 export async function resolveToolPath(rootDir, inputPath) {
@@ -72,8 +85,11 @@ function appendLimited(chunks, state, chunk, maxBytes) {
     state.storedBytes += buffer.length;
     return;
   }
-  chunks.push(buffer.subarray(0, remaining));
-  state.storedBytes += remaining;
+  const accepted = utf8BoundaryLength(buffer, remaining);
+  if (accepted > 0) {
+    chunks.push(buffer.subarray(0, accepted));
+    state.storedBytes += accepted;
+  }
   state.truncated = true;
 }
 
@@ -91,7 +107,12 @@ export function captureProcess(
   return new Promise((resolve, reject) => {
     const stdoutChunks = [];
     const stderrChunks = [];
-    const state = {
+    const stdoutState = {
+      storedBytes: 0,
+      totalBytes: 0,
+      truncated: false,
+    };
+    const stderrState = {
       storedBytes: 0,
       totalBytes: 0,
       truncated: false,
@@ -149,10 +170,10 @@ export function captureProcess(
     }
 
     child.stdout.on("data", (chunk) => {
-      appendLimited(stdoutChunks, state, chunk, maxOutputBytes);
+      appendLimited(stdoutChunks, stdoutState, chunk, maxOutputBytes);
     });
     child.stderr.on("data", (chunk) => {
-      appendLimited(stderrChunks, state, chunk, maxOutputBytes);
+      appendLimited(stderrChunks, stderrState, chunk, maxOutputBytes);
     });
     child.on("error", (error) => {
       finish(() =>
@@ -167,7 +188,7 @@ export function captureProcess(
     });
     child.on("close", (exitCode, signal) => {
       finish(() => {
-        resolve({ exitCode: exitCode ?? (signal ? 1 : 0), signal, stdout: Buffer.concat(stdoutChunks).toString("utf8"), stderr: Buffer.concat(stderrChunks).toString("utf8"), truncated: state.truncated, totalBytes: state.totalBytes });
+        resolve({ exitCode: exitCode ?? (signal ? 1 : 0), signal, stdout: Buffer.concat(stdoutChunks).toString("utf8"), stderr: Buffer.concat(stderrChunks).toString("utf8"), truncated: stdoutState.truncated || stderrState.truncated, totalBytes: stdoutState.totalBytes + stderrState.totalBytes });
       });
     });
   });

--- a/packages/smithers/tests/tools-unit.test.js
+++ b/packages/smithers/tests/tools-unit.test.js
@@ -284,7 +284,11 @@ describe("process helpers and bash tool", () => {
       ["-e", "process.stdout.write('abc'); process.stderr.write('def')"],
       { cwd: root, maxOutputBytes: 3, timeoutMs: 1000 },
     );
-    expect(splitOutput.truncated).toBe(true);
+    // stdout and stderr each get their own 3-byte budget, so both fit
+    // exactly and nothing is dropped.
+    expect(splitOutput.stdout).toBe("abc");
+    expect(splitOutput.stderr).toBe("def");
+    expect(splitOutput.truncated).toBe(false);
     expect(splitOutput.totalBytes).toBe(6);
 
     await expectSmithersCode(
@@ -327,6 +331,70 @@ describe("process helpers and bash tool", () => {
     } finally {
       process.kill = originalKill;
     }
+  });
+
+  test("gives stdout and stderr independent byte budgets", async () => {
+    const root = await makeRoot();
+
+    // Noisy stderr (well over the limit) must not steal budget from a real
+    // stdout payload that fits comfortably under the limit. With a shared
+    // budget, the stderr flood would truncate or drop the stdout output.
+    const result = await captureProcess(
+      process.execPath,
+      [
+        "-e",
+        "process.stderr.write('e'.repeat(50)); process.stdout.write('keep-me')",
+      ],
+      { cwd: root, maxOutputBytes: 10, timeoutMs: 1000 },
+    );
+
+    expect(result.stdout).toBe("keep-me");
+    expect(result.stderr).toBe("e".repeat(10));
+    expect(result.truncated).toBe(true);
+    expect(result.totalBytes).toBe(57);
+  });
+
+  test("truncateToBytes never emits a replacement char mid-codepoint", async () => {
+    // U+1F600 (grinning face) encodes to 4 UTF-8 bytes.
+    const emoji = "\u{1F600}";
+    expect(Buffer.byteLength(emoji, "utf8")).toBe(4);
+
+    const text = `ab${emoji}cd`;
+    // Cutting at 3 bytes lands in the middle of the emoji's 4-byte sequence.
+    for (let maxBytes = 2; maxBytes <= 5; maxBytes += 1) {
+      const truncated = truncateToBytes(text, maxBytes);
+      expect(truncated).not.toContain("�");
+    }
+    // The partial emoji is dropped entirely rather than corrupted.
+    expect(truncateToBytes(text, 4)).toBe("ab");
+    expect(truncateToBytes(text, 5)).toBe("ab");
+    // A complete emoji is kept once enough bytes are available.
+    expect(truncateToBytes(text, 6)).toBe(`ab${emoji}`);
+
+    // CJK characters encode to 3 UTF-8 bytes each; a mid-character cut must
+    // not produce a replacement char either.
+    const cjk = "你好"; // 你好
+    expect(Buffer.byteLength(cjk, "utf8")).toBe(6);
+    expect(truncateToBytes(cjk, 4)).toBe("你");
+    expect(truncateToBytes(cjk, 4)).not.toContain("�");
+  });
+
+  test("captured output is not corrupted by a mid-codepoint byte limit", async () => {
+    const root = await makeRoot();
+
+    // Emit several multibyte codepoints, then cap the budget at a byte count
+    // that necessarily lands inside one of them.
+    const result = await captureProcess(
+      process.execPath,
+      ["-e", "process.stdout.write('\\u{1F600}\\u{1F600}\\u{1F600}')"],
+      { cwd: root, maxOutputBytes: 6, timeoutMs: 1000 },
+    );
+
+    expect(result.stdout).not.toContain("�");
+    // 6 bytes holds exactly the first emoji (4 bytes); the partial second one
+    // is dropped instead of corrupted.
+    expect(result.stdout).toBe("\u{1F600}");
+    expect(result.truncated).toBe(true);
   });
 
   test("executes commands and reports command failures", async () => {


### PR DESCRIPTION
## Bug

`packages/smithers/src/tools/utils.js` had two related defects in process-output capture:

1. **Shared capture budget starves a stream.** `captureProcess` used a single `state.storedBytes` budget shared between the stdout and stderr `data` handlers. A process that writes a lot of stderr (warnings, progress noise) would exhaust the shared `maxOutputBytes` allowance before stdout was written, silently dropping real `grep`/`bash` output that the caller actually needs.

2. **UTF-8 truncation emits replacement chars.** `truncateToBytes` (and the slicing in `appendLimited`) cut the UTF-8 `Buffer` at an arbitrary byte offset. When that offset landed in the middle of a multi-byte codepoint, decoding the partial sequence produced a U+FFFD (`�`) replacement character, corrupting the tail of the captured output.

### Failure scenario

- Run a command whose stderr is large and whose stdout is the real result. Shared budget fills with stderr, stdout comes back empty/truncated even though the data was produced.
- Capture output ending in a multi-byte character (accents, CJK, emoji) right at the byte limit; the returned string ends in `�`.

## Fix

1. Give stdout and stderr **independent** `storedBytes`/`totalBytes`/`truncated` state objects so neither stream can consume the other's allowance. The resolved result reports `truncated` if either stream truncated and `totalBytes` as the sum.

2. Add a `utf8BoundaryLength` helper that snaps a byte length down to a UTF-8 codepoint boundary by backing off trailing continuation bytes (`0x80`–`0xBF`). Both `truncateToBytes` and `appendLimited` now truncate on a codepoint boundary, so no incomplete sequence is ever decoded and no replacement char is produced.

Verified with a standalone check that no cut position across multi-byte (2-byte accent, 4-byte emoji) strings yields a `�`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)