### PR TITLE
fix(errors): make isSmithersError not match arbitrary {code,message} objects

### DIFF
--- a/packages/errors/src/isSmithersError.js
+++ b/packages/errors/src/isSmithersError.js
@@ -1,12 +1,18 @@
-
+import { isKnownSmithersErrorCode } from "./isKnownSmithersErrorCode.js";
+import { SmithersError } from "./SmithersError.js";
 /** @typedef {import("./SmithersError.js").SmithersError} SmithersError */
 /**
  * @param {unknown} value
  * @returns {value is SmithersError}
  */
 export function isSmithersError(value) {
+    if (value instanceof SmithersError) {
+        return true;
+    }
     return Boolean(value &&
         typeof value === "object" &&
         "code" in value &&
+        typeof (/** @type {{ code?: unknown }} */ (value).code) === "string" &&
+        isKnownSmithersErrorCode(/** @type {{ code: string }} */ (value).code) &&
         "message" in value);
 }

--- a/packages/errors/tests/errors-core.test.js
+++ b/packages/errors/tests/errors-core.test.js
@@ -196,9 +196,16 @@ describe("SmithersError", () => {
     expect(error).toBeInstanceOf(SmithersError);
   });
 
-  test("isSmithersError accepts Smithers-style objects", () => {
-    expect(isSmithersError({ code: "X", message: "Y" })).toBe(true);
+  test("isSmithersError accepts genuine SmithersErrors", () => {
+    expect(isSmithersError(new SmithersError("INVALID_INPUT", "Bad input"))).toBe(true);
+    expect(isSmithersError({ code: "INVALID_INPUT", message: "Y" })).toBe(true);
     expect(isSmithersError(new Error("plain"))).toBe(false);
+  });
+
+  test("isSmithersError rejects foreign errors and arbitrary objects", () => {
+    expect(isSmithersError({ code: "X", message: "Y" })).toBe(false);
+    expect(isSmithersError({ code: "ENOENT", message: "no such file" })).toBe(false);
+    expect(isSmithersError(Object.assign(new Error("fs"), { code: "ENOENT" }))).toBe(false);
   });
 });
 

--- a/packages/errors/tests/errors-core.test.js
+++ b/packages/errors/tests/errors-core.test.js
@@ -375,6 +375,32 @@ describe("toSmithersError", () => {
     expect(wrapped.cause).toBe(cause);
   });
 
+  test("wraps Node-style error objects instead of returning them unwrapped", () => {
+    // Regression: a Node system error like { code: "ENOENT", message } must not
+    // be mistaken for a SmithersError. It should be wrapped, not returned as-is,
+    // and the foreign libuv code must not leak into the SmithersError code.
+    const foreign = { code: "ENOENT", message: "no such file" };
+    const wrapped = toSmithersError(foreign);
+    expect(wrapped).not.toBe(foreign);
+    expect(wrapped).toBeInstanceOf(SmithersError);
+    expect(wrapped.code).toBe("INTERNAL_ERROR");
+    expect(isKnownSmithersErrorCode(wrapped.code)).toBe(true);
+    expect(wrapped.cause).toBe(foreign);
+  });
+
+  test("wraps Node Error instances carrying an errno code", () => {
+    const foreign = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    const wrapped = toSmithersError(foreign, "connect");
+    expect(wrapped).not.toBe(foreign);
+    expect(wrapped).toBeInstanceOf(SmithersError);
+    expect(wrapped.code).toBe("INTERNAL_ERROR");
+    expect(isKnownSmithersErrorCode(wrapped.code)).toBe(true);
+    expect(wrapped.summary).toBe("connect: connect ECONNREFUSED");
+    expect(wrapped.cause).toBe(foreign);
+  });
+
   test("primitive causes are stringified", () => {
     const wrapped = toSmithersError(404);
     expect(wrapped.code).toBe("INTERNAL_ERROR");


### PR DESCRIPTION
## Bug

`packages/errors/src/isSmithersError.js` used a purely structural check that only required a value to be an object with `code` and `message` properties. That predicate matches far more than genuine SmithersErrors:

- Node system errors carry a `code` (e.g. `ENOENT`, `EACCES`) and a `message`, so they were classified as SmithersErrors.
- Many third-party libraries throw `{ code, message }`-shaped errors that were also misclassified.

## Failure scenario

`toSmithersError` (via `isSmithersErrorLike`) trusts `isSmithersError`:

- When a foreign error matched, `toSmithersError` returned it **unwrapped** (so callers got a non-SmithersError back), or
- copied the foreign `code` (an invalid libuv code like `ENOENT`) onto the wrapped SmithersError.

Either way the resulting `code` is not a valid `SmithersErrorCode`, which breaks retry classification and any logic keyed off the error code (e.g. the gateway's `isSmithersError(error)` branches that pick log level / RPC status).

## Fix

Tighten the predicate to identify genuine SmithersErrors only:

- pass when the value is `instanceof SmithersError`, or
- pass when it is a plain object whose `code` is a **known** `SmithersErrorCode` (via `isKnownSmithersErrorCode`).

This still accepts SmithersErrors that were serialized and reconstructed over the wire (their `code` remains a known code), while rejecting generic `Error` / Node-errno objects whose codes are not in the known set. `toSmithersError` continues to wrap foreign errors correctly.

Tests in `packages/errors/tests/errors-core.test.js` were updated to assert the tightened semantics (genuine instances and known-code objects pass; arbitrary `{code,message}` and `ENOENT`-style errors are rejected). Full `errors-core` suite passes (62/62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)