### PR TITLE
fix(engine): treat post-commit bridge failure in approveNode as non-fatal

### DIFF
--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -1068,10 +1068,22 @@ export function createSemanticToolDefinitions(options = {}) {
                 }
                 const approval = matches[0];
                 if (input.action === "approve") {
-                    await Effect.runPromise(approveNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision));
+                    await Effect.runPromise(approveNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision)).catch((error) => {
+                        // Re-throw real failures (e.g. INVALID_INPUT from validateNodeWaitingForApproval).
+                        // Post-commit bridge errors are already swallowed in approveNode and will not
+                        // reach here — the durable approval state was committed before any bridge call.
+                        // If this catch fires, the approval was NOT committed and the run is still gated.
+                        throw error;
+                    });
                 }
                 else {
-                    await Effect.runPromise(denyNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision));
+                    await Effect.runPromise(denyNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision)).catch((error) => {
+                        // Re-throw real failures (e.g. INVALID_INPUT from validateNodeWaitingForApproval).
+                        // Post-commit bridge errors are already swallowed in denyNode and will not
+                        // reach here — the durable denial state was committed before any bridge call.
+                        // If this catch fires, the denial was NOT committed and the run is still gated.
+                        throw error;
+                    });
                 }
                 const run = await adapter.getRun(approval.runId);
                 return {

--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -1067,23 +1067,14 @@ export function createSemanticToolDefinitions(options = {}) {
                     });
                 }
                 const approval = matches[0];
+                // Post-commit bridge errors are already swallowed inside approveNode/denyNode
+                // (approvals.js) and will not propagate here. Any rejection that does reach
+                // this await is a real failure (e.g. INVALID_INPUT) and should propagate normally.
                 if (input.action === "approve") {
-                    await Effect.runPromise(approveNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision)).catch((error) => {
-                        // Re-throw real failures (e.g. INVALID_INPUT from validateNodeWaitingForApproval).
-                        // Post-commit bridge errors are already swallowed in approveNode and will not
-                        // reach here — the durable approval state was committed before any bridge call.
-                        // If this catch fires, the approval was NOT committed and the run is still gated.
-                        throw error;
-                    });
+                    await Effect.runPromise(approveNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision));
                 }
                 else {
-                    await Effect.runPromise(denyNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision)).catch((error) => {
-                        // Re-throw real failures (e.g. INVALID_INPUT from validateNodeWaitingForApproval).
-                        // Post-commit bridge errors are already swallowed in denyNode and will not
-                        // reach here — the durable denial state was committed before any bridge call.
-                        // If this catch fires, the denial was NOT committed and the run is still gated.
-                        throw error;
-                    });
+                    await Effect.runPromise(denyNode(adapter, approval.runId, approval.nodeId, approval.iteration ?? 0, input.note, input.decidedBy, input.decision));
                 }
                 const run = await adapter.getRun(approval.runId);
                 return {

--- a/packages/engine/src/approvals.js
+++ b/packages/engine/src/approvals.js
@@ -134,7 +134,7 @@ export function approveNode(adapter, runId, nodeId, iteration, note, decidedBy, 
                 // while the approval is already consumed — worse than the bridge
                 // being a no-op.
                 const message = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
-                Effect.runSync(Effect.logWarning(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`));
+                console.warn(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`);
             })
         );
     }).pipe(Effect.annotateLogs({
@@ -230,7 +230,7 @@ export function denyNode(adapter, runId, nodeId, iteration, note, decidedBy, dec
                 // while the denial is already consumed — worse than the bridge
                 // being a no-op.
                 const message = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
-                Effect.runSync(Effect.logWarning(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`));
+                console.warn(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`);
             })
         );
     }).pipe(Effect.annotateLogs({

--- a/packages/engine/src/approvals.js
+++ b/packages/engine/src/approvals.js
@@ -118,13 +118,25 @@ export function approveNode(adapter, runId, nodeId, iteration, note, decidedBy, 
         });
         yield* trackEvent(event);
         yield* Effect.logInfo(autoApproved ? "approval auto-approved" : "approval granted");
-        yield* Effect.promise(() => bridgeApprovalResolve(adapter, runId, nodeId, iteration, {
-            approved: true,
-            note: note ?? null,
-            decidedBy: decidedBy ?? null,
-            decisionJson: serializeDecision(decision),
-            autoApproved,
-        }));
+        yield* Effect.promise(() =>
+            bridgeApprovalResolve(adapter, runId, nodeId, iteration, {
+                approved: true,
+                note: note ?? null,
+                decidedBy: decidedBy ?? null,
+                decisionJson: serializeDecision(decision),
+                autoApproved,
+            }).catch((bridgeError) => {
+                // The approval is already durably committed in the DB. A bridge
+                // failure here is non-fatal: the in-process deferred will not be
+                // signalled, but the run will recover on its next heartbeat/resume
+                // because the persisted approval row drives re-hydration. Failing
+                // the Effect here would strand the caller with an INTERNAL_ERROR
+                // while the approval is already consumed — worse than the bridge
+                // being a no-op.
+                const message = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
+                Effect.runSync(Effect.logWarning(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`));
+            })
+        );
     }).pipe(Effect.annotateLogs({
         runId,
         nodeId,
@@ -203,12 +215,24 @@ export function denyNode(adapter, runId, nodeId, iteration, note, decidedBy, dec
         });
         yield* trackEvent(event);
         yield* Effect.logInfo("approval denied");
-        yield* Effect.promise(() => bridgeApprovalResolve(adapter, runId, nodeId, iteration, {
-            approved: false,
-            note: note ?? null,
-            decidedBy: decidedBy ?? null,
-            decisionJson: serializeDecision(decision),
-        }));
+        yield* Effect.promise(() =>
+            bridgeApprovalResolve(adapter, runId, nodeId, iteration, {
+                approved: false,
+                note: note ?? null,
+                decidedBy: decidedBy ?? null,
+                decisionJson: serializeDecision(decision),
+            }).catch((bridgeError) => {
+                // The denial is already durably committed in the DB. A bridge
+                // failure here is non-fatal: the in-process deferred will not be
+                // signalled, but the run will recover on its next heartbeat/resume
+                // because the persisted approval row drives re-hydration. Failing
+                // the Effect here would strand the caller with an INTERNAL_ERROR
+                // while the denial is already consumed — worse than the bridge
+                // being a no-op.
+                const message = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
+                Effect.runSync(Effect.logWarning(`[approvals] post-commit bridgeApprovalResolve failed (non-fatal, run will re-drive on resume): ${message}`));
+            })
+        );
     }).pipe(Effect.annotateLogs({
         runId,
         nodeId,


### PR DESCRIPTION
## Summary

- In `packages/engine/src/approvals.js`, post-commit `bridgeApprovalResolve()` failures in both `approveNode` and `denyNode` are now caught and logged as warnings rather than propagating as errors to callers
- The approval DB transaction is the durable source of truth; if the bridge call fails after commit, the run will re-drive on its next heartbeat or resume
- Updated error handling in `apps/cli/src/mcp/semantic-tools.js` to clarify that post-commit bridge errors no longer surface as `INTERNAL_ERROR`

## Test plan

- [ ] Approve a gate via MCP `resolve_approval` → should return success even if bridge notification fails internally
- [ ] Verify that `list_pending_approvals` returns empty after approval (approval was consumed)
- [ ] Verify run advances on next heartbeat/resume after approval

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)