### PR TITLE
✨ feat(cli): serve gateway for empty workspaces

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -1647,7 +1647,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see Installation for wh
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[70]:
+commands[71]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1749,6 +1749,11 @@ commands[70]:
       interval,i,string,10s,Poll interval
       stale-threshold,t,string,30s,Heartbeat staleness threshold before resume
       max-concurrent,c,number,3,Max runs resumed per poll
+  - name: gateway
+    purpose: Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run
+    flags[2]{name,short,type,default,desc}:
+      host,H,string,127.0.0.1,Gateway bind address
+      port,p,number,7331,Gateway port
   - name: ps
     purpose: List active, paused, and recently completed runs
     flags[5]{name,short,type,default,desc}:

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -29,7 +29,7 @@ import { spawn } from "node:child_process";
 import { buildAgentAskRequestRow, isHumanRequestPastTimeout, validateHumanRequestValue, waitForHumanAnswer, } from "@smithers-orchestrator/engine/human-requests";
 import { SmithersError } from "@smithers-orchestrator/errors";
 import { assertMaxBytes, assertMaxStringLength } from "@smithers-orchestrator/db/input-bounds";
-import { findAndOpenDb } from "./find-db.js";
+import { findAndOpenDb, findSmithersDb } from "./find-db.js";
 import { buildAskKindFields, buildAskPromptText, buildAskUniqueToken, formatAskHumanResolveHelp, parseChoices, resolveAskHumanContext, } from "./ask-human.js";
 import { chatAttemptKey, formatChatAttemptHeader, formatChatBlock, parseAgentEvent, parseChatAttemptMeta, parseNodeOutputEvent, selectChatAttempts, } from "./chat.js";
 import { buildHijackLaunchSpec, isNativeHijackCandidate, launchHijackSession, resolveHijackCandidate, waitForHijackCandidate, } from "./hijack.js";
@@ -1322,6 +1322,10 @@ const superviseOptions = z.object({
     staleThreshold: z.string().default("30s").describe("Heartbeat staleness threshold before resume"),
     maxConcurrent: z.number().int().min(1).default(3).describe("Max runs resumed per poll"),
 });
+const gatewayOptions = z.object({
+    host: z.string().default("127.0.0.1").describe("Gateway bind address"),
+    port: z.number().int().min(1).default(7331).describe("Gateway port"),
+});
 const psOptions = z.object({
     status: z.string().optional().describe("Filter by status: running, waiting-approval, waiting-event, waiting-timer, continued, finished, failed, cancelled"),
     limit: z.number().int().min(1).default(20).describe("Maximum runs to return"),
@@ -1896,6 +1900,65 @@ async function executeUpCommand(c, workflowPath, options, fail) {
     catch (err) {
         return fail({ code: "RUN_FAILED", message: err?.message ?? String(err), exitCode: 1 });
     }
+}
+/**
+ * @param {{ host: string; port: number }} options
+ * @returns {Promise<{ url: string; workspace: string; dbPath: string; workflows: string[] }>}
+ */
+async function runGatewayCommand(options) {
+    const localPackDir = resolvePackDirs(process.cwd()).find((dir) => dir.scope === "local")?.packDir;
+    const localWorkspace = localPackDir ? dirname(localPackDir) : undefined;
+    const dbPath = localWorkspace
+        ? resolve(localWorkspace, "smithers.db")
+        : findSmithersDb(process.cwd());
+    const workspace = localWorkspace ?? dirname(dbPath);
+    process.chdir(workspace);
+    const [{ Gateway }, { createSmithers }] = await Promise.all([
+        import("@smithers-orchestrator/server/gateway"),
+        import("smithers-orchestrator"),
+    ]);
+    const gateway = new Gateway({ heartbeatMs: 15_000 });
+    const workspaceApi = createSmithers({}, { dbPath });
+    const workspaceWorkflow = workspaceApi.smithers(() => React.createElement(workspaceApi.Workflow, { name: "workspace" }));
+    ensureSmithersTables(workspaceWorkflow.db);
+    setupSqliteCleanup(workspaceWorkflow);
+    const workflows = [];
+    for (const discovered of discoverWorkflows(workspace)) {
+        try {
+            const workflow = await loadWorkflow(discovered.entryFile);
+            ensureSmithersTables(workflow.db);
+            setupSqliteCleanup(workflow);
+            gateway.register(discovered.id, workflow);
+            workflows.push(discovered.id);
+        }
+        catch (error) {
+            process.stderr.write(`[smithers] Skipping workflow ${discovered.id}: ${error?.message ?? String(error)}\n`);
+        }
+    }
+    if (workflows.length === 0) {
+        gateway.register("workspace", workspaceWorkflow);
+        workflows.push("workspace");
+    }
+    const server = await gateway.listen({ host: options.host, port: options.port });
+    const address = server.address();
+    const port = address && typeof address === "object" ? address.port : options.port;
+    const url = `http://${options.host}:${port}`;
+    process.stderr.write(`[smithers] Gateway listening on ${url}\n`);
+    process.stderr.write(`[smithers] Workspace: ${workspace}\n`);
+    process.stderr.write(`[smithers] Database: ${dbPath}\n`);
+    process.stderr.write(`[smithers] Registered workflows: ${workflows.join(", ")}\n`);
+    await new Promise((resolvePromise) => {
+        const shutdown = () => {
+            gateway.close()
+                .catch((error) => {
+                process.stderr.write(`[smithers] Gateway shutdown error: ${error?.message ?? String(error)}\n`);
+            })
+                .finally(resolvePromise);
+        };
+        process.once("SIGINT", shutdown);
+        process.once("SIGTERM", shutdown);
+    });
+    return { url, workspace, dbPath, workflows };
 }
 const workflowCli = Cli.create({
     name: "workflow",
@@ -2711,6 +2774,30 @@ const cli = Cli.create({
             return c.error(opts);
         };
         return executeUpCommand(c, c.args.workflow, c.options, fail);
+    },
+})
+    // =========================================================================
+    // smithers gateway
+    // =========================================================================
+    .command("gateway", {
+    description: "Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run.",
+    options: gatewayOptions,
+    alias: { host: "H", port: "p" },
+    async run(c) {
+        const fail = (opts) => {
+            commandExitOverride = opts.exitCode ?? 1;
+            return c.error(opts);
+        };
+        try {
+            const result = await runGatewayCommand(c.options);
+            return c.ok(result);
+        }
+        catch (err) {
+            if (err instanceof SmithersError) {
+                return fail({ code: err.code, message: err.message, exitCode: 4 });
+            }
+            return fail({ code: "GATEWAY_FAILED", message: err?.message ?? String(err), exitCode: 1 });
+        }
     },
 })
     // =========================================================================

--- a/apps/cli/tests/gateway-command.test.js
+++ b/apps/cli/tests/gateway-command.test.js
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createServer } from "node:net";
+import { resolve } from "node:path";
+import { createTempRepo, runSmithers, writeTestWorkflow } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+const CLI_ENTRY = resolve(import.meta.dir, "..", "src", "index.js");
+
+async function findOpenPort() {
+    const server = createServer();
+    await new Promise((resolvePromise, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolvePromise);
+    });
+    const address = server.address();
+    await new Promise((resolvePromise) => server.close(resolvePromise));
+    if (!address || typeof address === "string") {
+        throw new Error("Could not allocate an open port");
+    }
+    return address.port;
+}
+
+async function waitFor(predicate, timeoutMs = 10_000) {
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+        const value = await predicate();
+        if (value) return value;
+        await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+    }
+    throw new Error("Timed out waiting for condition");
+}
+
+async function stopProcess(child, closePromise) {
+    child.kill("SIGTERM");
+    const closed = await Promise.race([
+        closePromise.then(() => true),
+        new Promise((resolvePromise) => setTimeout(() => resolvePromise(false), 2_000)),
+    ]);
+    if (!closed) {
+        child.kill("SIGKILL");
+        await closePromise;
+    }
+}
+
+test("gateway help distinguishes the multi-run Gateway from up --serve", () => {
+    const repo = createTempRepo();
+    const result = runSmithers(["gateway", "--help"], {
+        cwd: repo.dir,
+        format: null,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("multi-run Gateway RPC/WS control plane");
+    expect(result.stdout).toContain("unlike up --serve");
+});
+
+test("gateway starts for an initialized workspace with no existing DB and listRuns is empty", async () => {
+    const repo = createTempRepo();
+    writeTestWorkflow(repo, ".smithers/workflows/basic.tsx");
+    const dbPath = repo.path("smithers.db");
+    expect(existsSync(dbPath)).toBe(false);
+
+    const port = await findOpenPort();
+    const child = spawn(process.execPath, ["run", CLI_ENTRY, "gateway", "--host", "127.0.0.1", "--port", String(port)], {
+        cwd: repo.dir,
+        env: {
+            ...process.env,
+            NO_COLOR: "1",
+            FORCE_COLOR: "0",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const closePromise = new Promise((resolvePromise) => child.once("close", resolvePromise));
+    try {
+        await waitFor(() => stderr.includes("Registered workflows:"));
+        expect(stderr).toContain(`Workspace: ${repo.dir}`);
+        expect(stderr).toContain(`Database: ${dbPath}`);
+        expect(stderr).toContain("Registered workflows: basic");
+        expect(existsSync(dbPath)).toBe(true);
+
+        const response = await fetch(`http://127.0.0.1:${port}/v1/rpc/listRuns`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({}),
+            signal: AbortSignal.timeout(3_000),
+        });
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.ok).toBe(true);
+        expect(body.payload).toEqual([]);
+    }
+    finally {
+        await stopProcess(child, closePromise);
+    }
+    expect(stdout).toBe("");
+}, 15_000);

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -32,7 +32,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[70]:
+commands[71]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -134,6 +134,11 @@ commands[70]:
       interval,i,string,10s,Poll interval
       stale-threshold,t,string,30s,Heartbeat staleness threshold before resume
       max-concurrent,c,number,3,Max runs resumed per poll
+  - name: gateway
+    purpose: Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run
+    flags[2]{name,short,type,default,desc}:
+      host,H,string,127.0.0.1,Gateway bind address
+      port,p,number,7331,Gateway port
   - name: ps
     purpose: List active, paused, and recently completed runs
     flags[5]{name,short,type,default,desc}:

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1627,7 +1627,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see [Installation](/ins
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[70]:
+commands[71]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1729,6 +1729,11 @@ commands[70]:
       interval,i,string,10s,Poll interval
       stale-threshold,t,string,30s,Heartbeat staleness threshold before resume
       max-concurrent,c,number,3,Max runs resumed per poll
+  - name: gateway
+    purpose: Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run
+    flags[2]{name,short,type,default,desc}:
+      host,H,string,127.0.0.1,Gateway bind address
+      port,p,number,7331,Gateway port
   - name: ps
     purpose: List active, paused, and recently completed runs
     flags[5]{name,short,type,default,desc}:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1647,7 +1647,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see Installation for wh
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[70]:
+commands[71]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1749,6 +1749,11 @@ commands[70]:
       interval,i,string,10s,Poll interval
       stale-threshold,t,string,30s,Heartbeat staleness threshold before resume
       max-concurrent,c,number,3,Max runs resumed per poll
+  - name: gateway
+    purpose: Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run
+    flags[2]{name,short,type,default,desc}:
+      host,H,string,127.0.0.1,Gateway bind address
+      port,p,number,7331,Gateway port
   - name: ps
     purpose: List active, paused, and recently completed runs
     flags[5]{name,short,type,default,desc}:

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -1647,7 +1647,7 @@ Always invoke as `bunx smithers-orchestrator <command>` (see Installation for wh
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[70]:
+commands[71]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1749,6 +1749,11 @@ commands[70]:
       interval,i,string,10s,Poll interval
       stale-threshold,t,string,30s,Heartbeat staleness threshold before resume
       max-concurrent,c,number,3,Max runs resumed per poll
+  - name: gateway
+    purpose: Serve the multi-run Gateway RPC/WS control plane for the workspace DB; unlike up --serve, this is not tied to one run
+    flags[2]{name,short,type,default,desc}:
+      host,H,string,127.0.0.1,Gateway bind address
+      port,p,number,7331,Gateway port
   - name: ps
     purpose: List active, paused, and recently completed runs
     flags[5]{name,short,type,default,desc}:


### PR DESCRIPTION
Closes #255

Updated the headless `smithers gateway` command so it resolves the local `.smithers` workspace, creates/initializes `smithers.db` for an empty workspace before serving, registers discovered workflows, and still falls back to an existing DB outside a workspace. Added a focused CLI integration test that checks help text, startup DB/workspace reporting, discovered workflow registration, DB creation, and `/v1/rpc/listRuns` returning an empty list for a new workspace. Existing docs/llms bundle edits remain in the worktree for the new public CLI surface.

---
Pipeline: Opus investigated, Codex implemented, Opus + Codex both approved in review, a human reviewed at the landing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)