### PR TITLE
🐛 fix: @smithers-orchestrator/pi-plugin inspector crashes on /smithers in Pi 0.78.1: render() expects theme arg but Pi 

### DIFF
--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -290,9 +290,10 @@ async function openInspector(ctx: ExtensionContext, run: TrackedRun) {
     ctx.ui.notify("/smithers requires interactive mode", "error");
     return;
   }
-  await ctx.ui.custom((_tui: unknown, theme: unknown, _kb: unknown, done: () => void) =>
+  await ctx.ui.custom((_tui: unknown, theme: any, _kb: unknown, done: () => void) =>
     new RunInspector(run.store, run.client, {
       workflowName: run.workflowName,
+      theme,
       onClose: done,
       onNotify: (message, level) => ctx.ui.notify(message, level),
     }),

--- a/packages/pi-plugin/src/index.d.ts
+++ b/packages/pi-plugin/src/index.d.ts
@@ -382,6 +382,7 @@ type Theme$1 = {
 };
 type RunInspectorOptions = {
     workflowName?: string;
+    theme?: Theme$1;
     onClose?: () => void;
     onNotify?: (message: string, level?: "info" | "warning" | "error") => void;
 };
@@ -392,6 +393,7 @@ declare class RunInspector {
     private readonly scrubber;
     private readonly tree;
     private readonly inspector;
+    private readonly theme;
     private readonly onClose;
     private readonly onNotify;
     private focus;
@@ -399,7 +401,7 @@ declare class RunInspector {
     private cachedWidth;
     constructor(store: DevToolsStore, client: DevToolsClient, options?: RunInspectorOptions);
     handleInput(data: string): void;
-    render(width: number, height: number | undefined, theme: Theme$1): string[];
+    render(width: number, height?: number, theme?: Theme$1): string[];
     invalidate(): void;
     dispose(): void;
     private cycleFocus;

--- a/packages/pi-plugin/src/views/RunInspector.ts
+++ b/packages/pi-plugin/src/views/RunInspector.ts
@@ -15,6 +15,7 @@ type FocusPane = "tree" | "inspector" | "scrubber";
 
 type RunInspectorOptions = {
   workflowName?: string;
+  theme?: Theme;
   onClose?: () => void;
   onNotify?: (message: string, level?: "info" | "warning" | "error") => void;
 };
@@ -41,6 +42,7 @@ export class RunInspector {
   private readonly scrubber: FrameScrubber;
   private readonly tree: RunTree;
   private readonly inspector: NodeInspector;
+  private readonly theme: Theme;
   private readonly onClose: () => void;
   private readonly onNotify: (message: string, level?: "info" | "warning" | "error") => void;
   private focus: FocusPane = "tree";
@@ -56,6 +58,7 @@ export class RunInspector {
     this.scrubber = new FrameScrubber(store);
     this.tree = new RunTree(store);
     this.inspector = new NodeInspector(store);
+    this.theme = options.theme ?? {};
     this.onClose = options.onClose ?? (() => undefined);
     this.onNotify = options.onNotify ?? (() => undefined);
     store.subscribe(() => this.invalidate());
@@ -114,7 +117,7 @@ export class RunInspector {
     }
   }
 
-  render(width: number, height = 34, theme: Theme) {
+  render(width: number, height = 34, theme: Theme = this.theme) {
     if (this.cachedLines && this.cachedWidth === width) {
       return this.cachedLines;
     }

--- a/packages/pi-plugin/tests/DevToolsStore.test.ts
+++ b/packages/pi-plugin/tests/DevToolsStore.test.ts
@@ -100,6 +100,25 @@ describe("DevToolsStore", () => {
     expect(store.selectedNode?.props.output).toBe("last value");
     expect(store.selectedGhostRecord?.unmountedFrameNo).toBe(1);
   });
+
+  test("RunInspector render matches Pi TUI width-only component calls", () => {
+    const store = new DevToolsStore({ ghostNodeCap: 8 });
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot(1, [task(2, "task:a", "running")]) });
+    const client = new DevToolsClient({ baseUrl: "http://127.0.0.1:1" });
+    const inspector = new RunInspector(store, client, {
+      workflowName: "fixture",
+      theme: {
+        fg: (_color, value) => value,
+        bold: (value) => value,
+      },
+    });
+
+    const lines = inspector.render(80).join("\n");
+
+    expect(lines).toContain("task:a");
+    expect(lines).toContain("RUNNING");
+    store.disconnect();
+  });
 });
 
 describe("DevToolsClient integration", () => {


### PR DESCRIPTION
Closes #225

Fixed the Pi inspector theme crash by storing the theme supplied by ctx.ui.custom(...) on RunInspector and using it as the default when Pi TUI calls render(width). Also updated the generated declaration file and added a focused test covering width-only render calls.

---
🤖 Investigated, implemented, and reviewed by Codex (gpt-5.x) inside an isolated worktree via the Smithers `close-issues` workflow.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>