### PR TITLE
🐛 fix: Approval request metadata should be inspectable through semantic tools

### DIFF
--- a/apps/cli/src/EnrichedNodeDetail.ts
+++ b/apps/cli/src/EnrichedNodeDetail.ts
@@ -53,6 +53,19 @@ export type EnrichedNodeDetail = {
         source: "cache" | "output-table" | "none";
         cacheKey: string | null;
     };
+    approval: {
+        runId: string;
+        nodeId: string;
+        iteration: number;
+        status: string;
+        requestedAtMs: number | null;
+        decidedAtMs: number | null;
+        note: string | null;
+        decidedBy: string | null;
+        request: unknown | null;
+        decision: unknown | null;
+        autoApproved: boolean;
+    } | null;
     limits: {
         toolPayloadBytesHuman: number;
         validatedOutputBytesHuman: number;

--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -151,6 +151,7 @@ const nodeDetailSchema = z.object({
         source: z.enum(["cache", "output-table", "none"]),
         cacheKey: z.string().nullable(),
     }),
+    approval: pendingApprovalSchema.nullable().optional(),
     limits: z.object({
         toolPayloadBytesHuman: z.number().int(),
         validatedOutputBytesHuman: z.number().int(),
@@ -752,6 +753,41 @@ function parsePendingApproval(row) {
     };
 }
 /**
+ * @param {SmithersDb} adapter
+ * @param {any} event
+ */
+async function parseEventWithApprovalRequest(adapter, event) {
+    const payload = parseJsonValue(event.payloadJson);
+    if ((event.type !== "ApprovalRequested" && event.type !== "NodeWaitingApproval") ||
+        !payload ||
+        typeof payload !== "object" ||
+        payload.request != null) {
+        return payload;
+    }
+    const eventPayload = payload;
+    const nodeId = typeof eventPayload.nodeId === "string"
+        ? eventPayload.nodeId
+        : typeof event.nodeId === "string"
+            ? event.nodeId
+            : null;
+    const iteration = typeof eventPayload.iteration === "number"
+        ? eventPayload.iteration
+        : typeof event.iteration === "number"
+            ? event.iteration
+            : null;
+    if (!nodeId || iteration == null) {
+        return payload;
+    }
+    const approval = await runPromise(adapter.getApproval(event.runId, nodeId, iteration));
+    if (!approval) {
+        return payload;
+    }
+    return {
+        ...eventPayload,
+        request: parseJsonValue(approval.requestJson),
+    };
+}
+/**
  * @param {any[]} approvals
  * @param {{ runId?: string; workflowName?: string; nodeId?: string; iteration?: number; }} filters
  */
@@ -1324,13 +1360,13 @@ export function createSemanticToolDefinitions(options = {}) {
                 });
                 return {
                     runId: input.runId,
-                    events: events.map((event) => ({
+                    events: await Promise.all(events.map(async (event) => ({
                         runId: event.runId,
                         seq: event.seq,
                         timestampMs: event.timestampMs,
                         type: event.type,
-                        payload: parseJsonValue(event.payloadJson),
-                    })),
+                        payload: await parseEventWithApprovalRequest(adapter, event),
+                    }))),
                 };
             })),
         },

--- a/apps/cli/src/node-detail.js
+++ b/apps/cli/src/node-detail.js
@@ -444,6 +444,7 @@ export function aggregateNodeDetailEffect(adapter, params) {
                 ? adapter.listCacheByNodeEffect(params.nodeId, node.outputTable, 20)
                 : Effect.succeed([]),
         ]);
+        const approvalRow = yield* adapter.getApproval(params.runId, params.nodeId, resolvedIteration);
         const attemptsDesc = attemptRows;
         const attempts = [...attemptsDesc].sort((left, right) => left.attempt - right.attempt);
         const toolCallsRaw = toolCallRows;
@@ -574,6 +575,21 @@ export function aggregateNodeDetailEffect(adapter, params) {
                 source: validatedOutput.source,
                 cacheKey: validatedOutput.cacheKey,
             },
+            approval: approvalRow
+                ? {
+                    runId: approvalRow.runId,
+                    nodeId: approvalRow.nodeId,
+                    iteration: approvalRow.iteration ?? 0,
+                    status: approvalRow.status,
+                    requestedAtMs: approvalRow.requestedAtMs ?? null,
+                    decidedAtMs: approvalRow.decidedAtMs ?? null,
+                    note: approvalRow.note ?? null,
+                    decidedBy: approvalRow.decidedBy ?? null,
+                    request: parseJsonValue(approvalRow.requestJson),
+                    decision: parseJsonValue(approvalRow.decisionJson),
+                    autoApproved: Boolean(approvalRow.autoApproved),
+                }
+                : null,
             limits: {
                 toolPayloadBytesHuman: MAX_TOOL_PAYLOAD_BYTES_HUMAN,
                 validatedOutputBytesHuman: MAX_VALIDATED_OUTPUT_BYTES_HUMAN,

--- a/apps/cli/tests/node-detail-unit.test.js
+++ b/apps/cli/tests/node-detail-unit.test.js
@@ -109,6 +109,7 @@ function makeAdapter(state = {}) {
         listScorerResultsEffect: () => Effect.succeed(data.scorers),
         getRawNodeOutputForIterationEffect: () => Effect.succeed(data.rawOutput),
         listCacheByNodeEffect: () => Effect.succeed(data.cacheRows),
+        getApproval: () => Effect.succeed(data.approval),
     };
 }
 

--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -215,6 +215,15 @@ function makeSemanticAdapter(overrides = {}) {
         historyEvents: [
             eventRow({ seq: 10, type: "RunStarted", payloadJson: JSON.stringify({ ok: true }) }),
             eventRow({ seq: 11, type: "RawPayload", payloadJson: "not json" }),
+            eventRow({
+                seq: 12,
+                type: "ApprovalRequested",
+                payloadJson: JSON.stringify({
+                    runId: "run-1",
+                    nodeId: "gate",
+                    iteration: 0,
+                }),
+            }),
         ],
         latestChildByRunId: new Map([
             ["run-1", { runId: "child-run" }],
@@ -248,6 +257,9 @@ function makeSemanticAdapter(overrides = {}) {
         listRunAncestry: async () => [baseRun, runRow({ runId: "parent-run", workflowName: "parent" })],
         getLatestChildRun: async (runId) => state.latestChildByRunId.get(runId),
         listAllPendingApprovals: async () => state.approvals,
+        getApproval: (runId, nodeId, iteration) => Effect.succeed(state.approvals.find((approval) => approval.runId === runId &&
+            approval.nodeId === nodeId &&
+            (approval.iteration ?? 0) === iteration)),
         listNodeIterationsEffect: (_runId, nodeId) => Effect.succeed(state.nodes.filter((node) => node.nodeId === nodeId)),
         listAttemptsEffect: (_runId, nodeId, iteration = 0) => Effect.succeed(state.attempts
             .filter((attempt) => attempt.nodeId === nodeId && (attempt.iteration ?? 0) === iteration)),
@@ -472,6 +484,16 @@ describe("semantic tool definitions", () => {
             runId: "run-1",
             nodeId: "gate",
             workflowName: "demo",
+            request: { question: "ship?" },
+        });
+        const gateNode = await harness.call("get_node_detail", {
+            runId: "run-1",
+            nodeId: "gate",
+        });
+        expect(gateNode.structuredContent.data.detail.approval).toMatchObject({
+            runId: "run-1",
+            nodeId: "gate",
+            request: { question: "ship?" },
         });
         const node = await harness.call("get_node_detail", {
             runId: "run-1",
@@ -551,6 +573,12 @@ describe("semantic tool definitions", () => {
         expect(events.structuredContent.data.events.map((event) => event.payload)).toEqual([
             { ok: true },
             "not json",
+            {
+                runId: "run-1",
+                nodeId: "gate",
+                iteration: 0,
+                request: { question: "ship?" },
+            },
         ]);
 
         expect(harness.state.cleanupCalls).toBeGreaterThanOrEqual(8);

--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -2134,8 +2134,12 @@ export class SmithersDb {
            a.iteration,
            a.status,
            a.requested_at_ms,
+           a.decided_at_ms,
            a.note,
            a.decided_by,
+           a.request_json,
+           a.decision_json,
+           a.auto_approved,
            r.workflow_name,
            r.status AS run_status,
            n.label AS node_label
@@ -2146,7 +2150,7 @@ export class SmithersDb {
           AND a.node_id = n.node_id
           AND a.iteration = n.iteration
          WHERE a.status = ?
-         ORDER BY COALESCE(a.requested_at_ms, 0) ASC, a.run_id, a.node_id, a.iteration`, ["requested"]));
+         ORDER BY COALESCE(a.requested_at_ms, 0) ASC, a.run_id, a.node_id, a.iteration`, ["requested"], { booleanColumns: ["autoApproved"] }));
     }
     /**
    * @param {string} workflowName

--- a/packages/engine/src/effect/deferred-state-bridge.js
+++ b/packages/engine/src/effect/deferred-state-bridge.js
@@ -1159,6 +1159,7 @@ async function resolveApprovalTaskStateBridge(adapter, db, runId, desc, eventBus
                 runId,
                 nodeId: desc.nodeId,
                 iteration: desc.iteration,
+                request: JSON.parse(requestJson),
                 timestampMs: requestedAtMs,
             }));
             await Effect.runPromise(eventBus.emitEventWithPersist({
@@ -1166,6 +1167,7 @@ async function resolveApprovalTaskStateBridge(adapter, db, runId, desc, eventBus
                 runId,
                 nodeId: desc.nodeId,
                 iteration: desc.iteration,
+                request: JSON.parse(requestJson),
                 timestampMs: requestedAtMs,
             }));
             await ensurePendingHumanRequest(adapter, runId, desc, requestedAtMs);


### PR DESCRIPTION
Closes #226

Fixed approval metadata exposure across semantic inspection paths. packages/db/src/adapter.js now includes request/decision metadata when listing all pending approvals, so list_pending_approvals returns the same request payload as get_run. apps/cli/src/node-detail.js and apps/cli/src/EnrichedNodeDetail.ts now expose an approval object for approval nodes, and apps/cli/src/mcp/semantic-tools.js includes that field plus hydrates approval event payloads with stored request metadata for existing events. packages/engine/src/effect/deferred-state-bridge.js now persists request metadata directly on new ApprovalRequested and NodeWaitingApproval events. Focused unit tests were updated in apps/cli/tests/semantic-tools-unit.test.js and apps/cli/tests/node-detail-unit.test.js.

---
🤖 Investigated, implemented, and reviewed by Codex (gpt-5.x) inside an isolated worktree via the Smithers `close-issues` workflow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>