### PR TITLE
Harden Pi plugin inspector and approval metadata

### DIFF
--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -472,6 +472,9 @@ describe("semantic tool definitions", () => {
             runId: "run-1",
             nodeId: "gate",
             workflowName: "demo",
+            request: { question: "ship?" },
+            decision: "not json",
+            autoApproved: false,
         });
         const node = await harness.call("get_node_detail", {
             runId: "run-1",

--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -2134,8 +2134,12 @@ export class SmithersDb {
            a.iteration,
            a.status,
            a.requested_at_ms,
+           a.decided_at_ms,
            a.note,
            a.decided_by,
+           a.request_json,
+           a.decision_json,
+           a.auto_approved,
            r.workflow_name,
            r.status AS run_status,
            n.label AS node_label
@@ -2146,7 +2150,7 @@ export class SmithersDb {
           AND a.node_id = n.node_id
           AND a.iteration = n.iteration
          WHERE a.status = ?
-         ORDER BY COALESCE(a.requested_at_ms, 0) ASC, a.run_id, a.node_id, a.iteration`, ["requested"]));
+         ORDER BY COALESCE(a.requested_at_ms, 0) ASC, a.run_id, a.node_id, a.iteration`, ["requested"], { booleanColumns: ["autoApproved"] }));
     }
     /**
    * @param {string} workflowName

--- a/packages/db/tests/db-adapter.test.js
+++ b/packages/db/tests/db-adapter.test.js
@@ -420,6 +420,9 @@ describe("SmithersDb adapter", () => {
             status: "requested",
             requestedAtMs: now - 2000,
             note: "needs operator review",
+            requestJson: JSON.stringify({ title: "Deploy?", summary: "Review deployment" }),
+            decisionJson: JSON.stringify({ option: "approve" }),
+            autoApproved: false,
         });
         await adapter.insertOrUpdateApproval({
             runId: "r2",
@@ -445,6 +448,9 @@ describe("SmithersDb adapter", () => {
             nodeLabel: "Deploy gate",
             status: "requested",
             note: "needs operator review",
+            requestJson: JSON.stringify({ title: "Deploy?", summary: "Review deployment" }),
+            decisionJson: JSON.stringify({ option: "approve" }),
+            autoApproved: false,
         });
     });
     test("insertCache and getCache", async () => {

--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -47,6 +47,15 @@ type TrackedRun = {
   store: DevToolsStore;
 };
 
+type SmithersRunSummary = {
+  runId?: string;
+  id?: string;
+  workflowName?: string | null;
+  workflow?: string | null;
+  status?: string;
+  state?: string;
+};
+
 const DEFAULT_BASE = "http://127.0.0.1:7331";
 const requireFromHere = createRequire(import.meta.url);
 
@@ -55,9 +64,10 @@ let smithersDocs: string | undefined;
 let mcpClient: Client | undefined;
 let mcpTransport: StdioClientTransport | undefined;
 let smithersToolContract: SmithersAgentContract | undefined;
-let pollInterval: ReturnType<typeof setInterval> | undefined;
 let activeRunId: string | undefined;
+let activeSessionToken: symbol | undefined;
 
+const pollIntervals = new Set<ReturnType<typeof setInterval>>();
 const runs = new Map<string, TrackedRun>();
 
 function getBase() {
@@ -222,8 +232,52 @@ function statusIcon(status: string) {
   }
 }
 
-function stripAnsi(value: string) {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
+export function parseRunIdArg(args: string) {
+  const trimmed = args.trim();
+  const match = trimmed.match(/\brun-[A-Za-z0-9_-]+\b/);
+  return match?.[0] ?? trimmed;
+}
+
+function parseMcpJsonPayload(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(text);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function mcpData(payload: Record<string, unknown> | undefined) {
+  const data = payload?.data;
+  return typeof data === "object" && data !== null && !Array.isArray(data) ? data as Record<string, unknown> : undefined;
+}
+
+async function listSmithersRunsFromMcp() {
+  const result = await callMcpTool("list_runs", { limit: 100 });
+  if (result.isError) {
+    throw new SmithersError("PI_MCP_ERROR", result.text);
+  }
+  const data = mcpData(parseMcpJsonPayload(result.text));
+  return Array.isArray(data?.runs) ? data.runs as SmithersRunSummary[] : [];
+}
+
+function runDisplayName(run: TrackedRun) {
+  return run.store.tree?.name ?? run.workflowName;
+}
+
+function runDisplayStatus(run: TrackedRun, fallback?: string) {
+  return run.store.runStatus !== "unknown" ? run.store.runStatus : fallback ?? "unknown";
+}
+
+function isStaleContextError(error: unknown) {
+  return error instanceof Error && /ctx is stale|Extension ctx is stale/i.test(error.message);
+}
+
+function clearPollIntervals() {
+  for (const interval of pollIntervals) {
+    clearInterval(interval);
+  }
+  pollIntervals.clear();
 }
 
 function collectNodeStates(run: TrackedRun) {
@@ -258,8 +312,12 @@ function collectErrors(run: TrackedRun) {
 }
 
 function trackRun(runId: string, workflowName = "workflow") {
+  runId = parseRunIdArg(runId);
   const existing = runs.get(runId);
   if (existing) {
+    if (existing.workflowName === "workflow" && workflowName !== "workflow") {
+      existing.workflowName = workflowName;
+    }
     activeRunId = runId;
     return existing;
   }
@@ -273,16 +331,23 @@ function trackRun(runId: string, workflowName = "workflow") {
 }
 
 function updateStatusBar(ctx: ExtensionContext) {
-  const active = [...runs.values()].filter((run) => !run.store.isRunFinished);
-  const failed = [...runs.values()].filter((run) => run.store.runStatus === "failed");
-  const parts: string[] = [];
-  if (active.length > 0) {
-    parts.push(`${active.length} active`);
+  try {
+    const active = [...runs.values()].filter((run) => !run.store.isRunFinished);
+    const failed = [...runs.values()].filter((run) => run.store.runStatus === "failed");
+    const parts: string[] = [];
+    if (active.length > 0) {
+      parts.push(`${active.length} active`);
+    }
+    if (failed.length > 0) {
+      parts.push(`${failed.length} failed`);
+    }
+    ctx.ui.setStatus?.("smithers", `smithers: ${parts.length > 0 ? parts.join("  ") : "idle"}`);
+  } catch (error) {
+    if (!isStaleContextError(error)) {
+      throw error;
+    }
+    clearPollIntervals();
   }
-  if (failed.length > 0) {
-    parts.push(`${failed.length} failed`);
-  }
-  ctx.ui.setStatus?.("smithers", parts.length > 0 ? `smithers: ${parts.join("  ")}` : undefined);
 }
 
 async function openInspector(ctx: ExtensionContext, run: TrackedRun) {
@@ -290,11 +355,16 @@ async function openInspector(ctx: ExtensionContext, run: TrackedRun) {
     ctx.ui.notify("/smithers requires interactive mode", "error");
     return;
   }
+  if (run.store.runId !== run.runId || run.store.connectionState.kind === "disconnected" || run.store.connectionState.kind === "error") {
+    run.store.connect(run.runId);
+  }
   await ctx.ui.custom((_tui: unknown, theme: unknown, _kb: unknown, done: () => void) =>
     new RunInspector(run.store, run.client, {
       workflowName: run.workflowName,
+      theme: (theme ?? {}) as any,
       onClose: done,
       onNotify: (message, level) => ctx.ui.notify(message, level),
+      requestRender: () => (_tui as { requestRender?: () => void }).requestRender?.(),
     }),
   );
 }
@@ -355,7 +425,13 @@ async function registerMcpTools(pi: ExtensionAPI, ctx: ExtensionContext) {
       });
     }
   } catch (error) {
-    ctx.ui.notify(`Smithers MCP: ${error instanceof Error ? error.message : String(error)}`, "warning");
+    try {
+      ctx.ui.notify(`Smithers MCP: ${error instanceof Error ? error.message : String(error)}`, "warning");
+    } catch (notifyError) {
+      if (!isStaleContextError(notifyError)) {
+        throw notifyError;
+      }
+    }
   }
 }
 
@@ -374,40 +450,28 @@ export function extension(pi: ExtensionAPI) {
   });
 
   pi.on("session_start", async (_event: unknown, ctx: ExtensionContext) => {
-    // Clear any timer left over from a previous session before re-arming, so a
-    // reload/session-replacement never leaves a timer holding a stale ctx.
-    if (pollInterval) {
-      clearInterval(pollInterval);
-    }
-    pollInterval = setInterval(() => {
-      // ctx becomes stale after reload/newSession/fork/switchSession; touching
-      // ctx.ui then throws. Stop polling instead of crashing the Pi process.
-      try {
-        updateStatusBar(ctx);
-      } catch {
-        if (pollInterval) {
-          clearInterval(pollInterval);
-          pollInterval = undefined;
-        }
+    clearPollIntervals();
+    const sessionToken = Symbol("smithers-session");
+    activeSessionToken = sessionToken;
+    const interval = setInterval(() => {
+      if (activeSessionToken !== sessionToken) {
+        clearInterval(interval);
+        pollIntervals.delete(interval);
+        return;
       }
+      updateStatusBar(ctx);
     }, 5_000);
+    pollIntervals.add(interval);
     await registerMcpTools(pi, ctx);
+    if (activeSessionToken !== sessionToken) {
+      return;
+    }
     if (ctx.hasUI) {
       ctx.ui.setHeader?.((_tui: unknown, theme: any) => ({
         render(width: number) {
-          return [truncateToWidth(` ${theme.fg("accent", theme.bold("smithers"))} ${theme.fg("muted", "PI inspector")}`, width)];
-        },
-        invalidate() {},
-      }));
-      ctx.ui.setFooter?.((_tui: unknown, theme: any, footerData: any) => ({
-        render(width: number) {
-          const statuses = footerData.getExtensionStatuses?.();
-          const smithersStatus = statuses?.get?.("smithers") ?? "smithers: idle";
-          const branch = footerData.getGitBranch?.();
-          const left = ` ${theme.fg("muted", smithersStatus)}`;
-          const right = branch ? theme.fg("dim", ` ${branch}`) : "";
-          const gap = Math.max(0, width - stripAnsi(left).length - stripAnsi(right).length);
-          return [truncateToWidth(left + " ".repeat(gap) + right, width)];
+          const fg = typeof theme?.fg === "function" ? theme.fg.bind(theme) : (_color: string, value: string) => value;
+          const bold = typeof theme?.bold === "function" ? theme.bold.bind(theme) : (value: string) => value;
+          return [truncateToWidth(` ${fg("accent", bold("smithers"))} ${fg("muted", "PI inspector")}`, width)];
         },
         invalidate() {},
       }));
@@ -416,9 +480,8 @@ export function extension(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
-    if (pollInterval) {
-      clearInterval(pollInterval);
-    }
+    activeSessionToken = undefined;
+    clearPollIntervals();
     for (const run of runs.values()) {
       run.store.disconnect();
     }
@@ -456,7 +519,7 @@ export function extension(pi: ExtensionAPI) {
   pi.registerCommand("smithers", {
     description: "Open the Smithers live run inspector",
     handler: async (args: string, ctx: ExtensionContext) => {
-      const requested = args.trim();
+      const requested = parseRunIdArg(args);
       let run = requested ? trackRun(requested) : activeRunId ? runs.get(activeRunId) : undefined;
       if (!run) {
         const runId = await ctx.ui.input("Run ID", "Enter the Smithers run ID to inspect");
@@ -465,6 +528,7 @@ export function extension(pi: ExtensionAPI) {
         }
         run = trackRun(runId);
       }
+      updateStatusBar(ctx);
       await openInspector(ctx, run);
     },
   });
@@ -477,34 +541,53 @@ export function extension(pi: ExtensionAPI) {
         .map((run) => ({ value: run.runId, label: `${run.workflowName} (${run.runId.slice(0, 8)})` }));
     },
     handler: async (args: string, ctx: ExtensionContext) => {
-      const runId = args.trim() || (await ctx.ui.input("Run ID", "Enter the Smithers run ID to watch"));
+      const runId = parseRunIdArg(args) || (await ctx.ui.input("Run ID", "Enter the Smithers run ID to watch"));
       if (!runId) {
         return;
       }
       const run = trackRun(runId);
-      ctx.ui.notify(`Watching run ${runId.slice(0, 8)}`, "info");
+      ctx.ui.notify(`Watching run ${run.runId.slice(0, 8)}`, "info");
       updateStatusBar(ctx);
       await openInspector(ctx, run);
     },
   });
 
   pi.registerCommand("smithers-runs", {
-    description: "List tracked Smithers runs",
+    description: "List Smithers runs",
     handler: async (_args: string, ctx: ExtensionContext) => {
+      ctx.ui.notify("Loading Smithers runs...", "info");
+      const discoveredRuns = await listSmithersRunsFromMcp().catch((error) => {
+        ctx.ui.notify(`Unable to list Smithers runs: ${error instanceof Error ? error.message : String(error)}`, "warning");
+        return [];
+      });
+      for (const discovered of discoveredRuns) {
+        const runId = discovered.runId ?? discovered.id;
+        if (!runId) {
+          continue;
+        }
+        trackRun(runId, discovered.workflowName ?? discovered.workflow ?? "workflow");
+      }
       if (runs.size === 0) {
-        ctx.ui.notify("No runs tracked", "info");
+        ctx.ui.notify("No Smithers runs found", "info");
         return;
       }
-      const runList = [...runs.values()];
-      const options = runList.map(
-        (run) => `${statusIcon(run.store.runStatus)} ${run.workflowName} (${run.runId.slice(0, 8)}) - ${run.store.runStatus}`,
-      );
+      const discoveredById = new Map(discoveredRuns.map((run) => [run.runId ?? run.id, run]));
+      const runList = [...runs.values()].sort((a, b) => b.runId.localeCompare(a.runId));
+      const options = runList.map((run) => {
+        const discovered = discoveredById.get(run.runId);
+        const status = runDisplayStatus(run, discovered?.status ?? discovered?.state);
+        const workflowName = runDisplayName(run) === "workflow"
+          ? discovered?.workflowName ?? discovered?.workflow ?? "workflow"
+          : runDisplayName(run);
+        return `${statusIcon(status)} ${workflowName} (${run.runId}) - ${status}`;
+      });
       const selected = await ctx.ui.select("Smithers Runs", options);
       if (!selected) {
         return;
       }
       const run = runList[options.indexOf(selected)];
       activeRunId = run.runId;
+      updateStatusBar(ctx);
       await openInspector(ctx, run);
     },
   });

--- a/packages/pi-plugin/src/runtime/DevToolsClient.ts
+++ b/packages/pi-plugin/src/runtime/DevToolsClient.ts
@@ -1,4 +1,9 @@
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { WebSocket } from "ws";
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 import type { DevToolsDelta, DevToolsSnapshot } from "@smithers-orchestrator/protocol";
@@ -75,6 +80,8 @@ type PendingRequest = {
 };
 
 const DEFAULT_BASE = "http://127.0.0.1:7331";
+const requireFromHere = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
 const AUDIT_ROW_ID_KEYS = new Set([
   "auditRowId",
   "audit_row_id",
@@ -84,6 +91,38 @@ const AUDIT_ROW_ID_KEYS = new Set([
   "audit_log_id",
 ]);
 const NESTED_AUDIT_CONTAINERS = ["result", "data", "mutation", "ack", "payload", "meta"];
+
+function resolveCliPath() {
+  try {
+    return requireFromHere.resolve("@smithers-orchestrator/cli");
+  } catch {
+    return resolve(dirname(fileURLToPath(import.meta.url)), "../../../../apps/cli/src/index.js");
+  }
+}
+
+function parseJsonObjectFromStdout(stdout: string) {
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) {
+      continue;
+    }
+    try {
+      return JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+  }
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+async function runCli(args: string[]) {
+  const { stdout } = await execFileAsync("bun", ["run", resolveCliPath(), ...args], {
+    cwd: process.cwd(),
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 15_000,
+  });
+  return stdout;
+}
 
 function toWsUrl(baseUrl: string) {
   const url = new URL(baseUrl);
@@ -139,8 +178,16 @@ function normalizeEvent(raw: unknown): DevToolsRuntimeEvent {
   throw new SmithersError("PI_DEVTOOLS_DECODE_ERROR", "Unknown DevTools event kind.");
 }
 
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown) {
+  return error instanceof SmithersError ? error.code : undefined;
+}
+
 function unsupportedRpc(error: unknown) {
-  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  const message = errorMessage(error).toLowerCase();
   return [
     "method not found",
     "unknown method",
@@ -149,6 +196,17 @@ function unsupportedRpc(error: unknown) {
     "unrecognized method",
     "not_found",
   ].some((phrase) => message.includes(phrase));
+}
+
+function gatewayUnavailable(error: unknown) {
+  const code = errorCode(error);
+  const message = errorMessage(error).toLowerCase();
+  return code === "PI_GATEWAY_HTTP_ERROR" ||
+    message.includes("fetch failed") ||
+    message.includes("econnrefused") ||
+    message.includes("connection refused") ||
+    message.includes("failed to connect") ||
+    message.includes("socket hang up");
 }
 
 function auditRowId(value: unknown): string | undefined {
@@ -325,7 +383,13 @@ export class DevToolsClient {
   ): AsyncGenerator<DevToolsRuntimeEvent> {
     let afterSeqCursor = afterSeq ?? this.lastSeqSeenByRunId.get(runId);
     while (!signal?.aborted) {
-      const connection = await GatewayWsConnection.open(toWsUrl(this.baseUrl));
+      let connection: GatewayWsConnection;
+      try {
+        connection = await GatewayWsConnection.open(toWsUrl(this.baseUrl));
+      } catch {
+        yield { version: 1, kind: "snapshot", snapshot: await this.getDevToolsSnapshot(runId) };
+        return;
+      }
       const abort = () => connection.close();
       signal?.addEventListener("abort", abort, { once: true });
       try {
@@ -398,14 +462,21 @@ export class DevToolsClient {
   }
 
   async getDevToolsSnapshot(runId: string, frameNo?: number) {
-    const snapshot = await this.rpc("getDevToolsSnapshot", {
-      runId,
-      ...(typeof frameNo === "number" ? { frameNo } : {}),
-    });
-    if (isRecord(snapshot) && typeof snapshot.seq === "number") {
-      this.lastSeqSeenByRunId.set(runId, Math.max(this.lastSeqSeenByRunId.get(runId) ?? 0, snapshot.seq));
+    try {
+      const snapshot = await this.rpc("getDevToolsSnapshot", {
+        runId,
+        ...(typeof frameNo === "number" ? { frameNo } : {}),
+      });
+      if (isRecord(snapshot) && typeof snapshot.seq === "number") {
+        this.lastSeqSeenByRunId.set(runId, Math.max(this.lastSeqSeenByRunId.get(runId) ?? 0, snapshot.seq));
+      }
+      return snapshot as DevToolsSnapshot & { runState?: RunStateView };
+    } catch (error) {
+      if (!gatewayUnavailable(error)) {
+        throw error;
+      }
+      return this.getCliDevToolsSnapshot(runId, frameNo, error);
     }
-    return snapshot as DevToolsSnapshot & { runState?: RunStateView };
   }
 
   async getNodeOutput(runId: string, nodeId: string, iteration?: number) {
@@ -425,25 +496,41 @@ export class DevToolsClient {
   }
 
   async approve(runId: string, nodeId: string, iteration = 0, note?: string) {
-    const payload = await this.rpc("approvals.decide", {
-      runId,
-      nodeId,
-      iteration,
-      approved: true,
-      note,
-    });
-    return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    try {
+      const payload = await this.rpc("approvals.decide", {
+        runId,
+        nodeId,
+        iteration,
+        approved: true,
+        note,
+      });
+      return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    } catch (error) {
+      if (!gatewayUnavailable(error)) {
+        throw error;
+      }
+      await this.cliMutation(["approve", runId, "--node", nodeId, "--iteration", String(iteration), ...(note ? ["--note", note] : [])], error);
+      return {} satisfies GatewayMutationResult;
+    }
   }
 
   async deny(runId: string, nodeId: string, iteration = 0, note?: string) {
-    const payload = await this.rpc("approvals.decide", {
-      runId,
-      nodeId,
-      iteration,
-      approved: false,
-      note,
-    });
-    return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    try {
+      const payload = await this.rpc("approvals.decide", {
+        runId,
+        nodeId,
+        iteration,
+        approved: false,
+        note,
+      });
+      return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    } catch (error) {
+      if (!gatewayUnavailable(error)) {
+        throw error;
+      }
+      await this.cliMutation(["deny", runId, "--node", nodeId, "--iteration", String(iteration), ...(note ? ["--note", note] : [])], error);
+      return {} satisfies GatewayMutationResult;
+    }
   }
 
   async signal(runId: string, signal: string, payload?: unknown, correlationId?: string) {
@@ -457,8 +544,16 @@ export class DevToolsClient {
   }
 
   async cancel(runId: string) {
-    const payload = await this.rpc("runs.cancel", { runId });
-    return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    try {
+      const payload = await this.rpc("runs.cancel", { runId });
+      return { auditRowId: auditRowId(payload) } satisfies GatewayMutationResult;
+    } catch (error) {
+      if (!gatewayUnavailable(error)) {
+        throw error;
+      }
+      await this.cliMutation(["cancel", runId], error);
+      return {} satisfies GatewayMutationResult;
+    }
   }
 
   async resume(runId: string) {
@@ -490,6 +585,40 @@ export class DevToolsClient {
     throw lastUnsupportedError instanceof Error
       ? lastUnsupportedError
       : new SmithersError("PI_UNSUPPORTED_MUTATION", "No supported gateway mutation RPC found.");
+  }
+
+  private async getCliDevToolsSnapshot(runId: string, frameNo: number | undefined, gatewayError: unknown) {
+    try {
+      const stdout = await runCli([
+        "tree",
+        runId,
+        "--json",
+        "--format",
+        "json",
+        ...(typeof frameNo === "number" ? ["--frame", String(frameNo)] : []),
+      ]);
+      const snapshot = parseJsonObjectFromStdout(stdout) as DevToolsSnapshot & { runState?: RunStateView };
+      if (typeof snapshot.seq === "number") {
+        this.lastSeqSeenByRunId.set(runId, Math.max(this.lastSeqSeenByRunId.get(runId) ?? 0, snapshot.seq));
+      }
+      return snapshot;
+    } catch (cliError) {
+      const gatewayMessage = errorMessage(gatewayError);
+      const cliMessage = errorMessage(cliError);
+      throw new SmithersError("PI_DEVTOOLS_SNAPSHOT_ERROR", `Gateway snapshot failed (${gatewayMessage}); CLI fallback failed (${cliMessage}).`, {
+        runId,
+      });
+    }
+  }
+
+  private async cliMutation(args: string[], gatewayError: unknown) {
+    try {
+      await runCli(args);
+    } catch (cliError) {
+      const gatewayMessage = errorMessage(gatewayError);
+      const cliMessage = errorMessage(cliError);
+      throw new SmithersError("PI_GATEWAY_MUTATION_ERROR", `Gateway mutation failed (${gatewayMessage}); CLI fallback failed (${cliMessage}).`);
+    }
   }
 
   private async rpc(method: string, params?: unknown) {

--- a/packages/pi-plugin/src/runtime/DevToolsStore.ts
+++ b/packages/pi-plugin/src/runtime/DevToolsStore.ts
@@ -56,6 +56,17 @@ function cloneSnapshot(snapshot: SnapshotWithRunState) {
   return structuredClone(snapshot);
 }
 
+function sameSnapshot(left: SnapshotWithRunState | undefined, right: SnapshotWithRunState) {
+  if (!left) {
+    return false;
+  }
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
 function findNode(root: DevToolsNode | undefined, id: number): DevToolsNode | undefined {
   if (!root) {
     return undefined;
@@ -113,6 +124,10 @@ function runStatusForRoot(root: DevToolsNode | undefined, fallback: string) {
     case "waiting-approval":
     case "blocked":
       return "waiting-approval";
+    case "waiting-event":
+      return "waiting-event";
+    case "waiting-timer":
+      return "waiting-timer";
     case "finished":
     case "complete":
     case "completed":
@@ -581,11 +596,15 @@ export class DevToolsStore {
   }
 
   private applySnapshotToLiveState(snapshot: SnapshotWithRunState) {
-    if (this.runId && snapshot.runId !== this.runId) {
+    const snapshotRunId = snapshot.runId ?? (snapshot as SnapshotWithRunState & { run_id?: string }).run_id;
+    if (this.runId && snapshotRunId && snapshotRunId !== this.runId) {
       this.disconnect();
       return false;
     }
-    if (snapshot.seq <= (this.liveSnapshot?.seq ?? 0) && this.liveSnapshot && !this.awaitingSnapshotAfterGapResync) {
+    if (snapshot.seq < (this.liveSnapshot?.seq ?? 0) && this.liveSnapshot && !this.awaitingSnapshotAfterGapResync) {
+      return false;
+    }
+    if (snapshot.seq === this.liveSnapshot?.seq && sameSnapshot(this.liveSnapshot, snapshot) && !this.awaitingSnapshotAfterGapResync) {
       return false;
     }
 
@@ -605,8 +624,10 @@ export class DevToolsStore {
     this.runStatus = runStatusForSnapshot(snapshot, this.runStatus);
     this.recordMountedFrames(snapshot.root, snapshot.frameNo);
     this.pruneGhostNodesNowActive(snapshot.root);
-    this.stateRunId = snapshot.runId;
-    this.lastSeqSeenByRunId.set(snapshot.runId, snapshot.seq);
+    this.stateRunId = snapshotRunId ?? this.runId;
+    if (this.stateRunId) {
+      this.lastSeqSeenByRunId.set(this.stateRunId, snapshot.seq);
+    }
     return true;
   }
 

--- a/packages/pi-plugin/src/views/FrameScrubber.ts
+++ b/packages/pi-plugin/src/views/FrameScrubber.ts
@@ -6,7 +6,7 @@ type Theme = {
   bold?: (value: string) => string;
 };
 
-function paint(theme: Theme, color: string, value: string) {
+function paint(theme: Theme = {}, color: string, value: string) {
   return theme.fg ? theme.fg(color, value) : value;
 }
 
@@ -33,7 +33,7 @@ export class FrameScrubber {
     return false;
   }
 
-  render(width: number, theme: Theme) {
+  render(width: number, theme: Theme = {}) {
     const W = Math.max(24, width);
     const latest = Math.max(0, this.store.latestFrameNo);
     const current = Math.min(this.store.displayedFrameNo, latest);

--- a/packages/pi-plugin/src/views/Header.ts
+++ b/packages/pi-plugin/src/views/Header.ts
@@ -6,11 +6,11 @@ type Theme = {
   bold?: (value: string) => string;
 };
 
-function paint(theme: Theme, color: string, value: string) {
+function paint(theme: Theme = {}, color: string, value: string) {
   return theme.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
+function bold(theme: Theme = {}, value: string) {
   return theme.bold ? theme.bold(value) : value;
 }
 
@@ -90,7 +90,7 @@ export class Header {
     private readonly workflowName = "workflow",
   ) {}
 
-  render(width: number, theme: Theme) {
+  render(width: number, theme: Theme = {}) {
     const W = Math.max(40, width);
     const runId = this.store.runId ?? "no-run";
     const state = this.store.runStatus;
@@ -122,10 +122,12 @@ export class Header {
     const connection =
       this.store.connectionState.kind === "streaming"
         ? ""
-        : ` ${paint(theme, "warning", this.store.connectionState.kind)}`;
+        : this.store.connectionState.kind === "error"
+          ? ` ${paint(theme, "warning", `error:${this.store.connectionState.error.message}`)}`
+          : ` ${paint(theme, "warning", this.store.connectionState.kind)}`;
     const left = [
       paint(theme, stateColor(state), bold(theme, state.toUpperCase())),
-      paint(theme, "muted", this.workflowName),
+      paint(theme, "muted", this.store.tree?.name === "workflow" ? this.workflowName : this.store.tree?.name ?? this.workflowName),
       paint(theme, "dim", runId.slice(0, 12)),
       runStateLabel ? paint(theme, "muted", runStateLabel) : "",
     ].filter(Boolean).join("  ");

--- a/packages/pi-plugin/src/views/NodeInspector.ts
+++ b/packages/pi-plugin/src/views/NodeInspector.ts
@@ -9,11 +9,11 @@ type Theme = {
 
 type InspectorTab = "output" | "diff" | "logs";
 
-function paint(theme: Theme, color: string, value: string) {
+function paint(theme: Theme = {}, color: string, value: string) {
   return theme.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
+function bold(theme: Theme = {}, value: string) {
   return theme.bold ? theme.bold(value) : value;
 }
 
@@ -51,6 +51,19 @@ function firstPresent(node: DevToolsNode, keys: string[]) {
     }
   }
   return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function approvalRequest(node: DevToolsNode) {
+  const approval = node.props.approval;
+  if (!isRecord(approval)) {
+    return undefined;
+  }
+  const request = approval.request;
+  return isRecord(request) ? request : undefined;
 }
 
 function renderJsonLines(value: unknown, fallback: string) {
@@ -123,7 +136,7 @@ export class NodeInspector {
     return "unhandled";
   }
 
-  render(width: number, height: number, theme: Theme) {
+  render(width: number, height: number, theme: Theme = {}) {
     const W = Math.max(28, width);
     const H = Math.max(4, height);
     const node = this.store.selectedNode;
@@ -172,11 +185,16 @@ export class NodeInspector {
 
   private bodyLines(node: DevToolsNode) {
     const calls = toolCalls(node);
+    const approval = isRecord(node.props.approval) ? node.props.approval : undefined;
     const taskLines = [
       ` task.nodeId: ${node.task?.nodeId ?? "-"}`,
       ` task.kind: ${node.task?.kind ?? "-"}`,
       ` task.agent: ${node.task?.agent ?? "-"}`,
       ` task.iteration: ${node.task?.iteration ?? 0}`,
+      ` state: ${nodeState(node)}`,
+      ...(typeof node.task?.label === "string" ? [` label: ${node.task.label}`] : []),
+      ...(typeof approval?.status === "string" ? [` approval.status: ${approval.status}`] : []),
+      ...(typeof approval?.requestedAt === "string" ? [` approval.requestedAt: ${approval.requestedAt}`] : []),
     ];
     const callLines = calls.length > 0 ? ["", " tool calls:", ...calls.map((call) => `  - ${call}`)] : [];
     switch (this.tab) {
@@ -186,7 +204,7 @@ export class NodeInspector {
           ...callLines,
           "",
           " output:",
-          ...renderJsonLines(firstPresent(node, ["output", "row", "result", "value"]), " (no output captured)"),
+          ...renderJsonLines(firstPresent(node, ["output", "row", "result", "value"]) ?? approvalRequest(node), " (no output captured)"),
         ];
       case "diff":
         return [

--- a/packages/pi-plugin/src/views/RunInspector.ts
+++ b/packages/pi-plugin/src/views/RunInspector.ts
@@ -15,11 +15,13 @@ type FocusPane = "tree" | "inspector" | "scrubber";
 
 type RunInspectorOptions = {
   workflowName?: string;
+  theme?: Theme;
   onClose?: () => void;
   onNotify?: (message: string, level?: "info" | "warning" | "error") => void;
+  requestRender?: () => void;
 };
 
-function paint(theme: Theme, color: string, value: string) {
+function paint(theme: Theme = {}, color: string, value: string) {
   return theme.fg ? theme.fg(color, value) : value;
 }
 
@@ -46,6 +48,10 @@ export class RunInspector {
   private focus: FocusPane = "tree";
   private cachedLines: string[] | undefined;
   private cachedWidth = 0;
+  private readonly theme: Theme;
+  private readonly requestRender: () => void;
+  private readonly unsubscribe: () => void;
+  private pendingAction: string | undefined;
 
   constructor(
     private readonly store: DevToolsStore,
@@ -56,9 +62,14 @@ export class RunInspector {
     this.scrubber = new FrameScrubber(store);
     this.tree = new RunTree(store);
     this.inspector = new NodeInspector(store);
+    this.theme = options.theme ?? {};
     this.onClose = options.onClose ?? (() => undefined);
     this.onNotify = options.onNotify ?? (() => undefined);
-    store.subscribe(() => this.invalidate());
+    this.requestRender = options.requestRender ?? (() => undefined);
+    this.unsubscribe = store.subscribe(() => {
+      this.invalidate();
+      this.requestRender();
+    });
   }
 
   handleInput(data: string) {
@@ -114,7 +125,7 @@ export class RunInspector {
     }
   }
 
-  render(width: number, height = 34, theme: Theme) {
+  render(width: number, height = 34, theme: Theme = this.theme) {
     if (this.cachedLines && this.cachedWidth === width) {
       return this.cachedLines;
     }
@@ -138,12 +149,13 @@ export class RunInspector {
     }
 
     const focusLabel = paint(theme, "accent", this.focus);
+    const working = this.pendingAction ? `  working:${this.pendingAction}` : "";
     lines.push(
       truncateToWidth(
         paint(
           theme,
           "dim",
-          ` focus:${stripAnsi(focusLabel)}  tab:focus  arrows/jk:tree  1-3:tabs  s:frames  a/d:approve/deny  w:rewind  c:cancel  q:close`,
+          ` focus:${stripAnsi(focusLabel)}${working}  tab:focus  arrows/jk:tree  1-3:tabs  s:frames  a/d:approve/deny  w:rewind  c:cancel  q:close`,
         ),
         W,
       ),
@@ -159,7 +171,7 @@ export class RunInspector {
   }
 
   dispose() {
-    this.store.disconnect();
+    this.unsubscribe();
   }
 
   private cycleFocus(delta: number) {
@@ -179,7 +191,25 @@ export class RunInspector {
       runId,
       nodeId,
       iteration: node.task?.iteration ?? 0,
+      state: typeof node.props.state === "string" ? node.props.state : "unknown",
     };
+  }
+
+  private async runExclusive(label: string, task: () => Promise<void>) {
+    if (this.pendingAction) {
+      this.onNotify(`${this.pendingAction} already in progress.`, "warning");
+      return;
+    }
+    this.pendingAction = label;
+    this.invalidate();
+    this.requestRender();
+    try {
+      await task();
+    } finally {
+      this.pendingAction = undefined;
+      this.invalidate();
+      this.requestRender();
+    }
   }
 
   private async approveSelected() {
@@ -188,12 +218,19 @@ export class RunInspector {
       this.onNotify("No task node selected.", "warning");
       return;
     }
-    try {
-      await this.client.approve(task.runId, task.nodeId, task.iteration);
-      this.onNotify(`Approved ${task.nodeId}.`, "info");
-    } catch (error) {
-      this.onNotify(error instanceof Error ? error.message : String(error), "error");
+    if (task.state !== "waiting-approval") {
+      this.onNotify("Selected node is not waiting for approval.", "warning");
+      return;
     }
+    await this.runExclusive("approve", async () => {
+      try {
+        await this.client.approve(task.runId, task.nodeId, task.iteration);
+        this.onNotify(`Approved ${task.nodeId}.`, "info");
+        this.store.connect(task.runId);
+      } catch (error) {
+        this.onNotify(error instanceof Error ? error.message : String(error), "error");
+      }
+    });
   }
 
   private async denySelected() {
@@ -202,24 +239,35 @@ export class RunInspector {
       this.onNotify("No task node selected.", "warning");
       return;
     }
-    try {
-      await this.client.deny(task.runId, task.nodeId, task.iteration);
-      this.onNotify(`Denied ${task.nodeId}.`, "warning");
-    } catch (error) {
-      this.onNotify(error instanceof Error ? error.message : String(error), "error");
+    if (task.state !== "waiting-approval") {
+      this.onNotify("Selected node is not waiting for approval.", "warning");
+      return;
     }
+    await this.runExclusive("deny", async () => {
+      try {
+        await this.client.deny(task.runId, task.nodeId, task.iteration);
+        this.onNotify(`Denied ${task.nodeId}.`, "warning");
+        this.store.connect(task.runId);
+      } catch (error) {
+        this.onNotify(error instanceof Error ? error.message : String(error), "error");
+      }
+    });
   }
 
   private async cancelRun() {
     if (!this.store.runId) {
       return;
     }
-    try {
-      await this.client.cancel(this.store.runId);
-      this.onNotify(`Cancelling ${this.store.runId.slice(0, 8)}.`, "warning");
-    } catch (error) {
-      this.onNotify(error instanceof Error ? error.message : String(error), "error");
-    }
+    const runId = this.store.runId;
+    await this.runExclusive("cancel", async () => {
+      try {
+        await this.client.cancel(runId);
+        this.onNotify(`Cancelling ${runId.slice(0, 8)}.`, "warning");
+        this.store.connect(runId);
+      } catch (error) {
+        this.onNotify(error instanceof Error ? error.message : String(error), "error");
+      }
+    });
   }
 
   private async rewindDisplayedFrame() {

--- a/packages/pi-plugin/src/views/RunTree.ts
+++ b/packages/pi-plugin/src/views/RunTree.ts
@@ -12,11 +12,11 @@ type TreeRow = {
   depth: number;
 };
 
-function paint(theme: Theme, color: string, value: string) {
+function paint(theme: Theme = {}, color: string, value: string) {
   return theme.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
+function bold(theme: Theme = {}, value: string) {
   return theme.bold ? theme.bold(value) : value;
 }
 
@@ -47,6 +47,7 @@ function stateIcon(node: DevToolsNode) {
     case "blocked":
     case "waitingapproval":
     case "waiting-approval":
+    case "waiting-event":
     case "waiting-timer":
       return "!";
     case "cancelled":
@@ -245,7 +246,7 @@ export class RunTree {
     return "unhandled";
   }
 
-  render(width: number, height: number, theme: Theme) {
+  render(width: number, height: number, theme: Theme = {}) {
     const W = Math.max(28, width);
     const H = Math.max(3, height);
     this.rebuildAutoExpansion();
@@ -298,7 +299,7 @@ export class RunTree {
     const line =
       `${marker}${indent}${chevron} ${paint(theme, stateColor(node), stateIcon(node))} ` +
       `${paint(theme, selected ? "accent" : "muted", `<${node.type}>`)} ` +
-      `${paint(theme, selected ? "accent" : "default", label)} ` +
+      `${paint(theme, selected ? "accent" : "muted", label)} ` +
       `${paint(theme, dim, summary)}${failedBubble}${ghost}`;
     return truncateToWidth(line, width);
   }
@@ -312,7 +313,8 @@ export class RunTree {
     this.expandedIds.add(root.id);
     const running = collectPathIds(root, (node) => stateIcon(node) === ">");
     const failed = collectPathIds(root, (node) => stateIcon(node) === "x");
-    for (const id of [...running, ...failed]) {
+    const waiting = collectPathIds(root, (node) => stateIcon(node) === "!");
+    for (const id of [...running, ...failed, ...waiting]) {
       if (!this.userCollapsedIds.has(id)) {
         this.expandedIds.add(id);
       }

--- a/packages/pi-plugin/tests/DevToolsStore.test.ts
+++ b/packages/pi-plugin/tests/DevToolsStore.test.ts
@@ -67,6 +67,32 @@ describe("DevToolsStore", () => {
       .toBe(stable(fresh));
   });
 
+  test("accepts enriched equal-sequence snapshots", () => {
+    const first = snapshot(1, [task(2, "task:a", "running")]);
+    const enriched = snapshot(1, [task(2, "task:a", "running", { output: { summary: "ready" } })]);
+    const store = new DevToolsStore({ ghostNodeCap: 8 });
+
+    store.connect("run-test");
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: first });
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: enriched });
+
+    expect(store.tree?.children[0]?.props.output).toEqual({ summary: "ready" });
+    store.disconnect();
+  });
+
+  test("accepts snapshots that omit runId when already connected", () => {
+    const first = snapshot(1, [task(2, "task:a", "running")]);
+    const { runId: _runId, ...withoutRunId } = first;
+    const store = new DevToolsStore({ ghostNodeCap: 8 });
+
+    store.connect("run-test");
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: withoutRunId as DevToolsSnapshot });
+
+    expect(store.tree?.children[0]?.task?.nodeId).toBe("task:a");
+    expect(store.runId).toBe("run-test");
+    store.disconnect();
+  });
+
   test("GapResync keeps the old displayed tree, discards deltas, then accepts a snapshot", () => {
     const first = snapshot(1, [task(2, "task:a", "running")]);
     const ignored = diffSnapshots(first, snapshot(3, [task(2, "task:a", "failed")]));
@@ -153,10 +179,7 @@ describe("DevToolsClient integration", () => {
     await waitFor(() => store.seq === 1);
 
     const inspector = new RunInspector(store, client, { workflowName: "fixture" });
-    const lines = inspector.render(100, 20, {
-      fg: (_color, value) => value,
-      bold: (value) => value,
-    }).join("\n");
+    const lines = inspector.render(100, 20).join("\n");
 
     expect(lines).toContain("task:a");
     expect(lines).toContain("finished");

--- a/packages/pi-plugin/tests/jsonSchemaToTypebox.test.ts
+++ b/packages/pi-plugin/tests/jsonSchemaToTypebox.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { jsonSchemaToTypebox, jsonSchemaTypeToTypebox } from "../src/extension.js";
+import { jsonSchemaToTypebox, jsonSchemaTypeToTypebox, parseRunIdArg } from "../src/extension.js";
 
 describe("jsonSchemaToTypebox", () => {
   test("maps object-typed params to a record instead of coercing to string (#223)", () => {
@@ -43,6 +43,14 @@ describe("jsonSchemaToTypebox", () => {
 
     expect(result.rows.type).toBe("array");
     expect(result.rows.items.type).toBe("object");
+  });
+});
+
+describe("parseRunIdArg", () => {
+  test("extracts run ids from malformed slash command args", () => {
+    expect(parseRunIdArg("thers run-1780959222920")).toBe("run-1780959222920");
+    expect(parseRunIdArg("run-abc_123-extra")).toBe("run-abc_123-extra");
+    expect(parseRunIdArg("plain-value")).toBe("plain-value");
   });
 });
 


### PR DESCRIPTION
## Summary

- harden the Pi run inspector against missing theme args, stale session contexts, repeated actions, and disconnected/error stores
- make `/smithers-runs` discover real Smithers runs through the semantic `list_runs` tool instead of only in-memory tracked runs
- add gateway-unavailable CLI fallbacks for devtools snapshots and approve/deny/cancel mutations
- preserve pending approval request/decision metadata in `listAllPendingApprovals` so semantic `list_pending_approvals` can show approval context

## Validation

- `bun test packages/db/tests/db-adapter.test.js apps/cli/tests/semantic-tools-unit.test.js packages/pi-plugin/tests`
- `bun run --cwd packages/pi-plugin typecheck`
- `bunx oxlint --react-plugin --node-plugin --import-plugin -A react/no-children-prop -A unicorn/no-thenable packages/pi-plugin/src packages/pi-plugin/tests packages/db/src/adapter.js packages/db/tests/db-adapter.test.js apps/cli/tests/semantic-tools-unit.test.js`

Closes #224.
Closes #225.
Helps #226.
References #223.