### PR TITLE
fix: extract outer final JSON object after prose

### DIFF
--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -51,6 +51,7 @@ import { createWorkflowVersioningRuntime, getWorkflowPatchDecisions, withWorkflo
 import { runWithCorrelationContext, updateCurrentCorrelationContext, withCorrelationContext, } from "@smithers-orchestrator/observability/correlation";
 import { extractWorkflowImportSpecifiers, getWorkflowImportScanLoader, readWorkflowEntryHash, readWorkflowGraphHash, resolveWorkflowImport, sha256Hex, } from "./workflow-hash.js";
 import { applyOptimizationArtifactToTasks } from "./optimization-artifact.js";
+import { extractBalancedJson, extractLastBalancedJson } from "./json-extraction.js";
 /** @typedef {import("@smithers-orchestrator/graph/GraphSnapshot").GraphSnapshot} GraphSnapshot */
 /** @typedef {import("./HijackState.ts").HijackState} HijackState */
 /** @typedef {import("@smithers-orchestrator/driver/RunOptions").RunOptions} RunOptions */
@@ -3184,62 +3185,6 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                     }
                     catch {
                         // Not valid JSON, try extraction
-                    }
-                    // Helper to extract balanced JSON from text (first occurrence)
-                    /**
-           * @param {string} str
-           * @returns {string | null}
-           */
-                    function extractBalancedJson(str) {
-                        const start = str.indexOf("{");
-                        if (start === -1)
-                            return null;
-                        let depth = 0;
-                        let inString = false;
-                        let escape = false;
-                        for (let i = start; i < str.length; i++) {
-                            const c = str[i];
-                            if (escape) {
-                                escape = false;
-                                continue;
-                            }
-                            if (c === "\\") {
-                                escape = true;
-                                continue;
-                            }
-                            if (c === '"' && !escape) {
-                                inString = !inString;
-                                continue;
-                            }
-                            if (inString)
-                                continue;
-                            if (c === "{")
-                                depth++;
-                            else if (c === "}") {
-                                depth--;
-                                if (depth === 0) {
-                                    return str.slice(start, i + 1);
-                                }
-                            }
-                        }
-                        return null;
-                    }
-                    // Helper to extract the LAST balanced JSON object in text.
-                    // Agents like Kimi emit all intermediate tool output before the final
-                    // required JSON, so searching from the end finds the right object.
-                    /**
-           * @param {string} str
-           * @returns {string | null}
-           */
-                    function extractLastBalancedJson(str) {
-                        let pos = str.lastIndexOf("{");
-                        while (pos >= 0) {
-                            const json = extractBalancedJson(str.slice(pos));
-                            if (json !== null)
-                                return json;
-                            pos = str.lastIndexOf("{", pos - 1);
-                        }
-                        return null;
                     }
                     // Try to extract JSON from code fence (```json ... ```)
                     if (output === undefined) {

--- a/packages/engine/src/json-extraction.js
+++ b/packages/engine/src/json-extraction.js
@@ -1,0 +1,64 @@
+/**
+ * Extract the first balanced JSON object from text.
+ *
+ * @param {string} str
+ * @returns {string | null}
+ */
+export function extractBalancedJson(str) {
+    const start = str.indexOf("{");
+    if (start === -1)
+        return null;
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let i = start; i < str.length; i++) {
+        const c = str[i];
+        if (escape) {
+            escape = false;
+            continue;
+        }
+        if (c === "\\") {
+            escape = true;
+            continue;
+        }
+        if (c === '"' && !escape) {
+            inString = !inString;
+            continue;
+        }
+        if (inString)
+            continue;
+        if (c === "{")
+            depth++;
+        else if (c === "}") {
+            depth--;
+            if (depth === 0) {
+                return str.slice(start, i + 1);
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Extract the last balanced JSON object from text.
+ *
+ * @param {string} str
+ * @returns {string | null}
+ */
+export function extractLastBalancedJson(str) {
+    let bestJson = null;
+    let bestEnd = -1;
+    let pos = str.indexOf("{");
+    while (pos >= 0) {
+        const json = extractBalancedJson(str.slice(pos));
+        if (json !== null) {
+            const end = pos + json.length;
+            if (end > bestEnd) {
+                bestJson = json;
+                bestEnd = end;
+            }
+        }
+        pos = str.indexOf("{", pos + 1);
+    }
+    return bestJson;
+}

--- a/packages/engine/tests/json-extraction.test.js
+++ b/packages/engine/tests/json-extraction.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { extractLastBalancedJson } from "../src/json-extraction.js";
+
+describe("JSON extraction", () => {
+    test("extracts the outer final JSON object after prose when it contains nested objects", () => {
+        const text = `I've reviewed the implementation and found a couple of issues.
+
+{
+  "approved": false,
+  "summary": "request changes",
+  "issues": [
+    {
+      "severity": "major",
+      "title": "First issue",
+      "recommendation": {
+        "action": "update tests",
+        "references": ["packages/engine/src/engine.js"]
+      }
+    },
+    {
+      "severity": "minor",
+      "title": "Doc drift",
+      "file": "docs/architecture/activity.md",
+      "recommendation": "Update the docs."
+    }
+  ]
+}`;
+
+        const extracted = extractLastBalancedJson(text);
+        expect(extracted).not.toBeNull();
+        expect(JSON.parse(extracted)).toEqual({
+            approved: false,
+            summary: "request changes",
+            issues: [
+                {
+                    severity: "major",
+                    title: "First issue",
+                    recommendation: {
+                        action: "update tests",
+                        references: ["packages/engine/src/engine.js"],
+                    },
+                },
+                {
+                    severity: "minor",
+                    title: "Doc drift",
+                    file: "docs/architecture/activity.md",
+                    recommendation: "Update the docs.",
+                },
+            ],
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add a focused regression for prose followed by a final verdict JSON object containing nested issue objects/arrays.
- Move the engine balanced JSON extraction helpers into a directly testable module.
- Update `extractLastBalancedJson` to select the balanced object that closes latest, so the outer final object wins over nested objects inside it.

Fixes #213.

## Validation
- `bun test packages/engine/tests/json-extraction.test.js` -> passed (1 test)
- `bun test packages/engine/tests/schema-retries.test.jsx packages/engine/tests/json-extraction.test.js` -> passed (5 tests)
- `bun run --cwd packages/engine typecheck` -> passed
- `bun run --cwd packages/engine test` -> failed: 545 passed, 1 failed in `failure-retryable-false.e2e.test.jsx`; rerun of that file alone reproduced the same elapsed-time threshold failure (`expected < 900ms`, observed ~1215ms) while call count remained 1. Not touched by this PR.
