### PR TITLE
fix(openapi): do not mask spec content parse errors by re-parsing the path

### DIFF
--- a/packages/openapi/src/loadSpecEffect.js
+++ b/packages/openapi/src/loadSpecEffect.js
@@ -37,14 +37,15 @@ export function loadSpecEffect(input) {
     return Effect.try({
         try: () => {
             // Try reading as file first
+            let content;
             try {
-                const content = readFileSync(str, "utf8");
-                return parseSpecText(content);
+                content = readFileSync(str, "utf8");
             }
             catch {
                 // Not a file — try parsing as raw text
                 return parseSpecText(str);
             }
+            return parseSpecText(content);
         },
         catch: (cause) => toSmithersError(cause, "openapi load spec"),
     });

--- a/packages/openapi/src/loadSpecSync.js
+++ b/packages/openapi/src/loadSpecSync.js
@@ -17,11 +17,12 @@ export function loadSpecSync(input) {
         return input;
     }
     const str = input;
+    let content;
     try {
-        const content = readFileSync(str, "utf8");
-        return parseSpecText(content);
+        content = readFileSync(str, "utf8");
     }
     catch {
         return parseSpecText(str);
     }
+    return parseSpecText(content);
 }

--- a/packages/openapi/tests/loadSpec-content-error.test.js
+++ b/packages/openapi/tests/loadSpec-content-error.test.js
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------
+// Regression: a real file path whose CONTENT is unparseable must surface the
+// genuine content-parse error, not the misleading path-as-text error produced
+// by re-parsing the file path string when content parsing throws.
+// ---------------------------------------------------------------------------
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { loadSpecSync } from "../src/loadSpecSync.js";
+import { loadSpecEffect } from "../src/loadSpecEffect.js";
+
+/**
+ * Write content to a temp file and return its path.
+ * @param {string} content
+ * @returns {string}
+ */
+function writeTempSpec(content) {
+    const dir = mkdtempSync(join(tmpdir(), "openapi-broken-"));
+    const filePath = join(dir, "openapi.json");
+    writeFileSync(filePath, content, "utf8");
+    return filePath;
+}
+
+// Broken JSON that also fails YAML parsing — guarantees parseSpecText throws
+// "Failed to parse OpenAPI spec as JSON or YAML".
+const brokenContent = '{ "openapi": "3.0.0", "paths": { ';
+
+describe("loadSpec surfaces content-parse errors for real file paths", () => {
+    test("loadSpecSync reports the genuine parse error, not the path", () => {
+        const filePath = writeTempSpec(brokenContent);
+        // Before the fix, the readFileSync content threw inside the try, the
+        // catch re-parsed the *file path string* as YAML (a valid scalar),
+        // and surfaced the misleading "...does not appear to be a valid
+        // OpenAPI spec" error. The corrected behavior surfaces the real
+        // content-parse failure.
+        expect(() => loadSpecSync(filePath)).toThrow(
+            "Failed to parse OpenAPI spec as JSON or YAML",
+        );
+        expect(() => loadSpecSync(filePath)).not.toThrow(
+            /does not appear to be a valid OpenAPI spec/,
+        );
+    });
+
+    test("loadSpecEffect reports the genuine parse error, not the path", async () => {
+        const filePath = writeTempSpec(brokenContent);
+        await expect(
+            Effect.runPromise(loadSpecEffect(filePath)),
+        ).rejects.toThrow("Failed to parse OpenAPI spec as JSON or YAML");
+    });
+});


### PR DESCRIPTION
## Bug

`packages/openapi/src/loadSpecSync.js` and `loadSpecEffect.js` both wrapped two distinct operations in a single `try`:

```js
const content = readFileSync(str, "utf8");
return parseSpecText(content);
```

The intent of the `catch` was a fallback: if `str` is not a file path, treat it as inline JSON/YAML spec text. But because `parseSpecText(content)` was *inside* the same `try`, a content-parse failure on a successfully-read file also fell into the `catch`.

## Failure scenario

Pass a valid file path whose contents are malformed JSON/YAML. `readFileSync` succeeds, `parseSpecText(content)` throws the genuine parse error — but that error is swallowed and the code instead calls `parseSpecText(str)`, parsing the file PATH string as spec text. The caller sees a confusing error about the path string rather than the real "invalid spec content" error.

## Fix

Narrow the `try` so only `readFileSync` (the path-vs-inline determination) is guarded. If the file reads successfully, `parseSpecText(content)` runs *outside* the catch, so a genuine content-parse error propagates. The fallback `parseSpecText(str)` now only runs when reading `str` as a file actually failed. Applied identically to both `loadSpecSync.js` and `loadSpecEffect.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)