### PR TITLE
fix(db): fail the Effect instead of throwing synchronously on missing runId column

### DIFF
--- a/packages/db/src/loadInputEffect.js
+++ b/packages/db/src/loadInputEffect.js
@@ -13,16 +13,18 @@ import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
  * @returns {Effect.Effect<Record<string, unknown> | undefined, SmithersError>}
  */
 export function loadInput(db, inputTable, runId) {
-    const cols = getTableColumns(inputTable);
-    const runIdCol = cols.runId;
-    if (!runIdCol) {
-        throw new SmithersError("DB_MISSING_COLUMNS", "schema.input must include runId column");
-    }
-    return Effect.tryPromise({
-        try: () => db.select().from(inputTable).where(eq(runIdCol, runId)).limit(1),
-        catch: (cause) => toSmithersError(cause, "load input", {
-            code: "DB_QUERY_FAILED",
-            details: { runId },
-        }),
-    }).pipe(Effect.map((rows) => rows[0]), Effect.annotateLogs({ runId }), Effect.withLogSpan("db:load-input"));
+    return Effect.suspend(() => {
+        const cols = getTableColumns(inputTable);
+        const runIdCol = cols.runId;
+        if (!runIdCol) {
+            return Effect.fail(new SmithersError("DB_MISSING_COLUMNS", "schema.input must include runId column"));
+        }
+        return Effect.tryPromise({
+            try: () => db.select().from(inputTable).where(eq(runIdCol, runId)).limit(1),
+            catch: (cause) => toSmithersError(cause, "load input", {
+                code: "DB_QUERY_FAILED",
+                details: { runId },
+            }),
+        }).pipe(Effect.map((rows) => rows[0]));
+    }).pipe(Effect.annotateLogs({ runId }), Effect.withLogSpan("db:load-input"));
 }

--- a/packages/db/src/snapshot.js
+++ b/packages/db/src/snapshot.js
@@ -53,18 +53,20 @@ function coerceBooleanColumns(rows, boolKeys) {
  * @returns {Effect.Effect<Record<string, unknown> | undefined, SmithersError>}
  */
 export function loadInputEffect(db, inputTable, runId) {
-    const cols = getTableColumns(inputTable);
-    const runIdCol = cols.runId;
-    if (!runIdCol) {
-        throw new SmithersError("DB_MISSING_COLUMNS", "schema.input must include runId column");
-    }
-    return Effect.tryPromise({
-        try: () => db.select().from(inputTable).where(eq(runIdCol, runId)).limit(1),
-        catch: (cause) => toSmithersError(cause, "load input", {
-            code: "DB_QUERY_FAILED",
-            details: { runId },
-        }),
-    }).pipe(Effect.map((rows) => rows[0]), Effect.annotateLogs({ runId }), Effect.withLogSpan("db:load-input"));
+    return Effect.suspend(() => {
+        const cols = getTableColumns(inputTable);
+        const runIdCol = cols.runId;
+        if (!runIdCol) {
+            return Effect.fail(new SmithersError("DB_MISSING_COLUMNS", "schema.input must include runId column"));
+        }
+        return Effect.tryPromise({
+            try: () => db.select().from(inputTable).where(eq(runIdCol, runId)).limit(1),
+            catch: (cause) => toSmithersError(cause, "load input", {
+                code: "DB_QUERY_FAILED",
+                details: { runId },
+            }),
+        }).pipe(Effect.map((rows) => rows[0]));
+    }).pipe(Effect.annotateLogs({ runId }), Effect.withLogSpan("db:load-input"));
 }
 /**
  * @param {BunSQLiteDatabase<Record<string, unknown>>} db

--- a/packages/db/tests/db-loadinput-missing-runid.test.js
+++ b/packages/db/tests/db-loadinput-missing-runid.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Exit } from "effect";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+import { loadInputEffect } from "../src/snapshot.js";
+
+// Input table deliberately missing a `runId` column to exercise the
+// DB_MISSING_COLUMNS path.
+const noRunIdTable = sqliteTable("test_input_no_runid", {
+    id: text("id").primaryKey(),
+    prompt: text("prompt"),
+});
+
+function createTestDb() {
+    const sqlite = new Database(":memory:");
+    sqlite.exec(`
+    CREATE TABLE test_input_no_runid (
+      id TEXT PRIMARY KEY,
+      prompt TEXT
+    );
+  `);
+    const db = drizzle(sqlite, { schema: { input: noRunIdTable } });
+    return { db, cleanup: () => sqlite.close() };
+}
+
+describe("loadInputEffect: missing runId column", () => {
+    test("does NOT throw synchronously during Effect construction", () => {
+        const { db, cleanup } = createTestDb();
+        try {
+            // Building the Effect must be pure: the missing-column error has to
+            // be deferred into the Effect, not thrown while constructing it.
+            let effect;
+            expect(() => {
+                effect = loadInputEffect(db, noRunIdTable, "run-1");
+            }).not.toThrow();
+            expect(effect).toBeDefined();
+        } finally {
+            cleanup();
+        }
+    });
+
+    test("fails the Effect with a DB_MISSING_COLUMNS SmithersError (catchable)", async () => {
+        const { db, cleanup } = createTestDb();
+        try {
+            const exit = await Effect.runPromiseExit(loadInputEffect(db, noRunIdTable, "run-1"));
+            expect(Exit.isFailure(exit)).toBe(true);
+
+            // The error must surface through the Effect error channel so callers
+            // can catch it, rather than escaping as a synchronous throw or defect.
+            const error = await Effect.runPromise(
+                loadInputEffect(db, noRunIdTable, "run-1").pipe(Effect.flip),
+            );
+            expect(error).toBeInstanceOf(SmithersError);
+            expect(error.code).toBe("DB_MISSING_COLUMNS");
+        } finally {
+            cleanup();
+        }
+    });
+
+    test("rejected runPromise carries the SmithersError, not an unrelated throw", async () => {
+        const { db, cleanup } = createTestDb();
+        try {
+            let caught;
+            try {
+                await Effect.runPromise(loadInputEffect(db, noRunIdTable, "run-1"));
+            } catch (err) {
+                caught = err;
+            }
+            expect(caught).toBeDefined();
+            // Effect wraps failures, so assert the SmithersError is reachable.
+            const message = caught instanceof Error ? caught.message : String(caught);
+            expect(message).toContain("schema.input must include runId column");
+        } finally {
+            cleanup();
+        }
+    });
+});


### PR DESCRIPTION
## Bug

`loadInput` in `packages/db/src/loadInputEffect.js` (and the duplicated `loadInputEffect` in `packages/db/src/snapshot.js`) is documented to return `Effect.Effect<Record<string, unknown> | undefined, SmithersError>`. However, on the missing-runId-column path it did:

```js
const cols = getTableColumns(inputTable);
const runIdCol = cols.runId;
if (!runIdCol) {
    throw new SmithersError("DB_MISSING_COLUMNS", "schema.input must include runId column");
}
```

This `throw` happens eagerly during Effect construction (when the function is called), not inside the Effect. It violates the `Effect<..., SmithersError>` contract: callers that expect to handle the failure via the Effect error channel (e.g. `Effect.catchTag`, `Effect.either`, `Effect.runPromiseExit`) get a synchronous exception at call time instead, and the error never flows through the typed failure channel.

## Failure scenario

A schema whose input table lacks a `runId` column causes `loadInput(db, inputTable, runId)` to throw synchronously the moment it is invoked, before the returned Effect is ever run, bypassing all Effect-based error handling around it.

## Fix

Wrap the body in `Effect.suspend(...)` so the column check runs inside the Effect and the missing-column case returns `Effect.fail(new SmithersError("DB_MISSING_COLUMNS", ...))`. The success path is unchanged (same query, same `DB_QUERY_FAILED` mapping, same `annotateLogs`/`withLogSpan`). The same fix is applied to the duplicated check in `snapshot.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)