### PR TITLE
fix(cli): correct GATEWAY_UNREACHABLE recovery hint to real Gateway startup

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -5432,7 +5432,7 @@ const cli = Cli.create({
     // and opens <gateway><uiPath>?runId=<runId>.
     // =========================================================================
     .command("ui", {
-    description: "Open the custom UI for a workflow run in your browser.",
+    description: "Open the custom UI for a workflow run in your browser. Requires a running Gateway with a registered workflow UI (start one with `smithers up <workflow.tsx> --serve ...`).",
     args: z.object({
         runId: z.string().optional().describe("Run to open. Defaults to the most recent run."),
     }),
@@ -5449,7 +5449,7 @@ const cli = Cli.create({
         // The Gateway serves the UI and owns the uiPath mapping, so it must be up.
         const reachable = await fetch(`${base}/health`).then((r) => r.ok, () => false);
         if (!reachable) {
-            return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start one with \`smithers gateway\`, or pass --gateway <url>.`);
+            return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start one with \`smithers up <workflow.tsx> --serve ...\`, or pass --gateway <url> to point at a running Gateway.`);
         }
         const rpc = async (method, params = {}) => {
             const res = await fetch(`${base}/v1/rpc/${method}`, {

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -5432,7 +5432,7 @@ const cli = Cli.create({
     // and opens <gateway><uiPath>?runId=<runId>.
     // =========================================================================
     .command("ui", {
-    description: "Open the custom UI for a workflow run in your browser. Requires a running Gateway with a registered workflow UI (start one with `smithers up <workflow.tsx> --serve ...`).",
+    description: "Open the custom UI for a workflow run in your browser. Requires a running Gateway with registered workflow UIs — start one programmatically (`new Gateway().register(workflow, { ui }).listen(7331)`) or run `.smithers/gateway.ts` if it exists.",
     args: z.object({
         runId: z.string().optional().describe("Run to open. Defaults to the most recent run."),
     }),
@@ -5449,7 +5449,7 @@ const cli = Cli.create({
         // The Gateway serves the UI and owns the uiPath mapping, so it must be up.
         const reachable = await fetch(`${base}/health`).then((r) => r.ok, () => false);
         if (!reachable) {
-            return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start one with \`smithers up <workflow.tsx> --serve ...\`, or pass --gateway <url> to point at a running Gateway.`);
+            return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start a Gateway with registered workflow UIs (e.g. run \`.smithers/gateway.ts\` or see the Gateway docs), or pass --gateway <url> to point at a running one. Note: \`smithers up --serve\` starts a lightweight serve server, not a full Gateway.`);
         }
         const rpc = async (method, params = {}) => {
             const res = await fetch(`${base}/v1/rpc/${method}`, {


### PR DESCRIPTION
## Summary

- Fixes the `GATEWAY_UNREACHABLE` error message in `smithers ui` to point to a real Gateway startup path instead of the nonexistent `smithers gateway` command
- Updates `ui --help` description to clarify that `ui` requires a full Gateway (not `smithers up --serve`, which starts a lightweight serve server lacking `/v1/rpc/*` routes)
- Both the error hint and the command description now point to `.smithers/gateway.ts` or programmatic `new Gateway().register(workflow, { ui }).listen(7331)`

## Test plan

- [ ] Run `smithers ui` against a port with nothing listening → error now shows the real Gateway startup path
- [ ] Run `smithers ui --help` → description accurately describes the Gateway prerequisite
- [ ] Run `smithers up <workflow.tsx> --serve` then `smithers ui` → error clarifies that `--serve` is not a full Gateway

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)