### PR TITLE
fix(db): parameterize getRawNodeOutput query

### DIFF
--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -10,7 +10,7 @@
 /** @typedef {import("./adapter/StaleRunRecord.ts").StaleRunRecord} StaleRunRecord */
 // @smithers-type-exports-end
 
-import { getTableName, sql } from "drizzle-orm";
+import { getTableName } from "drizzle-orm";
 import { Effect, Exit, FiberId, Metric } from "effect";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { getSqlMessageStorage } from "./sql-message-storage.js";
@@ -1111,9 +1111,11 @@ export class SmithersDb {
    */
     getRawNodeOutput(tableName, runId, nodeId) {
         return runnableEffect(this.read(`get raw node output ${tableName}`, () => {
-            const query = sql.raw(`SELECT * FROM "${tableName}" WHERE run_id = '${runId}' AND node_id = '${nodeId}' ORDER BY iteration DESC LIMIT 1`);
-            const res = this.db.get(query);
-            return Promise.resolve(res ?? null);
+            const escaped = tableName.replaceAll(`"`, `""`);
+            const client = this.db.session.client;
+            const stmt = client.query(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? ORDER BY iteration DESC LIMIT 1`);
+            const row = stmt.get(runId, nodeId);
+            return Promise.resolve(row ?? null);
         }).pipe(Effect.catchAll(() => Effect.succeed(null))));
     }
     /**

--- a/packages/db/tests/db-getRawNodeOutput.test.js
+++ b/packages/db/tests/db-getRawNodeOutput.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { SmithersDb } from "../src/adapter.js";
+import { zodToTable } from "../src/zodToTable.js";
+import { zodToCreateTableSQL } from "../src/zodToCreateTableSQL.js";
+import { z } from "zod";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+/**
+ * Build a SmithersDb backed by an in-memory sqlite db that contains a single
+ * output table created from the given zod schema.
+ *
+ * @param {string} tableName
+ * @param {z.ZodObject<any>} schema
+ */
+function createDbWithOutputTable(tableName, schema) {
+    const table = zodToTable(tableName, schema);
+    const sqlite = new Database(":memory:");
+    sqlite.exec(zodToCreateTableSQL(tableName, schema));
+    const db = drizzle(sqlite, { schema: { [tableName]: table } });
+    return { adapter: new SmithersDb(db), table };
+}
+
+describe("getRawNodeOutput", () => {
+    test("returns the row when node_id contains a single quote", async () => {
+        const tableName = "out";
+        const { adapter, table } = createDbWithOutputTable(tableName, z.object({ title: z.string() }));
+
+        // A node_id with an apostrophe used to break the interpolated SQL
+        // string and silently return null (via catchAll). The parameterized
+        // query must handle it correctly.
+        const runId = "run-1";
+        const nodeId = "o'brien";
+
+        await adapter.upsertOutputRow(table, { runId, nodeId, iteration: 0 }, { title: "hello" });
+
+        const row = await adapter.getRawNodeOutput(tableName, runId, nodeId);
+
+        expect(row).not.toBeNull();
+        expect(row?.node_id).toBe(nodeId);
+        expect(row?.run_id).toBe(runId);
+        expect(row?.title).toBe("hello");
+    });
+
+    test("returns the row when run_id contains a single quote", async () => {
+        const tableName = "out";
+        const { adapter, table } = createDbWithOutputTable(tableName, z.object({ title: z.string() }));
+
+        const runId = "run-o'malley";
+        const nodeId = "n1";
+
+        await adapter.upsertOutputRow(table, { runId, nodeId, iteration: 0 }, { title: "world" });
+
+        const row = await adapter.getRawNodeOutput(tableName, runId, nodeId);
+
+        expect(row).not.toBeNull();
+        expect(row?.run_id).toBe(runId);
+        expect(row?.title).toBe("world");
+    });
+
+    test("returns the latest iteration for a quoted node_id", async () => {
+        const tableName = "out";
+        const { adapter, table } = createDbWithOutputTable(tableName, z.object({ title: z.string() }));
+
+        const runId = "run-1";
+        const nodeId = "o'brien";
+
+        await adapter.upsertOutputRow(table, { runId, nodeId, iteration: 0 }, { title: "first" });
+        await adapter.upsertOutputRow(table, { runId, nodeId, iteration: 1 }, { title: "second" });
+
+        const row = await adapter.getRawNodeOutput(tableName, runId, nodeId);
+
+        expect(row).not.toBeNull();
+        expect(row?.iteration).toBe(1);
+        expect(row?.title).toBe("second");
+    });
+});


### PR DESCRIPTION
## Bug

`packages/db/src/adapter.js`: `getRawNodeOutput` built raw SQL by interpolating `runId`/`nodeId` directly into the query string via `sql.raw`:

```js
const query = sql.raw(`SELECT * FROM "${tableName}" WHERE run_id = '${runId}' AND node_id = '${nodeId}' ORDER BY iteration DESC LIMIT 1`);
```

This differs from the sibling `getRawNodeOutputForIteration`, which uses `?` bound parameters.

## Failure scenario

A single quote in an id (`runId`/`nodeId`) breaks the SQL syntax. Because the read is wrapped in `Effect.catchAll(() => Effect.succeed(null))`, the failure is swallowed and the caller silently receives `null` instead of the row. Beyond the silent-null bug, string interpolation of untrusted ids into SQL on a public export is a latent injection footgun.

## Fix

Rewrite `getRawNodeOutput` to use bound parameters, exactly like `getRawNodeOutputForIteration`:

```js
const escaped = tableName.replaceAll(`"`, `""`);
const client = this.db.session.client;
const stmt = client.query(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? ORDER BY iteration DESC LIMIT 1`);
const row = stmt.get(runId, nodeId);
```

The table name is escaped the same way as the sibling. `runId`/`nodeId` are no longer interpolated into the SQL string. The now-unused `sql` import from `drizzle-orm` is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)