### PR TITLE
fix(cli): honor down --force staleness check and fix dead waiting-state CTAs

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -682,6 +682,11 @@ async function* streamRunEventsCommand(c) {
                 },
             });
         }
+        let lastWaitingStatus = run.status === "waiting-approval" ||
+            run.status === "waiting-event" ||
+            run.status === "waiting-timer"
+            ? run.status
+            : undefined;
         while (true) {
             await new Promise((resolve) => setTimeout(resolve, 500));
             const newEvents = await adapter.listEvents(c.args.runId, lastSeq, 200);
@@ -691,6 +696,11 @@ async function* streamRunEventsCommand(c) {
             }
             const currentRun = await adapter.getRun(c.args.runId);
             const currentStatus = currentRun?.status;
+            if (currentStatus === "waiting-approval" ||
+                currentStatus === "waiting-event" ||
+                currentStatus === "waiting-timer") {
+                lastWaitingStatus = currentStatus;
+            }
             if (currentStatus !== "running" &&
                 currentStatus !== "waiting-approval" &&
                 currentStatus !== "waiting-event" &&
@@ -703,13 +713,13 @@ async function* streamRunEventsCommand(c) {
                 const ctaCommands = [
                     { command: `inspect ${c.args.runId}`, description: "Inspect run state" },
                 ];
-                if (currentStatus === "waiting-approval") {
+                if (lastWaitingStatus === "waiting-approval") {
                     ctaCommands.push({ command: `approve ${c.args.runId}`, description: "Approve run" });
                 }
-                if (currentStatus === "waiting-event") {
+                if (lastWaitingStatus === "waiting-event") {
                     ctaCommands.push({ command: `why ${c.args.runId}`, description: "Explain signal wait" });
                 }
-                if (currentStatus === "waiting-timer") {
+                if (lastWaitingStatus === "waiting-timer") {
                     ctaCommands.push({ command: `why ${c.args.runId}`, description: "Explain timer wait" });
                 }
                 return c.ok(undefined, { cta: { commands: ctaCommands } });
@@ -4293,7 +4303,7 @@ const cli = Cli.create({
     .command("down", {
     description: "Cancel all active runs. Like 'docker compose down' for workflows.",
     options: z.object({
-        force: z.boolean().default(false).describe("Cancel runs even if they appear stale"),
+        force: z.boolean().default(false).describe("Cancel runs even if they still appear live (default only cancels stale runs)"),
     }),
     async run(c) {
         const fail = (opts) => {
@@ -4318,7 +4328,13 @@ const cli = Cli.create({
                 }
                 const now = Date.now();
                 let cancelled = 0;
+                let skipped = 0;
                 for (const run of allActive) {
+                    if (isRunHeartbeatFresh(run) && !c.options.force) {
+                        process.stderr.write(`• Skipped (still live): ${run.runId}. Use --force to cancel anyway.\n`);
+                        skipped++;
+                        continue;
+                    }
                     const inProgress = await adapter.listInProgressAttempts(run.runId);
                     const attempts = await adapter.listAttemptsForRun(run.runId);
                     for (const attempt of inProgress) {
@@ -4337,7 +4353,10 @@ const cli = Cli.create({
                     process.stderr.write(`⊘ Cancelled: ${run.runId}\n`);
                     cancelled++;
                 }
-                return c.ok({ cancelled, runs: allActive.map((r) => r.runId) }, { cta: { commands: [{ command: `ps`, description: "Verify all runs stopped" }] } });
+                if (cancelled === 0 && skipped > 0) {
+                    return c.ok({ cancelled, skipped, message: "All active runs are still live. Use --force to cancel them." });
+                }
+                return c.ok({ cancelled, skipped, runs: allActive.map((r) => r.runId) }, { cta: { commands: [{ command: `ps`, description: "Verify all runs stopped" }] } });
             }
             finally {
                 cleanup();

--- a/apps/cli/tests/down-command.test.js
+++ b/apps/cli/tests/down-command.test.js
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+const CLI_ENTRY = resolve(import.meta.dir, "../src/index.js");
+
+/**
+ * @param {ReturnType<typeof createTempRepo>} repo
+ */
+function openRepoDb(repo) {
+    const sqlite = new Database(repo.path("smithers.db"));
+    const db = drizzle(sqlite);
+    ensureSmithersTables(db);
+    return {
+        sqlite,
+        adapter: new SmithersDb(db),
+    };
+}
+
+/**
+ * @param {SmithersDb} adapter
+ * @param {string} runId
+ * @param {Record<string, unknown>} [overrides]
+ */
+async function insertRunningRun(adapter, runId, overrides = {}) {
+    const now = Date.now();
+    await adapter.insertRun({
+        runId,
+        workflowName: "down-fixture",
+        workflowPath: "workflow.tsx",
+        status: "running",
+        createdAtMs: now - 10_000,
+        startedAtMs: now - 9_000,
+        finishedAtMs: null,
+        // Default to a fresh heartbeat (isRunHeartbeatFresh => true).
+        heartbeatAtMs: now,
+        ...overrides,
+    });
+}
+
+describe("smithers down --force staleness check", () => {
+    // Regression: `down` declared a `--force` flag but never read it, so it
+    // unconditionally cancelled every active run. A run whose heartbeat is
+    // still fresh must be treated as live and skipped unless --force is passed.
+    test("without --force, a run with a FRESH heartbeat is skipped (not cancelled)", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertRunningRun(adapter, "fresh-run", { heartbeatAtMs: Date.now() });
+
+            const result = runSmithers(["down"], { cwd: repo.dir, format: "json" });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.json).toMatchObject({ cancelled: 0, skipped: 1 });
+            expect(result.stderr).toContain("Skipped (still live): fresh-run");
+
+            // The fresh run must remain untouched.
+            const after = await adapter.getRun("fresh-run");
+            expect(after?.status).toBe("running");
+        }
+        finally {
+            sqlite.close();
+        }
+    }, 60_000);
+
+    test("with --force, a run with a FRESH heartbeat IS cancelled", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertRunningRun(adapter, "fresh-run", { heartbeatAtMs: Date.now() });
+
+            const result = runSmithers(["down", "--force"], { cwd: repo.dir, format: "json" });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.json).toMatchObject({ cancelled: 1, skipped: 0 });
+
+            const after = await adapter.getRun("fresh-run");
+            expect(after?.status).toBe("cancelled");
+        }
+        finally {
+            sqlite.close();
+        }
+    }, 60_000);
+
+    test("without --force, a run with a STALE heartbeat is still cancelled", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            // Heartbeat well past the staleness threshold (30s).
+            await insertRunningRun(adapter, "stale-run", { heartbeatAtMs: Date.now() - 120_000 });
+
+            const result = runSmithers(["down"], { cwd: repo.dir, format: "json" });
+
+            expect(result.exitCode).toBe(0);
+            expect(result.json).toMatchObject({ cancelled: 1, skipped: 0 });
+
+            const after = await adapter.getRun("stale-run");
+            expect(after?.status).toBe("cancelled");
+        }
+        finally {
+            sqlite.close();
+        }
+    }, 60_000);
+});
+
+describe("smithers logs --follow waiting-state CTA", () => {
+    // Regression: the waiting-approval/event/timer CTA branches keyed off
+    // `currentStatus`, but the follow loop only exits once the run is NOT in a
+    // waiting state, so currentStatus could never be a waiting status inside the
+    // exit block — the hints were dead code. The fix tracks the last waiting
+    // status observed and bases the CTA hints on that.
+    test("a run ending in waiting-approval emits the approve CTA hint", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            const now = Date.now();
+            await adapter.insertRun({
+                runId: "wa-run",
+                workflowName: "down-fixture",
+                workflowPath: "workflow.tsx",
+                status: "waiting-approval",
+                createdAtMs: now - 10_000,
+                startedAtMs: now - 9_000,
+                finishedAtMs: null,
+                heartbeatAtMs: now,
+            });
+            // Seed an event so the follow loop emits a recognizable line once it
+            // has started — our deterministic signal that the loop is running.
+            await adapter.insertEventWithNextSeq({
+                runId: "wa-run",
+                type: "STARTUP_MARKER",
+                timestampMs: now,
+                payloadJson: JSON.stringify({ marker: true }),
+            });
+
+            const proc = Bun.spawn(
+                [process.execPath, "run", CLI_ENTRY, "logs", "wa-run", "--follow"],
+                { cwd: repo.dir, stdout: "pipe", stderr: "pipe", env: { ...process.env } },
+            );
+
+            // Read stdout incrementally. Only once the marker line appears (the
+            // loop is confirmed running while the run is waiting-approval) do we
+            // transition the run to a terminal state, so the loop exits through
+            // the waiting-state CTA branch deterministically.
+            const decoder = new TextDecoder();
+            let stdout = "";
+            const reader = proc.stdout.getReader();
+            const deadline = Date.now() + 40_000;
+            let transitioned = false;
+            while (Date.now() < deadline) {
+                const { value, done } = await reader.read();
+                if (done) {
+                    break;
+                }
+                stdout += decoder.decode(value, { stream: true });
+                if (!transitioned && stdout.includes("STARTUP_MARKER")) {
+                    transitioned = true;
+                    await adapter.updateRun("wa-run", {
+                        status: "cancelled",
+                        finishedAtMs: Date.now(),
+                    });
+                }
+            }
+            await proc.exited;
+
+            expect(transitioned).toBe(true);
+            expect(proc.exitCode).toBe(0);
+            // The fixed CTA must surface the approve hint for the prior waiting state.
+            expect(stdout).toContain("approve wa-run");
+            expect(stdout).toContain("inspect wa-run");
+        }
+        finally {
+            sqlite.close();
+        }
+    }, 60_000);
+});


### PR DESCRIPTION
## Bugs

Both in `apps/cli/src/index.js`:

### 1. `down` ignored its `--force` flag
The `down` command declared a `force` option ("Cancel runs even if they appear stale") but never read it. The cancellation loop force-cancelled **every** active run unconditionally, regardless of whether the run still had a fresh heartbeat.

**Failure scenario:** `smithers down` would kill a still-live, actively-running workflow with no way for the default (no-force) invocation to spare it. The documented "only cancel stale runs by default" semantics were never honored.

**Fix:** Mirror the existing `up --resume` call site (`isRunHeartbeatFresh(existing) && !options.force`). The loop now skips runs whose heartbeat is fresh unless `--force` is passed, prints a "Skipped (still live)" notice, and reports the `skipped` count. Because `isRunHeartbeatFresh` only returns true for `running` runs with a recent heartbeat, paused waiting-* runs are still cancelled as before. Clarified the flag description.

### 2. Dead waiting-state CTA branches in `logs --follow`
After the `logs --follow` loop, the approve/why CTA hints were keyed off `currentStatus`, but the loop only **exits** when `currentStatus` is NOT one of `waiting-approval`/`waiting-event`/`waiting-timer`. So those `if` branches were unreachable and the intended hints were never emitted.

**Fix:** Track the last waiting status observed during the loop (seeded from the initial run status) and base the approve/why CTA hints on that, so the hints actually fire when a followed run ends after having been in a waiting state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)