### PR TITLE
🐛 fix(cli): ship observability stack assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ composite patterns. See [Components](https://smithers.sh/components/workflow).
 ## Deeper capabilities
 
 - **Observability**: every run emits Prometheus metrics and OpenTelemetry traces. Bring up
-  the local stack with `bunx smithers-orchestrator observability up` (Grafana, Prometheus, Tempo, OTLP
+  the local stack with `bunx smithers-orchestrator observability --detach` (Grafana, Prometheus, Tempo, OTLP
   collector) and serve metrics with `bunx smithers-orchestrator up workflow.tsx --serve --metrics`.
 - **Evals**: run repeatable workflow regressions from JSON/JSONL cases with
   `bunx smithers-orchestrator eval workflow.tsx --cases evals/smoke.jsonl --suite smoke`; the command exits

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -245,7 +245,7 @@ can rewind, fork, and replay any run.
 ```bash
 bunx smithers-orchestrator up workflow.tsx --run-id abc123 --resume true   # resume after a crash
 bunx smithers-orchestrator rewind abc123 --frame 4                         # time-travel to an earlier frame
-bunx smithers-orchestrator observability up                                # Grafana + Prometheus + Tempo + OTLP
+bunx smithers-orchestrator observability --detach                          # Grafana + Prometheus + Tempo + OTLP
 bunx smithers-orchestrator up workflow.tsx --serve --metrics               # HTTP API, SSE events, and /metrics
 ```
 

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -4929,12 +4929,21 @@ const cli = Cli.create({
             commandExitOverride = opts.exitCode ?? 1;
             return c.error(opts);
         };
-        const composeDir = resolve(dirname(new URL(import.meta.url).pathname), "../../observability");
+        const moduleDir = dirname(fileURLToPath(import.meta.url));
+        const composeDirCandidates = [
+            resolve(moduleDir, "../../observability"),
+            resolve(moduleDir, "../../../observability"),
+        ];
+        const composeDir = composeDirCandidates.find((dir) => existsSync(resolve(dir, "docker-compose.otel.yml"))) ?? composeDirCandidates[0];
         const composeFile = resolve(composeDir, "docker-compose.otel.yml");
         if (!existsSync(composeFile)) {
             return fail({
                 code: "COMPOSE_NOT_FOUND",
-                message: `Docker Compose file not found at ${composeFile}. Ensure the smithers-orchestrator package includes the observability/ directory.`,
+                message: [
+                    `Docker Compose file not found. Checked ${composeDirCandidates.map((dir) => resolve(dir, "docker-compose.otel.yml")).join(", ")}.`,
+                    `Reinstall smithers-orchestrator or upgrade @smithers-orchestrator/observability to a version that ships the local stack assets, then run "smithers observability --detach".`,
+                    `Docker with Compose support is required.`,
+                ].join(" "),
                 exitCode: 1,
             });
         }

--- a/apps/cli/tests/observability-package.test.js
+++ b/apps/cli/tests/observability-package.test.js
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../../../..");
+const OBSERVABILITY_PACKAGE_DIR = resolve(REPO_ROOT, "apps/observability");
+
+test("observability package ships the local Docker Compose stack assets", () => {
+    const manifest = JSON.parse(readFileSync(resolve(OBSERVABILITY_PACKAGE_DIR, "package.json"), "utf8"));
+    const files = new Set(manifest.files ?? []);
+
+    expect(files.has("docker-compose.otel.yml")).toBe(true);
+    expect(files.has("otel-collector-config.yml")).toBe(true);
+    expect(files.has("prometheus/")).toBe(true);
+    expect(files.has("tempo/")).toBe(true);
+    expect(files.has("loki/")).toBe(true);
+    expect(files.has("grafana/")).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "docker-compose.otel.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "otel-collector-config.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "prometheus/prometheus.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "tempo/tempo.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "loki/loki-config.yaml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "grafana/provisioning/datasources/datasources.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "grafana/provisioning/dashboards/dashboards.yml"))).toBe(true);
+    expect(existsSync(resolve(OBSERVABILITY_PACKAGE_DIR, "grafana/dashboards/smithers-dashboard.json"))).toBe(true);
+});
+
+test("docs and Smithers skill use the supported observability CLI shape", () => {
+    const checkedFiles = [
+        "README.md",
+        "docs/index.mdx",
+        "docs/why/durable-open-orchestration.mdx",
+        "docs/guides/monitoring-logs.mdx",
+        "skills/smithers/SKILL.md",
+    ];
+
+    for (const file of checkedFiles) {
+        const contents = readFileSync(resolve(REPO_ROOT, file), "utf8");
+        expect(contents).not.toMatch(/\bsmithers(?:-orchestrator)?\s+observability\s+up\b/);
+    }
+});

--- a/apps/observability/docker-compose.otel.yml
+++ b/apps/observability/docker-compose.otel.yml
@@ -1,0 +1,104 @@
+version: "3.9"
+
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.148.0
+    restart: unless-stopped
+    command: ["--config", "/etc/otelcol/config.yml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otelcol/config.yml:ro
+    ports:
+      - "4317:4317"   # gRPC
+      - "4318:4318"   # HTTP (Smithers sends here)
+      - "8889:8889"   # Prometheus exporter scrape endpoint
+    depends_on:
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/otelcol-contrib", "--version"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  loki:
+    image: grafana/loki:3.3.2
+    restart: unless-stopped
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    volumes:
+      - ./loki/loki-config.yaml:/etc/loki/local-config.yaml:ro
+      - ./data/loki:/loki
+    ports:
+      - "3100:3100"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:3100/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 10s
+
+  prometheus:
+    image: prom/prometheus:v3.2.0
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./data/prometheus:/prometheus
+    ports:
+      - "9090:9090"
+    depends_on:
+      otel-collector:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+      start_period: 10s
+
+  tempo:
+    image: grafana/tempo:2.7.0
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo/tempo.yml"]
+    volumes:
+      - ./tempo/tempo.yml:/etc/tempo/tempo.yml:ro
+      - ./data/tempo:/tmp/tempo
+    ports:
+      - "3200:3200"   # Tempo query API
+      - "4317"        # OTLP gRPC (internal)
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:3200/api/search"]
+      interval: 10s
+      timeout: 5s
+      retries: 24
+      start_period: 20s
+
+  grafana:
+    image: grafana/grafana:11.5.0
+    restart: unless-stopped
+    environment:
+      # Local dev default is "admin"; override via env for anything shared.
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-admin}
+      # Anonymous browsing stays on for frictionless local dev, but read-only.
+      - GF_AUTH_ANONYMOUS_ENABLED=${GF_AUTH_ANONYMOUS_ENABLED:-true}
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=${GF_AUTH_ANONYMOUS_ORG_ROLE:-Viewer}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - ./data/grafana:/var/lib/grafana
+    ports:
+      - "3001:3000"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+      tempo:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://127.0.0.1:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 24
+      start_period: 20s

--- a/apps/observability/grafana/dashboards/smithers-dashboard.json
+++ b/apps/observability/grafana/dashboards/smithers-dashboard.json
@@ -1,0 +1,453 @@
+{
+  "uid": "smithers-overview",
+  "title": "Smithers Overview",
+  "tags": ["smithers", "ai", "orchestration"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "editable": true,
+  "panels": [
+    {
+      "type": "row",
+      "title": "Overview",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1
+    },
+    {
+      "type": "stat",
+      "title": "Active Runs",
+      "id": 2,
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "smithers_smithers_runs_active", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Total Runs",
+      "id": 3,
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "smithers_smithers_runs_total", "refId": "A" }],
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Active Nodes",
+      "id": 4,
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "smithers_smithers_nodes_active", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "area"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Node Success Rate",
+      "id": 5,
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "(smithers_smithers_nodes_finished / (smithers_smithers_nodes_finished + smithers_smithers_nodes_failed > 0)) * 100 or vector(100)",
+        "refId": "A"
+      }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 99 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "min": 0,
+          "max": 100
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Cache Hit Rate",
+      "id": 6,
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "(smithers_smithers_cache_hits / (smithers_smithers_cache_hits + smithers_smithers_cache_misses > 0)) * 100 or vector(0)",
+        "refId": "A"
+      }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 30 },
+              { "color": "green", "value": 70 }
+            ]
+          },
+          "color": { "mode": "thresholds" },
+          "min": 0,
+          "max": 100
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none"
+      }
+    },
+    {
+      "type": "stat",
+      "title": "DB Retries",
+      "id": 7,
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "smithers_smithers_db_retries", "refId": "A" }],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "color": { "mode": "thresholds" }
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "value",
+        "graphMode": "area"
+      }
+    },
+
+    {
+      "type": "row",
+      "title": "Runs & Nodes",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10
+    },
+    {
+      "type": "timeseries",
+      "title": "Node Throughput",
+      "id": 11,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "rate(smithers_smithers_nodes_started[5m])", "legendFormat": "Started", "refId": "A" },
+        { "expr": "rate(smithers_smithers_nodes_finished[5m])", "legendFormat": "Finished", "refId": "B" },
+        { "expr": "rate(smithers_smithers_nodes_failed[5m])", "legendFormat": "Failed", "refId": "C" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10, "gradientMode": "scheme" },
+          "color": { "mode": "palette-classic" },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom", "calcs": ["mean", "max"] }
+      }
+    },
+    {
+      "type": "heatmap",
+      "title": "Node Duration",
+      "id": 12,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "sum(increase(smithers_smithers_node_duration_ms_bucket[5m])) by (le)",
+        "legendFormat": "{{le}}",
+        "refId": "A",
+        "format": "heatmap"
+      }],
+      "options": {
+        "calculate": false,
+        "yAxis": { "unit": "ms" },
+        "color": { "mode": "scheme", "scheme": "Oranges", "steps": 64 },
+        "cellGap": 1
+      }
+    },
+
+    {
+      "type": "row",
+      "title": "Tools",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 20
+    },
+    {
+      "type": "timeseries",
+      "title": "Tool Call Rate",
+      "id": 21,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "rate(smithers_smithers_tool_calls_total[5m])",
+        "legendFormat": "Tool Calls / sec",
+        "refId": "A"
+      }],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "fixed", "fixedColor": "purple" },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "heatmap",
+      "title": "Tool Duration",
+      "id": 22,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "sum(increase(smithers_smithers_tool_duration_ms_bucket[5m])) by (le)",
+        "legendFormat": "{{le}}",
+        "refId": "A",
+        "format": "heatmap"
+      }],
+      "options": {
+        "calculate": false,
+        "yAxis": { "unit": "ms" },
+        "color": { "mode": "scheme", "scheme": "Blues", "steps": 64 },
+        "cellGap": 1
+      }
+    },
+
+    {
+      "type": "row",
+      "title": "Infrastructure",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 30
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Request Latency",
+      "id": 31,
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(smithers_smithers_http_request_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(smithers_smithers_http_request_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(smithers_smithers_http_request_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 5 },
+          "color": { "mode": "palette-classic" },
+          "unit": "ms"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "heatmap",
+      "title": "DB Query Duration",
+      "id": 32,
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "sum(increase(smithers_smithers_db_query_ms_bucket[5m])) by (le)",
+        "legendFormat": "{{le}}",
+        "refId": "A",
+        "format": "heatmap"
+      }],
+      "options": {
+        "calculate": false,
+        "yAxis": { "unit": "ms" },
+        "color": { "mode": "scheme", "scheme": "Greens", "steps": 64 },
+        "cellGap": 1
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "VCS & Hot Reload",
+      "id": 33,
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(smithers_smithers_hot_reloads[5m])",
+          "legendFormat": "Hot Reloads / sec",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(smithers_smithers_hot_reload_failures[5m])",
+          "legendFormat": "Reload Failures / sec",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(smithers_smithers_vcs_duration_ms_bucket[5m])) by (le))",
+          "legendFormat": "VCS p95 (ms)",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+
+    {
+      "type": "row",
+      "title": "Approvals",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 40
+    },
+    {
+      "type": "timeseries",
+      "title": "Approval Flow",
+      "id": 41,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "rate(smithers_smithers_approvals_requested[5m])", "legendFormat": "Requested", "refId": "A" },
+        { "expr": "rate(smithers_smithers_approvals_granted[5m])", "legendFormat": "Granted", "refId": "B" },
+        { "expr": "rate(smithers_smithers_approvals_denied[5m])", "legendFormat": "Denied", "refId": "C" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "bars", "lineWidth": 1, "fillOpacity": 50 },
+          "color": { "mode": "palette-classic" },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Request Rate",
+      "id": 42,
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{
+        "expr": "rate(smithers_smithers_http_requests[5m])",
+        "legendFormat": "Requests / sec",
+        "refId": "A"
+      }],
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 15, "gradientMode": "scheme" },
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "unit": "reqps"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      }
+    },
+
+    {
+      "type": "row",
+      "title": "Traces",
+      "collapsed": true,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 41 },
+      "id": 50,
+      "panels": [
+        {
+          "type": "traces",
+          "title": "Recent Traces",
+          "id": 51,
+          "gridPos": { "h": 12, "w": 24, "x": 0, "y": 42 },
+          "datasource": { "type": "tempo", "uid": "tempo" },
+          "targets": [{
+            "datasource": { "type": "tempo", "uid": "tempo" },
+            "queryType": "traceqlSearch",
+            "limit": 20,
+            "tableType": "traces",
+            "filters": [
+              { "id": "service-name", "tag": "service.name", "operator": "=", "value": ["smithers"], "scope": "resource" }
+            ],
+            "refId": "A"
+          }]
+        }
+      ]
+    }
+  ]
+}

--- a/apps/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/apps/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/apps/observability/grafana/provisioning/datasources/datasources.yml
+++ b/apps/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,49 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      exemplarTraceIdDestinations:
+        - name: traceID
+          datasourceUid: tempo
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToLogs:
+        datasourceUid: loki
+        tags: ["service.name"]
+        mappedTags:
+          - key: service.name
+            value: service.name
+        mapTagNamesEnabled: false
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+        filterByTraceID: false
+        filterBySpanID: false
+      tracesToMetrics:
+        datasourceUid: prometheus
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+      nodeGraph:
+        enabled: true

--- a/apps/observability/loki/loki-config.yaml
+++ b/apps/observability/loki/loki-config.yaml
@@ -1,0 +1,35 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false

--- a/apps/observability/otel-collector-config.yml
+++ b/apps/observability/otel-collector-config.yml
@@ -1,0 +1,38 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    namespace: smithers
+  otlp_grpc/tempo:
+    endpoint: "tempo:4317"
+    tls:
+      insecure: true
+  otlp_http/loki:
+    endpoint: "http://loki:3100/otlp"
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp_grpc/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp_http/loki]

--- a/apps/observability/package.json
+++ b/apps/observability/package.json
@@ -22,7 +22,13 @@
     }
   },
   "files": [
-    "src/"
+    "src/",
+    "docker-compose.otel.yml",
+    "otel-collector-config.yml",
+    "prometheus/",
+    "tempo/",
+    "loki/",
+    "grafana/"
   ],
   "scripts": {
     "build": "tsup --dts-only",

--- a/apps/observability/prometheus/prometheus.yml
+++ b/apps/observability/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "otel-collector"
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/apps/observability/tempo/tempo.yml
+++ b/apps/observability/tempo/tempo.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -204,7 +204,7 @@ can rewind, fork, and replay any run.
 ```bash
 bunx smithers-orchestrator up workflow.tsx --run-id abc123 --resume true   # resume after a crash
 bunx smithers-orchestrator rewind abc123 --frame 4                         # time-travel to an earlier frame
-bunx smithers-orchestrator observability up                                # Grafana + Prometheus + Tempo + OTLP
+bunx smithers-orchestrator observability --detach                          # Grafana + Prometheus + Tempo + OTLP
 bunx smithers-orchestrator up workflow.tsx --serve --metrics               # HTTP API, SSE events, and /metrics
 ```
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -222,7 +222,7 @@ can rewind, fork, and replay any run.
 ```bash
 bunx smithers-orchestrator up workflow.tsx --run-id abc123 --resume true   # resume after a crash
 bunx smithers-orchestrator rewind abc123 --frame 4                         # time-travel to an earlier frame
-bunx smithers-orchestrator observability up                                # Grafana + Prometheus + Tempo + OTLP
+bunx smithers-orchestrator observability --detach                          # Grafana + Prometheus + Tempo + OTLP
 bunx smithers-orchestrator up workflow.tsx --serve --metrics               # HTTP API, SSE events, and /metrics
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -245,7 +245,7 @@ can rewind, fork, and replay any run.
 ```bash
 bunx smithers-orchestrator up workflow.tsx --run-id abc123 --resume true   # resume after a crash
 bunx smithers-orchestrator rewind abc123 --frame 4                         # time-travel to an earlier frame
-bunx smithers-orchestrator observability up                                # Grafana + Prometheus + Tempo + OTLP
+bunx smithers-orchestrator observability --detach                          # Grafana + Prometheus + Tempo + OTLP
 bunx smithers-orchestrator up workflow.tsx --serve --metrics               # HTTP API, SSE events, and /metrics
 ```
 

--- a/docs/why/durable-open-orchestration.mdx
+++ b/docs/why/durable-open-orchestration.mdx
@@ -149,7 +149,7 @@ This is the claim a skeptic should test first, so we will be specific. The same 
 ```bash
 bunx smithers-orchestrator init        # scaffold the workflow pack
 bunx smithers-orchestrator up workflow.tsx --serve --metrics   # HTTP API, SSE stream, Prometheus
-bunx smithers-orchestrator observability up               # Grafana, Prometheus, Tempo, one command
+bunx smithers-orchestrator observability --detach         # Grafana, Prometheus, Tempo, one command
 ```
 
 <Frame caption="Live frames stream over the gateway as the run executes. Every state transition, every attempt, every retry is already a row you can scrub back through.">

--- a/skills/smithers/SKILL.md
+++ b/skills/smithers/SKILL.md
@@ -231,7 +231,7 @@ The same substrate carries the concerns you'd otherwise bolt on later:
 - **Memory**: cross-run facts + history per namespace; `memory={{ recall, save }}` auto-injects the top-K relevant facts; query with `smithers memory`.
 - **Hot mode**: `--hot true` re-renders against persisted state when you edit the workflow or an `.mdx` prompt mid-run; finished tasks stay put.
 - **Time travel**: every render is a frame: `smithers timeline | fork | replay | rewind | diff | timetravel | retry-task`.
-- **Observability / serving**: `smithers observability up` (Grafana/Prometheus/Tempo/OTLP); `smithers up … --serve --metrics` exposes an HTTP API, SSE event stream, and `/metrics`. A workflow can even serve its own React front-end.
+- **Observability / serving**: `smithers observability --detach` (Grafana/Prometheus/Tempo/OTLP); `smithers observability --down` stops it; `smithers up … --serve --metrics` exposes an HTTP API, SSE event stream, and `/metrics`. A workflow can even serve its own React front-end.
 - **Agents**: pluggable runtimes (claude, codex, antigravity, kimi, amp, forge, Effect-native) configured in `agents.ts`; `agent={[primary, fallback]}` falls back on failure.
 - **Tools**: built-in `read`/`write`/`edit`/`bash`/`grep`/`ls` with path containment (`--root`); `smithers openapi <spec>` generates typed AI SDK tools from an OpenAPI spec.
 - **Integrations**: run Smithers itself as an MCP server (`smithers mcp add`), sync skills into agent dirs (`smithers skills add`), durable schedules (`smithers cron`), pager-style `smithers alerts`, a structured `<HumanTask>` queue (`smithers human`), and `smithers hijack` to hand off a live agent session.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -245,7 +245,7 @@ can rewind, fork, and replay any run.
 ```bash
 bunx smithers-orchestrator up workflow.tsx --run-id abc123 --resume true   # resume after a crash
 bunx smithers-orchestrator rewind abc123 --frame 4                         # time-travel to an earlier frame
-bunx smithers-orchestrator observability up                                # Grafana + Prometheus + Tempo + OTLP
+bunx smithers-orchestrator observability --detach                          # Grafana + Prometheus + Tempo + OTLP
 bunx smithers-orchestrator up workflow.tsx --serve --metrics               # HTTP API, SSE events, and /metrics
 ```
 


### PR DESCRIPTION
Closes #262

Shipped the local observability Docker Compose stack with the observability package, updated CLI compose path resolution to support installed and monorepo layouts with an actionable COMPOSE_NOT_FOUND message, reconciled docs/README/skill command examples to the supported `observability --detach` and `--down` flag syntax, and added a focused packaging/docs parity test that now covers README.md.

---
Pipeline: Opus investigated, Codex implemented, Opus + Codex both approved in review, a human reviewed at the landing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)