### PR TITLE
🐛 fix(pi-plugin): guard inspector render theme

### DIFF
--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -293,6 +293,7 @@ async function openInspector(ctx: ExtensionContext, run: TrackedRun) {
   await ctx.ui.custom((_tui: unknown, theme: unknown, _kb: unknown, done: () => void) =>
     new RunInspector(run.store, run.client, {
       workflowName: run.workflowName,
+      theme: theme as { fg?: (color: string, value: string) => string; bold?: (value: string) => string },
       onClose: done,
       onNotify: (message, level) => ctx.ui.notify(message, level),
     }),

--- a/packages/pi-plugin/src/views/FrameScrubber.ts
+++ b/packages/pi-plugin/src/views/FrameScrubber.ts
@@ -6,8 +6,8 @@ type Theme = {
   bold?: (value: string) => string;
 };
 
-function paint(theme: Theme, color: string, value: string) {
-  return theme.fg ? theme.fg(color, value) : value;
+function paint(theme: Theme | undefined, color: string, value: string) {
+  return theme?.fg ? theme.fg(color, value) : value;
 }
 
 export class FrameScrubber {

--- a/packages/pi-plugin/src/views/Header.ts
+++ b/packages/pi-plugin/src/views/Header.ts
@@ -6,12 +6,12 @@ type Theme = {
   bold?: (value: string) => string;
 };
 
-function paint(theme: Theme, color: string, value: string) {
-  return theme.fg ? theme.fg(color, value) : value;
+function paint(theme: Theme | undefined, color: string, value: string) {
+  return theme?.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
-  return theme.bold ? theme.bold(value) : value;
+function bold(theme: Theme | undefined, value: string) {
+  return theme?.bold ? theme.bold(value) : value;
 }
 
 function stateColor(status: string) {

--- a/packages/pi-plugin/src/views/NodeInspector.ts
+++ b/packages/pi-plugin/src/views/NodeInspector.ts
@@ -9,12 +9,12 @@ type Theme = {
 
 type InspectorTab = "output" | "diff" | "logs";
 
-function paint(theme: Theme, color: string, value: string) {
-  return theme.fg ? theme.fg(color, value) : value;
+function paint(theme: Theme | undefined, color: string, value: string) {
+  return theme?.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
-  return theme.bold ? theme.bold(value) : value;
+function bold(theme: Theme | undefined, value: string) {
+  return theme?.bold ? theme.bold(value) : value;
 }
 
 function compact(value: unknown) {

--- a/packages/pi-plugin/src/views/RunInspector.ts
+++ b/packages/pi-plugin/src/views/RunInspector.ts
@@ -15,12 +15,13 @@ type FocusPane = "tree" | "inspector" | "scrubber";
 
 type RunInspectorOptions = {
   workflowName?: string;
+  theme?: Theme;
   onClose?: () => void;
   onNotify?: (message: string, level?: "info" | "warning" | "error") => void;
 };
 
-function paint(theme: Theme, color: string, value: string) {
-  return theme.fg ? theme.fg(color, value) : value;
+function paint(theme: Theme | undefined, color: string, value: string) {
+  return theme?.fg ? theme.fg(color, value) : value;
 }
 
 function stripAnsi(value: string) {
@@ -44,6 +45,7 @@ export class RunInspector {
   private readonly onClose: () => void;
   private readonly onNotify: (message: string, level?: "info" | "warning" | "error") => void;
   private focus: FocusPane = "tree";
+  private readonly theme: Theme;
   private cachedLines: string[] | undefined;
   private cachedWidth = 0;
 
@@ -56,6 +58,7 @@ export class RunInspector {
     this.scrubber = new FrameScrubber(store);
     this.tree = new RunTree(store);
     this.inspector = new NodeInspector(store);
+    this.theme = options.theme ?? {};
     this.onClose = options.onClose ?? (() => undefined);
     this.onNotify = options.onNotify ?? (() => undefined);
     store.subscribe(() => this.invalidate());
@@ -114,7 +117,7 @@ export class RunInspector {
     }
   }
 
-  render(width: number, height = 34, theme: Theme) {
+  render(width: number, height = 34, theme: Theme = this.theme) {
     if (this.cachedLines && this.cachedWidth === width) {
       return this.cachedLines;
     }

--- a/packages/pi-plugin/src/views/RunTree.ts
+++ b/packages/pi-plugin/src/views/RunTree.ts
@@ -12,12 +12,12 @@ type TreeRow = {
   depth: number;
 };
 
-function paint(theme: Theme, color: string, value: string) {
-  return theme.fg ? theme.fg(color, value) : value;
+function paint(theme: Theme | undefined, color: string, value: string) {
+  return theme?.fg ? theme.fg(color, value) : value;
 }
 
-function bold(theme: Theme, value: string) {
-  return theme.bold ? theme.bold(value) : value;
+function bold(theme: Theme | undefined, value: string) {
+  return theme?.bold ? theme.bold(value) : value;
 }
 
 function stateOf(node: DevToolsNode) {

--- a/packages/pi-plugin/tests/DevToolsStore.test.ts
+++ b/packages/pi-plugin/tests/DevToolsStore.test.ts
@@ -153,10 +153,7 @@ describe("DevToolsClient integration", () => {
     await waitFor(() => store.seq === 1);
 
     const inspector = new RunInspector(store, client, { workflowName: "fixture" });
-    const lines = inspector.render(100, 20, {
-      fg: (_color, value) => value,
-      bold: (value) => value,
-    }).join("\n");
+    const lines = inspector.render(100).join("\n");
 
     expect(lines).toContain("task:a");
     expect(lines).toContain("finished");


### PR DESCRIPTION
## Summary
- capture the Pi `ctx.ui.custom(...)` theme when constructing the Smithers run inspector
- default inspector renders to that captured theme, or a no-op theme when Pi calls `render(width)` without a theme argument
- make view paint helpers tolerate an absent theme so `/smithers` does not crash on render

Fixes #225.

## Validation
- bun test packages/pi-plugin/tests
- bun run --cwd packages/pi-plugin typecheck
- bunx oxlint --react-plugin --node-plugin --import-plugin -A react/no-children-prop -A unicorn/no-thenable packages/pi-plugin/src/extension.ts packages/pi-plugin/src/views packages/pi-plugin/tests/DevToolsStore.test.ts
