### PR TITLE
fix(studio): settle pending RPC promises on terminal unmount before clearing

### DIFF
--- a/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
+++ b/apps/smithers-studio-2/src/GhosttyTerminalPane.tsx
@@ -129,6 +129,9 @@ function usePtySession(tabId: string, write: (data: string) => void) {
       ws.close();
       wsRef.current = null;
       sessionIdRef.current = null;
+      for (const cb of pendingRef.current.values()) {
+        cb.reject(new Error("terminal unmounted"));
+      }
       pendingRef.current.clear();
     };
   }, [tabId, write, rpcCall]);


### PR DESCRIPTION
## Bug

In `apps/smithers-studio-2/src/GhosttyTerminalPane.tsx`, the `usePtySession` effect cleanup called `pendingRef.current.clear()` synchronously immediately after `ws.close()`.

`WebSocket.close()` is asynchronous: the `onclose` handler (which is responsible for rejecting every pending RPC callback with a `"connection closed"` error) fires on a later tick. By that point the cleanup had already emptied the pending map, so `onclose` iterated over an empty map.

## Failure scenario

If a component using the terminal unmounts (e.g. switching tabs / closing the pane) while an `rpcCall` (such as `session.create` or `session.resize`) is still in flight, that promise never settles — it neither resolves nor rejects. The `await rpcCall(...)` site hangs forever and the callback leaks.

## Fix

In the cleanup, explicitly reject every entry in `pendingRef.current` with a `"terminal unmounted"` error before clearing the map, instead of relying on the asynchronous `onclose` handler to do it after `clear()` has already run. The `ws.close()` call is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)