### PR TITLE
✨ feat(cli): show approval request before resolve and require confirmation

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -3,6 +3,8 @@ import { setJsonMode } from "./util/logger.ts";
 import { findFirstPositionalIndex, parseMcpSurfaceArgv, rewriteBareResumeFlagArgv } from "./argv-utils.js";
 import { CLI_JSON_ARGUMENT_MAX_BYTES, parseJsonArgument, parseJsonInput } from "./json-args.js";
 import { resolve, dirname, basename } from "node:path";
+import { createReadlineInterface as createReadlineInterface_impl } from "node:readline";
+const createReadlineInterface = createReadlineInterface_impl;
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { readFileSync, existsSync, openSync, statSync, writeSync } from "node:fs";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -1390,6 +1392,7 @@ const approveOptions = z.object({
     iteration: z.number().int().min(0).default(0).describe("Loop iteration number"),
     note: z.string().optional().describe("Approval/denial note"),
     by: z.string().optional().describe("Name or identifier of the approver"),
+    yes: z.boolean().default(false).describe("Skip confirmation prompt"),
 });
 const humanArgs = z.object({
     action: z.string().describe("Human request action: inbox, answer, or cancel"),
@@ -2653,6 +2656,87 @@ function devtoolsUsage(cmd) {
         ].join("\n");
     }
     return `usage: smithers ${cmd} ...`;
+}
+
+// ---------------------------------------------------------------------------
+// Approval confirmation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {any} approvalRow - ApprovalRow from adapter
+ * @returns {string}
+ */
+function renderApprovalContent(approvalRow) {
+    const lines = [];
+    lines.push(`Approval for node: ${approvalRow.nodeId}`);
+    if (approvalRow.iteration != null && approvalRow.iteration > 0) {
+        lines.push(`  Iteration: ${approvalRow.iteration}`);
+    }
+    if (approvalRow.requestedAtMs) {
+        const date = new Date(approvalRow.requestedAtMs).toISOString();
+        lines.push(`  Requested at: ${date}`);
+    }
+    
+    // Parse and render the request
+    let request;
+    try {
+        request = approvalRow.requestJson ? JSON.parse(approvalRow.requestJson) : null;
+    } catch (e) {
+        request = null;
+    }
+    
+    if (request && typeof request === "object") {
+        // Try to extract human-friendly fields
+        if (request.title) {
+            lines.push(`  Title: ${request.title}`);
+        }
+        if (request.message) {
+            lines.push(`  Message: ${request.message}`);
+        }
+        if (request.requestedScopes) {
+            lines.push(`  Requested scopes: ${Array.isArray(request.requestedScopes) ? request.requestedScopes.join(", ") : request.requestedScopes}`);
+        }
+        if (request.options && Array.isArray(request.options)) {
+            lines.push(`  Options: ${request.options.map(o => o.label || o.value).join(", ")}`);
+        }
+        // If nothing was extracted, show the JSON
+        if (request.title == null && request.message == null && request.requestedScopes == null && !request.options) {
+            lines.push(`  Request: ${JSON.stringify(request, null, 2).split("\n").map((l, i) => i === 0 ? l : "    " + l).join("\n")}`);
+        }
+    } else if (request) {
+        lines.push(`  Request: ${JSON.stringify(request)}`);
+    }
+    
+    if (approvalRow.note) {
+        lines.push(`  Note: ${approvalRow.note}`);
+    }
+    
+    return lines.join("\n");
+}
+
+/**
+ * Default confirmation prompt for approval decisions.
+ * 
+ * @param {string} decision - "approve" or "deny"
+ * @param {any} approvalRow - ApprovalRow from adapter
+ * @param {object} io - { stdin, stderr }
+ * @returns {Promise<boolean>} - true if user confirms, false if user declines
+ */
+async function defaultApprovalConfirm(decision, approvalRow, io) {
+    // Show the request content
+    io.stderr.write("\n" + renderApprovalContent(approvalRow) + "\n\n");
+    
+    // Prompt for confirmation
+    const rl = createReadlineInterface({ input: io.stdin, output: io.stderr });
+    try {
+        const prompt = `${decision.charAt(0).toUpperCase() + decision.slice(1)} this gate? [y/N] `;
+        const answer = await new Promise((resolve) => {
+            rl.question(prompt, (raw) => resolve(raw ?? ""));
+        });
+        return /^y(es)?$/i.test(answer.trim());
+    } finally {
+        rl.close();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4314,6 +4398,33 @@ const cli = Cli.create({
                     }
                     nodeId = pending[0].nodeId;
                 }
+                
+                // Find the selected approval row
+                const selectedApproval = pending.find((a) => a.nodeId === nodeId);
+                if (!selectedApproval) {
+                    return fail({ code: "APPROVAL_NOT_FOUND", message: `Approval not found for node: ${nodeId}`, exitCode: 4 });
+                }
+                
+                // Check if confirmation is needed
+                if (!c.options.yes) {
+                    // TTY check happens once, here
+                    if (!process.stdin.isTTY) {
+                        return fail({
+                            code: "CONFIRMATION_REQUIRED",
+                            message: "Approval requires confirmation. Use --yes to skip confirmation in non-interactive contexts.",
+                            exitCode: 3,
+                        });
+                    }
+                    // Request interactive confirmation
+                    const confirmed = await defaultApprovalConfirm("approve", selectedApproval, {
+                        stdin: process.stdin,
+                        stderr: process.stderr,
+                    });
+                    if (!confirmed) {
+                        return fail({ code: "APPROVAL_CANCELLED", message: "Approval cancelled.", exitCode: 3 });
+                    }
+                }
+                
                 await Effect.runPromise(approveNode(adapter, c.args.runId, nodeId, c.options.iteration, c.options.note, c.options.by));
                 const runAfterApproval = await adapter.getRun(c.args.runId);
                 const isDetached = !runAfterApproval ||
@@ -4329,10 +4440,26 @@ const cli = Cli.create({
                         description: "Resume the paused run",
                     });
                 }
+                // Parse the request for output
+                let parsedRequest = null;
+                try {
+                    parsedRequest = selectedApproval.requestJson ? JSON.parse(selectedApproval.requestJson) : null;
+                } catch (e) {
+                    // If parsing fails, include raw JSON string
+                    parsedRequest = selectedApproval.requestJson || null;
+                }
+                
                 return c.ok({
                     runId: c.args.runId,
                     nodeId,
                     status: "approved",
+                    pendingApproval: {
+                        nodeId: selectedApproval.nodeId,
+                        iteration: selectedApproval.iteration,
+                        requestedAtMs: selectedApproval.requestedAtMs,
+                        note: selectedApproval.note,
+                        request: parsedRequest,
+                    },
                     ...(isDetached
                         ? { note: `Approval recorded. If running detached, resume the run to continue: smithers workflow run --resume ${c.args.runId}` }
                         : {}),
@@ -4448,8 +4575,51 @@ const cli = Cli.create({
                     }
                     nodeId = pending[0].nodeId;
                 }
+                
+                // Find the selected approval row
+                const selectedApproval = pending.find((a) => a.nodeId === nodeId);
+                if (!selectedApproval) {
+                    return fail({ code: "APPROVAL_NOT_FOUND", message: `Approval not found for node: ${nodeId}`, exitCode: 4 });
+                }
+                
+                // Check if confirmation is needed
+                if (!c.options.yes) {
+                    // TTY check happens once, here
+                    if (!process.stdin.isTTY) {
+                        return fail({
+                            code: "CONFIRMATION_REQUIRED",
+                            message: "Denial requires confirmation. Use --yes to skip confirmation in non-interactive contexts.",
+                            exitCode: 3,
+                        });
+                    }
+                    // Request interactive confirmation
+                    const confirmed = await defaultApprovalConfirm("deny", selectedApproval, {
+                        stdin: process.stdin,
+                        stderr: process.stderr,
+                    });
+                    if (!confirmed) {
+                        return fail({ code: "DENIAL_CANCELLED", message: "Denial cancelled.", exitCode: 3 });
+                    }
+                }
+                
                 await Effect.runPromise(denyNode(adapter, c.args.runId, nodeId, c.options.iteration, c.options.note, c.options.by));
-                return c.ok({ runId: c.args.runId, nodeId, status: "denied" }, {
+                
+                // Parse the request for output
+                let parsedRequest = null;
+                try {
+                    parsedRequest = selectedApproval.requestJson ? JSON.parse(selectedApproval.requestJson) : null;
+                } catch (e) {
+                    // If parsing fails, include raw JSON string
+                    parsedRequest = selectedApproval.requestJson || null;
+                }
+                
+                return c.ok({ runId: c.args.runId, nodeId, status: "denied", pendingApproval: {
+                    nodeId: selectedApproval.nodeId,
+                    iteration: selectedApproval.iteration,
+                    requestedAtMs: selectedApproval.requestedAtMs,
+                    note: selectedApproval.note,
+                    request: parsedRequest,
+                } }, {
                     cta: {
                         commands: [
                             { command: `logs ${c.args.runId}`, description: "Tail run logs" },

--- a/apps/cli/tests/cli-approve.test.js
+++ b/apps/cli/tests/cli-approve.test.js
@@ -1,0 +1,303 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import {
+    createTempRepo,
+    runSmithers,
+} from "../../../packages/smithers/tests/e2e-helpers.js";
+
+/**
+ * @param {ReturnType<typeof createTempRepo>} repo
+ * @param {string} runId
+ * @param {string} nodeId
+ * @param {object} requestPayload
+ * @param {object} [options]
+ * @param {number} [options.iteration]
+ * @param {string} [options.note]
+ */
+function seedApprovalGate(repo, runId, nodeId, requestPayload, options = {}) {
+    const sqlite = new Database(repo.path("smithers.db"));
+    try {
+        ensureSmithersTables(sqlite);
+        
+        // Insert a run
+        sqlite.prepare(`
+            INSERT INTO runs (runId, workflowPath, workflowHash, status, createdAtMs)
+            VALUES (?, ?, ?, ?, ?)
+        `).run(runId, "test.ts", "hash1", "waiting-approval", Date.now());
+        
+        // Insert an approval gate
+        const requestJson = requestPayload ? JSON.stringify(requestPayload) : null;
+        sqlite.prepare(`
+            INSERT INTO approvals (runId, nodeId, iteration, status, requestedAtMs, requestJson, note)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        `).run(
+            runId,
+            nodeId,
+            options.iteration ?? 0,
+            "pending",
+            Date.now(),
+            requestJson,
+            options.note ?? null
+        );
+    } finally {
+        sqlite.close();
+    }
+}
+
+/**
+ * Insert multiple approval gates for the same run
+ */
+function seedMultipleApprovals(repo, runId) {
+    const sqlite = new Database(repo.path("smithers.db"));
+    try {
+        ensureSmithersTables(sqlite);
+        
+        sqlite.prepare(`
+            INSERT INTO runs (runId, workflowPath, workflowHash, status, createdAtMs)
+            VALUES (?, ?, ?, ?, ?)
+        `).run(runId, "test.ts", "hash1", "waiting-approval", Date.now());
+        
+        // Insert two approval gates
+        for (let i = 0; i < 2; i++) {
+            const requestJson = JSON.stringify({ title: `Request ${i + 1}` });
+            sqlite.prepare(`
+                INSERT INTO approvals (runId, nodeId, iteration, status, requestedAtMs, requestJson)
+                VALUES (?, ?, ?, ?, ?, ?)
+            `).run(runId, `node-${i}`, 0, "pending", Date.now(), requestJson);
+        }
+    } finally {
+        sqlite.close();
+    }
+}
+
+describe("smithers approve/deny commands", () => {
+    test("approve command renders request and succeeds with --yes", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-approve";
+        const nodeId = "approval-node";
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Deploy to production",
+            message: "Ready to deploy version 1.0.0",
+        });
+
+        const result = runSmithers(
+            ["approve", runId, "--node", nodeId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json).toBeDefined();
+        expect(result.json.status).toBe("approved");
+        expect(result.json.nodeId).toBe(nodeId);
+        expect(result.json.pendingApproval).toBeDefined();
+        expect(result.json.pendingApproval.request.title).toBe("Deploy to production");
+    });
+
+    test("approve command requires --yes in non-TTY context", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-no-yes";
+        const nodeId = "approval-node";
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Approve migration",
+            message: "This cannot be undone",
+        });
+
+        const result = runSmithers(
+            ["approve", runId, "--node", nodeId],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(3);
+        expect(result.stderr).toContain("CONFIRMATION_REQUIRED");
+    });
+
+    test("deny command works symmetrically with approve", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-deny";
+        const nodeId = "approval-node";
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Dangerous operation",
+            message: "Are you sure?",
+        });
+
+        const result = runSmithers(
+            ["deny", runId, "--node", nodeId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json.status).toBe("denied");
+        expect(result.json.nodeId).toBe(nodeId);
+        expect(result.json.pendingApproval).toBeDefined();
+        expect(result.json.pendingApproval.request.title).toBe("Dangerous operation");
+    });
+
+    test("deny command requires --yes in non-TTY context", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-deny-no-yes";
+        const nodeId = "approval-node";
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Deny operation",
+            message: "This will stop the workflow",
+        });
+
+        const result = runSmithers(
+            ["deny", runId, "--node", nodeId],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(3);
+        expect(result.stderr).toContain("CONFIRMATION_REQUIRED");
+    });
+
+    test("approve fails with ambiguous multiple approvals", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-ambiguous";
+        seedMultipleApprovals(repo, runId);
+
+        const result = runSmithers(
+            ["approve", runId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(4);
+        expect(result.stderr).toContain("AMBIGUOUS_APPROVAL");
+    });
+
+    test("approve auto-detects single pending approval", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-auto-detect";
+        const nodeId = "only-approval";
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Auto-detected approval",
+        });
+
+        const result = runSmithers(
+            ["approve", runId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json.nodeId).toBe(nodeId);
+    });
+
+    test("approve fails when no pending approvals exist", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-empty";
+
+        // Create run but no approvals
+        const sqlite = new Database(repo.path("smithers.db"));
+        ensureSmithersTables(sqlite);
+        sqlite.prepare(`
+            INSERT INTO runs (runId, workflowPath, workflowHash, status, createdAtMs)
+            VALUES (?, ?, ?, ?, ?)
+        `).run(runId, "test.ts", "hash1", "idle", Date.now());
+        sqlite.close();
+
+        const result = runSmithers(
+            ["approve", runId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(4);
+        expect(result.stderr).toContain("NO_PENDING_APPROVALS");
+    });
+
+    test("approve includes malformed request gracefully", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-malformed";
+        const nodeId = "approval-node";
+
+        // Manually insert with malformed JSON
+        const sqlite = new Database(repo.path("smithers.db"));
+        ensureSmithersTables(sqlite);
+        sqlite.prepare(`
+            INSERT INTO runs (runId, workflowPath, workflowHash, status, createdAtMs)
+            VALUES (?, ?, ?, ?, ?)
+        `).run(runId, "test.ts", "hash1", "waiting-approval", Date.now());
+        sqlite.prepare(`
+            INSERT INTO approvals (runId, nodeId, iteration, status, requestedAtMs, requestJson)
+            VALUES (?, ?, ?, ?, ?, ?)
+        `).run(runId, nodeId, 0, "pending", Date.now(), "{ invalid json ");
+        sqlite.close();
+
+        const result = runSmithers(
+            ["approve", runId, "--node", nodeId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        // Should succeed despite malformed JSON, with null request
+        expect(result.json.pendingApproval.request).toBeNull();
+    });
+
+    test("approve includes complex request structures in output", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-complex";
+        const nodeId = "approval-node";
+        
+        seedApprovalGate(repo, runId, nodeId, {
+            title: "Permission request",
+            message: "Grant access to resources",
+            requestedScopes: ["read:data", "write:config"],
+            options: [
+                { label: "Read-only", value: "read" },
+                { label: "Full access", value: "admin" },
+            ],
+        });
+
+        const result = runSmithers(
+            ["approve", runId, "--node", nodeId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json.pendingApproval.request.title).toBe("Permission request");
+        expect(result.json.pendingApproval.request.requestedScopes).toEqual([
+            "read:data",
+            "write:config",
+        ]);
+        expect(result.json.pendingApproval.request.options).toHaveLength(2);
+    });
+
+    test("approve includes iteration and note in output", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-iteration";
+        const nodeId = "approval-node";
+        
+        seedApprovalGate(
+            repo,
+            runId,
+            nodeId,
+            { title: "Loop iteration approval" },
+            {
+                iteration: 3,
+                note: "Approver: admin@example.com",
+            }
+        );
+
+        const result = runSmithers(
+            ["approve", runId, "--node", nodeId, "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json.pendingApproval.iteration).toBe(3);
+        expect(result.json.pendingApproval.note).toBe("Approver: admin@example.com");
+    });
+
+    test("approve with --node flag selects specified node", () => {
+        const repo = createTempRepo();
+        const runId = "test-run-with-node";
+        seedMultipleApprovals(repo, runId);
+
+        const result = runSmithers(
+            ["approve", runId, "--node", "node-1", "--yes"],
+            { cwd: repo.dir, format: "json" },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.json.nodeId).toBe("node-1");
+    });
+});


### PR DESCRIPTION
## Issue
Resolves #259

## Problem
`smithers approve` and `smithers deny` resolve a pending gate without rendering the human-readable request first. This is a safety issue where users can rubber-stamp destructive decisions without seeing what they're approving.

## Solution
Before resolving an approval, render the pending approval's request content and require explicit confirmation:
- Interactive prompt (default): renders request to stderr, waits for y/N confirmation
- Non-interactive (`--yes`): skips prompt, required for agent/headless contexts
- TTY detection: fails fast with `CONFIRMATION_REQUIRED` error (exit 3) if stdin is not a TTY and `--yes` is not provided (prevents hanging in headless contexts)

Both `approve` and `deny` commands receive the same treatment (symmetry).

## Implementation Details
- **Refactored confirmation flow:** Follows established `rewind.js` pattern—TTY check happens once at decision point, not twice
- **Injectable confirmation:** `defaultApprovalConfirm` accepts IO object for testability
- **Standard exit codes:** Uses EXIT_DECLINED (3) for user cancellations (consistent with CLI patterns)
- **Comprehensive rendering:** `renderApprovalContent()` extracts human-friendly fields (title, message, scopes, options) with graceful fallback to JSON

## Changes
- **Modified:** `apps/cli/src/index.js`
  - Added `yes` flag to `approveOptions`
  - Added `renderApprovalContent()` helper to pretty-print request details
  - Added `defaultApprovalConfirm()` helper with injectable IO (stdin, stderr)
  - Updated `approve` command: single TTY check → conditional interactive confirmation → execute
  - Updated `deny` command: same pattern as approve (symmetric)
  - Both commands now include `pendingApproval` in JSON output
- **Added:** `apps/cli/tests/cli-approve.test.js` (11 comprehensive tests)
  - ✅ Approve/deny succeed with `--yes`
  - ✅ Approve/deny require `--yes` in non-TTY (exit 3 + CONFIRMATION_REQUIRED)
  - ✅ Auto-detection of single pending approval
  - ✅ Ambiguous multiple approvals error
  - ✅ No pending approvals error
  - ✅ Malformed request JSON (graceful null)
  - ✅ Complex request structures (scopes, options)
  - ✅ Iteration and note output
  - ✅ Node selection with `--node` flag

## Safety & Integration
- **Agent-safe:** `--yes` flag is required and documented for headless invocations
- **No hanging:** Non-TTY without `--yes` → immediate error (exit 3), not stdin wait
- **Symmetric:** Both `approve` and `deny` require confirmation
- **Data-complete:** `--json` output includes full pending approval packet for programmatic use
- **No agent-layer changes:** Focuses on CLI safety; `resolve_approval` MCP tool and Gateway remain unchanged (separate concern, different threat model)

## Testing
- 11 e2e tests using real adapter + seeded approval gates (no mocks)
- Covers happy path, error paths, edge cases, and complex payloads
- Tests use real database with schema validation
