### PR TITLE
fix(agents): truncate stderr on a UTF-8 codepoint boundary

### DIFF
--- a/packages/agents/src/BaseCliAgent/truncateToBytes.js
+++ b/packages/agents/src/BaseCliAgent/truncateToBytes.js
@@ -9,5 +9,22 @@ export function truncateToBytes(text, maxBytes) {
     const buf = Buffer.from(text, "utf8");
     if (buf.length <= maxBytes)
         return text;
-    return buf.subarray(0, maxBytes).toString("utf8");
+    let end = maxBytes;
+    // Back off any UTF-8 continuation bytes (0b10xxxxxx) so the slice ends on a
+    // codepoint boundary, then drop the lead byte if its sequence is incomplete.
+    while (end > 0 && (buf[end] & 0xc0) === 0x80)
+        end--;
+    if (end > 0) {
+        const lead = buf[end - 1];
+        let seqLen = 1;
+        if ((lead & 0xe0) === 0xc0)
+            seqLen = 2;
+        else if ((lead & 0xf0) === 0xe0)
+            seqLen = 3;
+        else if ((lead & 0xf8) === 0xf0)
+            seqLen = 4;
+        if ((end - 1) + seqLen > maxBytes)
+            end--;
+    }
+    return buf.subarray(0, end).toString("utf8");
 }

--- a/packages/agents/tests/truncate-to-bytes.test.js
+++ b/packages/agents/tests/truncate-to-bytes.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { truncateToBytes } from "../src/BaseCliAgent/truncateToBytes.js";
+
+const REPLACEMENT_CHAR = "�";
+
+describe("truncateToBytes", () => {
+  test("cuts before a 4-byte emoji instead of emitting U+FFFD", () => {
+    // "abc" = 3 bytes, "😀" = 4 bytes. maxBytes=5 lands mid-emoji.
+    const result = truncateToBytes("abc😀def", 5);
+    expect(result).toBe("abc");
+    expect(result).not.toContain(REPLACEMENT_CHAR);
+  });
+
+  test("cuts before a 3-byte CJK character instead of emitting U+FFFD", () => {
+    // "ab" = 2 bytes, "中" = 3 bytes. maxBytes=4 lands mid-character.
+    const result = truncateToBytes("ab中文", 4);
+    expect(result).toBe("ab");
+    expect(result).not.toContain(REPLACEMENT_CHAR);
+  });
+
+  test("cuts before a 2-byte character instead of emitting U+FFFD", () => {
+    // "a" = 1 byte, "é" = 2 bytes. maxBytes=2 lands mid-character.
+    const result = truncateToBytes("aébc", 2);
+    expect(result).toBe("a");
+    expect(result).not.toContain(REPLACEMENT_CHAR);
+  });
+
+  test("never produces a replacement char at any cut offset within a multibyte string", () => {
+    const text = "a😀b中c日本語dé";
+    const totalBytes = Buffer.byteLength(text, "utf8");
+    for (let max = 1; max < totalBytes; max++) {
+      const result = truncateToBytes(text, max);
+      expect(result).not.toContain(REPLACEMENT_CHAR);
+      // Result must be a clean prefix of the original.
+      expect(text.startsWith(result)).toBe(true);
+      // Result must fit within the byte budget.
+      expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(max);
+    }
+  });
+
+  test("keeps a complete multibyte character that fits exactly on the boundary", () => {
+    // "abc" = 3 bytes, "😀" = 4 bytes => 7 bytes total; maxBytes=7 keeps the emoji.
+    const result = truncateToBytes("abc😀", 7);
+    expect(result).toBe("abc😀");
+    expect(result).not.toContain(REPLACEMENT_CHAR);
+  });
+
+  test("returns within-limit multibyte input unchanged", () => {
+    const text = "abc😀def";
+    expect(truncateToBytes(text, 1000)).toBe(text);
+  });
+
+  test("returns input unchanged when maxBytes is falsy or non-positive", () => {
+    const text = "abc😀def";
+    expect(truncateToBytes(text, 0)).toBe(text);
+    expect(truncateToBytes(text, -5)).toBe(text);
+    expect(truncateToBytes(text, undefined)).toBe(text);
+  });
+});


### PR DESCRIPTION
## Bug

`packages/agents/src/BaseCliAgent/truncateToBytes.js` sliced the UTF-8 buffer at an arbitrary byte offset:

```js
return buf.subarray(0, maxBytes).toString("utf8");
```

When `maxBytes` lands in the middle of a multibyte UTF-8 sequence (any non-ASCII character — accented letters, currency symbols, CJK, emoji), the slice cuts the codepoint in half. Decoding the resulting partial sequence yields a `U+FFFD` (`�`) replacement character at the end of the truncated string.

## Failure scenario

Truncating stderr containing multibyte characters — e.g. truncating `"abc€€"` (each `€` is 3 bytes) at 5 bytes previously decoded to `"abc�"` instead of `"abc"`. Any agent stderr containing non-ASCII bytes near the truncation limit would surface a stray replacement char.

## Fix

Before decoding, back the cut offset off any UTF-8 continuation bytes (`0b10xxxxxx`), then inspect the preceding lead byte: if its declared sequence length would extend past `maxBytes`, drop that incomplete lead byte too. The slice then always ends on a codepoint boundary and decodes cleanly. The early-return for input already within the limit (and for non-positive `maxBytes`) is unchanged.

Verified manually across 2-, 3-, and 4-byte sequences and all boundary offsets: no output contains `U+FFFD`, and none exceeds `maxBytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)