### PR TITLE
🔧 chore(cli): canonicalize Smithers MCP invocation

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -326,15 +326,16 @@ Most teams should start with the workflow pack. It gives you a working `.smither
 ## Always Run with `bunx`
 
 <Warning>
-  Every CLI invocation in these docs is `bunx smithers-orchestrator <command>`. Do **not**
-  install Smithers globally and do **not** use the bare `smithers` or `bunx smithers`
-  shorthand. The bare name `smithers` is a different npm package, so `bunx smithers` runs
+  Agents, MCP configs, and docs should use `bunx smithers-orchestrator <command>`.
+  Do **not** use `bunx smithers`: `smithers` is only the installed binary alias. On
+  npm, `smithers` is an unrelated package, so `bunx smithers` can download and run
   something else entirely.
 </Warning>
 
-- `bunx` resolves the package locally if your project depends on it, otherwise it pulls and runs the latest published version.
 - The published npm package is [`smithers-orchestrator`](https://www.npmjs.com/package/smithers-orchestrator).
-- A global install creates version-drift problems across machines, CI, and contributors. With `bunx`, every project pins Smithers through its own `package.json`.
+- `bunx smithers-orchestrator ...` works from any directory and uses the project-pinned dependency when one exists.
+- The package also installs a `smithers` binary alias. Use `smithers ...` only when the current environment intentionally provides that binary, such as a project script that resolves `node_modules/.bin/smithers`.
+- Avoid global installs: a global `smithers` on PATH can drift from the project version and shadow the project-pinned binary.
 
 If you previously ran `npm i -g smithers-orchestrator`, uninstall it (`npm rm -g smithers-orchestrator`) and switch to `bunx`.
 
@@ -7436,7 +7437,7 @@ Use the MCP server when an AI agent should drive Smithers autonomously. Use the 
 ### Start the server
 
 ```bash
-smithers --mcp
+bunx smithers-orchestrator --mcp
 ```
 
 This starts the semantic surface: a stable, structured tool set for AI agent consumption, documented on this page.
@@ -7445,13 +7446,13 @@ Two additional surfaces are available via `--surface`:
 
 ```bash
 # Semantic tools only (default)
-smithers --mcp --surface semantic
+bunx smithers-orchestrator --mcp --surface semantic
 
 # Raw CLI-mirroring tools only
-smithers --mcp --surface raw
+bunx smithers-orchestrator --mcp --surface raw
 
 # Both surfaces registered on the same server
-smithers --mcp --surface both
+bunx smithers-orchestrator --mcp --surface both
 ```
 
 Use `--surface raw` only for direct CLI parity. Prefer the semantic surface for new integrations: every tool returns a `{ ok, data, error }` envelope with Zod-validated input and output schemas.

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2661,6 +2661,7 @@ const cli = Cli.create({
     name: "smithers",
     description: "Durable AI workflow orchestrator. Run, monitor, and manage workflow executions.",
     version: readPackageVersion(),
+    mcp: { command: "bunx smithers-orchestrator --mcp" },
 })
     // =========================================================================
     // smithers init

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -8,15 +8,16 @@ Most teams should start with the workflow pack. It gives you a working `.smither
 ## Always Run with `bunx`
 
 <Warning>
-  Every CLI invocation in these docs is `bunx smithers-orchestrator <command>`. Do **not**
-  install Smithers globally and do **not** use the bare `smithers` or `bunx smithers`
-  shorthand. The bare name `smithers` is a different npm package, so `bunx smithers` runs
+  Agents, MCP configs, and docs should use `bunx smithers-orchestrator <command>`.
+  Do **not** use `bunx smithers`: `smithers` is only the installed binary alias. On
+  npm, `smithers` is an unrelated package, so `bunx smithers` can download and run
   something else entirely.
 </Warning>
 
-- `bunx` resolves the package locally if your project depends on it, otherwise it pulls and runs the latest published version.
 - The published npm package is [`smithers-orchestrator`](https://www.npmjs.com/package/smithers-orchestrator).
-- A global install creates version-drift problems across machines, CI, and contributors. With `bunx`, every project pins Smithers through its own `package.json`.
+- `bunx smithers-orchestrator ...` works from any directory and uses the project-pinned dependency when one exists.
+- The package also installs a `smithers` binary alias. Use `smithers ...` only when the current environment intentionally provides that binary, such as a project script that resolves `node_modules/.bin/smithers`.
+- Avoid global installs: a global `smithers` on PATH can drift from the project version and shadow the project-pinned binary.
 
 If you previously ran `npm i -g smithers-orchestrator`, uninstall it (`npm rm -g smithers-orchestrator`) and switch to `bunx`.
 

--- a/docs/integrations/mcp-server.mdx
+++ b/docs/integrations/mcp-server.mdx
@@ -14,7 +14,7 @@ Use the MCP server when an AI agent should drive Smithers autonomously. Use the 
 ### Start the server
 
 ```bash
-smithers --mcp
+bunx smithers-orchestrator --mcp
 ```
 
 This starts the semantic surface: a stable, structured tool set for AI agent consumption, documented on this page.
@@ -23,13 +23,13 @@ Two additional surfaces are available via `--surface`:
 
 ```bash
 # Semantic tools only (default)
-smithers --mcp --surface semantic
+bunx smithers-orchestrator --mcp --surface semantic
 
 # Raw CLI-mirroring tools only
-smithers --mcp --surface raw
+bunx smithers-orchestrator --mcp --surface raw
 
 # Both surfaces registered on the same server
-smithers --mcp --surface both
+bunx smithers-orchestrator --mcp --surface both
 ```
 
 Use `--surface raw` only for direct CLI parity. Prefer the semantic surface for new integrations: every tool returns a `{ ok, data, error }` envelope with Zod-validated input and output schemas.

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -303,15 +303,16 @@ Most teams should start with the workflow pack. It gives you a working `.smither
 ## Always Run with `bunx`
 
 <Warning>
-  Every CLI invocation in these docs is `bunx smithers-orchestrator <command>`. Do **not**
-  install Smithers globally and do **not** use the bare `smithers` or `bunx smithers`
-  shorthand. The bare name `smithers` is a different npm package, so `bunx smithers` runs
+  Agents, MCP configs, and docs should use `bunx smithers-orchestrator <command>`.
+  Do **not** use `bunx smithers`: `smithers` is only the installed binary alias. On
+  npm, `smithers` is an unrelated package, so `bunx smithers` can download and run
   something else entirely.
 </Warning>
 
-- `bunx` resolves the package locally if your project depends on it, otherwise it pulls and runs the latest published version.
 - The published npm package is [`smithers-orchestrator`](https://www.npmjs.com/package/smithers-orchestrator).
-- A global install creates version-drift problems across machines, CI, and contributors. With `bunx`, every project pins Smithers through its own `package.json`.
+- `bunx smithers-orchestrator ...` works from any directory and uses the project-pinned dependency when one exists.
+- The package also installs a `smithers` binary alias. Use `smithers ...` only when the current environment intentionally provides that binary, such as a project script that resolves `node_modules/.bin/smithers`.
+- Avoid global installs: a global `smithers` on PATH can drift from the project version and shadow the project-pinned binary.
 
 If you previously ran `npm i -g smithers-orchestrator`, uninstall it (`npm rm -g smithers-orchestrator`) and switch to `bunx`.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -326,15 +326,16 @@ Most teams should start with the workflow pack. It gives you a working `.smither
 ## Always Run with `bunx`
 
 <Warning>
-  Every CLI invocation in these docs is `bunx smithers-orchestrator <command>`. Do **not**
-  install Smithers globally and do **not** use the bare `smithers` or `bunx smithers`
-  shorthand. The bare name `smithers` is a different npm package, so `bunx smithers` runs
+  Agents, MCP configs, and docs should use `bunx smithers-orchestrator <command>`.
+  Do **not** use `bunx smithers`: `smithers` is only the installed binary alias. On
+  npm, `smithers` is an unrelated package, so `bunx smithers` can download and run
   something else entirely.
 </Warning>
 
-- `bunx` resolves the package locally if your project depends on it, otherwise it pulls and runs the latest published version.
 - The published npm package is [`smithers-orchestrator`](https://www.npmjs.com/package/smithers-orchestrator).
-- A global install creates version-drift problems across machines, CI, and contributors. With `bunx`, every project pins Smithers through its own `package.json`.
+- `bunx smithers-orchestrator ...` works from any directory and uses the project-pinned dependency when one exists.
+- The package also installs a `smithers` binary alias. Use `smithers ...` only when the current environment intentionally provides that binary, such as a project script that resolves `node_modules/.bin/smithers`.
+- Avoid global installs: a global `smithers` on PATH can drift from the project version and shadow the project-pinned binary.
 
 If you previously ran `npm i -g smithers-orchestrator`, uninstall it (`npm rm -g smithers-orchestrator`) and switch to `bunx`.
 
@@ -7436,7 +7437,7 @@ Use the MCP server when an AI agent should drive Smithers autonomously. Use the 
 ### Start the server
 
 ```bash
-smithers --mcp
+bunx smithers-orchestrator --mcp
 ```
 
 This starts the semantic surface: a stable, structured tool set for AI agent consumption, documented on this page.
@@ -7445,13 +7446,13 @@ Two additional surfaces are available via `--surface`:
 
 ```bash
 # Semantic tools only (default)
-smithers --mcp --surface semantic
+bunx smithers-orchestrator --mcp --surface semantic
 
 # Raw CLI-mirroring tools only
-smithers --mcp --surface raw
+bunx smithers-orchestrator --mcp --surface raw
 
 # Both surfaces registered on the same server
-smithers --mcp --surface both
+bunx smithers-orchestrator --mcp --surface both
 ```
 
 Use `--surface raw` only for direct CLI parity. Prefer the semantic surface for new integrations: every tool returns a `{ ok, data, error }` envelope with Zod-validated input and output schemas.

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -731,7 +731,7 @@ Use the MCP server when an AI agent should drive Smithers autonomously. Use the 
 ### Start the server
 
 ```bash
-smithers --mcp
+bunx smithers-orchestrator --mcp
 ```
 
 This starts the semantic surface: a stable, structured tool set for AI agent consumption, documented on this page.
@@ -740,13 +740,13 @@ Two additional surfaces are available via `--surface`:
 
 ```bash
 # Semantic tools only (default)
-smithers --mcp --surface semantic
+bunx smithers-orchestrator --mcp --surface semantic
 
 # Raw CLI-mirroring tools only
-smithers --mcp --surface raw
+bunx smithers-orchestrator --mcp --surface raw
 
 # Both surfaces registered on the same server
-smithers --mcp --surface both
+bunx smithers-orchestrator --mcp --surface both
 ```
 
 Use `--surface raw` only for direct CLI parity. Prefer the semantic surface for new integrations: every tool returns a `{ ok, data, error }` envelope with Zod-validated input and output schemas.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -326,15 +326,16 @@ Most teams should start with the workflow pack. It gives you a working `.smither
 ## Always Run with `bunx`
 
 <Warning>
-  Every CLI invocation in these docs is `bunx smithers-orchestrator <command>`. Do **not**
-  install Smithers globally and do **not** use the bare `smithers` or `bunx smithers`
-  shorthand. The bare name `smithers` is a different npm package, so `bunx smithers` runs
+  Agents, MCP configs, and docs should use `bunx smithers-orchestrator <command>`.
+  Do **not** use `bunx smithers`: `smithers` is only the installed binary alias. On
+  npm, `smithers` is an unrelated package, so `bunx smithers` can download and run
   something else entirely.
 </Warning>
 
-- `bunx` resolves the package locally if your project depends on it, otherwise it pulls and runs the latest published version.
 - The published npm package is [`smithers-orchestrator`](https://www.npmjs.com/package/smithers-orchestrator).
-- A global install creates version-drift problems across machines, CI, and contributors. With `bunx`, every project pins Smithers through its own `package.json`.
+- `bunx smithers-orchestrator ...` works from any directory and uses the project-pinned dependency when one exists.
+- The package also installs a `smithers` binary alias. Use `smithers ...` only when the current environment intentionally provides that binary, such as a project script that resolves `node_modules/.bin/smithers`.
+- Avoid global installs: a global `smithers` on PATH can drift from the project version and shadow the project-pinned binary.
 
 If you previously ran `npm i -g smithers-orchestrator`, uninstall it (`npm rm -g smithers-orchestrator`) and switch to `bunx`.
 
@@ -7436,7 +7437,7 @@ Use the MCP server when an AI agent should drive Smithers autonomously. Use the 
 ### Start the server
 
 ```bash
-smithers --mcp
+bunx smithers-orchestrator --mcp
 ```
 
 This starts the semantic surface: a stable, structured tool set for AI agent consumption, documented on this page.
@@ -7445,13 +7446,13 @@ Two additional surfaces are available via `--surface`:
 
 ```bash
 # Semantic tools only (default)
-smithers --mcp --surface semantic
+bunx smithers-orchestrator --mcp --surface semantic
 
 # Raw CLI-mirroring tools only
-smithers --mcp --surface raw
+bunx smithers-orchestrator --mcp --surface raw
 
 # Both surfaces registered on the same server
-smithers --mcp --surface both
+bunx smithers-orchestrator --mcp --surface both
 ```
 
 Use `--surface raw` only for direct CLI parity. Prefer the semantic surface for new integrations: every tool returns a `{ ok, data, error }` envelope with Zod-validated input and output schemas.


### PR DESCRIPTION
## What

Generated MCP configs emitted `bunx smithers --mcp`, but `smithers` is only the installed binary alias. The npm package is `smithers-orchestrator`, and `smithers` is an **unrelated** package on npm. So outside a project that already depends on Smithers, `bunx smithers --mcp` downloads and runs the wrong software, which is exactly the confusion several agent harnesses (Codex, etc.) hit when following the docs.

This PR makes every agent-facing invocation canonical:

- **`apps/cli/src/index.js`** — override the incur MCP registration command so `smithers mcp add` emits `bunx smithers-orchestrator --mcp`. incur's default specifier detection looks up the CLI name (`smithers`) in the host package's dependencies, doesn't find it (the dep key is `smithers-orchestrator`), and falls back to `bunx smithers --mcp`; the explicit `mcp.command` override fixes that for all supported agents while still letting a user's `--command` flag win.
- **`docs/installation.mdx`** — clarify that `smithers` is the installed binary alias for the `smithers-orchestrator` package, that `bunx smithers` can resolve to an unrelated npm package, and when bare `smithers` is legitimate.
- **`docs/integrations/mcp-server.mdx`** — replace `smithers --mcp` examples with `bunx smithers-orchestrator --mcp`.
- Regenerated `llms` doc mirrors (`bun scripts/generate-llms.ts && bun scripts/optimize-llms-full.ts`).

## Scope

Deliberately minimal. Generated CLI skills still emit `requires_bin: smithers` / `command: smithers ...`, which has the same PATH-precondition brittleness. That is tracked separately in smithersai/smithers#237 and is best solved by a first-class incur option separating CLI name from package-runner invocation prefix.

## Validation

- `node scripts/check-docs.mjs` — all docs use `bunx smithers-orchestrator`, no em-dashes, no hyphenated placeholders.
- `pnpm -C apps/cli typecheck`.
- Regenerating the `llms` mirrors produces no drift beyond this diff.

Refs smithersai/smithers#237