### PR TITLE
fix(pi-plugin): release SSE reader and guard JSON.parse in events generator

### DIFF
--- a/packages/pi-plugin/src/api/SmithersPiHttpClient.ts
+++ b/packages/pi-plugin/src/api/SmithersPiHttpClient.ts
@@ -65,22 +65,34 @@ export class SmithersPiHttpClient {
     const decoder = new TextDecoder();
     let buffer = "";
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
 
-      buffer += decoder.decode(value, { stream: true });
-      const parts = buffer.split("\n\n");
-      buffer = parts.pop() ?? "";
+        buffer += decoder.decode(value, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
 
-      for (const part of parts) {
-        const line = part.split("\n").find((item) => item.startsWith("data: "));
-        if (line) {
-          yield JSON.parse(line.slice(6));
+        for (const part of parts) {
+          const line = part
+            .split("\n")
+            .find((item) => item.startsWith("data: "));
+          if (line) {
+            const payload = line.slice(6);
+            try {
+              yield JSON.parse(payload);
+            } catch {
+              // Skip malformed SSE frames instead of aborting the stream.
+            }
+          }
         }
       }
+    } finally {
+      await reader.cancel().catch(() => {});
+      reader.releaseLock();
     }
   }
 }

--- a/packages/pi-plugin/tests/SmithersPiHttpClient.test.ts
+++ b/packages/pi-plugin/tests/SmithersPiHttpClient.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { SmithersPiHttpClient } from "../src/api/SmithersPiHttpClient.js";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+type ReaderSpy = {
+  releaseLockCalls: number;
+  cancelCalls: number;
+};
+
+/**
+ * Build a Response-like object whose body's reader is instrumented so we can
+ * assert the generator releases / cancels it. The stream emits the provided
+ * UTF-8 chunks in order, then completes.
+ */
+function streamResponse(chunks: string[]): { res: unknown; spy: ReaderSpy } {
+  const spy: ReaderSpy = { releaseLockCalls: 0, cancelCalls: 0 };
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  const body = {
+    getReader() {
+      const reader = stream.getReader();
+      return {
+        read: () => reader.read(),
+        cancel: (reason?: unknown) => {
+          spy.cancelCalls += 1;
+          return reader.cancel(reason);
+        },
+        releaseLock: () => {
+          spy.releaseLockCalls += 1;
+          return reader.releaseLock();
+        },
+      };
+    },
+  };
+
+  const res = { ok: true, body };
+  return { res, spy };
+}
+
+function sseFrame(payload: string): string {
+  return `data: ${payload}\n\n`;
+}
+
+describe("SmithersPiHttpClient.events", () => {
+  test("skips malformed data frames instead of throwing out of the generator", async () => {
+    const { res } = streamResponse([
+      sseFrame(JSON.stringify({ n: 1 })),
+      sseFrame("{not valid json"),
+      sseFrame(JSON.stringify({ n: 2 })),
+    ]);
+    globalThis.fetch = (async () => res) as typeof fetch;
+
+    const client = new SmithersPiHttpClient({ baseUrl: "http://example" });
+
+    const received: unknown[] = [];
+    // Must not reject: the malformed middle frame would throw without the guard.
+    for await (const event of client.events("/stream")) {
+      received.push(event);
+    }
+
+    expect(received).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  test("releases the reader after the stream completes (try/finally)", async () => {
+    const { res, spy } = streamResponse([sseFrame(JSON.stringify({ n: 1 }))]);
+    globalThis.fetch = (async () => res) as typeof fetch;
+
+    const client = new SmithersPiHttpClient({ baseUrl: "http://example" });
+
+    for await (const _event of client.events("/stream")) {
+      // drain
+    }
+
+    expect(spy.cancelCalls).toBe(1);
+    expect(spy.releaseLockCalls).toBe(1);
+  });
+
+  test("releases the reader on an early consumer break (try/finally)", async () => {
+    const { res, spy } = streamResponse([
+      sseFrame(JSON.stringify({ n: 1 })),
+      sseFrame(JSON.stringify({ n: 2 })),
+      sseFrame(JSON.stringify({ n: 3 })),
+    ]);
+    globalThis.fetch = (async () => res) as typeof fetch;
+
+    const client = new SmithersPiHttpClient({ baseUrl: "http://example" });
+
+    for await (const _event of client.events("/stream")) {
+      // Break before consuming the whole stream; finally must still run.
+      break;
+    }
+
+    expect(spy.cancelCalls).toBe(1);
+    expect(spy.releaseLockCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Bug

`packages/pi-plugin/src/api/SmithersPiHttpClient.ts` — the `events()` async generator had two problems in its SSE read loop:

1. **Unguarded `JSON.parse`**: each `data:` line was parsed with `JSON.parse(line.slice(6))` directly inside the loop with no try/catch. A single malformed/partial frame would throw and abort the entire generator, killing the event stream.
2. **Leaked reader/connection**: the reader obtained via `res.body.getReader()` was never released on error, early consumer `break`, or generator `return`. The lock on the stream (and the underlying connection) leaked.

### Failure scenario

A consumer iterating `for await (const ev of client.events(path))` either breaks early or encounters one corrupt SSE frame. In the first case the reader's lock is never released; in the second the corrupt frame throws straight out of the generator, terminating the subscription instead of skipping the bad frame.

## Fix

- Wrap the read loop in `try/finally`. In `finally`, call `reader.cancel().catch(() => {})` and `reader.releaseLock()` so the reader is released on throw, normal return, or consumer break (generator `.return()` runs the finally block).
- Guard the per-frame `JSON.parse` in its own try/catch so a malformed frame is skipped rather than aborting the generator.
- Existing SSE framing is preserved: `data:` line detection and `\n\n` buffering are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)