### PR TITLE
fix(observability): make withCorrelationContext visible to the imperative logger

### DIFF
--- a/apps/observability/src/_coreCorrelation/withCorrelationContext.js
+++ b/apps/observability/src/_coreCorrelation/withCorrelationContext.js
@@ -11,5 +11,12 @@ import { mergeCorrelationContext } from "./mergeCorrelationContext.js";
  */
 export function withCorrelationContext(effect, patch) {
     const next = mergeCorrelationContext(correlationStorage.getStore(), patch);
-    return next ? effect.pipe(Effect.locally(correlationContextFiberRef, next)) : effect;
+    if (!next)
+        return effect;
+    const located = effect.pipe(Effect.locally(correlationContextFiberRef, next));
+    return Effect.acquireUseRelease(Effect.sync(() => {
+        const previous = correlationStorage.getStore();
+        correlationStorage.enterWith(next);
+        return previous;
+    }), () => located, (previous) => Effect.sync(() => correlationStorage.enterWith(previous)));
 }


### PR DESCRIPTION
## Bug

`apps/observability/src/_coreCorrelation/withCorrelationContext.js` wrote the merged correlation context **only** into the Effect `FiberRef` (via `Effect.locally(correlationContextFiberRef, next)`).

The imperative logger in `apps/observability/src/logging.js` reads correlation via `getCurrentCorrelationContext()`, which is **AsyncLocalStorage-only**, and it emits each log on a freshly forked fiber (`Effect.runFork`) that does not inherit the caller's `FiberRef`. As a result, any context patched solely through `withCorrelationContext` was invisible to log annotations — a latent annotation-loss footgun.

## Failure scenario

```js
withCorrelationContext(
  Effect.sync(() => logInfo("processing")), // imperative logger
  { runId, nodeId },
)
```

The `logInfo` call reads correlation from ALS, finds nothing, and the emitted log loses its `runId`/`nodeId` annotations even though the context was patched on the FiberRef.

## Fix

Propagate the merged context to the `AsyncLocalStorage` store for the duration of the effect using `Effect.acquireUseRelease`:

- **acquire**: save the previous store and `enterWith(next)`
- **use**: run the effect (FiberRef still set via `Effect.locally`, so `R`, errors, and interruption are preserved)
- **release**: restore the previous store

This scopes the ALS store to the effect's execution and never leaks (verified that the store is `undefined` again after the effect, including on failure). The FiberRef behavior is unchanged, so context is not double-applied, and existing ALS-based correlation continues to merge as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)