### PR TITLE
🐛 fix(server): bridge detached gateway run events

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -8644,11 +8644,17 @@ type GatewayOptions = {
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;              // custom gateway UI; true mounts the built-in console
   operatorUi?: GatewayOperatorUiConfig | false; // default { path: "/console" }; false disables
-  defaults?: { cliAgentTools?: "all" | "explicit-only" };
+  defaults?: {
+    cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
+  };
   maxBodyBytes?: number;             // default 1_048_576 for POST /rpc
   maxPayload?: number;               // default 1_048_576 for WebSocket frames
   maxConnections?: number;           // default 1_000
   eventWindowSize?: number;          // default 10_000 per-run replay frames
+  outOfProcessEventBridge?: boolean; // default true; streams persisted events from detached runs
+  outOfProcessEventBridgePollMs?: number; // default 1_000
   headersTimeout?: number;           // default 30_000
   requestTimeout?: number;           // default 60_000
 };

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -361,11 +361,17 @@ type GatewayOptions = {
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;              // custom gateway UI; true mounts the built-in console
   operatorUi?: GatewayOperatorUiConfig | false; // default { path: "/console" }; false disables
-  defaults?: { cliAgentTools?: "all" | "explicit-only" };
+  defaults?: {
+    cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
+  };
   maxBodyBytes?: number;             // default 1_048_576 for POST /rpc
   maxPayload?: number;               // default 1_048_576 for WebSocket frames
   maxConnections?: number;           // default 1_000
   eventWindowSize?: number;          // default 10_000 per-run replay frames
+  outOfProcessEventBridge?: boolean; // default true; streams persisted events from detached runs
+  outOfProcessEventBridgePollMs?: number; // default 1_000
   headersTimeout?: number;           // default 30_000
   requestTimeout?: number;           // default 60_000
 };

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8644,11 +8644,17 @@ type GatewayOptions = {
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;              // custom gateway UI; true mounts the built-in console
   operatorUi?: GatewayOperatorUiConfig | false; // default { path: "/console" }; false disables
-  defaults?: { cliAgentTools?: "all" | "explicit-only" };
+  defaults?: {
+    cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
+  };
   maxBodyBytes?: number;             // default 1_048_576 for POST /rpc
   maxPayload?: number;               // default 1_048_576 for WebSocket frames
   maxConnections?: number;           // default 1_000
   eventWindowSize?: number;          // default 10_000 per-run replay frames
+  outOfProcessEventBridge?: boolean; // default true; streams persisted events from detached runs
+  outOfProcessEventBridgePollMs?: number; // default 1_000
   headersTimeout?: number;           // default 30_000
   requestTimeout?: number;           // default 60_000
 };

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -693,11 +693,17 @@ type GatewayOptions = {
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;              // custom gateway UI; true mounts the built-in console
   operatorUi?: GatewayOperatorUiConfig | false; // default { path: "/console" }; false disables
-  defaults?: { cliAgentTools?: "all" | "explicit-only" };
+  defaults?: {
+    cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
+  };
   maxBodyBytes?: number;             // default 1_048_576 for POST /rpc
   maxPayload?: number;               // default 1_048_576 for WebSocket frames
   maxConnections?: number;           // default 1_000
   eventWindowSize?: number;          // default 10_000 per-run replay frames
+  outOfProcessEventBridge?: boolean; // default true; streams persisted events from detached runs
+  outOfProcessEventBridgePollMs?: number; // default 1_000
   headersTimeout?: number;           // default 30_000
   requestTimeout?: number;           // default 60_000
 };

--- a/packages/server/src/GatewayDefaults.ts
+++ b/packages/server/src/GatewayDefaults.ts
@@ -1,3 +1,5 @@
 export type GatewayDefaults = {
   cliAgentTools?: "all" | "explicit-only";
+  outOfProcessEventBridge?: boolean;
+  outOfProcessEventBridgePollMs?: number;
 };

--- a/packages/server/src/GatewayOptions.ts
+++ b/packages/server/src/GatewayOptions.ts
@@ -24,6 +24,17 @@ export type GatewayOptions = {
    */
   eventWindowSize?: number;
   /**
+   * Bridge persisted run events from the workspace DB into live Gateway streams
+   * for runs executed by another process.
+   * @default true
+   */
+  outOfProcessEventBridge?: boolean;
+  /**
+   * Poll interval (in milliseconds) for the out-of-process event bridge.
+   * @default 1000
+   */
+  outOfProcessEventBridgePollMs?: number;
+  /**
    * Maximum time (in milliseconds) allowed for the HTTP parser to receive the
    * complete headers of a single request. Helps mitigate slowloris attacks.
    * @default 30000

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -134,7 +134,10 @@ const DEFAULT_MAX_BODY_BYTES = 1_048_576;
 const DEFAULT_MAX_CONNECTIONS = 1_000;
 const DEFAULT_HEADERS_TIMEOUT = 30_000;
 const DEFAULT_REQUEST_TIMEOUT = 60_000;
+const DEFAULT_OUT_OF_PROCESS_EVENT_BRIDGE_POLL_MS = 1_000;
+const OUT_OF_PROCESS_EVENT_BRIDGE_PAGE_LIMIT = 500;
 const RUN_EVENT_HEARTBEAT_MS = 1_000;
+const TERMINAL_RUN_STATUSES = new Set(["finished", "failed", "cancelled", "continued"]);
 export const GATEWAY_RPC_MAX_PAYLOAD_BYTES = DEFAULT_MAX_BODY_BYTES;
 export const GATEWAY_RPC_MAX_DEPTH = 32;
 export const GATEWAY_RPC_MAX_ARRAY_LENGTH = 256;
@@ -1257,6 +1260,8 @@ export class Gateway {
     maxPayload;
     maxConnections;
     eventWindowSize;
+    outOfProcessEventBridge;
+    outOfProcessEventBridgePollMs;
     headersTimeout;
     requestTimeout;
     auth;
@@ -1303,6 +1308,10 @@ export class Gateway {
     server = null;
     wsServer = null;
     schedulerTimer = null;
+    outOfProcessEventBridgeTimer = null;
+    outOfProcessEventBridgeStopped = true;
+    outOfProcessEventBridgeLastFedSeq = new Map();
+    outOfProcessEventBridgeDrainedRuns = new Set();
     stateVersion = 0;
     startedAtMs = nowMs();
     /**
@@ -1324,6 +1333,10 @@ export class Gateway {
         this.eventWindowSize = options.eventWindowSize === undefined
             ? GATEWAY_EVENT_WINDOW_DEFAULT
             : Math.floor(assertPositiveFiniteInteger("eventWindowSize", Number(options.eventWindowSize)));
+        this.outOfProcessEventBridge = options.outOfProcessEventBridge ?? options.defaults?.outOfProcessEventBridge ?? true;
+        this.outOfProcessEventBridgePollMs = options.outOfProcessEventBridgePollMs === undefined && options.defaults?.outOfProcessEventBridgePollMs === undefined
+            ? DEFAULT_OUT_OF_PROCESS_EVENT_BRIDGE_POLL_MS
+            : Math.floor(assertPositiveFiniteInteger("outOfProcessEventBridgePollMs", Number(options.outOfProcessEventBridgePollMs ?? options.defaults?.outOfProcessEventBridgePollMs)));
         this.headersTimeout = options.headersTimeout === undefined
             ? DEFAULT_HEADERS_TIMEOUT
             : Math.floor(assertPositiveFiniteInteger("headersTimeout", Number(options.headersTimeout)));
@@ -2327,6 +2340,7 @@ export class Gateway {
         this.wsServer = wsServer;
         await this.syncRegisteredSchedules();
         this.startScheduler();
+        this.startOutOfProcessEventBridge();
         return server;
     }
     async close() {
@@ -2352,6 +2366,7 @@ export class Gateway {
             clearInterval(this.schedulerTimer);
             this.schedulerTimer = null;
         }
+        this.stopOutOfProcessEventBridge();
         if (this.server) {
             const server = this.server;
             this.server = null;
@@ -2388,6 +2403,121 @@ export class Gateway {
             void this.processDueCrons();
             void this.processDueTimers();
         }, intervalMs);
+    }
+    startOutOfProcessEventBridge() {
+        this.stopOutOfProcessEventBridge();
+        if (!this.outOfProcessEventBridge) {
+            return;
+        }
+        this.outOfProcessEventBridgeStopped = false;
+        const loop = () => {
+            if (this.outOfProcessEventBridgeStopped) {
+                return;
+            }
+            void this.pollOutOfProcessRunEvents()
+                .catch((error) => {
+                emitGatewayLog("warning", "Out-of-process event bridge poll failed", {
+                    error: errorToJson(error),
+                }, "gateway:events");
+            })
+                .finally(() => {
+                if (!this.outOfProcessEventBridgeStopped) {
+                    this.outOfProcessEventBridgeTimer = setTimeout(loop, this.outOfProcessEventBridgePollMs);
+                    this.outOfProcessEventBridgeTimer.unref?.();
+                }
+            });
+        };
+        loop();
+    }
+    stopOutOfProcessEventBridge() {
+        this.outOfProcessEventBridgeStopped = true;
+        if (this.outOfProcessEventBridgeTimer) {
+            clearTimeout(this.outOfProcessEventBridgeTimer);
+            this.outOfProcessEventBridgeTimer = null;
+        }
+        this.outOfProcessEventBridgeLastFedSeq.clear();
+        this.outOfProcessEventBridgeDrainedRuns.clear();
+    }
+    async pollOutOfProcessRunEvents() {
+        const seenAdapters = new Set();
+        const liveRunIds = new Set();
+        for (const entry of this.workflows.values()) {
+            const adapter = this.adapterForWorkflow(entry.workflow);
+            if (seenAdapters.has(adapter)) {
+                continue;
+            }
+            seenAdapters.add(adapter);
+            const runs = await adapter.listRuns(1_000);
+            for (const run of runs) {
+                const runId = asString(run.runId);
+                if (!runId) {
+                    continue;
+                }
+                liveRunIds.add(runId);
+                if (this.outOfProcessEventBridgeDrainedRuns.has(runId)) {
+                    continue;
+                }
+                const terminal = TERMINAL_RUN_STATUSES.has(asString(run.status) ?? "");
+                await this.feedOutOfProcessRunEvents(adapter, runId, terminal);
+            }
+        }
+        for (const runId of [...this.outOfProcessEventBridgeDrainedRuns]) {
+            if (!liveRunIds.has(runId)) {
+                this.outOfProcessEventBridgeDrainedRuns.delete(runId);
+            }
+        }
+        for (const runId of [...this.outOfProcessEventBridgeLastFedSeq.keys()]) {
+            if (!liveRunIds.has(runId)) {
+                this.outOfProcessEventBridgeLastFedSeq.delete(runId);
+            }
+        }
+    }
+    async feedOutOfProcessRunEvents(adapter, runId, terminal) {
+        if (this.runRegistry.has(runId)) {
+            this.outOfProcessEventBridgeDrainedRuns.add(runId);
+            this.outOfProcessEventBridgeLastFedSeq.delete(runId);
+            return;
+        }
+        let afterSeq = this.outOfProcessEventBridgeLastFedSeq.get(runId) ?? -1;
+        for (;;) {
+            const rows = await adapter.listEventHistory(runId, {
+                afterSeq,
+                limit: OUT_OF_PROCESS_EVENT_BRIDGE_PAGE_LIMIT,
+            });
+            let maxSeq = afterSeq;
+            for (const row of rows) {
+                const seq = typeof row.seq === "number" ? row.seq : Number(row.seq);
+                if (Number.isFinite(seq) && seq > maxSeq) {
+                    maxSeq = seq;
+                }
+                const payloadJson = typeof row.payloadJson === "string"
+                    ? row.payloadJson
+                    : typeof row.payload_json === "string"
+                        ? row.payload_json
+                        : undefined;
+                if (!payloadJson) {
+                    continue;
+                }
+                try {
+                    this.handleSmithersEvent(JSON.parse(payloadJson));
+                }
+                catch {
+                    continue;
+                }
+            }
+            const advanced = maxSeq > afterSeq;
+            if (advanced) {
+                afterSeq = maxSeq;
+                this.outOfProcessEventBridgeLastFedSeq.set(runId, maxSeq);
+            }
+            if (!terminal || rows.length < OUT_OF_PROCESS_EVENT_BRIDGE_PAGE_LIMIT || !advanced) {
+                break;
+            }
+        }
+        if (terminal) {
+            this.outOfProcessEventBridgeDrainedRuns.add(runId);
+            this.outOfProcessEventBridgeLastFedSeq.delete(runId);
+        }
     }
     async syncRegisteredSchedules() {
         for (const entry of this.workflows.values()) {

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -117,6 +117,8 @@ type GatewayAuthConfig$1 = {
 
 type GatewayDefaults$1 = {
     cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
 };
 
 type GatewayOperatorUiConfig$1 = {
@@ -177,6 +179,17 @@ type GatewayOptions$1 = {
      * @default 10000
      */
     eventWindowSize?: number;
+    /**
+     * Bridge persisted run events from the workspace DB into live Gateway streams
+     * for runs executed by another process.
+     * @default true
+     */
+    outOfProcessEventBridge?: boolean;
+    /**
+     * Poll interval (in milliseconds) for the out-of-process event bridge.
+     * @default 1000
+     */
+    outOfProcessEventBridgePollMs?: number;
     /**
      * Maximum time (in milliseconds) allowed for the HTTP parser to receive the
      * complete headers of a single request. Helps mitigate slowloris attacks.

--- a/packages/server/tests/gateway.test.jsx
+++ b/packages/server/tests/gateway.test.jsx
@@ -899,4 +899,86 @@ describe("Gateway", () => {
         expect(gateway.runRegistry.has(runId)).toBe(false);
         await client.close();
     });
+    test("streams persisted events from detached runs through the built-in bridge", async () => {
+        const dbPath = makeDbPath("detached-events");
+        dbPaths.push(dbPath);
+        const workflow = createValueWorkflow(dbPath);
+        gateway = new Gateway({
+            protocol: 1,
+            features: ["streaming", "runs"],
+            heartbeatMs: 100,
+            outOfProcessEventBridgePollMs: 25,
+            auth: {
+                mode: "token",
+                tokens: {
+                    "op-token": {
+                        role: "operator",
+                        scopes: ["*"],
+                        userId: "user:will",
+                    },
+                },
+            },
+        });
+        gateway.register("basic", workflow);
+        const adapter = gateway.adapterForWorkflow(workflow);
+        await adapter.insertRun({
+            runId: "detached-run",
+            workflowName: "gateway-basic",
+            status: "running",
+            createdAtMs: Date.now(),
+        });
+        server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+        const port = getPort(server);
+        const { client } = await connectGateway(port, "op-token");
+        const subscribed = await client.request("streamRunEvents", { runId: "detached-run" });
+        expect(subscribed.ok).toBe(true);
+        await adapter.insertEventWithNextSeq({
+            runId: "detached-run",
+            timestampMs: Date.now(),
+            type: "NodeStarted",
+            payloadJson: JSON.stringify({
+                type: "NodeStarted",
+                runId: "detached-run",
+                nodeId: "task1",
+            }),
+        });
+        const event = await client.waitFor((message) => message.type === "event" && message.event === "node.started");
+        expect(event.payload.runId).toBe("detached-run");
+        expect(event.payload.nodeId).toBe("task1");
+        await client.close();
+    });
+    test("does not replay persisted copies for in-process runs after registry cleanup", async () => {
+        const dbPath = makeDbPath("in-process-bridge-skip");
+        dbPaths.push(dbPath);
+        const workflow = createValueWorkflow(dbPath);
+        gateway = new Gateway({ heartbeatMs: 100 });
+        gateway.register("basic", workflow);
+        const adapter = gateway.adapterForWorkflow(workflow);
+        await adapter.insertRun({
+            runId: "in-process-run",
+            workflowName: "gateway-basic",
+            status: "running",
+            createdAtMs: Date.now(),
+        });
+        await adapter.insertEventWithNextSeq({
+            runId: "in-process-run",
+            timestampMs: Date.now(),
+            type: "NodeStarted",
+            payloadJson: JSON.stringify({
+                type: "NodeStarted",
+                runId: "in-process-run",
+                nodeId: "task1",
+            }),
+        });
+        let fed = 0;
+        gateway.handleSmithersEvent = () => {
+            fed += 1;
+        };
+        gateway.runRegistry.set("in-process-run", {});
+        await gateway.pollOutOfProcessRunEvents();
+        gateway.runRegistry.delete("in-process-run");
+        await adapter.updateRun("in-process-run", { status: "finished" });
+        await gateway.pollOutOfProcessRunEvents();
+        expect(fed).toBe(0);
+    });
 });

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -8644,11 +8644,17 @@ type GatewayOptions = {
   auth?: GatewayAuthConfig;
   ui?: GatewayUiConfig;              // custom gateway UI; true mounts the built-in console
   operatorUi?: GatewayOperatorUiConfig | false; // default { path: "/console" }; false disables
-  defaults?: { cliAgentTools?: "all" | "explicit-only" };
+  defaults?: {
+    cliAgentTools?: "all" | "explicit-only";
+    outOfProcessEventBridge?: boolean;
+    outOfProcessEventBridgePollMs?: number;
+  };
   maxBodyBytes?: number;             // default 1_048_576 for POST /rpc
   maxPayload?: number;               // default 1_048_576 for WebSocket frames
   maxConnections?: number;           // default 1_000
   eventWindowSize?: number;          // default 10_000 per-run replay frames
+  outOfProcessEventBridge?: boolean; // default true; streams persisted events from detached runs
+  outOfProcessEventBridgePollMs?: number; // default 1_000
   headersTimeout?: number;           // default 30_000
   requestTimeout?: number;           // default 60_000
 };


### PR DESCRIPTION
Closes #254

Added a default-on Gateway out-of-process event bridge that polls persisted _smithers_events for non-in-process runs, feeds them through handleSmithersEvent, skips runs seen in runRegistry to avoid duplicate streaming, drains terminal detached runs, and tears down cleanly on close. Added GatewayOptions/GatewayDefaults fields, updated generated server declarations and Gateway docs/llms bundles, and covered detached event delivery plus in-process no-replay behavior in gateway tests.

---
Pipeline: Opus investigated, Codex implemented, Opus + Codex both approved in review, a human reviewed at the landing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)