### PR TITLE
🐛 fix(cli): reject OpenCode-only smart defaults

### DIFF
--- a/.smithers/agents.ts
+++ b/.smithers/agents.ts
@@ -17,8 +17,11 @@ export const providers = {
   gemini1: new SmithersGeminiAgent({ model: "gemini-3.1-pro-preview", configDir: path.join(homedir(), ".gemini"), cwd: process.cwd() }),
 } as const;
 
+// kimi providers stay out of the default pools: a kimi auth-setup error is
+// fatal (the engine fails the run instead of failing over), so an expired
+// kimi OAuth in a failover chain kills runs. Re-add deliberately if needed.
 export const agents = {
   cheapFast: [providers.claudeSonnet, providers.claude],
-  smart: [providers.claude, providers.claudeSonnet, providers.codex, providers.kimi1, providers.codex1, providers.gemini1],
-  smartTool: [providers.claude, providers.claudeSonnet, providers.codex, providers.kimi1, providers.codex1, providers.gemini1],
+  smart: [providers.claude, providers.claudeSonnet, providers.codex, providers.codex1, providers.gemini1],
+  smartTool: [providers.claude, providers.claudeSonnet, providers.codex, providers.codex1, providers.gemini1],
 } as const satisfies Record<string, AgentLike[]>;

--- a/.smithers/agents.ts
+++ b/.smithers/agents.ts
@@ -6,25 +6,19 @@ import { type AgentLike, ClaudeCodeAgent as SmithersClaudeCodeAgent, CodexAgent 
 
 export const providers = {
   claude: new SmithersClaudeCodeAgent({ model: "claude-opus-4-7", cwd: process.cwd() }),
-  codex: new SmithersCodexAgent({ model: "gpt-5.3-codex", cwd: process.cwd(), skipGitRepoCheck: true }),
+  codex: new SmithersCodexAgent({ model: "gpt-5.3", cwd: process.cwd(), skipGitRepoCheck: true }),
   opencode: new SmithersOpenCodeAgent({ model: "anthropic/claude-opus-4-20250514", cwd: process.cwd() }),
-  pi: new SmithersPiAgent({ provider: "openai", model: "gpt-5.3-codex" }),
+  pi: new SmithersPiAgent({ provider: "openai", model: "gpt-5.3" }),
   kimi: new SmithersKimiAgent({ model: "kimi-latest" }),
   amp: new SmithersAmpAgent(),
   claudeSonnet: new SmithersClaudeCodeAgent({ model: "claude-sonnet-4-6", cwd: process.cwd() }),
   kimi1: new SmithersKimiAgent({ model: "kimi-latest", configDir: path.join(homedir(), ".smithers/accounts/kimi-1"), cwd: process.cwd() }),
-  codex1: new SmithersCodexAgent({ model: "gpt-5.3-codex", configDir: path.join(homedir(), ".codex"), skipGitRepoCheck: true, cwd: process.cwd() }),
+  codex1: new SmithersCodexAgent({ model: "gpt-5.3", configDir: path.join(homedir(), ".codex"), skipGitRepoCheck: true, cwd: process.cwd() }),
   gemini1: new SmithersGeminiAgent({ model: "gemini-3.1-pro-preview", configDir: path.join(homedir(), ".gemini"), cwd: process.cwd() }),
 } as const;
 
-// LOCAL OVERRIDE (uncommitted, dogfooding session): the codex providers reject
-// `gpt-5.3-codex` under ChatGPT auth, opencode runs on an uncredited Anthropic
-// API key, and the kimi accounts' OAuth has expired — all local credential
-// issues, not a shared-config fix. A kimi auth-setup error is fatal (the engine
-// fails the run instead of failing over), so leading arrays with it kills runs.
-// Restrict to the two reliable ClaudeCode subscription providers. See issue #236.
 export const agents = {
   cheapFast: [providers.claudeSonnet, providers.claude],
-  smart: [providers.claude, providers.claudeSonnet],
-  smartTool: [providers.claude, providers.claudeSonnet],
+  smart: [providers.claude, providers.claudeSonnet, providers.codex, providers.kimi1, providers.codex1, providers.gemini1],
+  smartTool: [providers.claude, providers.claudeSonnet, providers.codex, providers.kimi1, providers.codex1, providers.gemini1],
 } as const satisfies Record<string, AgentLike[]>;

--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -171,9 +171,10 @@ const LOCAL_SCAFFOLDED_PROVIDER_FILES = {
 };
 const TIER_PREFERENCES = {
     cheapFast: { order: ["claudeSonnet", "kimi", "vibe", "antigravity", "pi"], maxSize: 2 },
-    smart: { order: ["claude", "claudeOpus", "codex", "opencode", "kimi", "antigravity", "amp"], maxSize: 3 },
-    smartTool: { order: ["codex", "opencode", "claude", "claudeOpus", "kimi", "antigravity", "amp"], maxSize: 3 },
+    smart: { order: ["claude", "claudeOpus", "codex", "kimi", "antigravity", "amp"], maxSize: 3 },
+    smartTool: { order: ["claude", "claudeOpus", "codex", "kimi", "antigravity", "amp"], maxSize: 3 },
 };
+const REQUIRED_DEFAULT_TIERS = ["smart", "smartTool"];
 const CONSTRUCTORS = {
     claude: {
         importName: "ClaudeCodeAgent",
@@ -627,7 +628,7 @@ function generateAccountsAgentsTs(accounts, env) {
         return members;
     };
     poolLines.push(`  smart: [${membersForFamilies("claude", "codex").map((m) => `providers.${m}`).join(", ")}],`);
-    poolLines.push(`  smartTool: [${membersForFamilies("codex", "claude").map((m) => `providers.${m}`).join(", ")}],`);
+    poolLines.push(`  smartTool: [${membersForFamilies("claude", "codex").map((m) => `providers.${m}`).join(", ")}],`);
     poolLines.push(`  cheapFast: [${membersForFamilies("kimi", "gemini", "codex", "claude").slice(0, 2).map((m) => `providers.${m}`).join(", ")}],`);
     return [
         "// smithers-source: generated",
@@ -792,24 +793,42 @@ export function generateAgentsTs(env = process.env, options = {}) {
     const fallbackIds = orderedProviders.map((p) => p.id);
     // Tier lines: detection-resolved members, then accounts whose engine
     // family is in the tier's preference order get appended.
-    const tierLines = Object.entries(TIER_PREFERENCES).flatMap(([tier, { order, maxSize }]) => {
+    const resolvedTiers = Object.entries(TIER_PREFERENCES).map(([tier, { order, maxSize }]) => {
         let resolved = order
             .filter((id) => allProviderIds.has(id))
             .slice(0, maxSize);
         if (resolved.length === 0) {
-            resolved = fallbackIds.slice(0, maxSize);
+            const fallbackPool = tier === "smart" || tier === "smartTool"
+                ? fallbackIds.filter((id) => id !== "opencode")
+                : fallbackIds;
+            resolved = fallbackPool.slice(0, maxSize);
         }
         const tierFamilies = new Set(order);
         const tierAccounts = registeredAccounts
             .filter((account) => tierFamilies.has(ACCOUNT_PROVIDER_POOL[account.provider]))
             .map((account) => labelToCamel(account.label));
         const merged = [...resolved, ...tierAccounts];
-        return renderTierLine(
+        return {
             tier,
-            merged,
-            renderUnavailablePreferenceComments(tier, order, allProviderIds, detectionsById),
-        );
+            members: merged,
+            lines: renderTierLine(
+                tier,
+                merged,
+                renderUnavailablePreferenceComments(tier, order, allProviderIds, detectionsById),
+            ),
+        };
     });
+    const missingRequiredTiers = REQUIRED_DEFAULT_TIERS.filter((tier) => {
+        const resolved = resolvedTiers.find((entry) => entry.tier === tier);
+        return !resolved || resolved.members.length === 0;
+    });
+    if (missingRequiredTiers.length > 0) {
+        throw new SmithersError(
+            "NO_USABLE_AGENTS",
+            `${formatNoUsableAgentsMessage(detections)} Detected agents cannot populate required default pools: ${missingRequiredTiers.join(", ")}.`,
+        );
+    }
+    const tierLines = resolvedTiers.flatMap((entry) => entry.lines);
     return [
         "// smithers-source: generated",
         ...(hasAccounts ? ["// Account providers (camelCase labels) come from ~/.smithers/accounts.json — managed via `smithers agent add|list|remove`."] : []),

--- a/apps/cli/tests/agents-ts-codegen.test.js
+++ b/apps/cli/tests/agents-ts-codegen.test.js
@@ -41,10 +41,9 @@ describe("generateAgentsTs (account-driven)", () => {
         // pools group by engine family
         expect(generated).toContain("claude: [providers.claudeWork, providers.claudePersonal]");
         expect(generated).toContain("codex: [providers.codexWork]");
-        // Smart pools are role-ordered: Claude/Fable first for planning/review,
-        // Codex/GPT first for implementation/tooling.
+        // Smart pools lead with subscription Claude so failover is not on the hot path.
         expect(generated).toContain("smart: [providers.claudeWork, providers.claudePersonal, providers.codexWork]");
-        expect(generated).toContain("smartTool: [providers.codexWork, providers.claudeWork, providers.claudePersonal]");
+        expect(generated).toContain("smartTool: [providers.claudeWork, providers.claudePersonal, providers.codexWork]");
     });
 
     test("path.join(homedir(), ...) is used for paths under $HOME", () => {
@@ -89,6 +88,26 @@ describe("generateAgentsTs (account-driven)", () => {
         expect(generated).toContain("// smithers-source: generated");
         // Detection-based output does NOT pull in the accounts.json header.
         expect(generated).not.toContain("~/.smithers/accounts.json");
+    });
+
+    test("detection smart pools lead with Claude and skip opencode", () => {
+        const env = newSmithersHome();
+        const generated = generateAgentsTs(env, {
+            preserveProviderIds: ["claude", "codex", "opencode"],
+        });
+
+        expect(generated).not.toContain("gpt-5.3-codex");
+        expect(generated).toContain("smart: [providers.claude, providers.claudeOpus, providers.codex]");
+        expect(generated).toContain("smartTool: [providers.claude, providers.claudeOpus, providers.codex]");
+        expect(generated).not.toContain("smart: [providers.claude, providers.claudeOpus, providers.codex, providers.opencode]");
+        expect(generated).not.toContain("smartTool: [providers.codex");
+    });
+
+    test("detection smart pools do not fall back to opencode-only", () => {
+        const env = newSmithersHome();
+        expect(() => generateAgentsTs(env, {
+            preserveProviderIds: ["opencode"],
+        })).toThrow("required default pools");
     });
 
     test("preserves generated detection providers when adding accounts in a different shell", () => {

--- a/apps/cli/tests/cli-agent-detection.test.js
+++ b/apps/cli/tests/cli-agent-detection.test.js
@@ -110,19 +110,15 @@ describe("detectAvailableAgents", () => {
         expect(opencode.hasAuthSignal).toBe(true);
         expect(opencode.usable).toBe(true);
     });
-    test("generated agents.ts can use OpenCode with the local scaffold file", () => {
+    test("generated agents.ts rejects OpenCode-only defaults", () => {
         const home = tempHome();
         const binDir = createExecutableDir();
         writeFakeOpenCodeBinary(binDir);
         mkdirSync(join(home, ".local", "share", "opencode"), { recursive: true });
         writeFileSync(join(home, ".local", "share", "opencode", "auth.json"), "{}\n");
-        const source = generateAgentsTs(envWithPath(home, binDir), {
+        expect(() => generateAgentsTs(envWithPath(home, binDir), {
             cwd: home,
-        });
-        expect(source).toContain('import { OpenCodeAgent } from "./agents/opencode";');
-        expect(source).toContain('export { OpenCodeAgent } from "./agents/opencode";');
-        expect(source).toContain("opencode: OpenCodeAgent");
-        expect(source).not.toContain("OpenCodeAgent as SmithersOpenCodeAgent");
+        })).toThrow("required default pools");
     });
     test("google api key detected for gemini", () => {
         const results = detectAvailableAgents({

--- a/apps/cli/tests/init-agents.e2e.test.js
+++ b/apps/cli/tests/init-agents.e2e.test.js
@@ -56,7 +56,7 @@ test("smithers init includes Codex implementation roles when Codex plus OPENAI_A
     expect(agentsSource).toContain("smart: Smithers would normally suggest Claude Code here");
     expect(agentsSource).toContain("cheapFast: Smithers would normally suggest Kimi here");
 });
-test("smithers init includes OpenCode roles when OpenCode CLI credentials are available", () => {
+test("smithers init rejects OpenCode-only credentials because default smart pools would be empty", () => {
     const repo = createTempRepo();
     const binDir = createExecutableDir();
     writeFakeOpenCodeBinary(binDir);
@@ -66,13 +66,13 @@ test("smithers init includes OpenCode roles when OpenCode CLI credentials are av
         format: "json",
         env: buildEnv(repo.dir, binDir),
     });
-    expect(result.exitCode).toBe(0);
-    const agentsSource = repo.read(".smithers/agents.ts");
-    expect(agentsSource).toContain('export { OpenCodeAgent } from "./agents/opencode";');
-    expect(agentsSource).toContain("opencode: OpenCodeAgent");
-    expect(agentsSource).toContain("smart: [providers.opencode]");
-    expect(agentsSource).toContain("smartTool: [providers.opencode]");
-    expect(agentsSource).toContain("smart: Smithers would normally suggest Codex here");
+    expect(result.exitCode).toBe(4);
+    expect(result.json).toMatchObject({
+        code: "NO_USABLE_AGENTS",
+    });
+    expect(JSON.stringify(result.json)).toContain("required default pools");
+    expect(JSON.stringify(result.json)).toContain("smart");
+    expect(JSON.stringify(result.json)).toContain("smartTool");
 });
 test("smithers init orders role chains correctly when multiple local agent CLIs are available", () => {
     const repo = createTempRepo();
@@ -97,7 +97,7 @@ test("smithers init orders role chains correctly when multiple local agent CLIs 
     const agentsSource = repo.read(".smithers/agents.ts");
     expect(agentsSource).toContain("cheapFast: [providers.claudeSonnet, providers.antigravity]");
     expect(agentsSource).toContain("smart: [providers.claude, providers.claudeOpus, providers.codex]");
-    expect(agentsSource).toContain("smartTool: [providers.codex, providers.opencode, providers.claude]");
+    expect(agentsSource).toContain("smartTool: [providers.claude, providers.claudeOpus, providers.codex]");
     expect(agentsSource).not.toContain("providers.gemini");
 });
 test("smithers init exits with a typed error when no usable agents are detected", () => {


### PR DESCRIPTION
Closes #236

Updated the live .smithers/agents.ts defaults to use ChatGPT-compatible Codex model IDs and keep smart/smartTool Claude-first without OpenCode. Updated apps/cli/src/agent-detection.js so generated defaults exclude OpenCode from smart pools and fail with NO_USABLE_AGENTS when required smart pools would be empty, preventing OpenCode-only init from producing broken agents.smart/agents.smartTool arrays. Adjusted focused codegen, detection, and init e2e tests to assert the new failure behavior and Claude-first ordering.

---
Pipeline: Opus investigated, Codex implemented, Opus + Codex both approved in review, a human reviewed at the landing gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)