### PR TITLE
fix(smithers): avoid leaking process exit listeners per Smithers instance

### DIFF
--- a/packages/smithers/src/create.js
+++ b/packages/smithers/src/create.js
@@ -249,8 +249,9 @@ export function createSmithers(schemas, opts) {
             sqlite.close();
         }
         catch { }
+        process.removeListener("exit", closeDb);
     };
-    process.on("exit", closeDb);
+    process.once("exit", closeDb);
     // 3. Auto-create tables, and ALTER any existing tables to add columns the
     // current schema introduced (CREATE TABLE IF NOT EXISTS would silently
     // skip the columns and a later upsert would fail with "no column named X").

--- a/packages/smithers/src/external/create-external-smithers.js
+++ b/packages/smithers/src/external/create-external-smithers.js
@@ -127,8 +127,9 @@ export function createExternalSmithers(config) {
             sqlite.close();
         }
         catch { }
+        process.removeListener("exit", closeDb);
     };
-    process.on("exit", closeDb);
+    process.once("exit", closeDb);
     const inputTable = sqliteTable("input", {
         runId: text("run_id").primaryKey(),
         payload: text("payload", { mode: "json" }).$type(),

--- a/packages/smithers/tests/exit-listener-leak-unit.test.js
+++ b/packages/smithers/tests/exit-listener-leak-unit.test.js
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { createExternalSmithers } from "../src/external/create-external-smithers.js";
+
+let tempDirs = [];
+
+function makeDbPath(prefix) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return join(dir, "smithers.db");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("createExternalSmithers exit-listener cleanup", () => {
+  // Regression: createExternalSmithers registered process.on("exit", closeDb)
+  // without ever removing it, so constructing/closing many instances (tests,
+  // gateway, hot reload) leaked one "exit" listener each, eventually tripping
+  // MaxListenersExceededWarning and retaining sqlite handles. The fix registers
+  // with process.once and removes the listener inside closeDb, so cleanup() must
+  // return the "exit" listener count to its baseline.
+  test("does not accumulate process exit listeners across create+cleanup cycles", () => {
+    const baseline = process.listenerCount("exit");
+
+    for (let i = 0; i < 25; i++) {
+      const workflow = createExternalSmithers({
+        dbPath: makeDbPath("smithers-exit-leak-"),
+        schemas: { result: z.object({ ok: z.boolean() }) },
+        agents: {},
+        buildFn: () => ({ kind: "text", text: "noop" }),
+      });
+      // While alive, exactly one extra listener should be registered.
+      expect(process.listenerCount("exit")).toBe(baseline + 1);
+      workflow.cleanup();
+      // After cleanup, the listener it registered must be detached.
+      expect(process.listenerCount("exit")).toBe(baseline);
+    }
+
+    // Net result: no leaked listeners regardless of how many were created.
+    expect(process.listenerCount("exit")).toBe(baseline);
+  });
+});


### PR DESCRIPTION
## Bug

Each call to `createSmithers` (`packages/smithers/src/create.js`) and `createExternalSmithers` (`packages/smithers/src/external/create-external-smithers.js`) registered a process exit hook via `process.on("exit", closeDb)` to gracefully close the bun:sqlite `Database`, but never removed it.

## Failure scenario

Repeated construction — test suites creating many instances, the gateway discovering/instantiating multiple workflows, or hot reload — accumulates one `"exit"` listener per instance. This:

- Triggers Node's `MaxListenersExceededWarning` once more than 10 listeners are attached.
- Retains the captured `sqlite` handle (and its closure) for the lifetime of the process, since the listener is never released even after the DB is closed via `cleanup()`.

## Fix

- Register the exit hook with `process.once("exit", closeDb)` instead of `process.on`.
- Inside `closeDb`, after closing the database, call `process.removeListener("exit", closeDb)` so the listener is detached whether `closeDb` runs on process exit or is invoked directly (e.g. `createExternalSmithers`'s `cleanup`).
- `closeDb` remains idempotent via the existing `dbClosed` guard.

Applied identically to both `create.js` and `create-external-smithers.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)