### PR TITLE
fix(engine): evict consumed entries from deferredResolutions map

### DIFF
--- a/packages/engine/src/effect/durable-deferred-bridge.js
+++ b/packages/engine/src/effect/durable-deferred-bridge.js
@@ -172,7 +172,11 @@ const deferredResolutions = new Map();
  */
 const awaitBridgeDeferred = async (executionId, _deferred) => {
     const exit = deferredResolutions.get(executionId);
-    return exit ? { _tag: "Complete", exit } : { _tag: "Pending" };
+    if (!exit) {
+        return { _tag: "Pending" };
+    }
+    deferredResolutions.delete(executionId);
+    return { _tag: "Complete", exit };
 };
 /**
  * @template Success, Error


### PR DESCRIPTION
## Bug

`packages/engine/src/effect/durable-deferred-bridge.js` holds a module-level `deferredResolutions` Map. It is written on every approval (`bridgeApprovalResolve`) and wait-for-event/signal (`bridgeWaitForEventResolve`) resolution via `resolveBridgeDeferred`, and read by `awaitBridgeDeferred` (through `awaitApprovalDurableDeferred` / `awaitWaitForEventDurableDeferred`). Entries were never removed.

## Failure scenario

Because the Map lives for the entire process lifetime and entries are never deleted, each resolved approval or delivered signal leaks one `Exit` object permanently. Over a long-running engine process handling many runs, the Map grows without bound — a steady memory leak proportional to the number of approvals/signals ever resolved.

## Fix

`awaitBridgeDeferred` now deletes the entry from the Map immediately after consuming it:

- Every value ever stored is an `Exit.succeed(...)` (the only two `resolveBridgeDeferred` call sites both use `Exit.succeed`).
- Both consumers in `deferred-state-bridge.js` finalize the node (transition to `finished`) on a successful read and do not re-poll that node/iteration afterward, so eviction on read does not break any double-consume path.
- A `Pending` result (no entry) is unchanged.

Behavior is otherwise unchanged.

## Note on sibling file

`packages/engine/src/effect/deferred-bridge.js` has a structurally similar module-level `deferredResolutions` Map, but it exposes a plain `getDeferredResolution` peek-style getter (no `Pending`/`Complete` consume contract) with no production callers. Converting its getter to delete-on-read would change its contract, so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)