### PR TITLE
fix(agents): clear per-check diagnostic timeout when the check resolves

### DIFF
--- a/packages/agents/src/diagnostics/runDiagnostics.js
+++ b/packages/agents/src/diagnostics/runDiagnostics.js
@@ -19,10 +19,15 @@ const PER_CHECK_TIMEOUT_MS = 5_000;
  */
 async function runCheck(check, ctx) {
     const start = performance.now();
+    /** @type {ReturnType<typeof setTimeout> | undefined} */
+    let timeoutHandle;
     try {
         return await Promise.race([
             check.run(ctx),
-            new Promise((_, reject) => setTimeout(() => reject(new SmithersError("AGENT_DIAGNOSTIC_TIMEOUT", "diagnostic check timed out", { timeoutMs: PER_CHECK_TIMEOUT_MS })), PER_CHECK_TIMEOUT_MS)),
+            new Promise((_, reject) => {
+                timeoutHandle = setTimeout(() => reject(new SmithersError("AGENT_DIAGNOSTIC_TIMEOUT", "diagnostic check timed out", { timeoutMs: PER_CHECK_TIMEOUT_MS })), PER_CHECK_TIMEOUT_MS);
+                timeoutHandle.unref?.();
+            }),
         ]);
     }
     catch (err) {
@@ -32,6 +37,9 @@ async function runCheck(check, ctx) {
             message: err instanceof Error ? err.message : String(err),
             durationMs: performance.now() - start,
         };
+    }
+    finally {
+        clearTimeout(timeoutHandle);
     }
 }
 /**

--- a/packages/agents/tests/run-diagnostics-timeout-cleared.test.js
+++ b/packages/agents/tests/run-diagnostics-timeout-cleared.test.js
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { runDiagnostics } from "../src/diagnostics/index.js";
+
+// ---------------------------------------------------------------------------
+// Regression: runCheck must clear its per-check timeout timer once the check
+// settles. Previously the setTimeout-based rejection timer was raced via
+// Promise.race but never cleared when check.run resolved first, leaving a
+// ~5s timer armed on a hot path (diagnostics run on every agent invocation).
+// See fix(agents): clear per-check diagnostic timeout when the check resolves.
+// ---------------------------------------------------------------------------
+describe("runDiagnostics per-check timeout cleanup", () => {
+    /** @type {ReturnType<typeof spyOn> | undefined} */
+    let setTimeoutSpy;
+    /** @type {ReturnType<typeof spyOn> | undefined} */
+    let clearTimeoutSpy;
+
+    afterEach(() => {
+        setTimeoutSpy?.mockRestore();
+        clearTimeoutSpy?.mockRestore();
+    });
+
+    test("clears the timeout timer when a check resolves quickly", async () => {
+        // Track every timer handle armed and cleared during the run so we can
+        // assert the per-check timeout timer does not stay armed.
+        /** @type {Set<unknown>} */
+        const armed = new Set();
+        /** @type {Set<unknown>} */
+        const cleared = new Set();
+
+        const realSetTimeout = globalThis.setTimeout;
+        const realClearTimeout = globalThis.clearTimeout;
+
+        setTimeoutSpy = spyOn(globalThis, "setTimeout").mockImplementation(
+            /** @type {any} */ ((fn, ms, ...args) => {
+                const handle = realSetTimeout(fn, ms, ...args);
+                armed.add(handle);
+                return handle;
+            }),
+        );
+        clearTimeoutSpy = spyOn(globalThis, "clearTimeout").mockImplementation(
+            /** @type {any} */ ((handle) => {
+                cleared.add(handle);
+                return realClearTimeout(handle);
+            }),
+        );
+
+        const strategy = {
+            agentId: "fast-agent",
+            command: "fast",
+            checks: [
+                {
+                    id: "cli_installed",
+                    // Resolves immediately — well before the per-check timeout.
+                    run: async () => ({
+                        id: "cli_installed",
+                        status: "pass",
+                        message: "found",
+                        durationMs: 0,
+                    }),
+                },
+            ],
+        };
+
+        const report = await runDiagnostics(strategy, { env: {}, cwd: "/tmp" });
+
+        // Sanity: the check resolved successfully (not via the timeout path).
+        expect(report.checks[0].status).toBe("pass");
+
+        // The per-check timeout timer was armed...
+        expect(armed.size).toBeGreaterThanOrEqual(1);
+        // ...and clearTimeout was called for it.
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+
+        // Every timer armed during the run must have been cleared. If the fix
+        // is missing, the per-check timeout handle stays in `armed` but never
+        // appears in `cleared`, and this assertion fails.
+        for (const handle of armed) {
+            expect(cleared.has(handle)).toBe(true);
+        }
+    });
+});


### PR DESCRIPTION
## Bug

`runCheck` in `packages/agents/src/diagnostics/runDiagnostics.js` races `check.run(ctx)` against a `setTimeout`-based rejection using `Promise.race`. The `setTimeout` handle was never captured, so when the check resolves before the timeout (the common case), the ~5s timer stays armed. It was also not `.unref()`'d.

## Failure scenario

Diagnostics run on every agent invocation. Each fast-resolving check left a non-unref'd ~5 second timer alive in the event loop. On a hot path this keeps the event loop from quiescing — short-lived processes (e.g. CLI invocations) can hang for up to 5s waiting for the orphaned timers to fire before exiting.

## Fix

Capture the `setTimeout` handle, call `.unref()` on it (guarded with optional chaining for non-Node runtimes), and `clearTimeout` it in a `finally` block once the race settles. The timeout duration (`PER_CHECK_TIMEOUT_MS`) and rejection behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)