### PR TITLE
fix(cli): truncate node-detail output on a UTF-8 boundary

### DIFF
--- a/apps/cli/src/node-detail.js
+++ b/apps/cli/src/node-detail.js
@@ -366,7 +366,30 @@ function truncateForHuman(text, maxBytes) {
     if (bytes.byteLength <= maxBytes) {
         return text;
     }
-    const clippedBytes = bytes.slice(0, maxBytes);
+    let cut = maxBytes;
+    while (cut > 0 && (bytes[cut] & 0xc0) === 0x80) {
+        cut -= 1;
+    }
+    if (cut > 0) {
+        let lead = cut - 1;
+        while (lead >= 0 && (bytes[lead] & 0xc0) === 0x80) {
+            lead -= 1;
+        }
+        if (lead >= 0) {
+            const leadByte = bytes[lead];
+            const expected = leadByte >= 0xf0
+                ? 4
+                : leadByte >= 0xe0
+                    ? 3
+                    : leadByte >= 0xc0
+                        ? 2
+                        : 1;
+            if (lead + expected > cut) {
+                cut = lead;
+            }
+        }
+    }
+    const clippedBytes = bytes.slice(0, cut);
     const clipped = clippedBytes.toString("utf8");
     return `${clipped}${suffix}`;
 }

--- a/apps/cli/tests/node-detail-unit.test.js
+++ b/apps/cli/tests/node-detail-unit.test.js
@@ -497,6 +497,72 @@ describe("node detail aggregation", () => {
         expect(circularFallback.output.cacheKey).toBe("cache-circular");
     });
 
+    test("truncates multibyte tool output on a codepoint boundary", () => {
+        // Build a string whose 1024th byte (the truncation point for tool
+        // payloads) lands inside a 4-byte emoji. One ASCII lead byte plus
+        // emojis means byte index 1024 is a UTF-8 continuation byte, so the
+        // pre-fix byte slice would decode to a U+FFFD replacement character.
+        const emojiOutput = "x" + "😀".repeat(400);
+        expect(Buffer.byteLength(emojiOutput, "utf8")).toBeGreaterThan(1024);
+        expect((Buffer.from(emojiOutput, "utf8")[1024] & 0xc0)).toBe(0x80);
+
+        // CJK characters are 3 bytes each; an odd ASCII prefix again forces
+        // the cut to land mid-character.
+        const cjkOutput = "yy" + "字".repeat(400);
+        expect(Buffer.byteLength(cjkOutput, "utf8")).toBeGreaterThan(1024);
+
+        const detail = baseDetail({
+            attempts: [
+                attemptRow({
+                    attempt: 1,
+                    state: "finished",
+                    durationMs: 10,
+                    tokenUsage: emptyUsage(),
+                    toolCalls: [
+                        { name: "emoji", status: "success", durationMs: 1, input: null, output: emojiOutput, error: null },
+                        { name: "cjk", status: "success", durationMs: 2, input: null, output: cjkOutput, error: null },
+                    ],
+                }),
+            ],
+        });
+
+        const human = renderNodeDetailHuman(detail, {
+            expandAttempts: true,
+            expandTools: true,
+        });
+
+        // The fix backs the cut off to a codepoint boundary, so the rendered
+        // output must never contain the U+FFFD replacement character.
+        expect(human).toContain("truncated, use --json for full output");
+        expect(human).not.toContain("�");
+    });
+
+    test("returns within-limit payloads unchanged", () => {
+        const shortOutput = "résumé 😀 字"; // well under any byte limit
+        const detail = baseDetail({
+            attempts: [
+                attemptRow({
+                    attempt: 1,
+                    state: "finished",
+                    durationMs: 5,
+                    tokenUsage: emptyUsage(),
+                    toolCalls: [
+                        { name: "short", status: "success", durationMs: 1, input: null, output: shortOutput, error: null },
+                    ],
+                }),
+            ],
+        });
+
+        const human = renderNodeDetailHuman(detail, {
+            expandAttempts: true,
+            expandTools: true,
+        });
+
+        expect(human).toContain(shortOutput);
+        expect(human).not.toContain("truncated, use --json for full output");
+        expect(human).not.toContain("�");
+    });
+
     test("fails when node or iteration is missing", async () => {
         const missingNode = await aggregateExit(makeAdapter({ nodes: [] }));
         expect(Exit.isFailure(missingNode)).toBe(true);


### PR DESCRIPTION
## Bug

`apps/cli/src/node-detail.js` `truncateForHuman` slices the UTF-8 `Buffer` at an arbitrary byte offset (`bytes.slice(0, maxBytes)`) and then decodes the result. When the cut offset lands in the middle of a multibyte UTF-8 character (e.g. an accented letter, currency symbol, CJK char, or emoji), the trailing partial bytes decode to a `U+FFFD` (`�`) replacement character.

## Failure scenario

Run `smithers node ...` (human output, not `--json`) on a node whose validated/raw output or tool-call payload exceeds the byte limit (`MAX_TOOL_PAYLOAD_BYTES_HUMAN` = 1024, `MAX_VALIDATED_OUTPUT_BYTES_HUMAN` = 10 KiB) and contains non-ASCII text near the truncation point. The rendered output ends in a stray `�` because the slice cut a codepoint in half.

## Fix

Before decoding, back the cut offset off:
1. any UTF-8 continuation bytes (`10xxxxxx`) at the boundary, and
2. an incomplete trailing multibyte sequence (a lead byte whose full character would extend past the cut),

so the slice always ends on a codepoint boundary. The truncation limits and the appended `... (truncated, use --json for full output)` suffix are unchanged.

Verified against 2-, 3-, and 4-byte characters and mixed strings at every possible cut offset: no replacement characters are produced and the body never exceeds `maxBytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)