### PR TITLE
fix(agents): strict Codex output schemas

### DIFF
--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -935,13 +935,10 @@ declare function zodToOpenAISchema(zodSchema: any): Promise<zod_v4_core.ZodStand
  * OpenAI's `response_format` imposes constraints beyond standard JSON Schema:
  *
  * 1. Every object node **must** include `"type": "object"`.
- * 2. `additionalProperties` must be a boolean or a valid sub-schema with a
- *    `type` key -- bare `{}` is rejected.
- * 3. `additionalProperties: true` is accepted but tells the model it can
- *    return extra keys -- set to `false` if you want strict conformance.
+ * 2. Structured output object nodes must set `additionalProperties: false`.
  *
- * Zod v4's `toJSONSchema()` can violate (1) when `z.looseObject()` is used:
- * it emits `{ additionalProperties: true }` without `"type": "object"`.
+ * Zod v4's `toJSONSchema()` can violate these rules when loose/passthrough
+ * objects are used. Codex rejects those schemas unless they are strict.
  *
  * This function fixes these issues in-place so any agent (Codex, future
  * OpenAI-backed agents, etc.) can safely use a JSON Schema for OpenAI.

--- a/packages/agents/src/sanitizeForOpenAI.js
+++ b/packages/agents/src/sanitizeForOpenAI.js
@@ -4,13 +4,10 @@
  * OpenAI's `response_format` imposes constraints beyond standard JSON Schema:
  *
  * 1. Every object node **must** include `"type": "object"`.
- * 2. `additionalProperties` must be a boolean or a valid sub-schema with a
- *    `type` key -- bare `{}` is rejected.
- * 3. `additionalProperties: true` is accepted but tells the model it can
- *    return extra keys -- set to `false` if you want strict conformance.
+ * 2. Structured output object nodes must set `additionalProperties: false`.
  *
- * Zod v4's `toJSONSchema()` can violate (1) when `z.looseObject()` is used:
- * it emits `{ additionalProperties: true }` without `"type": "object"`.
+ * Zod v4's `toJSONSchema()` can violate these rules when loose/passthrough
+ * objects are used. Codex rejects those schemas unless they are strict.
  *
  * This function fixes these issues in-place so any agent (Codex, future
  * OpenAI-backed agents, etc.) can safely use a JSON Schema for OpenAI.
@@ -19,20 +16,14 @@ export function sanitizeForOpenAI(node) {
     if (node == null || typeof node !== "object")
         return;
     const obj = node;
-    // Rule 1 & 2: If a node has `additionalProperties`, it must also
-    // have `"type": "object"`.  Zod's toJSONSchema omits `type` on
-    // passthrough objects, which OpenAI rejects.
+    // Rule 1: If a node has `additionalProperties`, it must also have
+    // `"type": "object"`. Zod can omit `type` on passthrough objects.
     if ("additionalProperties" in obj && !("type" in obj)) {
         obj.type = "object";
     }
-    // Rule 2b: If `additionalProperties` is an empty object `{}`,
-    // OpenAI rejects it because it lacks a `type` key.  Coerce to `true`
-    // which is semantically equivalent and accepted by OpenAI.
-    if (typeof obj.additionalProperties === "object" &&
-        obj.additionalProperties !== null &&
-        !Array.isArray(obj.additionalProperties) &&
-        Object.keys(obj.additionalProperties).length === 0) {
-        obj.additionalProperties = true;
+    // Rule 2: Codex/OpenAI structured outputs require strict object schemas.
+    if (obj.type === "object" && obj.additionalProperties !== false) {
+        obj.additionalProperties = false;
     }
     // Recurse into all sub-schemas
     for (const value of Object.values(obj)) {

--- a/packages/agents/tests/codex-support.test.js
+++ b/packages/agents/tests/codex-support.test.js
@@ -3,6 +3,7 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { CodexAgent } from "../src/index.js";
+import { z } from "zod";
 const originalPath = process.env.PATH ?? "";
 /**
  * @param {string} stdoutScript
@@ -20,6 +21,26 @@ afterEach(() => {
     delete process.env.CODEX_ARGS_FILE;
 });
 describe("Codex CLI agent", () => {
+    test("sanitizes z.looseObject outputSchema for Codex structured output", async () => {
+        const agent = new CodexAgent();
+        const command = await agent.buildCommand({
+            prompt: "extract the document",
+            cwd: process.cwd(),
+            options: {
+                outputSchema: z.looseObject({ document: z.string() }),
+            },
+        });
+        try {
+            const schemaPath = command.args[command.args.indexOf("--output-schema") + 1];
+            const schema = JSON.parse(await readFile(schemaPath, "utf8"));
+            expect(schema.type).toBe("object");
+            expect(schema.additionalProperties).toBe(false);
+            expect(schema.additionalProperties).not.toEqual({});
+        }
+        finally {
+            await command.cleanup?.();
+        }
+    });
     test("resumes an existing session when resumeSession is provided", async () => {
         const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-codex-args-"));
         const argsFile = join(argsFileDir, "args.json");

--- a/packages/agents/tests/schema-openai-sanitize.test.js
+++ b/packages/agents/tests/schema-openai-sanitize.test.js
@@ -9,11 +9,11 @@ describe("zodToOpenAISchema", () => {
         expect(result.type).toBe("object");
         expect(result.properties?.name?.type).toBe("string");
     });
-    test("loose object has type: object", async () => {
+    test("loose object has type: object and strict additionalProperties", async () => {
         const schema = z.object({ document: z.string() }).catchall(z.unknown());
         const result = await zodToOpenAISchema(schema);
         expect(result.type).toBe("object");
-        expect(result.additionalProperties).toBeDefined();
+        expect(result.additionalProperties).toBe(false);
     });
     test("nested loose objects all have type: object", async () => {
         const inner = z.object({ value: z.number() }).catchall(z.unknown());
@@ -29,6 +29,19 @@ describe("zodToOpenAISchema", () => {
         const result = await zodToOpenAISchema(schema);
         const itemSchema = result.properties?.items?.items;
         expect(itemSchema?.type).toBe("object");
+    });
+    test("z.looseObject output schemas are strict enough for Codex structured output", async () => {
+        const schema = z.looseObject({ document: z.string() });
+        const result = await zodToOpenAISchema(schema);
+        expect(result.type).toBe("object");
+        expect(result.additionalProperties).toBe(false);
+        expect(result.additionalProperties).not.toEqual({});
+    });
+    test("ordinary strict object schemas keep additionalProperties false", async () => {
+        const schema = z.object({ document: z.string() });
+        const result = await zodToOpenAISchema(schema);
+        expect(result.type).toBe("object");
+        expect(result.additionalProperties).toBe(false);
     });
 });
 describe("sanitizeForOpenAI", () => {
@@ -48,22 +61,22 @@ describe("sanitizeForOpenAI", () => {
         sanitizeForOpenAI(schema);
         expect(schema.type).toBe("object");
     });
-    test("coerces empty object additionalProperties to true", () => {
+    test("coerces empty object additionalProperties to false", () => {
         const schema = {
             type: "object",
             additionalProperties: {},
         };
         sanitizeForOpenAI(schema);
-        expect(schema.additionalProperties).toBe(true);
+        expect(schema.additionalProperties).toBe(false);
     });
-    test("leaves non-empty additionalProperties schema alone", () => {
+    test("coerces non-empty additionalProperties schema to false", () => {
         const subSchema = { type: "string" };
         const schema = {
             type: "object",
             additionalProperties: subSchema,
         };
         sanitizeForOpenAI(schema);
-        expect(schema.additionalProperties).toEqual({ type: "string" });
+        expect(schema.additionalProperties).toBe(false);
     });
     test("recursively fixes deeply nested schemas", () => {
         const schema = {


### PR DESCRIPTION
## Summary
- sanitize Codex/OpenAI structured output JSON schemas so object nodes use `additionalProperties: false`
- add z.looseObject regression coverage for zodToOpenAISchema and CodexAgent --output-schema file generation
- keep ordinary strict z.object schemas strict

Fixes #211.

## Tests
- `bun test packages/agents/tests/schema-openai-sanitize.test.js` ✅ 12 pass
- `bun test packages/agents/tests/schema-openai-sanitize.test.js packages/agents/tests/codex-support.test.js` ✅ 14 pass
- `pnpm --filter @smithers-orchestrator/agents typecheck` ✅
- `pnpm --filter @smithers-orchestrator/agents test` ❌ 220 pass, 7 skip, 1 fail: pre-existing/out-of-scope `BaseCliAgent timeouts > idle timeout resets on stdout activity` timed out after 5000ms; rerunning `bun test packages/agents/tests/base-cli-agent-timeouts.test.js` reproduced the same timeout failure.