### PR TITLE
fix(engine,driver): warn on structured-output fallback; strip metadata from ctx.output

### DIFF
--- a/packages/components/tests/context-comprehensive.test.js
+++ b/packages/components/tests/context-comprehensive.test.js
@@ -12,7 +12,7 @@ describe("SmithersCtx edge cases", () => {
             input: {},
             outputs: { tbl: [row] },
         });
-        expect(ctx.output("tbl", { nodeId: "n" })).toBe(row);
+        expect(ctx.output("tbl", { nodeId: "n" })).toEqual({ v: 1 });
     });
     test("output falls back to ctx.iteration when key.iteration is undefined", () => {
         const row = { nodeId: "n", iteration: 2, v: "val" };
@@ -22,7 +22,7 @@ describe("SmithersCtx edge cases", () => {
             input: {},
             outputs: { tbl: [row] },
         });
-        expect(ctx.output("tbl", { nodeId: "n" })).toBe(row);
+        expect(ctx.output("tbl", { nodeId: "n" })).toEqual({ v: "val" });
     });
     test("output throws descriptive error on missing row", () => {
         const ctx = new SmithersCtx({
@@ -169,7 +169,7 @@ describe("SmithersCtx edge cases", () => {
             input: {},
             outputs: { my_table: [row] },
         });
-        expect(ctx.output("my_table", { nodeId: "n" })).toBe(row);
+        expect(ctx.output("my_table", { nodeId: "n" })).toEqual({});
     });
 });
 describe("createSmithersContext", () => {

--- a/packages/components/tests/context.test.js
+++ b/packages/components/tests/context.test.js
@@ -14,7 +14,7 @@ describe("SmithersCtx", () => {
             input: {},
             outputs: { tbl: [row] },
         });
-        expect(ctx.output("tbl", { nodeId: "a" })).toBe(row);
+        expect(ctx.output("tbl", { nodeId: "a" })).toEqual({ value: 42 });
     });
     test("output matches explicit iteration over default", () => {
         const row0 = { nodeId: "a", iteration: 0, v: 1 };
@@ -25,7 +25,7 @@ describe("SmithersCtx", () => {
             input: {},
             outputs: { tbl: [row0, row1] },
         });
-        expect(ctx.output("tbl", { nodeId: "a", iteration: 1 })).toBe(row1);
+        expect(ctx.output("tbl", { nodeId: "a", iteration: 1 })).toEqual({ v: 2 });
     });
     test("outputMaybe returns undefined for missing row", () => {
         const ctx = new SmithersCtx({ runId: "r1", iteration: 0, input: {}, outputs: {} });
@@ -39,7 +39,7 @@ describe("SmithersCtx", () => {
             input: {},
             outputs: { tbl: [row] },
         });
-        expect(ctx.outputMaybe("tbl", { nodeId: "n" })).toBe(row);
+        expect(ctx.outputMaybe("tbl", { nodeId: "n" })).toEqual({});
     });
     test("latest returns highest iteration row", () => {
         const rows = [
@@ -219,6 +219,6 @@ describe("SmithersCtx", () => {
             outputs: { myOutput: [row] },
             zodToKeyName,
         });
-        expect(ctx.output(schema, { nodeId: "n" })).toBe(row);
+        expect(ctx.output(schema, { nodeId: "n" })).toEqual({ v: 1 });
     });
 });

--- a/packages/driver/src/SmithersCtx.js
+++ b/packages/driver/src/SmithersCtx.js
@@ -1,4 +1,5 @@
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
+import { stripAutoColumns } from "@smithers-orchestrator/db/output";
 import { buildCurrentScopes } from "./buildCurrentScopes.js";
 import { filterRowsByNodeId } from "./filterRowsByNodeId.js";
 import { normalizeInputRow } from "./normalizeInputRow.js";
@@ -9,7 +10,7 @@ import { withLogicalIterationShortcuts } from "./withLogicalIterationShortcuts.j
 /** @typedef {import("./RunAuthContext.ts").RunAuthContext} RunAuthContext */
 /** @typedef {import("./SmithersRuntimeConfig.ts").SmithersRuntimeConfig} SmithersRuntimeConfig */
 /** @typedef {unknown} TableRef */
-/** @typedef {Record<string, unknown> & { iteration?: number; nodeId?: string }} OutputRow */
+/** @typedef {Record<string, unknown>} OutputRow User-visible output row — harness metadata fields (runId, nodeId, iteration) are stripped. */
 /**
  * @template Schema
  * @typedef {import("./OutputAccessor.ts").OutputAccessor<Schema>} OutputAccessor
@@ -90,7 +91,7 @@ export class SmithersCtx {
         if (!row) {
             throw new SmithersError("MISSING_OUTPUT", `Missing output for nodeId=${key.nodeId} iteration=${key.iteration ?? 0}`, { nodeId: key.nodeId, iteration: key.iteration ?? 0 });
         }
-        return row;
+        return /** @type {OutputRow} */ (stripAutoColumns(row));
     }
     /**
      * @param {TableRef} table
@@ -98,7 +99,8 @@ export class SmithersCtx {
      * @returns {OutputRow | undefined}
      */
     outputMaybe(table, key) {
-        return this.resolveRow(table, key);
+        const row = this.resolveRow(table, key);
+        return row !== undefined ? /** @type {OutputRow} */ (stripAutoColumns(row)) : undefined;
     }
     /**
      * @param {TableRef} table

--- a/packages/driver/src/index.d.ts
+++ b/packages/driver/src/index.d.ts
@@ -253,10 +253,8 @@ type SmithersCtxOptions$1 = SmithersCtxOptions$2;
 type RunAuthContext$1 = RunAuthContext$2;
 type SmithersRuntimeConfig = SmithersRuntimeConfig$1;
 type TableRef = unknown;
-type OutputRow = Record<string, unknown> & {
-    iteration?: number;
-    nodeId?: string;
-};
+/** User-visible output row — harness metadata fields (runId, nodeId, iteration) are stripped. */
+type OutputRow = Record<string, unknown>;
 type OutputAccessor$1<Schema> = OutputAccessor$2<Schema>;
 
 type WorkflowElement = {

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -3066,6 +3066,14 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                 let effectivePrompt = desc.prompt ?? "";
                 supportsNativeStructuredOutput = effectiveAgent.supportsNativeStructuredOutput === true;
                 if (desc.outputTable && !supportsNativeStructuredOutput) {
+                    const engineName = typeof attemptMeta.agentEngine === "string"
+                        ? attemptMeta.agentEngine
+                        : (effectiveAgent.constructor?.name ?? "unknown");
+                    console.warn(
+                        `[smithers] Task "${desc.nodeId}" has an output schema but engine "${engineName}" does not support native structured output. ` +
+                        `Falling back to prompt-injection + text JSON extraction. Schema validity does not guarantee meaningful output — ` +
+                        `consider switching to an engine that declares supportsNativeStructuredOutput=true (Anthropic, OpenAI).`
+                    );
                     const schemaDesc = describeSchemaShape(desc.outputTable, desc.outputSchema);
                     const jsonInstructions = [
                         "**REQUIRED OUTPUT** — You MUST return ONLY a raw JSON object matching this schema:",


### PR DESCRIPTION
## Summary

- `packages/engine/src/engine.js`: emits `console.warn` when a `Task` with an `output` schema falls back to prompt-injection + text JSON extraction because the engine doesn't declare `supportsNativeStructuredOutput`. Warning includes node id and engine name.
- `packages/driver/src/SmithersCtx.js`: `ctx.output()` and `ctx.outputMaybe()` now strip harness metadata (`runId`, `nodeId`, `iteration`) from the returned object — callers only see schema fields, not internal DB row columns.
- `packages/driver/src/index.d.ts`: updated `OutputRow` type and doc comment to reflect stripped contract.
- Updated test assertions in `packages/components/tests/context.test.js` and `context-comprehensive.test.js` (46/46 pass).

## Test plan

- [ ] Run a `Task` with `output={schema}` on a Pi/Codex engine → see console.warn in logs
- [ ] Run a `Task` with `output={schema}` on Anthropic/OpenAI engine → no warn
- [ ] `ctx.output()` in a task handler → returned object has no `runId`/`nodeId`/`iteration` keys
- [ ] Serializing `ctx.output()` into a downstream prompt → no harness metadata leaked

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)