### PR TITLE
🐛 fix(cli): flush large command stdout synchronously so piped output isn't truncated

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -493,7 +493,9 @@ async function printSmithersDocs(c, file, errorCode) {
     if (wantsJson) {
         return c.ok({ url: source.url, content: body });
     }
-    process.stdout.write(body.endsWith("\n") ? body : `${body}\n`);
+    // Synchronous write: the docs bundle exceeds the OS pipe buffer (~64KB), so a
+    // plain async write would be truncated when the process exits. See writeStdoutSync.
+    writeStdoutSync(body.endsWith("\n") ? body : `${body}\n`);
     return c.ok(undefined);
 }
 /**
@@ -5950,6 +5952,31 @@ function rewriteChatCreateArgv(argv) {
         ...argv.slice(subcommandIndex + 1),
     ];
 }
+/**
+ * Write to stdout synchronously so large outputs are fully flushed before the
+ * process exits. incur writes command results via an async `process.stdout.write`
+ * and the framework then calls process.exit(); on a pipe the OS buffer is only
+ * ~64KB, so anything larger (e.g. `docs-full --json`, whose JSON payload exceeds
+ * 64KB) is truncated mid-write. A blocking writeSync — the same approach already
+ * used for the ask-human prompt on fd 2 — guarantees every byte lands first.
+ * Handles partial writes plus a backpressured (EAGAIN) or closed (EPIPE) pipe.
+ * @param {string} s
+ */
+function writeStdoutSync(s) {
+    const buf = Buffer.from(s, "utf8");
+    let offset = 0;
+    while (offset < buf.length) {
+        try {
+            offset += writeSync(1, buf, offset, buf.length - offset);
+        }
+        catch (err) {
+            const code = /** @type {NodeJS.ErrnoException} */ (err)?.code;
+            if (code === "EAGAIN") continue;
+            if (code === "EPIPE") return;
+            throw err;
+        }
+    }
+}
 async function main() {
     const rawArgv = process.argv.slice(2);
     let argv = rawArgv.map((arg) => (arg === "-v" ? "--version" : arg));
@@ -6012,6 +6039,9 @@ async function main() {
     let exitCodeFromServe;
     try {
         await cli.serve(argv, {
+            stdout(s) {
+                writeStdoutSync(s);
+            },
             exit(code) {
                 exitCodeFromServe = code;
             },


### PR DESCRIPTION
## Problem

`docs-full` and `docs-full --json` (and any command whose output exceeds the ~64KB OS pipe buffer) were **truncated** when piped. The CLI's framework (incur) writes results via an async `process.stdout.write` and then the process exits; on a pipe, anything past the buffer is dropped before it flushes. For `docs-full --json` (~374KB) this produced invalid, truncated JSON — `apps/cli/tests/docs-command.test.js` > `docs-full --json prints the packaged full docs` fails in CI with `JSON Parse error: Unterminated string`.

## Fix

Add `writeStdoutSync(s)` — a blocking `writeSync(1, ...)` with a partial-write loop, EAGAIN retry, and EPIPE swallow (mirroring the existing `writeSync(2, ...)` used for the ask-human prompt) — and route output through it:
- pass it as incur's `options.stdout` in `cli.serve(...)` (covers `--json`/structured output)
- use it for the direct `docs`/`docs-full` plain write

Every byte now lands before exit, so piped output is never truncated.

## Verification

- `docs-full` piped: 65679 → 374312 bytes (full)
- `docs-full --json` piped: 65536 (truncated) → 387573 bytes, valid JSON, full 374174-byte content
- `bun test apps/cli/tests/docs-command.test.js`: 11 pass / 0 fail
- Reviewed by Codex (gpt-5.5).

Note: this fixes one of the two long-standing red `test` checks on `main`; the unrelated `smithers init --global` CI-only failure is separate.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>