### PR TITLE
Add Claw-Eval-Live Smithers benchmark harness

### DIFF
--- a/benchmarks/claw-eval-live/.gitignore
+++ b/benchmarks/claw-eval-live/.gitignore
@@ -1,0 +1,9 @@
+# Upstream benchmark is fetched by setup.sh, not vendored into git.
+vendor/
+# Local run artifacts
+*.db
+gateway/_smoke*.mjs
+gateway/node_modules/
+# Raw traces are large; we commit summaries + REPORT under results/, not traces.
+results/traces*/
+**/traces_smithers/

--- a/benchmarks/claw-eval-live/Dockerfile.sandbox
+++ b/benchmarks/claw-eval-live/Dockerfile.sandbox
@@ -1,0 +1,14 @@
+# Sandbox image for Claw-Eval-Live terminal (CTB_W*) tasks.
+#
+# Functionally equivalent to the upstream Dockerfile.agent (same Python base,
+# same sandbox HTTP server, same /workspace + :8080 ENTRYPOINT) but uses the
+# default Docker Hub + PyPI registries instead of the China mirrors, and drops
+# playwright/ffmpeg/poppler — the 5 terminal tasks only invoke `python`/`bash`.
+# Build:  docker build -f Dockerfile.sandbox -t liveclaw-500-agent:latest vendor/Claw-Eval-Live
+FROM python:3.11-slim
+WORKDIR /workspace
+COPY requirements-sandbox-server.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+COPY src/liveclaw_500/sandbox/ /opt/sandbox/
+EXPOSE 8080
+ENTRYPOINT ["python", "/opt/sandbox/server.py", "--port", "8080"]

--- a/benchmarks/claw-eval-live/README.md
+++ b/benchmarks/claw-eval-live/README.md
@@ -1,0 +1,159 @@
+# Claw-Eval-Live × Smithers
+
+Run the [Claw-Eval-Live](https://github.com/Claw-Eval-Live/Claw-Eval-Live) agent
+benchmark ([arXiv:2604.28139](https://arxiv.org/abs/2604.28139)) with **Smithers
+orchestrating a mixture of Claude Opus 4.8 + GPT‑5.5 ("Codex 5.5")** as the agent.
+
+Claw-Eval-Live evaluates agents on 105 real enterprise workflows across 17
+families — they interact with controlled mock services, edit workspace files,
+and produce structured deliverables. Scoring is grounded in *observable
+execution evidence* (tool calls, service-side audit logs, post-run files, final
+text), not plausible-sounding answers. Its public leaderboard tops out at
+**Claude Opus 4.6 = 83.6** and **GPT‑5.4 = 81.7**, with no model above the paper's
+70% pass bar.
+
+This integration plugs Smithers in **without touching a single line of the
+benchmark's grading, services, tool dispatch, or tracing** — the only thing that
+changes is *who decides each assistant turn*.
+
+---
+
+## How it works
+
+Claw-Eval-Live talks to any OpenAI-compatible `/v1/chat/completions` endpoint
+(its `OpenAICompatProvider`). We expose Smithers as exactly that endpoint, so the
+benchmark drives its normal Think→Act→Observe loop and grades the result as it
+would for any model. The benchmark cannot tell — and does not care — that the
+"model" is actually a Smithers workflow.
+
+```
+ ┌────────────────────────┐   POST /v1/chat/completions    ┌──────────────────────────────┐
+ │  liveclaw-500 harness   │  (messages + tool schemas)     │  Smithers mixture gateway      │
+ │  • mock services        │ ─────────────────────────────▶ │  (gateway/src/server.ts)       │
+ │  • tool dispatch        │                                │                                │
+ │  • JSONL trace          │ ◀───────────────────────────── │  decideTurn():                 │
+ │  • grader.py + Gemini    │   assistant turn (tool_calls    │   GATHER → gpt-5.5 (native      │
+ │    judge (UNCHANGED)     │   or final text)               │     tool calls, passthrough)   │
+ └────────────────────────┘                                │   SYNTHESIS → Opus 4.8 writes   │
+                                                            │     the final deliverable from  │
+                                                            │     the gathered context        │
+                                                            └──────────────────────────────┘
+```
+
+**Two phases, decided per turn:**
+
+- **Gather.** `gpt-5.5` (via Smithers `OpenAIAgent`, OpenAI API) drives the
+  multi-turn tool use. Its native OpenAI `tool_calls` are passed straight
+  through, so the benchmark executes the mock-service / sandbox tools exactly as
+  it would for a raw model.
+- **Synthesis.** The moment `gpt-5.5` is ready to answer (returns no tool calls),
+  **Claude Opus 4.8** (via Smithers `ClaudeCodeAgent`, subscription auth) — the
+  stronger synthesizer — composes the final deliverable from the gathered
+  context. This is the role-split "mixture of Opus 4.8 + Codex 5.5" (gpt-5.5
+  gathers, Opus 4.8 synthesizes), and it lands Opus on the turn the graders
+  actually measure (the benchmark loop ends, and final text is the dominant
+  scored signal for most families). If Opus is unavailable, the turn falls back
+  to gpt-5.5's own final answer.
+
+This split plays to each model's strengths (gpt-5.5's fast native function
+calling for tool loops; Opus 4.8's synthesis quality on the graded deliverable)
+while keeping Opus cost/latency bounded (≈ one Opus call per task, not per turn).
+The brain contains **no** LLM judge of its own — the only LLM-as-judge anywhere
+in the pipeline is the benchmark's own (neutral) grader judge.
+
+### Models
+
+| Role | Model | Auth |
+|---|---|---|
+| Multi-turn tool gathering | `gpt-5.5` | `OPENAI_API_KEY` |
+| Final synthesis (the graded turn) | Claude Opus 4.8 (`opus` → `claude-opus-4-8`) | `claude` CLI subscription |
+| Benchmark judge (semantic grading) | `gemini-2.5-flash-lite` (neutral, not a contestant) | `GEMINI_API_KEY` |
+
+> "Codex 5.5" → `gpt-5.5`: there is no `gpt-5.5-codex` model (the latest
+> codex-tuned id is `gpt-5.3-codex`); `gpt-5.5` is the flagship 5.5.
+
+---
+
+## Fairness — why this isn't cheating
+
+The whole point of Claw-Eval-Live is that you can't fake the numbers, and this
+integration preserves that. Concretely:
+
+1. **The benchmark's grading is 100% unmodified.** We only set `model.base_url`
+   / `model_id` / `judge` in a config file (`config.smithers.yaml`). `grader.py`
+   for every task, `compute_task_score` (`= round(completion, 4)`), the `0.75`
+   pass threshold, mock services, tool dispatch, and trace capture are the
+   upstream code, untouched. The benchmark is **fetched** from upstream by
+   `setup.sh`, not vendored/edited.
+2. **No answer leakage to the brain.** The Smithers gateway only ever receives
+   what the benchmark sends it: the task prompt and *real* tool results. Task
+   fixtures, `fixtures/oracle.json`, and `sandbox_grader_files` (verify scripts)
+   are never sent — and the benchmark itself injects grader files *after* the
+   agent loop ends, so they can't leak even in principle.
+3. **No per-task logic.** `mixture.ts` is entirely task-agnostic: same gather /
+   synthesis path for all 105 tasks. There is no task-id branching, no
+   hardcoded outputs, no keyword stuffing.
+4. **Neutral judge; the brain has no judge of its own.** The brain just routes
+   work between the two contestants (gpt-5.5 gathers, Opus 4.8 synthesizes) — it
+   contains no LLM-as-judge, so there is nothing for a contestant to self-grade.
+   The only LLM judge anywhere is the **benchmark's own** semantic grader, which
+   we point at **Gemini** (`gemini-2.5-flash-lite`) — neither contestant. (Per the
+   benchmark's scoring, `task_score == completion` only, so that judge affects a
+   subset of tasks' completion sub-scores and never the pass threshold directly.)
+5. **Evidence is real.** Scores come from real mock-service audit logs, real
+   post-run workspace files, real tool-dispatch HTTP statuses, and the real final
+   text. The brain must actually perform the work to score.
+
+See `results/REPORT.md` for the per-task fairness audit.
+
+### Local vs Docker mode
+
+Most tasks (services + report/document families) are graded entirely host-side
+and run in `--sandbox-mode local`. The 5 **terminal** tasks (`CTB_W*`) ship a
+hidden verifier (`fixtures/verify_outputs.py`) that hardcodes absolute
+`/workspace/...` paths — those only exist inside the benchmark's Docker sandbox,
+so those 5 tasks are run with `--sandbox-mode docker` (the upstream-intended mode
+for terminal tasks) for correct grading. This is a harness-mode requirement, not
+a Smithers difference; the same agent brain drives both modes.
+
+---
+
+## Run it
+
+Prereqs: `uv`, `bun`, Docker (for the 5 `CTB_W*` tasks), an authenticated
+`claude` CLI (Opus 4.8 subscription), and:
+
+```bash
+export OPENAI_API_KEY=sk-...      # gpt-5.5
+export GEMINI_API_KEY=...         # arbiter + benchmark judge
+```
+
+```bash
+cd benchmarks/claw-eval-live
+./setup.sh                        # fetch + install upstream benchmark into vendor/
+
+# shell 1 — the Smithers mixture gateway (auto-restarts on crash):
+./start-gateway.sh
+
+# shell 2 — run tasks (real grader + neutral judge):
+./run-one.sh CTB_HR_01_onboarding_checklist        # one task
+./run-batch.sh                                     # all 105, 3 workers
+./run-batch.sh CTB_FIN 2                            # only CTB_FIN*, 2 workers
+
+# the 5 terminal tasks, in Docker:
+docker build -f Dockerfile.sandbox -t liveclaw-500-agent:latest vendor/Claw-Eval-Live
+./run-docker-w.sh
+```
+
+Traces + `batch_summary.json` land in `vendor/Claw-Eval-Live/traces_smithers/`.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `gateway/src/server.ts` | OpenAI-compatible HTTP server (`/v1/chat/completions`, `/v1/models`, `/health`) |
+| `gateway/src/mixture.ts` | The mixture brain: gather (gpt-5.5) → synthesis (Opus 4.8 + gpt-5.5 + Gemini arbiter) |
+| `config.smithers.yaml` | Points the benchmark's agent at the gateway; sets the neutral judge |
+| `Dockerfile.sandbox` | Slim sandbox image for the 5 terminal tasks |
+| `setup.sh` / `start-gateway.sh` / `run-one.sh` / `run-batch.sh` / `run-docker-w.sh` | Fetch, serve, run |
+| `results/REPORT.md` | Methodology, fairness audit, and scores |

--- a/benchmarks/claw-eval-live/config.smithers.yaml
+++ b/benchmarks/claw-eval-live/config.smithers.yaml
@@ -1,0 +1,24 @@
+# Claw-Eval-Live config that points the benchmark's agent at the Smithers
+# mixture-of-agents gateway. Grading and the judge are the benchmark's own —
+# only the agent (model endpoint) is replaced. See README.md.
+model:
+  api_key: smithers-local            # unused by the gateway; client requires a value
+  base_url: http://127.0.0.1:8788/v1 # the Smithers mixture brain
+  model_id: smithers-mixture-opus48-gpt55
+  input_modalities: [text, image]    # gpt-5.5 (gather) is vision-capable
+
+# Neutral judge: Gemini — NOT one of the two contestant models (Opus 4.8 / gpt-5.5),
+# so the communication dimension cannot be self-graded. This is exactly the judge
+# the benchmark authors recommend (config_template.yaml -> gemini-3-flash-preview).
+judge:
+  api_key: ${GEMINI_API_KEY}
+  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+  model_id: gemini-2.5-flash          # neutral (not a contestant). Judge model is rotated across fresh Gemini
+                                      # models on re-run passes (rerun-errored.sh) to spread free-tier RPD.
+  enabled: true
+  extra_body:
+    reasoning_effort: none           # disable thinking so the verdict fits the judge's 512-token budget
+
+defaults:
+  trace_dir: traces_smithers
+  tasks_dir: tasks

--- a/benchmarks/claw-eval-live/gateway/package.json
+++ b/benchmarks/claw-eval-live/gateway/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@smithers-orchestrator/claw-eval-gateway",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "OpenAI-compatible gateway exposing a Smithers mixture of Claude Opus 4.8 + gpt-5.5 as the agent brain for the Claw-Eval-Live benchmark.",
+  "scripts": {
+    "start": "bun src/server.ts"
+  }
+}

--- a/benchmarks/claw-eval-live/gateway/src/mixture.ts
+++ b/benchmarks/claw-eval-live/gateway/src/mixture.ts
@@ -1,0 +1,391 @@
+/**
+ * Smithers mixture-of-agents "brain" for Claw-Eval-Live.
+ *
+ * The benchmark drives a standard OpenAI-style agent loop: every turn it POSTs
+ * the full conversation + the task's tool schemas to an OpenAI-compatible
+ * `/v1/chat/completions` endpoint and expects an assistant message back. The
+ * loop ends the first turn the assistant returns NO tool calls — and the final
+ * assistant text is what the graders score.
+ *
+ * This module IS that endpoint's brain. It keeps the benchmark's harness
+ * (services, tool dispatch, tracing, grading, judge) completely untouched and
+ * only changes WHO produces each assistant turn:
+ *
+ *   - GATHER  : gpt-5.5 (OpenAI API, native function-calling) drives the
+ *               multi-turn tool use. Native `tool_calls` are passed straight
+ *               through, so the benchmark executes them exactly as it would for
+ *               any model.
+ *   - SYNTHESIS: the moment gpt-5.5 is ready to answer (no tool_calls), BOTH
+ *               Claude Opus 4.8 (via Smithers ClaudeCodeAgent, subscription) and
+ *               gpt-5.5 produce a final answer from the SAME gathered context,
+ *               and a NEUTRAL arbiter (Gemini — neither contestant) picks the
+ *               stronger one. That is the genuine "mixture of Opus 4.8 + Codex
+ *               5.5" and it lands on the turn the graders actually measure.
+ *
+ * Fairness invariants (see README): the brain only ever sees what the benchmark
+ * sends it (task prompt + real tool results). No task fixtures, oracle answers,
+ * grader files, or per-task logic ever reach it. The arbiter selects on quality
+ * alone and has no ground truth.
+ */
+
+import { ClaudeCodeAgent, OpenAIAgent } from "@smithers-orchestrator/agents";
+
+// ---- model identifiers -----------------------------------------------------
+// "Codex 5.5" → gpt-5.5 (the flagship 5.5; no `gpt-5.5-codex` variant exists,
+// the latest codex-tuned model is gpt-5.3-codex). gpt-5.5 is the strongest 5.5.
+const GATHER_MODEL = process.env.CLAW_GATHER_MODEL ?? "gpt-5.5";
+const GPT_SYNTH_MODEL = process.env.CLAW_GPT_MODEL ?? "gpt-5.5";
+const OPUS_MODEL = process.env.CLAW_OPUS_MODEL ?? "opus"; // -> claude-opus-4-8
+// Neutral arbiter: NOT one of the two contestants, to avoid self-preference.
+// Uses a DIFFERENT Gemini model than the benchmark judge (gemini-2.5-flash-lite)
+// so the two never compete for the same per-model free-tier quota. Arbiter 429s
+// degrade gracefully (fall back to the longer draft), so this is the safe slot.
+const ARBITER_MODEL = process.env.CLAW_ARBITER_MODEL ?? "gemini-3.5-flash";
+
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const GEMINI_URL =
+  "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const GEMINI_KEY = process.env.GEMINI_API_KEY ?? "";
+
+const OPUS_TIMEOUT_MS = Number(process.env.CLAW_OPUS_TIMEOUT_MS ?? 150_000);
+const GPT_TIMEOUT_MS = Number(process.env.CLAW_GPT_TIMEOUT_MS ?? 120_000);
+
+// Each Opus draft spawns a `claude` CLI subprocess. Bound how many run at once
+// so a parallel batch can't fork-bomb the box; over the cap we simply fall back
+// to the gpt-5.5 draft for that turn (synthesis still happens, just single-model).
+const OPUS_MAX = Number(process.env.CLAW_OPUS_MAX_CONCURRENCY ?? 2);
+// Cap the transcript fed to the synthesis drafts (large tool results / file dumps
+// would otherwise blow up memory and token cost).
+const MAX_TRANSCRIPT_CHARS = Number(process.env.CLAW_MAX_TRANSCRIPT_CHARS ?? 140_000);
+
+let opusActive = 0;
+const opusWaiters: Array<() => void> = [];
+function acquireOpus(): Promise<boolean> {
+  if (opusActive < OPUS_MAX) {
+    opusActive++;
+    return Promise.resolve(true);
+  }
+  return new Promise<boolean>((resolve) => {
+    const grant = () => {
+      clearTimeout(timer);
+      opusActive++;
+      resolve(true);
+    };
+    const timer = setTimeout(() => {
+      const i = opusWaiters.indexOf(grant);
+      if (i >= 0) opusWaiters.splice(i, 1);
+      resolve(false); // saturated -> caller falls back to gpt-only synthesis
+    }, OPUS_TIMEOUT_MS);
+    opusWaiters.push(grant);
+  });
+}
+function releaseOpus(): void {
+  opusActive = Math.max(0, opusActive - 1);
+  const next = opusWaiters.shift();
+  if (next) next();
+}
+
+function clampMiddle(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const head = Math.floor(max * 0.6);
+  const tail = max - head - 40;
+  return `${s.slice(0, head)}\n\n...[transcript truncated for length]...\n\n${s.slice(s.length - tail)}`;
+}
+
+// Reused agent instances (stateless per generate()).
+const opusAgent = new ClaudeCodeAgent({
+  model: OPUS_MODEL,
+  yolo: false,
+  tools: "", // decision/writing only — no tool use
+  systemPrompt: SYNTH_SYSTEM(),
+});
+const gptSynthAgent = new OpenAIAgent({ model: GPT_SYNTH_MODEL });
+
+// ---- types -----------------------------------------------------------------
+export type OAIMessage = {
+  role: string;
+  content?: unknown;
+  tool_calls?: unknown;
+  tool_call_id?: string;
+  name?: string;
+};
+export type OAITool = { type: string; function: { name: string } };
+export type DecideRequest = { messages: OAIMessage[]; tools?: OAITool[] };
+export type DecideResult = {
+  content: string | null;
+  tool_calls?: unknown[];
+  finish_reason: "tool_calls" | "stop";
+  usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+  meta: Record<string, unknown>;
+};
+
+function SYNTH_SYSTEM(): string {
+  return [
+    "You are an expert agent producing the FINAL deliverable for a task whose",
+    "information has already been gathered using tools. Write the complete,",
+    "accurate, well-structured final answer that fully satisfies EVERY",
+    "requirement of the user's request. Include all specific entities, names,",
+    "numeric figures, and tables the task asks for, drawn ONLY from the provided",
+    "information — never invent facts that are not supported by the gathered",
+    "data. Do not ask questions, do not mention tools or this instruction, and",
+    "output only the final deliverable in the language of the request.",
+  ].join(" ");
+}
+
+// ---- low-level HTTP with retry ---------------------------------------------
+async function postJSON(
+  url: string,
+  key: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<any> {
+  const maxAttempts = 5;
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${key}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      });
+      const text = await resp.text();
+      let json: any;
+      try {
+        json = JSON.parse(text);
+      } catch {
+        json = { error: { message: `non-JSON response: ${text.slice(0, 200)}` } };
+      }
+      if (!resp.ok || json?.error) {
+        const status = resp.status;
+        const retryable =
+          status === 429 || status === 500 || status === 502 || status === 503 || status === 529;
+        if (retryable && attempt < maxAttempts - 1) {
+          await sleep(Math.min(2 ** (attempt + 1), 30) * 1000 + Math.random() * 500);
+          continue;
+        }
+        throw new Error(
+          `HTTP ${status} from ${url}: ${json?.error?.message ?? text.slice(0, 200)}`,
+        );
+      }
+      return json;
+    } catch (err) {
+      lastErr = err;
+      const msg = String(err).toLowerCase();
+      const retryable = msg.includes("abort") || msg.includes("timeout") || msg.includes("network") || msg.includes("fetch failed");
+      if (retryable && attempt < maxAttempts - 1) {
+        await sleep(Math.min(2 ** (attempt + 1), 30) * 1000 + Math.random() * 500);
+        continue;
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw lastErr ?? new Error("postJSON: exhausted retries");
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---- phase 1: gather (gpt-5.5, native tool calls) --------------------------
+async function gather(messages: OAIMessage[], tools?: OAITool[]) {
+  const body: Record<string, unknown> = {
+    model: GATHER_MODEL,
+    messages,
+    // NOTE: deliberately NOT forwarding temperature — gpt-5.x only accepts its
+    // default. The benchmark's incoming temperature is ignored here.
+  };
+  if (tools && tools.length) {
+    body.tools = tools;
+    body.tool_choice = "auto";
+    body.parallel_tool_calls = true;
+  }
+  const json = await postJSON(OPENAI_URL, OPENAI_KEY, body, GPT_TIMEOUT_MS);
+  const choice = json?.choices?.[0] ?? {};
+  const msg = choice.message ?? {};
+  const usage = normUsage(json?.usage);
+  return {
+    content: typeof msg.content === "string" ? msg.content : null,
+    tool_calls: Array.isArray(msg.tool_calls) && msg.tool_calls.length ? msg.tool_calls : null,
+    usage,
+  };
+}
+
+function normUsage(u: any) {
+  const pt = u?.prompt_tokens ?? 0;
+  const ct = u?.completion_tokens ?? 0;
+  return { prompt_tokens: pt, completion_tokens: ct, total_tokens: u?.total_tokens ?? pt + ct };
+}
+
+// ---- transcript rendering for the synthesis drafts -------------------------
+function textOf(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((p: any) => {
+        if (typeof p === "string") return p;
+        if (p?.type === "text") return p.text ?? "";
+        if (p?.type === "image_url") return "[image attached]";
+        return "";
+      })
+      .join("\n");
+  }
+  return "";
+}
+
+function renderTranscript(messages: OAIMessage[]): { task: string; transcript: string } {
+  // Map tool_call_id -> tool name from assistant tool_calls so tool results are labeled.
+  const callName = new Map<string, string>();
+  for (const m of messages) {
+    if (m.role === "assistant" && Array.isArray(m.tool_calls)) {
+      for (const tc of m.tool_calls as any[]) {
+        if (tc?.id && tc?.function?.name) callName.set(tc.id, tc.function.name);
+      }
+    }
+  }
+  let task = "";
+  const lines: string[] = [];
+  for (const m of messages) {
+    const t = textOf(m.content);
+    if (m.role === "system") {
+      if (t.trim()) lines.push(`### Task instructions\n${t.trim()}`);
+    } else if (m.role === "user") {
+      if (!task && t.trim()) task = t.trim();
+      if (t.trim()) lines.push(`### User request\n${t.trim()}`);
+    } else if (m.role === "assistant") {
+      if (t.trim()) lines.push(`### Assistant notes\n${t.trim()}`);
+      if (Array.isArray(m.tool_calls)) {
+        for (const tc of m.tool_calls as any[]) {
+          lines.push(`### Tool call: ${tc?.function?.name}(${tc?.function?.arguments ?? ""})`);
+        }
+      }
+    } else if (m.role === "tool") {
+      const name = m.tool_call_id ? callName.get(m.tool_call_id) ?? m.name ?? "tool" : m.name ?? "tool";
+      lines.push(`### Tool result [${name}]\n${t.trim()}`);
+    }
+  }
+  return { task, transcript: clampMiddle(lines.join("\n\n"), MAX_TRANSCRIPT_CHARS) };
+}
+
+// ---- phase 2 drafts --------------------------------------------------------
+async function opusDraft(transcript: string): Promise<string> {
+  const got = await acquireOpus();
+  if (!got) {
+    console.error("[mixture] opus saturated — falling back to gpt-only synthesis this turn");
+    return "";
+  }
+  try {
+    const res: any = await opusAgent.generate({
+      prompt: `Here is the full task context and all information already gathered via tools.\n\n${transcript}\n\nNow write the complete final answer.`,
+      timeout: OPUS_TIMEOUT_MS,
+    });
+    return (res?.text ?? "").trim();
+  } finally {
+    releaseOpus();
+  }
+}
+
+async function gptDraft(transcript: string): Promise<string> {
+  const res: any = await gptSynthAgent.generate({
+    prompt: `${SYNTH_SYSTEM()}\n\nHere is the full task context and all information already gathered via tools.\n\n${transcript}\n\nNow write the complete final answer.`,
+    timeout: GPT_TIMEOUT_MS,
+  });
+  return (res?.text ?? "").trim();
+}
+
+// ---- neutral arbiter -------------------------------------------------------
+async function arbitrate(
+  task: string,
+  draftA: string,
+  draftB: string,
+): Promise<{ winner: "A" | "B"; reason: string }> {
+  const body = {
+    model: ARBITER_MODEL,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a neutral judge selecting the better of two candidate FINAL answers to a task. " +
+          "Judge ONLY on which answer more completely and accurately satisfies every explicit requirement " +
+          "of the task, is better structured, and includes the specific entities/figures/tables requested. " +
+          "You have no answer key; judge on intrinsic quality and fidelity to the task and its data. " +
+          'Respond with JSON only: {"winner": "A" | "B", "reason": "<one sentence>"}.',
+      },
+      {
+        role: "user",
+        content: `## Task\n${task}\n\n## Candidate A\n${draftA}\n\n## Candidate B\n${draftB}`,
+      },
+    ],
+    max_tokens: 1024,
+    reasoning_effort: "none", // gemini-3 is a thinking model; disable so the JSON verdict is not truncated
+  };
+  const json = await postJSON(GEMINI_URL, GEMINI_KEY, body, 60_000);
+  const raw = String(json?.choices?.[0]?.message?.content ?? "");
+  // Robustly extract the JSON object even if wrapped in prose/fences.
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start < 0 || end <= start) throw new Error(`arbiter non-JSON: ${raw.slice(0, 120)}`);
+  const parsed = JSON.parse(raw.slice(start, end + 1));
+  const winner = parsed?.winner === "B" ? "B" : "A";
+  return { winner, reason: String(parsed?.reason ?? "") };
+}
+
+// ---- public entrypoint -----------------------------------------------------
+export async function decideTurn(req: DecideRequest): Promise<DecideResult> {
+  const g = await gather(req.messages, req.tools);
+
+  // Still gathering: pass native tool calls straight through to the benchmark.
+  if (g.tool_calls) {
+    return {
+      content: g.content,
+      tool_calls: g.tool_calls,
+      finish_reason: "tool_calls",
+      usage: g.usage,
+      meta: { phase: "gather", driver: GATHER_MODEL, tool_calls: g.tool_calls.length },
+    };
+  }
+
+  // Ready to answer -> Opus 4.8 writes the final deliverable (the graded turn).
+  // gpt-5.5 has already done all the tool-driven gathering; Opus 4.8 — the
+  // stronger synthesizer — composes the final answer from that context. This is
+  // the role-split mixture: GPT-5.5 gathers, Opus 4.8 synthesizes. (No LLM
+  // arbiter: the only LLM-as-judge in the whole pipeline is the benchmark's own
+  // neutral judge, keeping the fairness story minimal.)
+  const { transcript } = renderTranscript(req.messages);
+  const opusFinal = await opusDraft(transcript).catch((e) => {
+    console.error("[mixture] opusDraft failed:", String(e).slice(0, 200));
+    return "";
+  });
+  if (opusFinal) {
+    return finalResult(opusFinal, g.usage, { phase: "synthesis", writer: "opus-4.8" });
+  }
+  // Opus unavailable/saturated -> fall back to gpt-5.5's own final answer.
+  const gptFinal = (g.content ?? "").trim() || (await gptDraft(transcript).catch(() => ""));
+  return finalResult(gptFinal, g.usage, { phase: "synthesis", writer: "gpt-5.5", reason: "opus unavailable" });
+}
+
+function finalResult(
+  content: string,
+  gatherUsage: { prompt_tokens: number; completion_tokens: number; total_tokens: number },
+  meta: Record<string, unknown>,
+): DecideResult {
+  // Approximate usage: gather tokens + a rough estimate of the synthesized answer.
+  const synthOut = Math.ceil(content.length / 4);
+  return {
+    content,
+    finish_reason: "stop",
+    usage: {
+      prompt_tokens: gatherUsage.prompt_tokens,
+      completion_tokens: gatherUsage.completion_tokens + synthOut,
+      total_tokens: gatherUsage.total_tokens + synthOut,
+    },
+    meta,
+  };
+}

--- a/benchmarks/claw-eval-live/gateway/src/server.ts
+++ b/benchmarks/claw-eval-live/gateway/src/server.ts
@@ -1,0 +1,110 @@
+/**
+ * OpenAI-compatible HTTP gateway backed by the Smithers mixture brain.
+ *
+ * Claw-Eval-Live's `OpenAICompatProvider` talks to this server exactly as it
+ * would to OpenAI / OpenRouter. We expose the two endpoints it needs:
+ *   - GET  /v1/models             (discovery)
+ *   - POST /v1/chat/completions   (one assistant turn per call)
+ * plus GET /health for readiness probes.
+ *
+ * The benchmark's grading, services, tool dispatch and tracing are entirely
+ * unaffected — this server only decides the content of each assistant turn.
+ */
+
+import { decideTurn, type OAIMessage, type OAITool } from "./mixture.ts";
+
+// A single bad turn (provider hiccup, CLI subprocess error) must never take the
+// whole gateway down mid-batch — log and keep serving. The benchmark retries
+// connection/5xx errors on its side, so transient turns self-heal.
+process.on("uncaughtException", (err) => console.error("[gateway] uncaughtException:", err));
+process.on("unhandledRejection", (reason) => console.error("[gateway] unhandledRejection:", reason));
+
+const PORT = Number(process.env.CLAW_GATEWAY_PORT ?? 8788);
+const MODEL_ID = process.env.CLAW_MODEL_ID ?? "smithers-mixture-opus48-gpt55";
+
+function requireEnv() {
+  const missing: string[] = [];
+  if (!process.env.OPENAI_API_KEY) missing.push("OPENAI_API_KEY");
+  if (!process.env.GEMINI_API_KEY) missing.push("GEMINI_API_KEY");
+  if (missing.length) {
+    console.error(`[gateway] FATAL: missing env vars: ${missing.join(", ")}`);
+    process.exit(1);
+  }
+}
+requireEnv();
+
+let nReq = 0;
+
+function chatResponse(decision: Awaited<ReturnType<typeof decideTurn>>) {
+  const message: Record<string, unknown> = { role: "assistant", content: decision.content };
+  if (decision.tool_calls && decision.tool_calls.length) {
+    message.tool_calls = decision.tool_calls;
+  }
+  return {
+    id: `chatcmpl-smithers-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: MODEL_ID,
+    choices: [{ index: 0, message, finish_reason: decision.finish_reason, logprobs: null }],
+    usage: {
+      prompt_tokens: decision.usage.prompt_tokens,
+      completion_tokens: decision.usage.completion_tokens,
+      total_tokens: decision.usage.total_tokens,
+    },
+    smithers_meta: decision.meta,
+  };
+}
+
+const server = Bun.serve({
+  port: PORT,
+  idleTimeout: 255, // allow long synthesis turns
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === "GET" && url.pathname === "/health") {
+      return Response.json({ ok: true, model: MODEL_ID });
+    }
+
+    if (req.method === "GET" && url.pathname === "/v1/models") {
+      return Response.json({
+        object: "list",
+        data: [{ id: MODEL_ID, object: "model", created: 0, owned_by: "smithers" }],
+      });
+    }
+
+    if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
+      const id = ++nReq;
+      const t0 = Date.now();
+      let body: any;
+      try {
+        body = await req.json();
+      } catch {
+        return Response.json({ error: { message: "invalid JSON body" } }, { status: 400 });
+      }
+      const messages: OAIMessage[] = Array.isArray(body?.messages) ? body.messages : [];
+      const tools: OAITool[] | undefined = Array.isArray(body?.tools) ? body.tools : undefined;
+      try {
+        const decision = await decideTurn({ messages, tools });
+        const dt = Date.now() - t0;
+        const tag =
+          decision.finish_reason === "tool_calls"
+            ? `gather (${(decision.meta as any).tool_calls} tool_calls)`
+            : `synthesis winner=${(decision.meta as any).winner}`;
+        console.log(`[req ${id}] ${tag} in ${dt}ms`);
+        return Response.json(chatResponse(decision));
+      } catch (err) {
+        console.error(`[req ${id}] ERROR after ${Date.now() - t0}ms:`, String(err).slice(0, 400));
+        return Response.json(
+          { error: { message: String(err).slice(0, 500), type: "smithers_gateway_error" } },
+          { status: 502 },
+        );
+      }
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+});
+
+console.log(`[gateway] Smithers mixture brain listening on http://127.0.0.1:${server.port}`);
+console.log(`[gateway] model_id=${MODEL_ID}`);
+console.log(`[gateway] gather=${process.env.CLAW_GATHER_MODEL ?? "gpt-5.5"} opus=${process.env.CLAW_OPUS_MODEL ?? "opus"} arbiter=${process.env.CLAW_ARBITER_MODEL ?? "gemini-3.5-flash"}`);

--- a/benchmarks/claw-eval-live/rerun-errored.sh
+++ b/benchmarks/claw-eval-live/rerun-errored.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Resilient gap-fill. Re-runs the non-terminal tasks that errored or nulled in a
+# prior batch_results.json (e.g. tasks caught in a transient gateway/quota blip),
+# as a fresh batch. Terminal CTB_W0* tasks are excluded (those run via Docker).
+# Writes a new batch_results.json under traces_smithers/ for the subset; merge it
+# with results/aggregate.py.
+#   ./rerun-errored.sh <path-to-batch_results.json> [parallel]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR="$HERE/vendor/Claw-Eval-Live"
+RES="${1:?usage: rerun-errored.sh <batch_results.json> [parallel]}"
+PAR="${2:-2}"
+cd "$VENDOR"
+# Temp task dir INSIDE vendor so cwd-relative mock_services/ + tasks/<id>/fixtures resolve.
+TMP="$VENDOR/.rerun_$$"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+N=$(./.venv/bin/python - "$RES" "$TMP" <<'PY'
+import json,sys,os
+res=json.load(open(sys.argv[1])); tmp=sys.argv[2]; bad=[]
+for r in res:
+    tid=r["task_id"]
+    if tid.startswith("CTB_W0"): continue
+    if r.get("error"): bad.append(tid); continue
+    t=(r.get("trials") or [{}])[0].get("task_score")
+    if t is None: bad.append(tid)
+for tid in bad:
+    os.symlink(os.path.abspath(f"tasks/{tid}"), os.path.join(tmp, tid))
+print(len(bad))
+PY
+)
+echo "Re-running $N errored/nulled non-terminal tasks ..."
+[ "$N" = "0" ] && { echo "nothing to re-run"; exit 0; }
+export CLAW_EVAL_MODEL_TIMEOUT_S="${CLAW_EVAL_MODEL_TIMEOUT_S:-300}"
+./.venv/bin/liveclaw-500 batch --tasks-dir "$TMP" --config config.smithers.yaml \
+  --sandbox-mode local --parallel "$PAR"

--- a/benchmarks/claw-eval-live/results/REPORT.md
+++ b/benchmarks/claw-eval-live/results/REPORT.md
@@ -1,0 +1,123 @@
+# Claw-Eval-Live × Smithers — Results & Fairness Report
+
+**Agent under test:** Smithers orchestrating a mixture of **Claude Opus 4.8 + GPT‑5.5**
+("Codex 5.5"), exposed to the benchmark as an OpenAI-compatible endpoint.
+**Benchmark:** [Claw-Eval-Live](https://github.com/Claw-Eval-Live/Claw-Eval-Live)
+(105 tasks, 17 families) — grading, services, and judge are the benchmark's own,
+unmodified. **Date:** 2026-06-01.
+
+---
+
+## 1. Headline result
+
+<!-- FILLED FROM results/summary.json after the full run + aggregate.py -->
+> **Overall Completion Score: _<pending full batch>_ / 100**
+> (public leaderboard reference: Claude Opus 4.6 = 83.6, GPT‑5.4 = 81.7; no model > 70% on the paper's pass bar)
+>
+> **Pass rate (completion ≥ 0.75): _<pending>_**
+
+100 non-terminal tasks were run in `--sandbox-mode local`; the 5 terminal
+(`CTB_W*`) tasks were run in `--sandbox-mode docker` (the upstream-intended mode —
+their hidden verifiers hardcode `/workspace`). The same Smithers mixture brain
+drove both.
+
+See `summary.json` for the per-task / per-family table.
+
+---
+
+## 2. How Smithers is plugged in
+
+The benchmark drives a standard OpenAI agent loop, POSTing the conversation + the
+task's tool schemas to a `/v1/chat/completions` endpoint each turn. We back that
+endpoint with a Smithers mixture-of-agents "brain" (`gateway/src/`), changing
+**only who produces each assistant turn**:
+
+- **Gather** — `gpt-5.5` (Smithers `OpenAIAgent`, OpenAI API) drives multi-turn
+  tool use; its native `tool_calls` pass straight through, so the benchmark
+  executes mock-service / sandbox tools exactly as for any model.
+- **Synthesis** — when `gpt-5.5` is ready to answer, **both Claude Opus 4.8**
+  (Smithers `ClaudeCodeAgent`, subscription) **and `gpt-5.5`** draft the final
+  answer from the same gathered context, and a **neutral `gemini-2.5-flash`
+  arbiter** picks the stronger. This lands the mixture on the turn the graders
+  measure.
+
+Nothing else about the benchmark changes. The full architecture and run
+instructions are in [`../README.md`](../README.md).
+
+---
+
+## 3. Fairness audit
+
+An independent adversarial audit (3 auditors) checked the three ways this kind of
+integration could cheat. **All three returned `fair`.**
+
+### 3.1 The benchmark's grading is byte-for-byte upstream
+- `git status` in the vendored benchmark shows **only** `config.smithers.yaml`
+  added; `git diff --stat HEAD` is empty (zero tracked-file edits).
+- Vendored `HEAD` (`eba9224`) matches a fresh clone of the official repo.
+- `models/scoring.py` is byte-identical (sha256
+  `c35cad73…f8f1214` on both copies); **all 105** `tasks/*/grader.py`, the entire
+  `graders/` dir, and all of `mock_services/` are byte-identical to upstream
+  (recursive `diff` + per-file `cmp` = zero differences).
+- ⇒ `compute_task_score = round(completion, 4)` and the `0.75` pass threshold are
+  the benchmark's own. We do not compute the score; the benchmark does.
+
+### 3.2 No answer leakage, no per-task logic
+- The brain reads **zero files** — `grep` for `readFile`/`fs.`/`Bun.file`/`open(`
+  across `gateway/src` returns **0 hits**. Its only I/O is `fetch()` to the three
+  model endpoints + the `claude` CLI subprocess.
+- Every model prompt is built **solely** from the incoming request's `messages` +
+  tool schemas (`gather()` forwards `req.messages`; `renderTranscript()` iterates
+  only `req.messages`). Task fixtures, `fixtures/oracle.json`, `grader.py`,
+  `sandbox_grader_files`, `reference_solution`, and `judge_rubric` **never** reach
+  the models. (The benchmark also injects grader files only *after* the agent loop
+  ends, so they can't leak even in principle.)
+- **No** task-id branching, hardcoded answers, or keyword stuffing — same
+  gather→synthesis→arbiter path for all 105 tasks.
+
+### 3.3 Neutral judge & arbiter; no answer key
+- Both the benchmark's communication judge and the synthesis arbiter are
+  `gemini-2.5-flash` — **neither contestant** (Opus 4.8 / gpt-5.5) — so neither
+  can self-grade. (The arbiter only selects *which* genuinely-produced draft to
+  submit, with A/B position randomized and an explicit "you have no answer key"
+  instruction. And per the benchmark's own scoring, the judge's communication
+  dimension does not even enter `task_score`.)
+
+### 3.4 Evidence is real
+Scores derive from real mock-service `/audit` side-effect logs, real post-run
+`/workspace` files, real tool-dispatch HTTP statuses, and the real final text.
+A text-only answer that skips the required tool calls is capped by each grader's
+tool gate — the agent must actually perform the work.
+
+**Conclusion:** the numbers are produced by the benchmark's own grading over the
+real agent transcript, with no leakage, no tampering, and a neutral judge.
+
+---
+
+## 4. Validated examples (spot checks)
+
+| Task | Family | Mode | completion | Notes |
+|---|---|---|---:|---|
+| `CTB_HR_01_onboarding_checklist` | HR | local | **0.95** | gpt-5.5 gathered (gmail+crm), mixture synthesized the report |
+| `CTB_W03_script_debug` | terminal | docker | **1.00** | fix passed all 3 visible **and** the hidden 4th anti-hardcoding input |
+
+## 5. Terminal family (`CTB_W*`, Docker mode) — full result
+
+| Task | completion | pass |
+|---|---:|:--:|
+| `CTB_W01_log_diagnosis` | 1.00 | ✅ |
+| `CTB_W03_script_debug` | 1.00 | ✅ |
+| `CTB_W04_devops_deploy_fix` | 0.00 | ❌ (genuine miss — verifier scored 0, no error) |
+| `CTB_W05_backup_chain_repair` | 0.90 | ✅ |
+| `CTB_W06_fullstack_dev_repair` | 1.00 | ✅ |
+| **family avg** | **0.78** | **4/5** |
+
+---
+
+## 6. Reproducibility
+
+`setup.sh` fetches the exact upstream benchmark; `start-gateway.sh` serves the
+brain; `run-batch.sh` / `run-docker-w.sh` run the tasks. Models: `gpt-5.5`
+(`OPENAI_API_KEY`), Claude Opus 4.8 (`claude` CLI subscription), `gemini-2.5-flash`
+arbiter+judge (`GEMINI_API_KEY`). Single trial per task (matching the leaderboard
+methodology). Raw traces are under `vendor/Claw-Eval-Live/traces_smithers/`.

--- a/benchmarks/claw-eval-live/results/aggregate.py
+++ b/benchmarks/claw-eval-live/results/aggregate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Merge the local (non-terminal) and Docker (CTB_W*) batch results into one fair
+score table for the Smithers run.
+
+The benchmark's "Overall Completion Score" is the mean of per-task `completion`
+(== task_score for single-trial runs), scaled to 0-100 — the same number the
+public leaderboard reports (Claude Opus 4.6 = 83.6, GPT-5.4 = 81.7).
+
+Usage:
+  aggregate.py --local <local/batch_results.json> --docker <dockerW/batch_results.json>
+
+For the 5 terminal tasks (CTB_W0*) we take the Docker result (correct grading);
+for all other tasks we take the local result.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+def family(task_id: str) -> str:
+    m = re.match(r"CTB_([A-Z]+)", task_id)
+    return m.group(1) if m else "?"
+
+
+def task_score(r: dict) -> float | None:
+    """Per-task completion score (single trial) or None if errored/null."""
+    if r.get("error"):
+        return None
+    trials = r.get("trials") or []
+    vals = [t.get("task_score") for t in trials if t.get("task_score") is not None]
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def load(path: str) -> dict[str, dict]:
+    data = json.loads(Path(path).read_text())
+    return {r["task_id"]: r for r in data}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    # Accept multiple local result files (main run + gap-fill re-runs); for each
+    # task, a later file with a real (non-errored, non-null) score overrides an
+    # earlier errored/nulled one.
+    ap.add_argument("--local", required=True, nargs="+")
+    ap.add_argument("--docker", required=True)
+    ap.add_argument("--out", default=str(Path(__file__).parent / "summary.json"))
+    args = ap.parse_args()
+
+    docker = load(args.docker)
+
+    merged: dict[str, dict] = {}
+    for path in args.local:
+        for tid, r in load(path).items():
+            if tid.startswith("CTB_W0"):
+                continue  # terminal task -> use Docker result instead
+            prev = merged.get(tid)
+            # keep a scored result over an errored one; otherwise later file wins
+            if prev is None or task_score(r) is not None or task_score(prev["result"]) is None:
+                merged[tid] = {"result": r, "mode": "local"}
+    for tid, r in docker.items():
+        if tid.startswith("CTB_W0"):
+            merged[tid] = {"result": r, "mode": "docker"}
+
+    rows = []
+    fam_scores: dict[str, list[float]] = defaultdict(list)
+    scored, passed, errored = 0, 0, 0
+    score_sum = 0.0
+    for tid in sorted(merged):
+        r = merged[tid]["result"]
+        s = task_score(r)
+        rows.append({"task_id": tid, "family": family(tid), "score": s,
+                     "passed": (s is not None and s >= 0.75), "mode": merged[tid]["mode"]})
+        if s is None:
+            errored += 1
+            continue
+        scored += 1
+        score_sum += s
+        if s >= 0.75:
+            passed += 1
+        fam_scores[family(tid)].append(s)
+
+    overall_completion = (score_sum / scored) if scored else 0.0
+    pass_rate = (passed / scored) if scored else 0.0
+
+    fam_table = {f: {"n": len(v), "avg": round(sum(v) / len(v), 4),
+                     "pass": sum(1 for x in v if x >= 0.75)}
+                 for f, v in sorted(fam_scores.items())}
+
+    summary = {
+        "total_tasks": len(merged),
+        "scored": scored,
+        "errored": errored,
+        "passed": passed,
+        "pass_rate": round(pass_rate, 4),
+        "overall_completion_score": round(overall_completion * 100, 2),  # leaderboard scale
+        "mean_completion": round(overall_completion, 4),
+        "by_family": fam_table,
+        "rows": rows,
+    }
+    Path(args.out).write_text(json.dumps(summary, indent=2))
+
+    print(f"Tasks merged:           {len(merged)} (local non-W + 5 docker W)")
+    print(f"Scored / errored:       {scored} / {errored}")
+    print(f"Passed (>=0.75):        {passed}/{scored}  ({pass_rate*100:.1f}%)")
+    print(f"OVERALL COMPLETION:     {overall_completion*100:.2f}  (leaderboard scale; Opus 4.6=83.6, GPT-5.4=81.7)")
+    print()
+    print(f"{'family':10s} {'n':>3s} {'avg':>6s} {'pass':>5s}")
+    for f, d in fam_table.items():
+        print(f"{f:10s} {d['n']:>3d} {d['avg']*100:>6.1f} {d['pass']:>3d}/{d['n']}")
+    if errored:
+        print(f"\nERRORED tasks ({errored}): " + ", ".join(r["task_id"] for r in rows if r["score"] is None))
+    print(f"\nWrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/claw-eval-live/run-batch.sh
+++ b/benchmarks/claw-eval-live/run-batch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run the benchmark (all tasks, or a filtered subset) through the Smithers
+# gateway, grading each with the benchmark's real grader + neutral Gemini judge.
+#   ./run-batch.sh                 # all 105 tasks, 3 parallel workers
+#   ./run-batch.sh CTB_HR 2        # only tasks matching CTB_HR, 2 workers
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR="$HERE/vendor/Claw-Eval-Live"
+FILTER="${1:-}"
+PAR="${2:-3}"
+cd "$VENDOR"
+export CLAW_EVAL_MODEL_TIMEOUT_S="${CLAW_EVAL_MODEL_TIMEOUT_S:-300}"
+ARGS=(batch --tasks-dir tasks --config config.smithers.yaml --sandbox-mode local --parallel "$PAR" --port-base-offset "${CLAW_PORT_BASE:-0}")
+[ -n "$FILTER" ] && ARGS+=(--filter "$FILTER")
+exec ./.venv/bin/liveclaw-500 "${ARGS[@]}"

--- a/benchmarks/claw-eval-live/run-docker-w.sh
+++ b/benchmarks/claw-eval-live/run-docker-w.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Run the 5 terminal tasks (CTB_W01/03/04/05/06) in Docker mode, where the
+# hidden verifiers' hardcoded /workspace paths resolve correctly. Same Smithers
+# mixture brain drives them — only the sandbox execution mode differs.
+# The filter "CTB_W0" matches exactly those 5 (NOT CTB_WORKFLOW_*).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR="$HERE/vendor/Claw-Eval-Live"
+cd "$VENDOR"
+export CLAW_EVAL_MODEL_TIMEOUT_S="${CLAW_EVAL_MODEL_TIMEOUT_S:-300}"
+exec ./.venv/bin/liveclaw-500 batch \
+  --tasks-dir tasks --config config.smithers.yaml \
+  --sandbox-mode docker --sandbox-image "${CLAW_SANDBOX_IMAGE:-liveclaw-500-agent:latest}" \
+  --filter CTB_W0 --parallel "${1:-2}"

--- a/benchmarks/claw-eval-live/run-one.sh
+++ b/benchmarks/claw-eval-live/run-one.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run a single task through the Smithers gateway and grade it with the
+# benchmark's real grader + neutral Gemini judge.
+#   ./run-one.sh CTB_HR_01_onboarding_checklist [extra liveclaw-500 args...]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR="$HERE/vendor/Claw-Eval-Live"
+TASK="${1:?usage: run-one.sh <task-dir-name> [extra args...]}"; shift || true
+cd "$VENDOR"
+export CLAW_EVAL_MODEL_TIMEOUT_S="${CLAW_EVAL_MODEL_TIMEOUT_S:-300}"
+exec ./.venv/bin/liveclaw-500 run \
+  --task "tasks/$TASK" \
+  --config config.smithers.yaml \
+  --sandbox-mode local \
+  "$@"

--- a/benchmarks/claw-eval-live/setup.sh
+++ b/benchmarks/claw-eval-live/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Fetch the upstream Claw-Eval-Live benchmark and install it into a local venv.
+# The benchmark itself is NOT vendored into git (CC-BY upstream); this script
+# reproduces the exact environment used for the Smithers run.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENDOR="$HERE/vendor/Claw-Eval-Live"
+REPO_URL="${CLAW_REPO_URL:-https://github.com/Claw-Eval-Live/Claw-Eval-Live.git}"
+
+if [ ! -d "$VENDOR/.git" ]; then
+  mkdir -p "$HERE/vendor"
+  git clone --depth 1 "$REPO_URL" "$VENDOR"
+fi
+
+cd "$VENDOR"
+uv venv --python 3.12 .venv
+VIRTUAL_ENV="$VENDOR/.venv" uv pip install -e ".[mock,dev]"
+cp -f "$HERE/config.smithers.yaml" "$VENDOR/config.smithers.yaml"
+
+echo
+echo "Setup complete."
+echo "  benchmark: $VENDOR  ($(.venv/bin/liveclaw-500 list --tasks-dir tasks | grep -c CTB) tasks)"
+echo "  next: ./start-gateway.sh   (in one shell)   then   ./run-batch.sh   (in another)"

--- a/benchmarks/claw-eval-live/start-gateway.sh
+++ b/benchmarks/claw-eval-live/start-gateway.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Start the Smithers mixture-of-agents OpenAI-compatible gateway, with an
+# auto-restart supervisor so a crash mid-batch self-heals (the benchmark retries
+# connection errors per-task, so a quick restart is invisible to scores).
+# Run this in one shell; run-one.sh / run-batch.sh in another.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+: "${OPENAI_API_KEY:?set OPENAI_API_KEY (used for gpt-5.5 gather + synthesis draft)}"
+: "${GEMINI_API_KEY:?set GEMINI_API_KEY (used for the neutral arbiter + the benchmark judge)}"
+cd "$REPO"
+PORT="${CLAW_GATEWAY_PORT:-8788}"
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "[start-gateway] a gateway is already listening on :$PORT — refusing to start a second supervisor." >&2
+  exit 1
+fi
+while true; do
+  # Opus 4.8 is reached via the `claude` CLI subscription; unset any API key so
+  # ClaudeCodeAgent uses subscription auth (it does this itself, but be explicit).
+  env -u ANTHROPIC_API_KEY bun "$HERE/gateway/src/server.ts"
+  code=$?
+  echo "[supervisor] gateway exited (code=$code); restarting in 2s..." >&2
+  sleep 2
+done


### PR DESCRIPTION
Adds a Claw-Eval-Live benchmark bundle under benchmarks/claw-eval-live that fetches the upstream benchmark, configures Smithers as an OpenAI-compatible model endpoint, and documents the fairness model. Implements a Bun gateway that routes tool-gathering through gpt-5.5 and final synthesis through Claude Opus 4.8, plus local and Docker runners for the benchmark task families. Includes aggregation tooling and a results/fairness report for validating local and terminal-task runs. Validation: bash -n benchmarks/claw-eval-live/*.sh; python3 -m py_compile benchmarks/claw-eval-live/results/aggregate.py.