### PR TITLE
fix(graph): only treat real Drizzle tables as output tables in extract

### DIFF
--- a/packages/graph/src/extract.js
+++ b/packages/graph/src/extract.js
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve as resolvePath } from "node:path";
+import { getTableName } from "drizzle-orm";
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 /** @typedef {import("./TaskDescriptor.ts").TaskDescriptor} TaskDescriptor */
 /** @typedef {import("./XmlNode.ts").XmlNode} XmlNode */
@@ -58,23 +59,18 @@ function isZodObject(value) {
 }
 /**
  * @param {unknown} value
- * @returns {string | undefined}
+ * @returns {boolean}
  */
-function maybeTableName(value) {
+function isDrizzleTable(value) {
     if (!value || typeof value !== "object")
-        return undefined;
-    const symbols = Object.getOwnPropertySymbols(value);
-    for (const symbol of symbols) {
-        const key = String(symbol);
-        if (key.includes("drizzle") || key.includes("Name")) {
-            const symbolValue = value[symbol];
-            if (typeof symbolValue === "string" && symbolValue.length > 0) {
-                return symbolValue;
-            }
-        }
+        return false;
+    try {
+        const name = getTableName(value);
+        return typeof name === "string" && name.length > 0;
     }
-    const named = value.name;
-    return typeof named === "string" && named.length > 0 ? named : undefined;
+    catch {
+        return false;
+    }
 }
 /**
  * @param {Record<string, unknown>} raw
@@ -90,13 +86,17 @@ function resolveOutput(raw) {
             outputSchema: undefined,
         };
     }
-    const outputRef = isZodObject(outputRaw) ? outputRaw : undefined;
-    const tableName = typeof outputRaw === "string" ? outputRaw : maybeTableName(outputRaw) ?? "";
-    const outputTable = outputRef ? null : typeof outputRaw === "string" ? null : outputRaw;
+    const outputTable = isDrizzleTable(outputRaw) ? outputRaw : null;
+    const outputTableName = outputTable
+        ? getTableName(outputTable)
+        : typeof outputRaw === "string"
+            ? outputRaw
+            : "";
+    const outputRef = !outputTable && isZodObject(outputRaw) ? outputRaw : undefined;
     const outputSchema = isZodObject(raw.outputSchema) ? raw.outputSchema : outputRef;
     return {
         outputTable,
-        outputTableName: tableName,
+        outputTableName,
         outputRef,
         outputSchema,
     };

--- a/packages/graph/tests/extract-output-drizzle.test.jsx
+++ b/packages/graph/tests/extract-output-drizzle.test.jsx
@@ -1,0 +1,46 @@
+/** @jsxImportSource smithers-orchestrator */
+import { describe, expect, test } from "bun:test";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { extractGraph } from "../src/extract.js";
+
+/**
+ * @param {string} tag
+ * @param {Record<string, any>} [rawProps]
+ * @param {HostNode[]} [children]
+ * @returns {HostElement}
+ */
+function hostEl(tag, rawProps = {}, children = []) {
+    const stringProps = {};
+    for (const [k, v] of Object.entries(rawProps)) {
+        if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+            stringProps[k] = String(v);
+        }
+    }
+    return { kind: "element", tag, props: stringProps, rawProps, children };
+}
+
+describe("resolveOutput drizzle handling (src/extract.js)", () => {
+    test("real drizzle table sets outputTable and outputTableName via getTableName", () => {
+        const table = sqliteTable("table_out", {
+            runId: text("run_id").primaryKey(),
+        });
+        const root = hostEl("smithers:task", { id: "table-task", output: table });
+        const result = extractGraph(root);
+        expect(result.tasks[0].outputTable).toBe(table);
+        expect(result.tasks[0].outputTableName).toBe("table_out");
+    });
+
+    test("plain non-Zod object is not treated as a table", () => {
+        // A bare object whose own properties (e.g. a `name` string) previously
+        // tricked the loose maybeTableName heuristic into emitting a bogus table
+        // descriptor with a stray/empty name. It must fall through to the
+        // non-table path: outputTable null and outputTableName "".
+        const root = hostEl("smithers:task", {
+            id: "object-task",
+            output: { name: "looks-like-a-table", nope: true },
+        });
+        const result = extractGraph(root);
+        expect(result.tasks[0].outputTable).toBeNull();
+        expect(result.tasks[0].outputTableName).toBe("");
+    });
+});


### PR DESCRIPTION
## Bug

`resolveOutput` in `packages/graph/src/extract.js` classified **any** non-string / non-Zod value as a Drizzle table. It set `outputTable = outputRaw` whenever the value was an object, and derived its name from a loose heuristic (`maybeTableName`, which scanned symbol keys containing `drizzle`/`Name` and fell back to `value.name`). This diverges from the authoritative `packages/graph/src/dom/extract.js`, which gates table classification on `isDrizzleTable` / `getTableName`.

## Failure scenario

When a task's `output` is an off-contract object (neither a string table name, a Zod object, nor a real Drizzle table), the old code produced a bogus table descriptor — typically with an empty `outputTableName`. That output is then either silently dropped from snapshots or surfaces later as a cryptic database error, instead of falling through to the normal registry / `UNKNOWN_OUTPUT_SCHEMA` handling.

## Fix

- Import `getTableName` from `drizzle-orm` and add an `isDrizzleTable` guard (mirroring `dom/extract.js`).
- `outputTable` is now set only when `outputRaw` is a genuine Drizzle table.
- `outputTableName` is derived via `getTableName(outputTable)` for tables, the string itself for string outputs, otherwise `""`.
- `outputRef` is only treated as a Zod ref when it is not a table.
- Non-table, non-Zod values now fall through to existing registry / `UNKNOWN_OUTPUT_SCHEMA` handling.
- Zod and string handling are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)