### PR TITLE
🐛 fix(agents): correct Antigravity CLI flags so `agy` launches

### DIFF
--- a/.smithers/gateway.ts
+++ b/.smithers/gateway.ts
@@ -1,0 +1,58 @@
+import { Gateway, mdxPlugin } from "smithers-orchestrator";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+
+mdxPlugin();
+
+const here = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(here, "..");
+process.chdir(projectRoot);
+
+const parsedPort = Number(process.env.PORT ?? "7331");
+const port = Number.isInteger(parsedPort) && parsedPort > 0 ? parsedPort : 7331;
+const host = process.env.HOST ?? "127.0.0.1";
+
+const gateway = new Gateway({ heartbeatMs: 15_000 });
+
+/** Pull the display name from a workflow's `// smithers-display-name:` header, else the key. */
+function displayName(key: string, source: string): string {
+  const match = source.match(/^\/\/\s*smithers-display-name:\s*(.+)$/m);
+  return match ? match[1].trim() : key;
+}
+
+// Mount each workflow + its UI (when a matching `ui/<key>.tsx` exists) independently.
+// A workflow that fails to import (e.g. a broken prompt/MDX) disables only itself —
+// the rest of the gateway and the other workflow UIs still come up.
+async function mountWorkflow(key: string, title: string) {
+  try {
+    const mod = await import("./workflows/" + key + ".tsx");
+    const uiEntry = resolve(here, "ui", key + ".tsx");
+    const options: { ui?: { entry: string; title: string } } = {};
+    if (existsSync(uiEntry)) options.ui = { entry: uiEntry, title };
+    gateway.register(key, mod.default, options);
+    if (options.ui) {
+      console.log("  " + title + " UI -> http://" + host + ":" + port + "/workflows/" + key);
+    } else {
+      console.log("  " + title + " (no UI)");
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn("[gateway] skipped " + key + ": " + message);
+  }
+}
+
+const workflowsDir = resolve(here, "workflows");
+const keys = readdirSync(workflowsDir)
+  .filter((file) => file.endsWith(".tsx"))
+  .map((file) => file.replace(/\.tsx$/, ""))
+  .sort();
+
+console.log("Workflows:");
+for (const key of keys) {
+  const source = readFileSync(join(workflowsDir, key + ".tsx"), "utf8");
+  await mountWorkflow(key, displayName(key, source));
+}
+
+await gateway.listen({ host, port });
+console.log("Smithers Gateway listening on http://" + host + ":" + port);

--- a/.smithers/tests/ship-tickets-ui.e2e.test.tsx
+++ b/.smithers/tests/ship-tickets-ui.e2e.test.tsx
@@ -1,0 +1,248 @@
+/** @jsxImportSource smithers-orchestrator */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createSmithers, Gateway, Sequence } from "smithers-orchestrator";
+import { z } from "zod/v4";
+
+/**
+ * Real-browser e2e for the `ship-tickets` monitoring UI. No route mocking, no
+ * fabricated RPC: a REAL Smithers Gateway serves the REAL `.smithers/ui/
+ * ship-tickets.tsx` (bundled on demand by the gateway's Bun build), driven by a
+ * REAL run whose node output + event frames the UI reads over the live RPC/WS.
+ *
+ * The run is produced by a deterministic `createSmithers` workflow that
+ * reproduces ship-tickets' EXACT node-id + output-schema contract
+ * (`manifest`, then per-ticket `<slug>:research|plan|implement|validate|
+ * review:0|merge`). The real ship-tickets workflow drives agents, git worktrees,
+ * and a `pnpm typecheck` merge gate — none of which complete deterministically
+ * headless — so, exactly like the studio-2 gateway fixture, the workflow is the
+ * seeded-deterministic part and EVERYTHING the UI touches (gateway, RPC, schema-
+ * bound node-output tables, the event window) is real.
+ *
+ * This is the check that caught the event-frame bug: the gateway emits frames
+ * shaped `{ event, payload: { nodeId, state }, seq }`, so the UI's pipeline /
+ * ledger (which derive per-ticket state from the event stream) only light up
+ * when nodeId is read from `payload` — a "serves 200" smoke can never catch that.
+ *
+ * Runs under bun (the orchestrator's SQLite layer uses bun:sqlite); Chromium is
+ * resolved from the studio-2 Playwright install.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../..");
+const uiEntry = resolve(here, "../ui/ship-tickets.tsx");
+const RUN_ID = "ship-tickets-e2e-run";
+
+// The two tickets the fixture run "ships". Titles + per-stage summary tokens are
+// deliberately unique so the assertions prove the UI rendered THIS run's output.
+const TICKETS = [
+  { slug: "0001-voice-capture", title: "Voice capture pipeline", id: ".smithers/tickets/ultragrill/0001-voice-capture.md" },
+  { slug: "0002-question-pool", title: "Rolling question pool", id: ".smithers/tickets/ultragrill/0002-question-pool.md" },
+];
+
+// EXACT schemas the ship-tickets UI extractors read (mirrors the real workflow +
+// ValidationLoop/Review component outputs).
+const researchSchema = z.object({ summary: z.string(), keyFindings: z.array(z.string()).default([]) });
+const planSchema = z.object({ summary: z.string(), steps: z.array(z.string()).default([]) });
+const implementSchema = z.object({ summary: z.string(), filesChanged: z.array(z.string()).default([]), allTestsPassing: z.boolean().default(true) });
+const validateSchema = z.object({ summary: z.string(), allPassed: z.boolean().default(true), failingSummary: z.string().nullable().default(null) });
+const reviewSchema = z.object({ reviewer: z.string(), approved: z.boolean(), feedback: z.string(), issues: z.array(z.any()).default([]) });
+const shipResultSchema = z.object({ ticketId: z.string(), branch: z.string(), status: z.enum(["merged", "skipped", "failed"]), summary: z.string() });
+const manifestSchema = z.object({
+  ticketsDir: z.string(),
+  tickets: z.array(z.object({ slug: z.string(), title: z.string(), id: z.string() })).default([]),
+});
+
+const tmpDir = mkdtempSync(join(tmpdir(), "ship-tickets-e2e-"));
+const dbPath = join(tmpDir, "runs.db");
+
+const { smithers, Workflow, Task, outputs } = createSmithers(
+  {
+    research: researchSchema,
+    plan: planSchema,
+    implement: implementSchema,
+    validate: validateSchema,
+    review: reviewSchema,
+    shipResult: shipResultSchema,
+    manifest: manifestSchema,
+  },
+  { dbPath },
+);
+
+function ticketNodes(t: (typeof TICKETS)[number]) {
+  return (
+    <Sequence key={t.slug}>
+      <Task id={`${t.slug}:research`} output={outputs.research}>
+        {{ summary: `RESEARCH-${t.slug}: grounded in the gateway + dev-server seams.`, keyFindings: [`finding-a-${t.slug}`, `finding-b-${t.slug}`] }}
+      </Task>
+      <Task id={`${t.slug}:plan`} output={outputs.plan}>
+        {{ summary: `PLAN-${t.slug}`, steps: [`step-one-${t.slug}`, `step-two-${t.slug}`] }}
+      </Task>
+      <Task id={`${t.slug}:implement`} output={outputs.implement}>
+        {{ summary: `IMPLEMENT-${t.slug}`, filesChanged: [`src/${t.slug}.ts`], allTestsPassing: true }}
+      </Task>
+      <Task id={`${t.slug}:validate`} output={outputs.validate}>
+        {{ summary: `VALIDATE-${t.slug}`, allPassed: true, failingSummary: null }}
+      </Task>
+      <Task id={`${t.slug}:review:0`} output={outputs.review}>
+        {{ reviewer: `reviewer-${t.slug}`, approved: true, feedback: `LGTM-${t.slug}`, issues: [] }}
+      </Task>
+      <Task id={`${t.slug}:merge`} output={outputs.shipResult}>
+        {{ ticketId: t.id, branch: `ship/${t.slug}`, status: "merged", summary: `MERGED-${t.slug} onto main` }}
+      </Task>
+    </Sequence>
+  );
+}
+
+const workflow = smithers(() => (
+  <Workflow name="ship-tickets">
+    <Sequence>
+      <Task id="manifest" output={outputs.manifest}>
+        {{ ticketsDir: ".smithers/tickets/ultragrill", tickets: TICKETS }}
+      </Task>
+      {TICKETS.map(ticketNodes)}
+    </Sequence>
+  </Workflow>
+));
+
+const gateway = new Gateway({ heartbeatMs: 250 });
+// The workflow's inferred schema generic is narrower than register's `SmithersWorkflow`
+// param (build's ctx is contravariant) — a fixture-only cast, exactly the shape the
+// gateway runs at runtime.
+gateway.register("ship-tickets", workflow as Parameters<typeof gateway.register>[1], {
+  ui: { entry: uiEntry, title: "Ship Tickets" },
+});
+
+let port = 0;
+let base = "";
+
+function findOpenPort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const p = typeof addr === "object" && addr ? addr.port : 0;
+      server.close(() => resolvePort(p));
+    });
+  });
+}
+
+async function waitForHealth(timeoutMs = 30_000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      if ((await fetch(`${base}/health`)).ok) return true;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+async function loadChromium() {
+  // `playwright` isn't a dependency of the workflow pack; resolve it dynamically
+  // (a non-literal specifier so tsc doesn't try to resolve it here), falling back
+  // to the studio-2 install where the browsers are downloaded.
+  const playwrightPkg = "playwright";
+  try {
+    return (await import(playwrightPkg)).chromium;
+  } catch {
+    return (await import(resolve(repoRoot, "apps/smithers-studio-2/node_modules/playwright/index.js"))).chromium;
+  }
+}
+
+beforeAll(async () => {
+  const auth = { triggeredBy: "e2e", scopes: ["*"], role: "operator", tokenId: null };
+  // Execute the run to completion BEFORE listening, so node output + the full
+  // event window exist the instant the browser connects (no spec/run race).
+  await gateway.startRun("ship-tickets", {}, auth, RUN_ID, { resume: false });
+  const inflight = gateway.inflightRuns.get(RUN_ID);
+  if (inflight) await inflight;
+
+  port = await findOpenPort();
+  base = `http://127.0.0.1:${port}`;
+  await gateway.listen({ port, host: "127.0.0.1" });
+});
+
+afterAll(async () => {
+  try {
+    await gateway.close();
+  } catch {}
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test("ship-tickets UI renders a real completed run end-to-end", async () => {
+  expect(await waitForHealth()).toBe(true);
+
+  const browser = await (await loadChromium()).launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    const errors: string[] = [];
+    page.on("pageerror", (err: Error) => errors.push(err.message));
+
+    await page.goto(`${base}/workflows/ship-tickets?runId=${RUN_ID}`, { waitUntil: "networkidle" });
+
+    // 1) The real bundle built + the app mounted to its root.
+    await page.waitForSelector('[data-testid="ship-tickets-ui"]', { timeout: 20_000 });
+
+    // 2) The pipeline lists both tickets from the manifest node output.
+    await page.waitForSelector('[data-testid="ship-pipeline"]', { timeout: 20_000 });
+    await page.waitForSelector('[data-testid="ship-ticket-0001-voice-capture"]', { timeout: 20_000 });
+    await page.waitForSelector('[data-testid="ship-ticket-0002-question-pool"]', { timeout: 20_000 });
+
+    // 3) EVENT-derived state: both tickets land (progress pill + ledger). This is
+    //    the assertion that fails unless nodeId is read from frame.payload.
+    await page.waitForFunction(
+      () => (document.querySelector('[data-testid="ship-progress"]')?.textContent ?? "").includes("2/2 landed"),
+      undefined,
+      { timeout: 20_000 },
+    );
+    await page.waitForSelector('[data-testid="ship-ledger"]', { timeout: 20_000 });
+
+    // 4) The default-selected ticket's detail renders THIS run's real node output
+    //    across every stage (research → merge), read over the live node-output RPC.
+    await page.waitForFunction(
+      (expected: string[]) => {
+        const text = document.body.textContent ?? "";
+        return expected.every((t) => text.includes(t));
+      },
+      [
+        "RESEARCH-0001-voice-capture",
+        "finding-a-0001-voice-capture",
+        "PLAN-0001-voice-capture",
+        "step-one-0001-voice-capture",
+        "IMPLEMENT-0001-voice-capture",
+        "src/0001-voice-capture.ts",
+        "VALIDATE-0001-voice-capture",
+        "reviewer-0001-voice-capture",
+        "MERGED-0001-voice-capture onto main",
+      ],
+      { timeout: 20_000 },
+    );
+
+    // 5) The per-ticket live-activity feed (also event-derived) shows node frames.
+    await page.waitForSelector('[data-testid="ticket-activity"]', { timeout: 20_000 });
+
+    // 6) Selecting the second ticket swaps the detail to ITS output.
+    await page.click('[data-testid="ship-ticket-0002-question-pool"]');
+    await page.waitForFunction(
+      () => (document.body.textContent ?? "").includes("MERGED-0002-question-pool onto main"),
+      undefined,
+      { timeout: 20_000 },
+    );
+
+    expect(errors).toEqual([]);
+
+    const ledgerText = await page.evaluate(
+      () => document.querySelector('[data-testid="ship-ledger"]')?.textContent ?? "",
+    );
+    expect(ledgerText).toContain("Voice capture pipeline");
+    expect(ledgerText).toContain("Rolling question pool");
+  } finally {
+    await browser.close();
+  }
+}, 120_000);

--- a/.smithers/tests/workflows-graph.smoke.test.ts
+++ b/.smithers/tests/workflows-graph.smoke.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Construct smoke for the REAL ship-tickets + verifiable-goals workflows.
+ *
+ * `smithers graph` renders the workflow's JSX into its node graph WITHOUT
+ * executing it (no agents, no git worktrees), so it's a fast, deterministic
+ * check that the real `.tsx` imports, its schemas are valid, and every node the
+ * monitoring UI depends on actually exists in the real workflow — catching any
+ * drift between the workflow's node-id contract and the UI that reads it.
+ *
+ * Invoked as `bun run apps/cli/src/index.js graph …` (the CLI entry directly),
+ * which bypasses the `smithers` shell-wrapper bin.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../..");
+const cliEntry = resolve(repoRoot, "apps/cli/src/index.js");
+const workflowsDir = resolve(here, "../workflows");
+
+function graph(workflow: string, input?: Record<string, unknown>): { code: number; out: string } {
+  const args = ["run", cliEntry, "graph", workflow, "--format", "json"];
+  if (input) args.push("--input", JSON.stringify(input));
+  const r = spawnSync(process.execPath, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: 120_000,
+  });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}\n${r.stderr ?? ""}` };
+}
+
+test("ship-tickets workflow renders its full per-ticket node contract", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "ship-tickets-graph-"));
+  try {
+    writeFileSync(join(tmp, "0001-sample.md"), "---\ntitle: Sample Goal\n---\n# Sample Goal\nBody.\n");
+    const { code, out } = graph(join(workflowsDir, "ship-tickets.tsx"), { ticketsDir: tmp });
+    expect(code).toBe(0);
+    // Every node id the UI's STAGES + manifest read must exist in the real graph.
+    for (const nodeId of [
+      "manifest",
+      "0001-sample:research",
+      "0001-sample:plan",
+      "0001-sample:implement",
+      "0001-sample:validate",
+      "0001-sample:review:0",
+      "0001-sample:merge",
+    ]) {
+      expect(out).toContain(`"${nodeId}"`);
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}, 130_000);
+
+test("verifiable-goals workflow renders without executing", () => {
+  const { code, out } = graph(join(workflowsDir, "verifiable-goals.tsx"));
+  expect(code).toBe(0);
+  expect(out).toContain('"goals"');
+  expect(out).toContain('"write"');
+}, 130_000);

--- a/.smithers/ui/ship-tickets.tsx
+++ b/.smithers/ui/ship-tickets.tsx
@@ -1,0 +1,639 @@
+/** @jsxImportSource react */
+import { useMemo, useState } from "react";
+import {
+  createGatewayReactRoot,
+  useGatewayActions,
+  useGatewayNodeOutput,
+  useGatewayRun,
+  useGatewayRunEvents,
+  useGatewayRuns,
+} from "smithers-orchestrator/gateway-react";
+
+const WORKFLOW_KEY = "ship-tickets";
+
+type RunSummary = { runId: string; workflowKey?: string; status?: string; createdAtMs?: number };
+
+// ── value coercion (mirrors the other workflow UIs) ────────────────────────
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+function asBool(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function asStringArray(value: unknown): string[] {
+  return asArray(value).filter((v): v is string => typeof v === "string");
+}
+function shortRunId(runId: string | undefined) {
+  return runId ? runId.slice(0, 8) : "--";
+}
+function runIdFromUrl(): string | undefined {
+  if (typeof location === "undefined") return undefined;
+  return new URLSearchParams(location.search).get("runId") ?? undefined;
+}
+function slugFromUrl(): string | undefined {
+  if (typeof location === "undefined") return undefined;
+  return new URLSearchParams(location.search).get("ticket") ?? undefined;
+}
+// Node output hooks deliver { status, row, schema }; unwrap the row.
+function rowOf(value: unknown): Record<string, unknown> {
+  const data = isRecord(value) ? value : {};
+  return isRecord(data.row) ? data.row : data;
+}
+
+// ── per-node extractors ────────────────────────────────────────────────────
+type TicketRef = { slug: string; title: string; id: string };
+function extractManifest(value: unknown): TicketRef[] {
+  const row = rowOf(value);
+  return asArray(row.tickets)
+    .filter(isRecord)
+    .map((t) => ({
+      slug: asString(t.slug) ?? "",
+      title: asString(t.title) ?? asString(t.slug) ?? "ticket",
+      id: asString(t.id) ?? "",
+    }))
+    .filter((t) => t.slug.length > 0);
+}
+
+type ResearchOutput = { summary: string; keyFindings: string[] };
+function extractResearch(value: unknown): ResearchOutput | null {
+  const row = rowOf(value);
+  const summary = asString(row.summary);
+  if (summary === undefined) return null;
+  return { summary, keyFindings: asStringArray(row.keyFindings) };
+}
+
+type PlanOutput = { summary: string; steps: string[] };
+function extractPlan(value: unknown): PlanOutput | null {
+  const row = rowOf(value);
+  const summary = asString(row.summary);
+  if (summary === undefined) return null;
+  return { summary, steps: asStringArray(row.steps) };
+}
+
+type ImplementOutput = { summary: string; filesChanged: string[]; allTestsPassing: boolean };
+function extractImplement(value: unknown): ImplementOutput | null {
+  const row = rowOf(value);
+  const summary = asString(row.summary);
+  if (summary === undefined) return null;
+  return {
+    summary,
+    filesChanged: asStringArray(row.filesChanged),
+    allTestsPassing: asBool(row.allTestsPassing) ?? true,
+  };
+}
+
+type ValidateOutput = { summary: string; allPassed: boolean; failingSummary: string | null };
+function extractValidate(value: unknown): ValidateOutput | null {
+  const row = rowOf(value);
+  const summary = asString(row.summary);
+  if (summary === undefined) return null;
+  return {
+    summary,
+    allPassed: asBool(row.allPassed) ?? true,
+    failingSummary: asString(row.failingSummary) ?? null,
+  };
+}
+
+type ReviewOutput = { reviewer: string; approved: boolean; feedback: string };
+function extractReview(value: unknown): ReviewOutput | null {
+  const row = rowOf(value);
+  const reviewer = asString(row.reviewer);
+  const approved = asBool(row.approved);
+  if (reviewer === undefined && approved === undefined) return null;
+  return {
+    reviewer: reviewer ?? "reviewer",
+    approved: approved ?? false,
+    feedback: asString(row.feedback) ?? "",
+  };
+}
+
+type ShipResult = { branch: string; status: string; summary: string };
+function extractShip(value: unknown): ShipResult | null {
+  const row = rowOf(value);
+  const status = asString(row.status);
+  if (status === undefined) return null;
+  return {
+    branch: asString(row.branch) ?? "",
+    status,
+    summary: asString(row.summary) ?? "",
+  };
+}
+
+// ── pipeline stage model ───────────────────────────────────────────────────
+type StageState = "pending" | "active" | "done" | "failed";
+const STAGES: Array<{ key: string; label: string; abbr: string; node: (slug: string) => string }> = [
+  { key: "research", label: "Research", abbr: "R", node: (s) => `${s}:research` },
+  { key: "plan", label: "Plan", abbr: "P", node: (s) => `${s}:plan` },
+  { key: "implement", label: "Implement", abbr: "I", node: (s) => `${s}:implement` },
+  { key: "validate", label: "Validate", abbr: "V", node: (s) => `${s}:validate` },
+  { key: "review", label: "Review", abbr: "Rv", node: (s) => `${s}:review:0` },
+  { key: "merge", label: "Merge", abbr: "M", node: (s) => `${s}:merge` },
+];
+
+function classifyType(type: string): StageState | "" {
+  if (type.includes("fail") || type.includes("error") || type.includes("cancel")) return "failed";
+  if (type.includes("complete") || type.includes("finish")) return "done";
+  if (type.includes("start")) return "active";
+  return "";
+}
+
+// The run-event stream wraps each node lifecycle event two levels deep:
+//   { event: "run.event",
+//     payload: { streamId, event: "node.finished", payload: { nodeId, state }, seq } }
+// so the classifiable label is `payload.event` (node.started/finished/failed) and
+// the nodeId is `payload.payload.nodeId`. We also accept shallower shapes so the
+// UI degrades gracefully if the frame envelope ever changes.
+type EventInfo = { nodeId: string; type: string; seq: number };
+function eventInfo(ev: unknown): EventInfo {
+  const frame = isRecord(ev) ? ev : {};
+  const inner = isRecord(frame.payload) ? frame.payload : {};
+  const nodePayload = isRecord(inner.payload) ? inner.payload : {};
+  const nodeId = asString(nodePayload.nodeId) ?? asString(inner.nodeId) ?? asString(frame.nodeId) ?? "";
+  const type = asString(inner.event) ?? asString(frame.type) ?? asString(nodePayload.state) ?? "";
+  const seq = typeof inner.seq === "number" ? inner.seq : typeof frame.seq === "number" ? frame.seq : 0;
+  return { nodeId, type, seq };
+}
+
+/** Latest-wins status per nodeId, derived from the ordered event stream. */
+function buildNodeStatus(events: unknown[]): Record<string, StageState> {
+  const map: Record<string, StageState> = {};
+  for (const ev of events) {
+    const { nodeId, type } = eventInfo(ev);
+    if (!nodeId) continue;
+    const cls = classifyType(type);
+    if (cls) map[nodeId] = cls;
+  }
+  return map;
+}
+
+type TicketProgress = {
+  stages: Array<{ key: string; label: string; abbr: string; state: StageState }>;
+  overall: "queued" | "running" | "failed" | "landed";
+  caption: string;
+};
+function ticketProgress(slug: string, nodeStatus: Record<string, StageState>): TicketProgress {
+  const stages = STAGES.map((st) => ({
+    key: st.key,
+    label: st.label,
+    abbr: st.abbr,
+    state: nodeStatus[st.node(slug)] ?? "pending",
+  }));
+  const mergeState = stages[stages.length - 1].state;
+  if (mergeState === "done") return { stages, overall: "landed", caption: "landed on main" };
+  const failed = stages.find((s) => s.state === "failed");
+  if (failed) return { stages, overall: "failed", caption: `${failed.label} failed` };
+  const active = stages.find((s) => s.state === "active");
+  if (active) return { stages, overall: "running", caption: active.label.toLowerCase() };
+  const lastDone = [...stages].reverse().find((s) => s.state === "done");
+  if (lastDone) return { stages, overall: "running", caption: `${lastDone.label.toLowerCase()} done` };
+  return { stages, overall: "queued", caption: "queued" };
+}
+
+const styles = [
+  ":root { --bg:#0c0c0e; --panel:#151518; --card:#1c1c1f; --text:#eee; --muted:#8a8a8e; --border:#262629; --primary:#5e6ad2; --ok:#4ade80; --err:#f87171; --warn:#fbbf24; color-scheme:dark; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif; }",
+  "* { box-sizing:border-box; }",
+  "body { margin:0; background:var(--bg); color:var(--text); font-size:13px; line-height:1.5; }",
+  "button,input,textarea { font:inherit; }",
+  ".shell { height:100vh; display:flex; flex-direction:column; overflow:hidden; }",
+  ".topbar { display:flex; align-items:center; justify-content:space-between; gap:16px; padding:12px 20px; border-bottom:1px solid var(--border); flex-wrap:wrap; }",
+  ".title-group { display:flex; align-items:center; gap:12px; min-width:0; }",
+  "h1 { margin:0; font-size:14px; font-weight:600; }",
+  ".pill { display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--muted); background:var(--panel); padding:4px 10px; border-radius:6px; border:1px solid var(--border); }",
+  ".pill .mono { font-family:ui-monospace,monospace; }",
+  ".progress-pill { color:var(--text); }",
+  ".progress-pill b { color:var(--ok); }",
+  ".toolbar { display:flex; align-items:center; gap:8px; flex:1; justify-content:flex-end; flex-wrap:wrap; }",
+  ".prompt { height:30px; padding:0 10px; border:1px solid var(--border); border-radius:6px; background:var(--panel); color:var(--text); }",
+  ".prompt.dir { min-width:220px; }",
+  ".check { display:inline-flex; align-items:center; gap:6px; font-size:12px; color:var(--muted); cursor:pointer; user-select:none; }",
+  ".button { height:30px; padding:0 12px; border:1px solid var(--border); border-radius:6px; background:var(--panel); color:var(--text); cursor:pointer; font-weight:500; }",
+  ".button:hover { background:var(--card); }",
+  ".button.primary { background:var(--primary); color:#fff; border-color:var(--primary); }",
+  ".button.danger { color:var(--err); }",
+  ".button:disabled { opacity:0.4; cursor:not-allowed; }",
+  ".badge { font-size:11px; font-weight:600; text-transform:uppercase; padding:3px 8px; border-radius:5px; border:1px solid var(--border); }",
+  ".badge.running { color:var(--warn); border-color:var(--warn); }",
+  ".badge.finished, .badge.landed, .badge.ok { color:var(--ok); border-color:var(--ok); }",
+  ".badge.failed, .badge.err { color:var(--err); border-color:var(--err); }",
+  ".badge.queued { color:var(--muted); }",
+  ".main { display:grid; grid-template-columns:minmax(300px,1.1fr) minmax(0,1.3fr) 260px; flex:1; overflow:hidden; }",
+  "@media (max-width:1040px){ .main { grid-template-columns:1fr; overflow:auto; } .col.mid,.sidebar { border-left:0; border-top:1px solid var(--border); } }",
+  ".col { padding:18px 20px; overflow:auto; }",
+  ".col.mid { border-left:1px solid var(--border); }",
+  ".section-head { margin:0 0 10px; font-size:11px; text-transform:uppercase; letter-spacing:0.05em; color:var(--muted); display:flex; align-items:center; justify-content:space-between; gap:8px; }",
+  ".pipeline { list-style:none; margin:0; padding:0; }",
+  ".ticket { width:100%; text-align:left; background:var(--card); border:1px solid var(--border); border-radius:10px; padding:12px 14px; margin-bottom:10px; cursor:pointer; color:var(--text); display:block; }",
+  ".ticket:hover { border-color:#33333a; }",
+  ".ticket.active { box-shadow:inset 3px 0 0 var(--primary); border-color:#33333a; }",
+  ".ticket-top { display:flex; align-items:center; gap:8px; justify-content:space-between; }",
+  ".ticket-title { font-weight:600; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }",
+  ".ticket-num { flex:0 0 auto; font-family:ui-monospace,monospace; font-size:11px; color:var(--muted); margin-right:2px; }",
+  ".ticket-caption { font-size:11px; color:var(--muted); margin-top:3px; }",
+  ".strip { display:flex; gap:4px; margin-top:10px; }",
+  ".seg { flex:1; height:22px; border-radius:5px; border:1px solid var(--border); background:var(--panel); display:flex; align-items:center; justify-content:center; font-size:10px; font-weight:600; color:var(--muted); }",
+  ".seg.done { background:rgba(74,222,128,0.16); border-color:var(--ok); color:var(--ok); }",
+  ".seg.active { background:rgba(251,191,36,0.16); border-color:var(--warn); color:var(--warn); }",
+  ".seg.failed { background:rgba(248,113,113,0.16); border-color:var(--err); color:var(--err); }",
+  ".panel { background:var(--card); border:1px solid var(--border); border-radius:10px; margin-bottom:12px; overflow:hidden; }",
+  ".panel-head { display:flex; align-items:center; justify-content:space-between; gap:10px; padding:11px 15px; cursor:pointer; }",
+  ".panel-head h2 { margin:0; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:var(--muted); }",
+  ".panel-head .left { display:flex; align-items:center; gap:8px; min-width:0; }",
+  ".panel-body { padding:0 15px 14px; }",
+  ".summary-text { font-size:13px; line-height:1.55; }",
+  ".findings, .steps, .files { list-style:none; margin:8px 0 0; padding:0; }",
+  ".findings li { display:flex; gap:8px; padding:5px 0; border-bottom:1px solid var(--border); }",
+  ".findings li:last-child, .steps li:last-child, .files li:last-child { border-bottom:0; }",
+  ".dot { flex:0 0 6px; height:6px; margin-top:7px; border-radius:50%; background:var(--primary); }",
+  ".steps li { display:flex; gap:12px; padding:8px 0; border-bottom:1px solid var(--border); }",
+  ".step-num { flex:0 0 22px; height:22px; border-radius:50%; background:var(--panel); border:1px solid var(--border); display:flex; align-items:center; justify-content:center; font-size:11px; color:var(--muted); }",
+  ".files li { font-family:ui-monospace,monospace; font-size:12px; padding:4px 0; border-bottom:1px solid var(--border); }",
+  ".muted { color:var(--muted); }",
+  ".ticket-head { display:flex; align-items:center; gap:10px; margin-bottom:12px; flex-wrap:wrap; }",
+  ".ticket-head h2 { margin:0; font-size:15px; }",
+  ".ticket-head .mono { font-family:ui-monospace,monospace; font-size:11px; color:var(--muted); }",
+  ".activity { list-style:none; margin:6px 0 0; padding:0; max-height:200px; overflow:auto; }",
+  ".activity li { display:flex; gap:8px; align-items:baseline; padding:4px 0; border-bottom:1px solid var(--border); font-size:12px; }",
+  ".activity .stage { font-family:ui-monospace,monospace; color:var(--muted); flex:0 0 84px; }",
+  ".activity .ev.done { color:var(--ok); }",
+  ".activity .ev.active { color:var(--warn); }",
+  ".activity .ev.failed { color:var(--err); }",
+  ".ledger { list-style:none; margin:0; padding:0; }",
+  ".ledger-row { display:flex; gap:10px; padding:10px 0; border-bottom:1px solid var(--border); align-items:flex-start; }",
+  ".ledger-row:last-child { border-bottom:0; }",
+  ".ledger-dot { flex:0 0 18px; height:18px; border-radius:50%; background:rgba(74,222,128,0.16); border:1px solid var(--ok); color:var(--ok); display:flex; align-items:center; justify-content:center; font-size:10px; }",
+  ".ledger-body { min-width:0; }",
+  ".ledger-title { font-weight:600; font-size:12px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }",
+  ".ledger-branch { font-family:ui-monospace,monospace; font-size:11px; color:var(--muted); }",
+  ".empty { color:var(--muted); text-align:center; padding:40px 16px; }",
+  ".launch-form { max-width:520px; margin:24px auto; background:var(--card); border:1px solid var(--border); border-radius:12px; padding:24px; }",
+  ".launch-form h2 { margin:0 0 4px; font-size:16px; }",
+  ".launch-form p { margin:0 0 18px; color:var(--muted); }",
+  ".launch-form .prompt { width:100%; height:34px; margin-bottom:12px; }",
+  ".field { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 0; border-bottom:1px solid var(--border); }",
+  ".sidebar { border-left:1px solid var(--border); background:var(--panel); overflow:auto; }",
+  ".side-head { padding:12px 16px; font-size:11px; text-transform:uppercase; letter-spacing:0.04em; color:var(--muted); border-bottom:1px solid var(--border); }",
+  ".side-body { padding:12px 16px; }",
+  ".run-row { width:100%; text-align:left; padding:10px 16px; border:0; border-bottom:1px solid var(--border); background:transparent; color:var(--text); cursor:pointer; display:flex; justify-content:space-between; gap:8px; }",
+  ".run-row:hover { background:var(--card); }",
+  ".run-row.active { background:var(--card); box-shadow:inset 2px 0 0 var(--primary); }",
+  ".run-row .mono { font-family:ui-monospace,monospace; font-size:11px; }",
+].join("\n");
+
+function statusClass(status: string | undefined) {
+  if (status === "running" || status === "continued") return "running";
+  if (status === "finished") return "finished";
+  if (status === "failed" || status === "cancelled") return "failed";
+  return "";
+}
+
+function Panel(props: { title: string; testId: string; badge?: { text: string; cls: string } | null; pending: boolean; pendingText: string; children?: any }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="panel" data-testid={props.testId}>
+      <div className="panel-head" onClick={() => setOpen((o) => !o)}>
+        <div className="left">
+          <h2>{props.title}</h2>
+          {props.badge ? <span className={"badge " + props.badge.cls}>{props.badge.text}</span> : null}
+        </div>
+        <span className="muted">{open ? "collapse" : "expand"}</span>
+      </div>
+      {open ? <div className="panel-body">{props.pending ? <div className="muted">{props.pendingText}</div> : props.children}</div> : null}
+    </div>
+  );
+}
+
+function stageLabelFromNode(nodeId: string, slug: string): string {
+  const suffix = nodeId.startsWith(slug + ":") ? nodeId.slice(slug.length + 1) : nodeId;
+  return suffix.split(":")[0];
+}
+
+// Detail for the selected ticket — calls per-node hooks (a child component so the
+// hook count stays constant regardless of how many tickets exist).
+function TicketDetail(props: { runId: string | undefined; ticket: TicketRef; events: unknown[] }) {
+  const { runId, ticket, events } = props;
+  const slug = ticket.slug;
+
+  const researchOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:research`, iteration: 0 });
+  const planOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:plan`, iteration: 0 });
+  const implementOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:implement`, iteration: 0 });
+  const validateOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:validate`, iteration: 0 });
+  const reviewOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:review:0`, iteration: 0 });
+  const mergeOut = useGatewayNodeOutput({ runId, nodeId: `${slug}:merge`, iteration: 0 });
+
+  const research = useMemo(() => extractResearch(researchOut.data), [researchOut.data]);
+  const plan = useMemo(() => extractPlan(planOut.data), [planOut.data]);
+  const implement = useMemo(() => extractImplement(implementOut.data), [implementOut.data]);
+  const validate = useMemo(() => extractValidate(validateOut.data), [validateOut.data]);
+  const review = useMemo(() => extractReview(reviewOut.data), [reviewOut.data]);
+  const ship = useMemo(() => extractShip(mergeOut.data), [mergeOut.data]);
+
+  const activity = useMemo(() => {
+    return events
+      .map(eventInfo)
+      .filter((e) => e.nodeId.startsWith(slug + ":"))
+      .slice(-14)
+      .reverse()
+      .map((e) => ({ seq: e.seq, stage: stageLabelFromNode(e.nodeId, slug), type: e.type }));
+  }, [events, slug]);
+
+  return (
+    <>
+      <div className="ticket-head">
+        <h2>{ticket.title}</h2>
+        <span className="mono">ship/{slug}</span>
+        {ship ? <span className={"badge " + (ship.status === "merged" ? "landed" : ship.status === "failed" ? "failed" : "queued")}>{ship.status}</span> : null}
+      </div>
+
+      <Panel title="Research" testId="st-research" badge={research ? { text: "ready", cls: "ok" } : null} pending={research === null} pendingText="Gathering context…">
+        {research ? (
+          <>
+            <div className="summary-text">{research.summary}</div>
+            {research.keyFindings.length > 0 ? (
+              <ul className="findings">{research.keyFindings.map((f, i) => <li key={i}><span className="dot" /><span>{f}</span></li>)}</ul>
+            ) : null}
+          </>
+        ) : null}
+      </Panel>
+
+      <Panel title="Plan" testId="st-plan" badge={plan ? { text: "ready", cls: "ok" } : null} pending={plan === null} pendingText="Creating plan…">
+        {plan ? (
+          <>
+            <div className="summary-text">{plan.summary}</div>
+            {plan.steps.length > 0 ? (
+              <ol className="steps">{plan.steps.map((s, i) => <li key={i}><span className="step-num">{i + 1}</span><span>{s}</span></li>)}</ol>
+            ) : null}
+          </>
+        ) : null}
+      </Panel>
+
+      <Panel
+        title="Implement"
+        testId="st-implement"
+        badge={implement ? (implement.allTestsPassing ? { text: "tests pass", cls: "ok" } : { text: "tests fail", cls: "err" }) : null}
+        pending={implement === null}
+        pendingText="Implementing…"
+      >
+        {implement ? (
+          <>
+            <div className="summary-text">{implement.summary}</div>
+            {implement.filesChanged.length > 0 ? (
+              <ul className="files">{implement.filesChanged.map((f, i) => <li key={i}>{f}</li>)}</ul>
+            ) : <div className="muted">No files changed yet.</div>}
+          </>
+        ) : null}
+      </Panel>
+
+      <Panel
+        title="Validate"
+        testId="st-validate"
+        badge={validate ? (validate.allPassed ? { text: "passed", cls: "ok" } : { text: "failed", cls: "err" }) : null}
+        pending={validate === null}
+        pendingText="Validating…"
+      >
+        {validate ? (
+          <>
+            <div className="summary-text">{validate.summary}</div>
+            {validate.failingSummary ? <div className="muted" style={{ marginTop: 6 }}>{validate.failingSummary}</div> : null}
+          </>
+        ) : null}
+      </Panel>
+
+      <Panel
+        title="Review"
+        testId="st-review"
+        badge={review ? (review.approved ? { text: "approved", cls: "ok" } : { text: "rejected", cls: "err" }) : null}
+        pending={review === null}
+        pendingText="Awaiting reviewer…"
+      >
+        {review ? (
+          <>
+            <strong>{review.reviewer}</strong>
+            {review.feedback ? <div className="muted" style={{ marginTop: 6 }}>{review.feedback}</div> : null}
+          </>
+        ) : null}
+      </Panel>
+
+      <Panel
+        title="Commit → Merge to main"
+        testId="st-merge"
+        badge={ship ? (ship.status === "merged" ? { text: "landed", cls: "landed" } : ship.status === "failed" ? { text: "failed", cls: "err" } : { text: ship.status, cls: "queued" }) : null}
+        pending={ship === null}
+        pendingText="Awaiting implementation to finish…"
+      >
+        {ship ? (
+          <>
+            {ship.branch ? <div className="mono muted" style={{ marginBottom: 6 }}>{ship.branch} → main</div> : null}
+            <div className="summary-text">{ship.summary}</div>
+          </>
+        ) : null}
+      </Panel>
+
+      <p className="section-head" style={{ marginTop: 16 }}>Live activity</p>
+      {activity.length > 0 ? (
+        <ul className="activity" data-testid="ticket-activity">
+          {activity.map((a) => (
+            <li key={a.seq}>
+              <span className="stage">{a.stage}</span>
+              <span className={"ev " + (classifyType(a.type) || "")}>{a.type || "event"}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="muted">No activity for this ticket yet.</div>
+      )}
+    </>
+  );
+}
+
+function App() {
+  const [selectedRunId, setSelectedRunId] = useState<string | undefined>(runIdFromUrl());
+  const [selectedSlug, setSelectedSlug] = useState<string | undefined>(slugFromUrl());
+  const [ticketsDir, setTicketsDir] = useState(".smithers/tickets/ultragrill");
+  const [baseBranch, setBaseBranch] = useState("main");
+  const [tdd, setTdd] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const runsQuery = useGatewayRuns({ filter: { limit: 20 } });
+  const actions = useGatewayActions();
+
+  const runs = useMemo(
+    () => ((runsQuery.data ?? []) as RunSummary[]).filter((r) => !r.workflowKey || r.workflowKey === WORKFLOW_KEY),
+    [runsQuery.data],
+  );
+  const activeRunId = selectedRunId ?? runIdFromUrl() ?? runs[0]?.runId;
+  const activeRun = runs.find((r) => r.runId === activeRunId);
+
+  const runDetail = useGatewayRun(activeRunId);
+  const stream = useGatewayRunEvents(activeRunId, { afterSeq: 0 });
+  const manifestOut = useGatewayNodeOutput({ runId: activeRunId, nodeId: "manifest", iteration: 0 });
+
+  const tickets = useMemo(() => extractManifest(manifestOut.data), [manifestOut.data]);
+  const events = stream.events ?? [];
+  const nodeStatus = useMemo(() => buildNodeStatus(events), [events]);
+
+  const progressByTicket = useMemo(() => {
+    const map: Record<string, TicketProgress> = {};
+    for (const t of tickets) map[t.slug] = ticketProgress(t.slug, nodeStatus);
+    return map;
+  }, [tickets, nodeStatus]);
+
+  const landed = tickets.filter((t) => progressByTicket[t.slug]?.overall === "landed");
+  const frontier = tickets.find((t) => progressByTicket[t.slug]?.overall !== "landed");
+  const activeSlug = selectedSlug ?? frontier?.slug ?? tickets[0]?.slug;
+  const selectedTicket = tickets.find((t) => t.slug === activeSlug);
+
+  const runStatus = (runDetail.data as RunSummary | undefined)?.status ?? activeRun?.status;
+  const eventCount = events.length;
+  const hasRun = Boolean(activeRunId);
+
+  function selectSlug(slug: string) {
+    setSelectedSlug(slug);
+    if (typeof history !== "undefined" && activeRunId) {
+      const params = new URLSearchParams(location.search);
+      params.set("runId", activeRunId);
+      params.set("ticket", slug);
+      history.replaceState(null, "", "?" + params.toString());
+    }
+  }
+
+  async function refresh() {
+    await Promise.all([runsQuery.refetch(), runDetail.refetch(), manifestOut.refetch()]);
+  }
+  async function launch() {
+    setBusy(true);
+    try {
+      const run = await actions.launchRun({ workflow: WORKFLOW_KEY, input: { ticketsDir, baseBranch, tdd } });
+      setSelectedRunId(run.runId);
+      setSelectedSlug(undefined);
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+  async function cancel() {
+    if (!activeRunId) return;
+    setBusy(true);
+    try {
+      await actions.cancelRun({ runId: activeRunId });
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="shell" data-testid="ship-tickets-ui">
+      <style>{styles}</style>
+      <header className="topbar">
+        <div className="title-group">
+          <h1>Ship Tickets</h1>
+          <span className="pill" data-testid="ship-runid"><span className="mono">{hasRun ? shortRunId(activeRunId) : "No run"}</span></span>
+          {hasRun ? <span className={"badge " + statusClass(runStatus)} data-testid="ship-status">{runStatus ?? "idle"}</span> : null}
+          {hasRun && tickets.length > 0 ? (
+            <span className="pill progress-pill" data-testid="ship-progress"><b>{landed.length}</b>/{tickets.length} landed</span>
+          ) : null}
+          {hasRun ? <span className="pill">{eventCount} events</span> : null}
+        </div>
+        <div className="toolbar">
+          <button className="button" data-testid="ship-refresh" onClick={() => void refresh()} disabled={busy}>Refresh</button>
+          {statusClass(runStatus) === "running" ? (
+            <button className="button danger" data-testid="ship-cancel" onClick={() => void cancel()} disabled={busy}>Cancel</button>
+          ) : null}
+          <button className="button primary" data-testid="ship-launch" onClick={() => void launch()} disabled={busy}>Launch</button>
+        </div>
+      </header>
+
+      <div className="main">
+        {/* ── pipeline ──────────────────────────────────────────────── */}
+        <div className="col left">
+          {!hasRun ? (
+            <div className="launch-form" data-testid="ship-empty">
+              <h2>Ship a ticket queue</h2>
+              <p>Each ticket runs research → plan → implement → validate → review in its own worktree, then commits and merges to the base branch — serially, so the branch advances one ticket at a time.</p>
+              <input className="prompt dir" value={ticketsDir} onChange={(e) => setTicketsDir(e.currentTarget.value)} placeholder="Tickets directory" data-testid="ship-ticketsdir" />
+              <div className="field"><label>Base branch</label><input className="prompt" style={{ width: 160 }} value={baseBranch} onChange={(e) => setBaseBranch(e.currentTarget.value)} /></div>
+              <div className="field"><label>Test-driven (tests first)</label><input type="checkbox" checked={tdd} onChange={(e) => setTdd(e.currentTarget.checked)} /></div>
+              <button className="button primary" data-testid="ship-launch-empty" onClick={() => void launch()} disabled={busy} style={{ marginTop: 14 }}>Launch Ship</button>
+            </div>
+          ) : (
+            <>
+              <p className="section-head">Pipeline <span>{tickets.length} tickets</span></p>
+              {tickets.length === 0 ? (
+                <div className="muted">Waiting for the ticket manifest…</div>
+              ) : (
+                <ul className="pipeline" data-testid="ship-pipeline">
+                  {tickets.map((t, i) => {
+                    const prog = progressByTicket[t.slug];
+                    return (
+                      <li key={t.slug}>
+                        <button className={"ticket" + (t.slug === activeSlug ? " active" : "")} data-testid={"ship-ticket-" + t.slug} onClick={() => selectSlug(t.slug)}>
+                          <div className="ticket-top">
+                            <span className="ticket-title"><span className="ticket-num">{String(i + 1).padStart(2, "0")}</span>{t.title}</span>
+                            <span className={"badge " + (prog?.overall ?? "queued")}>{prog?.overall ?? "queued"}</span>
+                          </div>
+                          <div className="ticket-caption">{prog?.caption}</div>
+                          <div className="strip">
+                            {(prog?.stages ?? STAGES.map((s) => ({ ...s, state: "pending" as StageState }))).map((s) => (
+                              <span key={s.key} className={"seg " + (s.state === "pending" ? "" : s.state)} title={s.label + " · " + s.state}>{s.abbr}</span>
+                            ))}
+                          </div>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* ── selected ticket detail ────────────────────────────────── */}
+        <div className="col mid">
+          {hasRun && selectedTicket ? (
+            <TicketDetail runId={activeRunId} ticket={selectedTicket} events={events} />
+          ) : (
+            <div className="empty" data-testid="ship-detail-empty">{hasRun ? "Select a ticket to watch its research → merge detail." : "Launch a run to watch tickets ship."}</div>
+          )}
+        </div>
+
+        {/* ── landed-on-main ledger + runs ──────────────────────────── */}
+        <aside className="sidebar">
+          <div className="side-head">Landed on {baseBranch}</div>
+          <div className="side-body">
+            {landed.length > 0 ? (
+              <ul className="ledger" data-testid="ship-ledger">
+                {landed.map((t) => (
+                  <li className="ledger-row" key={t.slug} onClick={() => selectSlug(t.slug)} style={{ cursor: "pointer" }}>
+                    <span className="ledger-dot">✓</span>
+                    <span className="ledger-body">
+                      <span className="ledger-title">{t.title}</span>
+                      <span className="ledger-branch">ship/{t.slug}</span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="muted">No commits on {baseBranch} yet.</div>
+            )}
+          </div>
+          <div className="side-head">Recent runs</div>
+          {runs.map((r) => (
+            <button key={r.runId} className={"run-row" + (r.runId === activeRunId ? " active" : "")} data-testid={"ship-run-" + r.runId} onClick={() => { setSelectedRunId(r.runId); setSelectedSlug(undefined); }}>
+              <span className="mono">{shortRunId(r.runId)}</span>
+              <span className={"badge " + statusClass(r.status)}>{r.status ?? "?"}</span>
+            </button>
+          ))}
+          {runs.length === 0 ? <div className="empty">No runs yet.</div> : null}
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+createGatewayReactRoot(<App />);

--- a/.smithers/workflows/ship-tickets.tsx
+++ b/.smithers/workflows/ship-tickets.tsx
@@ -1,0 +1,213 @@
+// smithers-source: authored
+// smithers-display-name: Ship Tickets
+/** @jsxImportSource smithers-orchestrator */
+import { createSmithers, Sequence, Worktree } from "smithers-orchestrator";
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve, relative } from "node:path";
+import { z } from "zod/v4";
+import { agents } from "../agents";
+import { ValidationLoop, implementOutputSchema, validateOutputSchema } from "../components/ValidationLoop";
+import { reviewOutputSchema } from "../components/Review";
+import ResearchPrompt from "../prompts/research.mdx";
+import PlanPrompt from "../prompts/plan.mdx";
+
+const researchOutputSchema = z.looseObject({
+  summary: z.string(),
+  keyFindings: z.array(z.string()).default([]),
+});
+
+const planOutputSchema = z.looseObject({
+  summary: z.string(),
+  steps: z.array(z.string()).default([]),
+});
+
+const shipResultSchema = z.object({
+  ticketId: z.string(),
+  branch: z.string(),
+  status: z.enum(["merged", "skipped", "failed"]),
+  summary: z.string(),
+});
+
+const manifestSchema = z.object({
+  ticketsDir: z.string(),
+  tickets: z.array(z.object({ slug: z.string(), title: z.string(), id: z.string() })).default([]),
+});
+
+const inputSchema = z.object({
+  ticketsDir: z.string().default(".smithers/tickets/ultragrill"),
+  baseBranch: z.string().default("main"),
+  tdd: z.boolean().default(false),
+});
+
+const { Workflow, Task, smithers, outputs } = createSmithers({
+  input: inputSchema,
+  research: researchOutputSchema,
+  plan: planOutputSchema,
+  implement: implementOutputSchema,
+  validate: validateOutputSchema,
+  review: reviewOutputSchema,
+  shipResult: shipResultSchema,
+  manifest: manifestSchema,
+});
+
+/** Pull a human title from a ticket's frontmatter or first H1, falling back to the slug. */
+function parseTitle(content: string, fallback: string): string {
+  const fm = content.match(/^title:\s*(.+)$/m);
+  if (fm) return fm[1].replace(/^["']|["']$/g, "").trim();
+  const h1 = content.match(/^#\s+(.+)$/m);
+  if (h1) return h1[1].trim();
+  return fallback;
+}
+
+function discoverTickets(ticketsDir: string): Array<{ id: string; slug: string; title: string; content: string }> {
+  const out: Array<{ id: string; slug: string; title: string; content: string }> = [];
+
+  function walk(dir: string, depth: number): void {
+    if (depth > 4) return;
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith(".")) continue;
+      const full = resolve(dir, e.name);
+      if (e.isDirectory()) {
+        walk(full, depth + 1);
+        continue;
+      }
+      if (!e.isFile() || !e.name.endsWith(".md")) continue;
+      if (e.name.toLowerCase() === "readme.md") continue;
+      const rel = relative(ticketsDir, full);
+      const slug = rel.replace(/\.md$/, "").replace(/[/\\]/g, "__");
+      const content = readFileSync(full, "utf8");
+      out.push({ id: relative(process.cwd(), full), slug, title: parseTitle(content, slug), content });
+    }
+  }
+
+  walk(ticketsDir, 0);
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Per-ticket done/feedback, scoped by slug — review rows share one table. */
+function buildFeedback(ctx: any, slug: string): { feedback: string | null; done: boolean } {
+  const validate = ctx.outputMaybe("validate", { nodeId: `${slug}:validate` });
+  const reviews = (ctx.outputs.review ?? []).filter(
+    (r: any) => typeof r.nodeId === "string" && r.nodeId.startsWith(`${slug}:review:`),
+  );
+
+  const validationPassed = validate !== undefined && validate.allPassed !== false;
+  const anyReviewApproved = reviews.length > 0 && reviews.some((r: any) => r.approved === true);
+  const done = validationPassed && anyReviewApproved;
+
+  if (validate === undefined) return { feedback: null, done: false };
+
+  const parts: string[] = [];
+  if (!validationPassed && validate.failingSummary) {
+    parts.push(`VALIDATION FAILED:\n${validate.failingSummary}`);
+  }
+  for (const review of reviews) {
+    if (review.approved === false) {
+      parts.push(`REVIEWER REJECTED:\n${review.feedback}`);
+      for (const issue of review.issues ?? []) {
+        parts.push(`  [${issue.severity}] ${issue.title}: ${issue.description}${issue.file ? ` (${issue.file})` : ""}`);
+      }
+    }
+  }
+  return { feedback: parts.length > 0 ? parts.join("\n\n") : null, done };
+}
+
+const mergePrompt = (slug: string, ticketId: string, baseBranch: string) =>
+  `You are landing ONE ticket's work onto ${baseBranch} with a commit-then-merge cadence.
+
+Worktree: .worktrees/ship-${slug}  (branch: ship/${slug})
+Ticket file: ${ticketId}
+
+Do exactly this, using bash:
+1. cd into the worktree (.worktrees/ship-${slug}) and run \`git add -A\`. If there is nothing to commit, set status "skipped" and stop. Otherwise commit with the repo's emoji + conventional-commit style — e.g. "✨ feat(ultragrill): <ticket title>" — ending with the Co-Authored-By trailer.
+2. Return to the main repo root, ensure ${baseBranch} is checked out and clean, and merge ship/${slug} into ${baseBranch} (fast-forward if possible, otherwise --no-ff).
+3. If there are conflicts, resolve them favoring correctness and the ticket's intent.
+4. Keep the gate green: run \`pnpm typecheck\` plus any directly relevant tests, and fix anything the merge broke before finishing.
+5. Do NOT push. Work only locally on ${baseBranch}.
+
+Report status "merged" on success or "failed" if you could not land it cleanly, with a one-line summary.`;
+
+function renderTicket(ctx: any, ticket: { id: string; slug: string; title: string; content: string }) {
+  const { slug } = ticket;
+  const research = ctx.outputMaybe("research", { nodeId: `${slug}:research` });
+  const plan = ctx.outputMaybe("plan", { nodeId: `${slug}:plan` });
+  const { feedback, done } = buildFeedback(ctx, slug);
+
+  const base = `Implement the ticket below.\n\nTICKET FILE: ${ticket.id}\n\n${ticket.content}`;
+
+  const researchBlock = research
+    ? `RESEARCH FINDINGS:\n${research.summary}\n\nKey findings:\n${research.keyFindings.map((f: string) => `- ${f}`).join("\n")}`
+    : null;
+
+  const planPrompt = [
+    base,
+    researchBlock,
+    ctx.input.tdd ? "IMPORTANT: Write tests FIRST. The plan MUST start with test steps before any implementation steps." : null,
+  ].filter(Boolean).join("\n\n---\n");
+
+  const implementPrompt = [
+    base,
+    researchBlock,
+    plan ? `IMPLEMENTATION PLAN:\n${plan.summary}\n\nSteps:\n${plan.steps.map((s: string, i: number) => `${i + 1}. ${s}`).join("\n")}` : null,
+    ctx.input.tdd ? "IMPORTANT: Follow the plan's test-first approach — tests before production code." : null,
+  ].filter(Boolean).join("\n\n---\n");
+
+  return (
+    <Sequence key={slug}>
+      <Worktree path={`.worktrees/ship-${slug}`} branch={`ship/${slug}`} baseBranch={ctx.input.baseBranch}>
+        <Sequence>
+          <Task id={`${slug}:research`} output={researchOutputSchema} agent={agents.smartTool}>
+            <ResearchPrompt prompt={base} />
+          </Task>
+          <Task id={`${slug}:plan`} output={planOutputSchema} agent={agents.smart}>
+            <PlanPrompt prompt={planPrompt} />
+          </Task>
+          <ValidationLoop
+            idPrefix={slug}
+            prompt={implementPrompt}
+            implementAgents={agents.smart}
+            validateAgents={agents.cheapFast}
+            reviewAgents={agents.smart}
+            feedback={feedback}
+            done={done}
+            maxIterations={3}
+          />
+        </Sequence>
+      </Worktree>
+
+      {/* Outside the worktree: commit the branch and merge it into the base branch. */}
+      <Task id={`${slug}:merge`} output={outputs.shipResult} agent={agents.smart} continueOnFail>
+        {mergePrompt(slug, ticket.id, ctx.input.baseBranch)}
+      </Task>
+    </Sequence>
+  );
+}
+
+export default smithers((ctx) => {
+  const tickets = discoverTickets(resolve(process.cwd(), ctx.input.ticketsDir));
+
+  return (
+    <Workflow name="ship-tickets">
+      {/* Serial: each ticket is fully implemented, committed, and merged to the
+          base branch before the next one starts — so main advances per commit
+          and later tickets build on already-landed work. */}
+      <Sequence>
+        {/* Manifest: the full ordered ticket list, so the monitoring UI can render
+            the whole pipeline — including not-yet-started tickets — from one read. */}
+        <Task id="manifest" output={outputs.manifest}>
+          {{
+            ticketsDir: ctx.input.ticketsDir,
+            tickets: tickets.map((t) => ({ slug: t.slug, title: t.title, id: t.id })),
+          }}
+        </Task>
+        {tickets.map((ticket) => renderTicket(ctx, ticket))}
+      </Sequence>
+    </Workflow>
+  );
+});

--- a/.smithers/workflows/verifiable-goals.tsx
+++ b/.smithers/workflows/verifiable-goals.tsx
@@ -1,0 +1,112 @@
+// smithers-source: authored
+// smithers-display-name: Verifiable Goals
+/** @jsxImportSource smithers-orchestrator */
+import { createSmithers } from "smithers-orchestrator";
+import { z } from "zod/v4";
+import { agents } from "../agents";
+
+const ticketSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  goal: z.string(),
+  spec: z.string(),
+  e2eVerification: z.string(),
+  acceptanceCriteria: z.array(z.string()).default([]),
+  dependsOn: z.array(z.string()).default([]),
+});
+
+const goalsSchema = z.looseObject({
+  summary: z.string(),
+  tickets: z.array(ticketSchema).default([]),
+});
+
+const writtenSchema = z.object({
+  dir: z.string(),
+  files: z.array(z.string()).default([]),
+});
+
+const inputSchema = z.object({
+  prompt: z.string().default("Break the work into independently verifiable goals."),
+  source: z.string().default(".smithers/proposals/real-time-collaboration.md"),
+  ticketsDir: z.string().default(".smithers/tickets/ultragrill"),
+});
+
+const { Workflow, Task, Sequence, smithers } = createSmithers({
+  input: inputSchema,
+  goals: goalsSchema,
+  written: writtenSchema,
+});
+
+const goalsPrompt = (source: string, prompt: string) =>
+  `You are decomposing a project into independently shippable, **verifiable goals** — one per ticket.
+
+${prompt}
+
+## Source
+Read the proposal/spec at: \`${source}\`
+Explore the codebase as needed to ground each goal in real files, components, and primitives. Verify assertions before writing — do not invent file paths.
+
+## What to produce
+A list of tickets. Each ticket is ONE verifiable goal — small enough to research → plan → implement in a single focused pass, large enough to be meaningful. Order them so dependencies come first (reference earlier slugs in \`dependsOn\`).
+
+For each ticket:
+- **slug**: short kebab-case id, unique and stable (e.g. "transcription-gateway-capability").
+- **title**: one line.
+- **goal**: the user-visible or system capability delivered, stated as an outcome.
+- **spec**: concrete implementation notes — which packages/files/primitives are involved, grounded in what you actually found.
+- **e2eVerification**: EXACTLY how we prove the goal is met via an **end-to-end test that drives a real backend** (no mocks, no route fabrication — repo policy). State the user-flow the test exercises, the seeded/real state it runs against, and the observable assertion that must pass. This is the ticket's definition of done.
+- **acceptanceCriteria**: a checklist of specific, checkable conditions.
+- **dependsOn**: slugs that must land first, or [].
+
+Prefer more small verifiable goals over a few big ones. Be exhaustive about coverage; keep each ticket tight.`;
+
+export default smithers((ctx) => (
+  <Workflow name="verifiable-goals">
+    <Sequence>
+      <Task id="goals" output={goalsSchema} agent={agents.smartTool}>
+        {goalsPrompt(ctx.input.source, ctx.input.prompt)}
+      </Task>
+
+      <Task id="write" output={writtenSchema}>
+        {async () => {
+          const fs = await import("node:fs");
+          const path = await import("node:path");
+          const current = ctx.outputMaybe("goals", { nodeId: "goals" });
+          if (!current) throw new Error("goals task produced no output");
+          const dir = path.resolve(process.cwd(), ctx.input.ticketsDir);
+          fs.mkdirSync(dir, { recursive: true });
+          const files: string[] = [];
+          current.tickets.forEach((t: any, i: number) => {
+            const index = String(i + 1).padStart(4, "0");
+            const file = path.join(dir, `${index}-${t.slug}.md`);
+            const body = [
+              `---`,
+              `slug: ${t.slug}`,
+              `title: ${JSON.stringify(t.title)}`,
+              `dependsOn: [${(t.dependsOn ?? []).join(", ")}]`,
+              `---`,
+              ``,
+              `# ${t.title}`,
+              ``,
+              `## Goal`,
+              t.goal,
+              ``,
+              `## Spec`,
+              t.spec,
+              ``,
+              `## E2E Verification (definition of done)`,
+              t.e2eVerification,
+              ``,
+              `## Acceptance Criteria`,
+              ...(t.acceptanceCriteria ?? []).map((c: string) => `- [ ] ${c}`),
+              ``,
+            ].join("\n");
+            fs.writeFileSync(file, body, "utf8");
+            files.push(path.relative(process.cwd(), file));
+          });
+          return { dir: ctx.input.ticketsDir, files };
+        }}
+      </Task>
+    </Sequence>
+  </Workflow>
+));

--- a/packages/agents/src/AntigravityAgent.js
+++ b/packages/agents/src/AntigravityAgent.js
@@ -211,13 +211,13 @@ export class AntigravityAgent extends BaseCliAgent {
     async buildCommand(params) {
         const args = [];
         const yoloEnabled = this.opts.dangerouslySkipPermissions ?? this.opts.yolo ?? this.yolo;
+        // The Antigravity CLI has no `--output-format` flag. This only selects
+        // how Smithers parses stdout; it is never forwarded to `agy`.
         const outputFormat = this.opts.outputFormat ??
             (params.options?.onEvent ? "stream-json" : "json");
-        const resumeSession = typeof params.options?.resumeSession === "string"
+        const resumeConversation = typeof params.options?.resumeSession === "string"
             ? params.options.resumeSession
             : this.opts.resume;
-        if (this.opts.debug)
-            args.push("--debug");
         pushFlag(args, "--model", this.opts.model ?? this.model);
         if (this.opts.sandbox)
             args.push("--sandbox");
@@ -232,18 +232,17 @@ export class AntigravityAgent extends BaseCliAgent {
                 pushList(args, "--allowed-tools", this.opts.allowedTools);
             }
         }
-        pushList(args, "--extensions", this.opts.extensions);
-        if (this.opts.listExtensions)
-            args.push("--list-extensions");
-        pushFlag(args, "--resume", resumeSession);
-        if (this.opts.listSessions)
-            args.push("--list-sessions");
-        pushFlag(args, "--delete-session", this.opts.deleteSession);
-        pushList(args, "--include-directories", this.opts.includeDirectories);
-        if (this.opts.screenReader)
-            args.push("--screen-reader");
+        // Resume a prior conversation. `agy` uses `--conversation=<id>` (alias
+        // `-c`); there is no `--resume`. Listing/switching conversations is the
+        // in-session `/resume` command, so there is no list/delete-session flag.
+        if (resumeConversation)
+            args.push(`--conversation=${resumeConversation}`);
+        // Extra workspace roots: `agy` uses `--add-dir`, not `--include-directories`.
+        pushList(args, "--add-dir", this.opts.includeDirectories);
+        // Extensions are now Plugins, managed out-of-band via `agy plugin <action>`
+        // rather than per-invocation `--extensions`/`--list-extensions` flags.
+        // `--gemini_dir` still works even though it is no longer listed in `agy --help`.
         pushFlag(args, "--gemini_dir", this.opts.geminiDir ?? this.opts.configDir);
-        pushFlag(args, "--output-format", outputFormat);
         if (this.extraArgs?.length)
             args.push(...this.extraArgs);
         const systemPrefix = params.systemPrompt

--- a/packages/agents/src/AntigravityAgentOptions.ts
+++ b/packages/agents/src/AntigravityAgentOptions.ts
@@ -1,20 +1,29 @@
 import type { BaseCliAgentOptions } from "./BaseCliAgent/BaseCliAgentOptions";
 
 export type AntigravityAgentOptions = BaseCliAgentOptions & {
-  debug?: boolean;
   model?: string;
   sandbox?: boolean;
   yolo?: boolean;
   dangerouslySkipPermissions?: boolean;
   allowedMcpServerNames?: string[];
   allowedTools?: string[];
-  extensions?: string[];
-  listExtensions?: boolean;
+  /**
+   * Conversation id to resume. Forwarded as `--conversation=<id>` (the
+   * Antigravity CLI also accepts the short `-c` form). There is no `--resume`
+   * flag, and listing/switching conversations is the in-session `/resume`
+   * command rather than a launch flag.
+   */
   resume?: string;
-  listSessions?: boolean;
-  deleteSession?: string;
+  /**
+   * Extra workspace directories to grant the agent. Forwarded as repeated
+   * `--add-dir` flags (the CLI has no `--include-directories`).
+   */
   includeDirectories?: string[];
-  screenReader?: boolean;
+  /**
+   * Parse mode for the CLI's print output. The Antigravity CLI has no
+   * `--output-format` flag, so this only selects how Smithers interprets
+   * stdout — it is not forwarded as a CLI argument.
+   */
   outputFormat?: "text" | "json" | "stream-json";
   /**
    * Antigravity CLI binary to execute. The official CLI currently installs

--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -439,20 +439,29 @@ type AmpAgentOptions = AmpAgentOptions$1;
 type CliOutputInterpreter$6 = CliOutputInterpreter$8;
 
 type AntigravityAgentOptions$1 = BaseCliAgentOptions$1 & {
-    debug?: boolean;
     model?: string;
     sandbox?: boolean;
     yolo?: boolean;
     dangerouslySkipPermissions?: boolean;
     allowedMcpServerNames?: string[];
     allowedTools?: string[];
-    extensions?: string[];
-    listExtensions?: boolean;
+    /**
+     * Conversation id to resume. Forwarded as `--conversation=<id>` (the
+     * Antigravity CLI also accepts the short `-c` form). There is no `--resume`
+     * flag, and listing/switching conversations is the in-session `/resume`
+     * command rather than a launch flag.
+     */
     resume?: string;
-    listSessions?: boolean;
-    deleteSession?: string;
+    /**
+     * Extra workspace directories to grant the agent. Forwarded as repeated
+     * `--add-dir` flags (the CLI has no `--include-directories`).
+     */
     includeDirectories?: string[];
-    screenReader?: boolean;
+    /**
+     * Parse mode for the CLI's print output. The Antigravity CLI has no
+     * `--output-format` flag, so this only selects how Smithers interprets
+     * stdout — it is not forwarded as a CLI argument.
+     */
     outputFormat?: "text" | "json" | "stream-json";
     binary?: string;
     configDir?: string;

--- a/packages/agents/tests/agent-config-dir.test.js
+++ b/packages/agents/tests/agent-config-dir.test.js
@@ -206,4 +206,50 @@ describe("AntigravityAgent configDir/apiKey", () => {
             await rm(dumpDir, { recursive: true, force: true });
         }
     });
+
+    // Regression for #202: the Antigravity CLI (`agy`) rejects unknown flags and
+    // exits immediately, so the args must match the real CLI surface.
+    test("emits only flags the agy CLI actually accepts", async () => {
+        const dumpDir = await mkdtemp(join(tmpdir(), "smithers-env-dump-"));
+        const dumpFile = join(dumpDir, "env.json");
+        const fake = await makeFakeCliWithEnvDump(
+            "agy",
+            'process.stdout.write(JSON.stringify({ text: "```json\\n{\\"summary\\":\\"ok\\"}\\n```\\n" }) + "\\n");',
+        );
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            process.env.SMITHERS_ENV_DUMP_FILE = dumpFile;
+            const agent = new AntigravityAgent({
+                resume: "d1d8a55b-cc27-4dd4-bc62-2f73015960d2",
+                includeDirectories: ["/tmp/extra-root"],
+                env: { PATH: process.env.PATH, SMITHERS_ENV_DUMP_FILE: dumpFile },
+            });
+            await agent.generate({ messages: [{ role: "user", content: "ping" }] });
+            const args = (await readEnvDump(dumpFile)).ARGS;
+
+            // Corrected flags.
+            expect(args).toContain("--conversation=d1d8a55b-cc27-4dd4-bc62-2f73015960d2");
+            expect(args).toContain("--add-dir");
+            expect(args).toContain("/tmp/extra-root");
+
+            // Flags that do not exist on `agy` must never be passed.
+            for (const dead of [
+                "--output-format",
+                "--include-directories",
+                "--resume",
+                "--screen-reader",
+                "--debug",
+                "--extensions",
+                "--list-extensions",
+                "--list-sessions",
+                "--delete-session",
+            ]) {
+                expect(args).not.toContain(dead);
+            }
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+            await rm(dumpDir, { recursive: true, force: true });
+        }
+    });
 });


### PR DESCRIPTION
## Problem

`AntigravityAgent` (`packages/agents/src/AntigravityAgent.js`) was forked from the Gemini CLI agent and inherited several flags that the Antigravity CLI (`agy`) does not accept. `agy` rejects an unknown flag and exits immediately, so the agent could fail to launch at all. Reported in #202.

## What changed

`buildCommand` now matches the real `agy` surface:

| Before | After |
| --- | --- |
| `--output-format <fmt>` | removed — the `json`/`stream-json` value is kept only as the internal stdout-parse mode, never passed to `agy` |
| `--include-directories` | `--add-dir` (repeated) |
| `--resume <id>` | `--conversation=<id>` |
| `--list-sessions` / `--delete-session` | removed — conversations are listed/switched via the in-session `/resume` command |
| `--screen-reader` | removed (does not exist) |
| `--debug` | removed (does not exist) |
| `--extensions` / `--list-extensions` | removed — extensions are now plugins, managed out-of-band via `agy plugin <action>` |
| `--gemini_dir` | kept (still works, just hidden from `--help`) |

Untouched because they're valid on `agy` and weren't reported: `--model`, `--sandbox`, `--dangerously-skip-permissions`, `--allowed-tools`, `--allowed-mcp-server-names`, `--prompt`.

Dead options (`debug`, `screenReader`, `extensions`, `listExtensions`, `listSessions`, `deleteSession`) are removed from `AntigravityAgentOptions`; no caller used them.

## Tests

Added a regression test (`agent-config-dir.test.js`) that drives a fake `agy`, captures the spawned argv, and asserts it contains `--conversation=<id>` and `--add-dir` and never any of the removed flags.

- `pnpm -C packages/agents typecheck` ✅
- `bun test packages/agents/tests/agent-config-dir.test.js` ✅ (6 pass)
- `bun test packages/agents/tests/capability-registry.test.js packages/agents/tests/agents-diagnostics.test.js` ✅ (24 pass)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
