### PR TITLE
fix(observability): resolve Codex sessions across local/UTC day folders and match Claude paths cross-platform

### DIFF
--- a/apps/observability/src/_sessionFileResolvers.js
+++ b/apps/observability/src/_sessionFileResolvers.js
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 /**
  * @param {string} dir
@@ -111,7 +111,7 @@ export async function resolveClaudeSessionFile(agent, cwd, sessionId) {
             if (info.isFile()) return direct;
         } catch {}
         const files = await listJsonlFiles(root);
-        const match = files.find((file) => file.endsWith(`/${sessionId}.jsonl`));
+        const match = files.find((file) => basename(file) === `${sessionId}.jsonl`);
         if (match) return match;
     }
     return null;
@@ -124,8 +124,13 @@ export async function resolveClaudeSessionFile(agent, cwd, sessionId) {
  * @returns {Promise<string | null>}
  */
 export async function resolveCodexSessionFile(agent, cwd, startedAtMs) {
-    const day = new Date(startedAtMs);
-    const dayRoots = buildCodexSessionRoots(agent).map((root) => join(root, String(day.getUTCFullYear()), String(day.getUTCMonth() + 1).padStart(2, "0"), String(day.getUTCDate()).padStart(2, "0")));
+    const dayFolders = new Set();
+    for (const offset of [-1, 0, 1]) {
+        const day = new Date(startedAtMs + offset * 24 * 60 * 60 * 1000);
+        dayFolders.add(join(String(day.getUTCFullYear()), String(day.getUTCMonth() + 1).padStart(2, "0"), String(day.getUTCDate()).padStart(2, "0")));
+        dayFolders.add(join(String(day.getFullYear()), String(day.getMonth() + 1).padStart(2, "0"), String(day.getDate()).padStart(2, "0")));
+    }
+    const dayRoots = buildCodexSessionRoots(agent).flatMap((root) => [...dayFolders].map((folder) => join(root, folder)));
     const candidates = (await Promise.all(dayRoots.map((root) => listJsonlFiles(root)))).flat();
     /** @type {{ file: string; delta: number } | null} */
     let best = null;

--- a/apps/observability/tests/sessionFileResolvers.test.js
+++ b/apps/observability/tests/sessionFileResolvers.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveClaudeSessionFile, resolveCodexSessionFile, } from "../src/_sessionFileResolvers.js";
+
+/** @returns {Promise<string>} */
+function makeTempDir() {
+    return mkdtemp(join(tmpdir(), "smithers-session-resolvers-"));
+}
+
+describe("resolveCodexSessionFile", () => {
+    /** @type {string | undefined} */
+    let savedTZ;
+    /** @type {string} */
+    let base;
+
+    // Pin the timezone so the local/UTC day boundary is deterministic regardless
+    // of the host. With TZ=UTC the local day and UTC day are identical, so the
+    // only way the file is found is by searching the adjacent (-1 day) folder.
+    beforeEach(async () => {
+        savedTZ = process.env.TZ;
+        process.env.TZ = "UTC";
+        base = await makeTempDir();
+    });
+    afterEach(async () => {
+        if (savedTZ === undefined) delete process.env.TZ;
+        else process.env.TZ = savedTZ;
+        await rm(base, { recursive: true, force: true });
+    });
+
+    test("finds a session stored in an adjacent day folder", async () => {
+        const cwd = "/work/proj";
+        // Run started just after midnight UTC on 2026-05-28, but the session was
+        // actually opened minutes earlier — its rollout file lives in the
+        // *previous* day folder (2026/05/27). The old resolver only looked at the
+        // UTC day of startedAtMs (2026/05/28) and missed it.
+        const startedAtMs = Date.UTC(2026, 4, 28, 0, 30, 0);
+        const sessionTimestamp = new Date(Date.UTC(2026, 4, 27, 23, 55, 0)).toISOString();
+
+        const adjacentDayDir = join(base, "2026", "05", "27");
+        await mkdir(adjacentDayDir, { recursive: true });
+        const sessionFile = join(adjacentDayDir, "rollout-2026-05-27-sess.jsonl");
+        await writeFile(sessionFile, `${JSON.stringify({
+            type: "session_meta",
+            payload: { cwd, timestamp: sessionTimestamp },
+        })}\n`);
+
+        const agent = { opts: { codexSessionDir: base } };
+        const resolved = await resolveCodexSessionFile(agent, cwd, startedAtMs);
+        expect(resolved).toBe(sessionFile);
+    });
+
+    test("returns null when no correlated session exists in nearby day folders", async () => {
+        const cwd = "/work/proj";
+        const startedAtMs = Date.UTC(2026, 4, 28, 0, 30, 0);
+        const agent = { opts: { codexSessionDir: base } };
+        expect(await resolveCodexSessionFile(agent, cwd, startedAtMs)).toBeNull();
+    });
+});
+
+describe("resolveClaudeSessionFile", () => {
+    /** @type {string} */
+    let base;
+    beforeEach(async () => {
+        base = await makeTempDir();
+    });
+    afterEach(async () => {
+        await rm(base, { recursive: true, force: true });
+    });
+
+    test("matches a session by basename regardless of which project folder holds it", async () => {
+        const sessionId = "11111111-2222-3333-4444-555555555555";
+        // The direct lookup derives the project folder from cwd, but the file is
+        // actually stored under a *different* project folder. The fallback must
+        // match on the file's basename (`<sessionId>.jsonl`), not on a hard-coded
+        // forward-slash suffix, to find it.
+        const otherProjectDir = join(base, "-some-other-project");
+        await mkdir(otherProjectDir, { recursive: true });
+        const sessionFile = join(otherProjectDir, `${sessionId}.jsonl`);
+        await writeFile(sessionFile, `${JSON.stringify({ type: "summary" })}\n`);
+
+        const agent = { opts: { claudeProjectsDir: base } };
+        const resolved = await resolveClaudeSessionFile(agent, "/work/some/other/cwd", sessionId);
+        expect(resolved).toBe(sessionFile);
+    });
+
+    test("matches a session whose path separator is not a forward slash (basename match)", async () => {
+        const sessionId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        // Simulate a recorded session path that uses a backslash separator (as a
+        // Windows host would produce). A basename comparison must still match it;
+        // the old `endsWith("/<id>.jsonl")` check only handled forward slashes.
+        const { basename } = await import("node:path/win32");
+        const windowsStylePath = `C:\\Users\\dev\\.claude\\projects\\proj\\${sessionId}.jsonl`;
+        expect(basename(windowsStylePath)).toBe(`${sessionId}.jsonl`);
+        // Sanity: the pre-fix forward-slash-only check would NOT match this path.
+        expect(windowsStylePath.endsWith(`/${sessionId}.jsonl`)).toBe(false);
+    });
+
+    test("returns null when sessionId is missing", async () => {
+        const agent = { opts: { claudeProjectsDir: base } };
+        expect(await resolveClaudeSessionFile(agent, "/work/proj", undefined)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Bug

`apps/observability/src/_sessionFileResolvers.js` had two session-resolution bugs:

1. **Codex day-folder mismatch.** `resolveCodexSessionFile` derived a single `YYYY/MM/DD` folder from `startedAtMs` using **UTC** components and scanned only that folder. But Codex writes its session folder using the **local** date. For runs in negative-UTC offsets (e.g. the Americas) or any run that straddles midnight, the local and UTC dates disagree, so the transcript lives in a folder the resolver never scans and the session is never correlated (returns `null`).

2. **Claude fallback breaks on Windows.** `resolveClaudeSessionFile`'s fallback matched `file.endsWith("/${sessionId}.jsonl")` with a hardcoded forward slash. On Windows, `path.join` produces backslash separators, so the suffix never matches and the fallback silently fails.

## Fix

1. For Codex, build candidate day folders from **both** the UTC date and the local date across the adjacent days (`-1`, `0`, `+1`), deduped via a `Set`. This guarantees the correct folder is scanned regardless of timezone offset or midnight straddle. Best-match selection (closest `session_meta` timestamp with a correlated cwd) is unchanged, and it still returns `null` when truly not found.

2. For the Claude fallback, match separator-agnostically via `basename(file) === \`${sessionId}.jsonl\``, mirroring the sibling `resolvePiSessionFile`. Added `basename` to the `node:path` import.

Both functions remain best-effort and return `null` when no transcript is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)