### PR TITLE
fix(devtools): emit sibling addNode ops in ascending index order

### DIFF
--- a/packages/devtools/src/diffSnapshots.js
+++ b/packages/devtools/src/diffSnapshots.js
@@ -183,7 +183,15 @@ export function diffSnapshots(a, b) {
     });
     /** @type {DevToolsDeltaOp[]} */
     const addOps = topLevelAddIds
-        .sort((leftId, rightId) => (to.get(leftId)?.node.depth ?? 0) - (to.get(rightId)?.node.depth ?? 0))
+        .sort((leftId, rightId) => {
+            const leftEntry = to.get(leftId);
+            const rightEntry = to.get(rightId);
+            const depthDiff = (leftEntry?.node.depth ?? 0) - (rightEntry?.node.depth ?? 0);
+            if (depthDiff !== 0) {
+                return depthDiff;
+            }
+            return (leftEntry?.index ?? 0) - (rightEntry?.index ?? 0);
+        })
         .map((id) => {
         const entry = to.get(id);
         return /** @type {DevToolsDeltaOp} */ ({

--- a/packages/devtools/tests/diffSnapshots.test.ts
+++ b/packages/devtools/tests/diffSnapshots.test.ts
@@ -72,6 +72,25 @@ describe("diffSnapshots + applyDelta round trip", () => {
       to: snapshot(8, node(1, [node(3), node(2)])),
     },
     {
+      // Regression: reordering three siblings [6,1,5] -> [1,6,5] removes and
+      // re-adds all of them. applyDelta splices each addNode at its precomputed
+      // final index without re-indexing, so the addNode ops MUST be emitted in
+      // ascending-index order. Previously add ops were ordered only by depth,
+      // leaving equal-depth siblings in arbitrary Set-iteration order, which
+      // corrupted sibling order on reorders.
+      name: "reorder three siblings [6,2,5] -> [2,6,5]",
+      from: snapshot(70, node(1, [node(6), node(2, [], { x: 1 }), node(5)])),
+      to: snapshot(71, node(1, [node(2, [], { x: 1 }), node(6), node(5)])),
+    },
+    {
+      // Regression: reorder existing siblings while also inserting a brand-new
+      // sibling. The new add and the reorder-induced re-adds share the same
+      // depth, so ascending-index ordering must interleave them correctly.
+      name: "reverse siblings with a new insert [10,20,30] -> [30,40,20,10]",
+      from: snapshot(72, node(1, [node(10), node(20), node(30)])),
+      to: snapshot(73, node(1, [node(30), node(40), node(20), node(10)])),
+    },
+    {
       name: "change only props on a leaf",
       from: snapshot(9, node(1, [node(2, [node(3, [], { value: "a" })])])),
       to: snapshot(10, node(1, [node(2, [node(3, [], { value: "b" })])])),


### PR DESCRIPTION
## Bug

In `packages/devtools/src/diffSnapshots.js`, `addNode` ops carry each node's final `index`, but the add-op list is sorted only by `depth`. For siblings sharing a parent (same depth), the comparator returns 0, leaving them in arbitrary `Set` iteration order.

## Failure scenario

`applyDelta` handles `addNode` by splicing the new node at `op.index` (clamped to the current children length) without re-deriving indices as it goes:

```js
const index = Math.max(0, Math.min(op.index, parent.node.children.length));
parent.node.children.splice(index, 0, cloneValue(op.node));
```

So if two siblings have target indices 1 and 3 but are emitted in order [3, 1], the index-3 insert is clamped against the not-yet-full children array and the subsequent index-1 insert lands in the wrong slot, corrupting sibling order on reorders.

## Fix

Sort the add ops by `depth`, then by ascending `index`, guaranteeing that for nodes sharing a parent the splice-at-index inserts run in ascending-index order and reconstruct correct sibling order. Minimal diff-side change; `applyDelta` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)