### PR TITLE
🐛 fix(pi-plugin): avoid blocking session reload on MCP startup

### DIFF
--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -53,6 +53,8 @@ let smithersDocs: string | undefined;
 let mcpClient: Client | undefined;
 let mcpTransport: StdioClientTransport | undefined;
 let smithersToolContract: SmithersAgentContract | undefined;
+let mcpToolsRegistered = false;
+let mcpToolsRegistration: Promise<void> | undefined;
 let pollInterval: ReturnType<typeof setInterval> | undefined;
 let activeRunId: string | undefined;
 
@@ -295,6 +297,19 @@ async function openInspector(ctx: ExtensionContext, run: TrackedRun) {
 }
 
 async function registerMcpTools(pi: ExtensionAPI, ctx: ExtensionContext) {
+  if (mcpToolsRegistered) {
+    return;
+  }
+  if (mcpToolsRegistration) {
+    return mcpToolsRegistration;
+  }
+  mcpToolsRegistration = registerMcpToolsInner(pi, ctx).finally(() => {
+    mcpToolsRegistration = undefined;
+  });
+  return mcpToolsRegistration;
+}
+
+async function registerMcpToolsInner(pi: ExtensionAPI, ctx: ExtensionContext) {
   try {
     const client = await ensureMcpClient();
     const { tools } = await client.listTools();
@@ -349,6 +364,7 @@ async function registerMcpTools(pi: ExtensionAPI, ctx: ExtensionContext) {
         },
       });
     }
+    mcpToolsRegistered = true;
   } catch (error) {
     ctx.ui.notify(`Smithers MCP: ${error instanceof Error ? error.message : String(error)}`, "warning");
   }
@@ -386,7 +402,7 @@ export function extension(pi: ExtensionAPI) {
         }
       }
     }, 5_000);
-    await registerMcpTools(pi, ctx);
+    void registerMcpTools(pi, ctx);
     updateStatusBar(ctx);
   });
 
@@ -398,12 +414,6 @@ export function extension(pi: ExtensionAPI) {
       run.store.disconnect();
     }
     runs.clear();
-    if (mcpTransport) {
-      await mcpTransport.close().catch(() => undefined);
-    }
-    mcpTransport = undefined;
-    mcpClient = undefined;
-    smithersToolContract = undefined;
   });
 
   pi.on("before_agent_start", async (event: { systemPrompt: string }) => {


### PR DESCRIPTION
## Summary
- register Smithers MCP tools in the background during Pi session startup
- dedupe in-flight MCP tool registration so reloads do not spawn duplicate registration work
- keep the MCP client alive across Pi session shutdown so reloads do not pay close/reconnect latency

## Validation
- bun test packages/pi-plugin/tests
- bun run --cwd packages/pi-plugin typecheck
- bunx oxlint --react-plugin --node-plugin --import-plugin -A react/no-children-prop -A unicorn/no-thenable packages/pi-plugin/src/extension.ts

## Notes
Pi supports runtime tool registration after startup; docs/extensions.md says pi.registerTool() refreshes tools immediately in the same session without /reload. This keeps session reload responsive while Smithers tools appear once MCP registration completes.