### PR TITLE
Fix Task fork prop types

### DIFF
--- a/packages/components/src/index.d.ts
+++ b/packages/components/src/index.d.ts
@@ -135,6 +135,14 @@ type TaskProps$2<Row, Output extends OutputTarget$1 = OutputTarget$1, D extends 
     needs?: Record<string, string>;
     /** Render-time typed dependencies. Keys resolve from task ids of the same name, or from matching `needs` entries. */
     deps?: D;
+    /**
+     * Start this agent task from a copy of another task's final agent session context.
+     * The fork source becomes an implicit dependency: this task waits for it to complete,
+     * then copies its conversation snapshot into a fresh, independent session and submits
+     * its own prompt. The source is never mutated. Inside a `<Loop>`, resolves to the
+     * latest completed snapshot for that task id. Requires an agent task.
+     */
+    fork?: string;
     skipIf?: boolean;
     needsApproval?: boolean;
     /** When paired with `needsApproval`, do not block unrelated downstream flow while the approval is pending. */

--- a/packages/smithers/src/__type-tests__/task-fork-jsx.test.tsx
+++ b/packages/smithers/src/__type-tests__/task-fork-jsx.test.tsx
@@ -1,0 +1,19 @@
+import { createSmithers } from "../index.js";
+import { z } from "zod";
+import type { AgentLike } from "@smithers-orchestrator/agents";
+
+const agent = {
+  generate: async () => ({ ok: true }),
+} satisfies AgentLike;
+
+const { Task, outputs } = createSmithers({
+  next: z.object({
+    ok: z.boolean(),
+  }),
+});
+
+const _TaskForkJsx = (
+  <Task id="next" output={outputs.next} agent={agent} fork="source">
+    Continue from the source task.
+  </Task>
+);


### PR DESCRIPTION
## Summary
- add `fork?: string` to the published components `TaskProps` declaration
- add a public Smithers TSX type regression for `<Task ... fork="source">`

Fixes #212.

## Checks
- `pnpm --filter @smithers-orchestrator/components typecheck`
- `pnpm --filter smithers-orchestrator typecheck`
- `pnpm typecheck`
- `pnpm --filter @smithers-orchestrator/components build`
- `git diff --check`