### PR TITLE
fix(react-reconciler): remove existing occurrence when moving a child

### DIFF
--- a/packages/react-reconciler/src/reconciler.js
+++ b/packages/react-reconciler/src/reconciler.js
@@ -116,6 +116,9 @@ const hostConfig = {
    * @returns {void}
    */
     appendChild(parent, child) {
+        const existing = parent.children.indexOf(child);
+        if (existing >= 0)
+            parent.children.splice(existing, 1);
         parent.children.push(child);
     },
     /**
@@ -150,6 +153,9 @@ const hostConfig = {
    * @returns {void}
    */
     insertBefore(parent, child, beforeChild) {
+        const existing = parent.children.indexOf(child);
+        if (existing >= 0)
+            parent.children.splice(existing, 1);
         const idx = parent.children.indexOf(beforeChild);
         if (idx >= 0)
             parent.children.splice(idx, 0, child);

--- a/packages/react-reconciler/tests/reconciler-move-no-duplicate.test.jsx
+++ b/packages/react-reconciler/tests/reconciler-move-no-duplicate.test.jsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { SmithersRenderer } from "../src/dom/renderer.js";
+import React from "react";
+
+/**
+ * Regression test for the mutation-mode move bug.
+ *
+ * In mutation mode React relocates an already-mounted keyed child by calling
+ * insertBefore/appendChild WITHOUT a preceding removeChild. The host config
+ * used to push/splice the child into parent.children without removing its
+ * current position, so a reordered keyed child appeared twice in the extracted
+ * graph. The fix removes any existing occurrence of the child before inserting.
+ *
+ * Render a keyed list [A, B] then re-render as [B, A]; the parent must end up
+ * with exactly two children in order [B, A] with no duplicated node.
+ */
+describe("reconciler keyed move", () => {
+    test("reordering keyed children moves a node instead of duplicating it", async () => {
+        const renderer = new SmithersRenderer();
+
+        const makeChild = (id) =>
+            React.createElement("smithers:task", { key: id, id, output: "out" });
+
+        await renderer.render(
+            React.createElement(
+                "smithers:parallel",
+                null,
+                makeChild("A"),
+                makeChild("B"),
+            ),
+        );
+
+        const firstRoot = renderer.getRoot();
+        expect(firstRoot.kind).toBe("element");
+        expect(firstRoot.children.map((c) => c.props.id)).toEqual(["A", "B"]);
+
+        // Re-render with the order swapped. React moves an existing child.
+        await renderer.render(
+            React.createElement(
+                "smithers:parallel",
+                null,
+                makeChild("B"),
+                makeChild("A"),
+            ),
+        );
+
+        const root = renderer.getRoot();
+        const ids = root.children.map((c) => c.props.id);
+
+        // Exactly two children, no duplicates, in the new order.
+        expect(root.children).toHaveLength(2);
+        expect(ids).toEqual(["B", "A"]);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});


### PR DESCRIPTION
## Bug

`packages/react-reconciler/src/reconciler.js`: In mutation mode, React moves an already-mounted child by calling `insertBefore` / `appendChild` **without** a preceding `removeChild`. The host config implementations pushed/spliced the child into `parent.children` without removing the child's current position.

## Failure scenario

When a keyed child list is reordered, React relocates an existing node via `appendChild`/`insertBefore`. Because the old position was never removed, the reordered child ended up present at two indices in `parent.children`, so the extracted workflow graph contained that node twice.

## Fix

In both `appendChild` and `insertBefore`, before pushing/splicing, find any existing index of `child` in `parent.children` and splice it out. This makes a move relocate the node instead of duplicating it, matching DOM single-parent semantics. In `insertBefore`, `beforeChild`'s index is computed after the removal so the recomputed insertion point stays correct. Mounting a brand-new child is unchanged (`indexOf` returns `-1`, no removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)