### PR TITLE
🐛 fix: MCP artifact serialization should preserve boolean values

### DIFF
--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -11,6 +11,7 @@
 // @smithers-type-exports-end
 
 import { getTableName } from "drizzle-orm";
+import { getTableColumns } from "drizzle-orm/utils";
 import { Effect, Exit, FiberId, Metric } from "effect";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { getSqlMessageStorage } from "./sql-message-storage.js";
@@ -25,6 +26,7 @@ import { camelToSnake } from "./utils/camelToSnake.js";
 /** @typedef {import("./adapter/AlertStatus.ts").AlertStatus} AlertStatus */
 /** @typedef {import("./adapter/AttemptRow.ts").AttemptRow} AttemptRow */
 /** @typedef {import("drizzle-orm/bun-sqlite").BunSQLiteDatabase} BunSQLiteDatabase */
+/** @typedef {import("drizzle-orm").Table} Table */
 /** @typedef {import("./adapter/EventHistoryQuery.ts").EventHistoryQuery} EventHistoryQuery */
 /** @typedef {import("./adapter/HumanRequestRow.ts").HumanRequestRow} HumanRequestRow */
 /** @typedef {import("./output/OutputKey.ts").OutputKey} OutputKey */
@@ -425,6 +427,85 @@ function resolveOutputTableName(table) {
     }
     catch {
         return "output";
+    }
+}
+/**
+ * @param {unknown} db
+ * @param {string} tableName
+ * @returns {unknown | null}
+ */
+function findDrizzleTableByName(db, tableName) {
+    const schema = /** @type {{ _?: { fullSchema?: Record<string, unknown> } }} */ (db)?._?.fullSchema;
+    if (!schema) return null;
+    for (const table of Object.values(schema)) {
+        try {
+            if (getTableName(/** @type {Table} */ (table)) === tableName) return table;
+        }
+        catch {
+            // Ignore non-table schema entries.
+        }
+    }
+    return null;
+}
+/**
+ * @param {unknown} table
+ * @returns {string[]}
+ */
+function getPhysicalBooleanColumnNames(table) {
+    try {
+        const cols = getTableColumns(/** @type {Table} */ (table));
+        const names = [];
+        for (const col of Object.values(cols)) {
+            const c = /** @type {Record<string, unknown> & { config?: { mode?: string }; mapFromDriverValue?: unknown; name?: unknown }} */ (/** @type {unknown} */ (col));
+            const mapFn = /** @type {{ toString?: () => string } | undefined} */ (c?.mapFromDriverValue);
+            if (c?.columnType === "SQLiteBoolean" ||
+                c?.config?.mode === "boolean" ||
+                c?.mode === "boolean" ||
+                c?.dataType === "boolean" ||
+                mapFn?.toString?.().includes("Boolean")) {
+                const name = typeof c.name === "string" ? c.name : null;
+                if (name) names.push(name);
+            }
+        }
+        return names;
+    }
+    catch {
+        return [];
+    }
+}
+/**
+ * @param {Record<string, unknown> | null | undefined} row
+ * @param {readonly string[]} columnNames
+ * @returns {Record<string, unknown> | null | undefined}
+ */
+function coerceRawBooleanColumns(row, columnNames) {
+    if (!row || columnNames.length === 0) return row;
+    const next = { ...row };
+    for (const columnName of columnNames) {
+        const value = next[columnName];
+        if (columnName in next && typeof value !== "boolean") {
+            if (value === 0 || value === 0n || value === "0") next[columnName] = false;
+            else if (value === 1 || value === 1n || value === "1") next[columnName] = true;
+        }
+    }
+    return next;
+}
+/**
+ * @param {unknown} client
+ * @param {string} tableName
+ * @returns {string[]}
+ */
+function getPersistedBooleanColumnNames(client, tableName) {
+    try {
+        const rows = /** @type {{ query: (sql: string) => { all: (...args: unknown[]) => Array<Record<string, unknown>> } }} */ (client)
+            .query(`SELECT column_name FROM _smithers_output_schema_columns WHERE table_name = ? AND kind = 'boolean'`)
+            .all(tableName);
+        return rows
+            .map((row) => row.column_name)
+            .filter((name) => typeof name === "string");
+    }
+    catch {
+        return [];
     }
 }
 /**
@@ -1191,14 +1272,19 @@ export class SmithersDb {
         return runnableEffect(this.read(`get raw node output ${tableName}`, () => {
             const escaped = tableName.replaceAll(`"`, `""`);
             if (this.internalStorage.dialect === POSTGRES) {
+                const boolColumns = getPhysicalBooleanColumnNames(findDrizzleTableByName(this.db, tableName));
                 return this.internalStorage
                     .queryOneRaw(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? ORDER BY iteration DESC LIMIT 1`, [runId, nodeId])
-                    .then((row) => row ?? null);
+                    .then((row) => coerceRawBooleanColumns(row ?? null, boolColumns) ?? null);
             }
             const client = this.db.session.client;
+            const boolColumns = [
+                ...getPersistedBooleanColumnNames(client, tableName),
+                ...getPhysicalBooleanColumnNames(findDrizzleTableByName(this.db, tableName)),
+            ];
             const stmt = client.query(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? ORDER BY iteration DESC LIMIT 1`);
             const row = stmt.get(runId, nodeId);
-            return Promise.resolve(row ?? null);
+            return Promise.resolve(coerceRawBooleanColumns(row ?? null, boolColumns) ?? null);
         }).pipe(Effect.catchAll(() => Effect.succeed(null))));
     }
     /**
@@ -1212,14 +1298,19 @@ export class SmithersDb {
         return runnableEffect(this.read(`get raw node output ${tableName} iteration ${iteration}`, () => {
             const escaped = tableName.replaceAll(`"`, `""`);
             if (this.internalStorage.dialect === POSTGRES) {
+                const boolColumns = getPhysicalBooleanColumnNames(findDrizzleTableByName(this.db, tableName));
                 return this.internalStorage
                     .queryOneRaw(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? AND iteration = ? LIMIT 1`, [runId, nodeId, iteration])
-                    .then((row) => row ?? null);
+                    .then((row) => coerceRawBooleanColumns(row ?? null, boolColumns) ?? null);
             }
             const client = this.db.session.client;
+            const boolColumns = [
+                ...getPersistedBooleanColumnNames(client, tableName),
+                ...getPhysicalBooleanColumnNames(findDrizzleTableByName(this.db, tableName)),
+            ];
             const stmt = client.query(`SELECT * FROM "${escaped}" WHERE run_id = ? AND node_id = ? AND iteration = ? LIMIT 1`);
             const row = stmt.get(runId, nodeId, iteration);
-            return Promise.resolve(row ?? null);
+            return Promise.resolve(coerceRawBooleanColumns(row ?? null, boolColumns) ?? null);
         }).pipe(Effect.catchAll(() => Effect.succeed(null))));
     }
     /**

--- a/packages/db/src/zodToCreateTableSQL.js
+++ b/packages/db/src/zodToCreateTableSQL.js
@@ -18,6 +18,21 @@ function sqliteTypeFor(zodFieldSchema) {
     }
     return "TEXT";
 }
+function sqliteKindFor(zodFieldSchema) {
+    const baseType = unwrapZodType(zodFieldSchema);
+    const baseTypeName = getZodBaseTypeName(baseType);
+    if (baseTypeName === "boolean")
+        return "boolean";
+    if (baseTypeName === "number" ||
+        baseTypeName === "int" ||
+        baseTypeName === "float")
+        return "number";
+    if (baseTypeName === "string" ||
+        baseTypeName === "enum" ||
+        baseTypeName === "literal")
+        return "string";
+    return "json";
+}
 function quoteIdentifier(identifier) {
     return `"${String(identifier).replaceAll(`"`, `""`)}"`;
 }
@@ -29,7 +44,7 @@ export function zodSchemaColumns(schema) {
     const out = [];
     const shape = schema.shape;
     for (const [key] of Object.entries(shape)) {
-        out.push({ name: camelToSnake(key), sqliteType: sqliteTypeFor(shape[key]) });
+        out.push({ name: camelToSnake(key), sqliteType: sqliteTypeFor(shape[key]), kind: sqliteKindFor(shape[key]) });
     }
     return out;
 }
@@ -68,6 +83,18 @@ export function zodToCreateTableSQL(tableName, schema, opts) {
  */
 export function syncZodTableSchema(sqlite, tableName, schema, opts) {
     sqlite.run(zodToCreateTableSQL(tableName, schema, opts));
+    if (!opts?.isInput) {
+        try {
+            sqlite.run(`CREATE TABLE IF NOT EXISTS _smithers_output_schema_columns (table_name TEXT NOT NULL, column_name TEXT NOT NULL, kind TEXT NOT NULL, PRIMARY KEY (table_name, column_name))`);
+            const stmt = sqlite.query(`INSERT INTO _smithers_output_schema_columns (table_name, column_name, kind) VALUES (?, ?, ?) ON CONFLICT(table_name, column_name) DO UPDATE SET kind = excluded.kind`);
+            for (const { name, kind } of zodSchemaColumns(schema)) {
+                stmt.run(tableName, name, kind);
+            }
+        }
+        catch {
+            // Schema metadata is best-effort; table creation remains the source of truth.
+        }
+    }
     let existing;
     const quotedTable = quoteIdentifier(tableName);
     try {

--- a/packages/db/tests/db-getRawNodeOutput.test.js
+++ b/packages/db/tests/db-getRawNodeOutput.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { SmithersDb } from "../src/adapter.js";
 import { zodToTable } from "../src/zodToTable.js";
-import { zodToCreateTableSQL } from "../src/zodToCreateTableSQL.js";
+import { syncZodTableSchema } from "../src/zodToCreateTableSQL.js";
 import { z } from "zod";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -16,9 +16,9 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 function createDbWithOutputTable(tableName, schema) {
     const table = zodToTable(tableName, schema);
     const sqlite = new Database(":memory:");
-    sqlite.exec(zodToCreateTableSQL(tableName, schema));
+    syncZodTableSchema(sqlite, tableName, schema);
     const db = drizzle(sqlite, { schema: { [tableName]: table } });
-    return { adapter: new SmithersDb(db), table };
+    return { adapter: new SmithersDb(db), db, sqlite, table };
 }
 
 describe("getRawNodeOutput", () => {
@@ -73,5 +73,41 @@ describe("getRawNodeOutput", () => {
         expect(row).not.toBeNull();
         expect(row?.iteration).toBe(1);
         expect(row?.title).toBe("second");
+    });
+
+    test("preserves persisted boolean schema metadata without a live drizzle schema", async () => {
+        const tableName = "boolean_results";
+        const { db, sqlite, table } = createDbWithOutputTable(tableName, z.object({
+            approved: z.boolean(),
+            declined: z.boolean(),
+            reviewed: z.boolean().nullable(),
+            generatedAt: z.string(),
+            count: z.number(),
+        }));
+        const schemaAdapter = new SmithersDb(db);
+        await schemaAdapter.upsertOutputRow(table, { runId: "run-1", nodeId: "gate", iteration: 0 }, {
+            approved: false,
+            declined: true,
+            reviewed: null,
+            generatedAt: "2026-06-09T00:00:00.000Z",
+            count: 1,
+        });
+
+        const rawAdapter = new SmithersDb(drizzle(sqlite));
+        const row = await rawAdapter.getRawNodeOutputForIteration(tableName, "run-1", "gate", 0);
+
+        expect(row).toMatchObject({
+            run_id: "run-1",
+            node_id: "gate",
+            iteration: 0,
+            approved: false,
+            declined: true,
+            reviewed: null,
+            generated_at: "2026-06-09T00:00:00.000Z",
+            count: 1,
+        });
+        expect(typeof row?.approved).toBe("boolean");
+        expect(typeof row?.declined).toBe("boolean");
+        expect(row?.reviewed).toBeNull();
     });
 });


### PR DESCRIPTION
Closes #227

Raw node-output reads (`getRawNodeOutput` and the by-iteration variant) now rehydrate SQLite's integer boolean storage (`0`/`1`) back into real JSON booleans on the semantic/MCP artifact surfaces, using schema-derived boolean column names (a persisted `_smithers_output_schema_columns` registry plus Drizzle column introspection). Nullable/absent booleans are preserved exactly (`null` stays `null`, never becomes `false`), and non-boolean numeric columns are left untouched. Adds a regression test covering `true`/`false`/`null` and a numeric column.

---
🤖 Investigated, implemented, and reviewed by Codex (gpt-5.5) in an isolated worktree via the Smithers `close-issues` workflow; the nullable-fidelity refinement + Codex re-review were driven by Claude.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>