### PR TITLE
🐛 fix(engine): advance ready loops without requiring run quiescence

### DIFF
--- a/packages/driver/src/WorkflowDriver.js
+++ b/packages/driver/src/WorkflowDriver.js
@@ -229,6 +229,10 @@ export class WorkflowDriver {
     outputTablesByNodeId = new Map();
     /** @type {OutputSnapshot} */
     baseOutputs = {};
+    /** @type {Map<string, Promise<{ key: string; task: TaskDescriptor; kind: "completed" | "failed" | "cancelled"; output?: unknown; error?: unknown }>>} */
+    inflightTasks = new Map();
+    /** @type {Array<{ key: string; task: TaskDescriptor; kind: "completed" | "failed" | "cancelled"; output?: unknown; error?: unknown }>} */
+    settledTasks = [];
     /**
      * @param {import("./WorkflowDriverOptions.ts").WorkflowDriverOptions<Schema>} options
      */
@@ -298,10 +302,12 @@ export class WorkflowDriver {
                     break;
                 }
                 case "ContinueAsNew":
+                    await this.drainInflight();
                     return this.continueAsNew(decision.transition);
                 case "Finished":
                     return decision.result;
                 case "Failed":
+                    await this.drainInflight();
                     return { runId, status: "failed", error: decision.error };
                 default:
                     return {
@@ -386,47 +392,98 @@ export class WorkflowDriver {
         if (context.signal?.aborted) {
             return this.cancelRun();
         }
-        let latestDecision;
-        let cancelled = false;
+        for (const task of tasks) {
+            this.startInflightTask(task, context);
+        }
+        return this.nextCompletionDecision();
+    }
+    /**
+   * Start a task without blocking the driver loop on its completion. Settled
+   * tasks queue in `settledTasks` and are reported to the session one at a
+   * time from `nextCompletionDecision`, so each decision is computed against
+   * fresh session state and a slow task never blocks scheduling work that
+   * became ready elsewhere in the graph (#267).
+   * @param {TaskDescriptor} task
+   * @param {{ runId: string; options: RunOptions; signal?: AbortSignal }} context
+   */
+    startInflightTask(task, context) {
+        const key = `${task.nodeId}::${task.iteration}`;
+        if (this.inflightTasks.has(key)) {
+            return;
+        }
+        const promise = (async () => {
+            try {
+                const output = await withAbort(Promise.resolve().then(() => this.executeTask(task, context)), context.signal);
+                return { key, task, kind: /** @type {const} */ ("completed"), output };
+            }
+            catch (error) {
+                if (context.signal?.aborted || isAbortError(error)) {
+                    return { key, task, kind: /** @type {const} */ ("cancelled") };
+                }
+                return { key, task, kind: /** @type {const} */ ("failed"), error };
+            }
+        })().then((settled) => {
+            this.inflightTasks.delete(key);
+            this.settledTasks.push(settled);
+            return settled;
+        });
+        this.inflightTasks.set(key, promise);
+    }
+    /**
+   * Wait for the next settled task (or an optional deadline) and report it to
+   * the session for a fresh decision. Completions that landed while a previous
+   * one was being processed drain from `settledTasks` first.
+   * @param {number | null} [deadlineMs]
+   * @returns {Promise<EngineDecision | RunResult>}
+   */
+    async nextCompletionDecision(deadlineMs = null) {
+        if (!this.session) {
+            throw new Error("WorkflowSession is not initialized.");
+        }
         const waitStart = performance.now();
         try {
-            await Promise.all(tasks.map(async (task) => {
-                let report;
-                try {
-                    const output = await withAbort(Promise.resolve().then(() => this.executeTask(task, context)), context.signal);
-                    report = await this.runEffect(this.session.taskCompleted({
-                        nodeId: task.nodeId,
-                        iteration: task.iteration,
-                        output,
-                    }));
+            if (this.settledTasks.length === 0 && this.inflightTasks.size > 0) {
+                const racers = [...this.inflightTasks.values()];
+                if (deadlineMs != null) {
+                    racers.push(sleepWithAbort(deadlineMs, this.activeOptions?.signal).then(() => null));
                 }
-                catch (error) {
-                    if (context.signal?.aborted || isAbortError(error)) {
-                        cancelled = true;
-                        return;
-                    }
-                    report = await this.runEffect(this.session.taskFailed({
-                        nodeId: task.nodeId,
-                        iteration: task.iteration,
-                        error,
-                    }));
-                }
-                if (isEngineDecision(report)) {
-                    latestDecision = report;
-                }
-            }));
+                await Promise.race(racers);
+            }
         }
         finally {
             await this.onSchedulerWait?.(performance.now() - waitStart, {
                 runId: this.activeRunId,
-                tasks,
+                tasks: [],
             });
         }
-        if (cancelled || context.signal?.aborted) {
+        if (this.activeOptions?.signal?.aborted) {
             return this.cancelRun();
         }
-        if (latestDecision) {
-            return latestDecision;
+        const settled = this.settledTasks.shift();
+        if (!settled) {
+            // Deadline elapsed (retry backoff / timer) without a completion —
+            // re-submit the last graph for a fresh decision.
+            if (this.lastGraph) {
+                return this.runEffect(this.session.submitGraph(this.lastGraph));
+            }
+            return { runId: this.activeRunId, status: "waiting-event" };
+        }
+        if (settled.kind === "cancelled") {
+            return this.cancelRun();
+        }
+        const report = settled.kind === "completed"
+            ? await this.runEffect(this.session.taskCompleted({
+                nodeId: settled.task.nodeId,
+                iteration: settled.task.iteration,
+                output: settled.output,
+            }))
+            : await this.runEffect(this.session.taskFailed({
+                nodeId: settled.task.nodeId,
+                iteration: settled.task.iteration,
+                error: settled.error,
+            }));
+        if (isEngineDecision(report)) {
+            return report;
         }
         if (typeof this.session.getNextDecision === "function") {
             return this.runEffect(this.session.getNextDecision());
@@ -434,10 +491,36 @@ export class WorkflowDriver {
         throw new Error("WorkflowSession did not provide the next EngineDecision.");
     }
     /**
+   * Await every in-flight task without reporting further decisions. Used
+   * before run-level exits (failure, continue-as-new) so task executors are
+   * not abandoned mid-write. This matches the pre-#267 barrier semantics:
+   * failure reporting waits for in-flight siblings (bounded by their
+   * timeouts), trading latency for the invariant that no executor writes
+   * after the run is terminal. Fail-fast would need a per-run abort threaded
+   * through executors.
+   */
+    async drainInflight() {
+        while (this.inflightTasks.size > 0) {
+            await Promise.allSettled([...this.inflightTasks.values()]);
+        }
+        this.settledTasks.length = 0;
+    }
+    /**
    * @param {WaitReason} reason
    * @returns {Promise<EngineDecision | RunResult>}
    */
     async handleWait(reason) {
+        if (this.inflightTasks.size > 0 || this.settledTasks.length > 0) {
+            // Work is still in flight — consume the next completion instead of
+            // suspending the run. Deadline-style waits keep their deadline so a
+            // retry backoff or timer elsewhere in the graph still fires on time.
+            const deadlineMs = reason._tag === "RetryBackoff"
+                ? Math.max(0, reason.waitMs)
+                : reason._tag === "Timer"
+                    ? Math.max(0, reason.resumeAtMs - Date.now())
+                    : null;
+            return this.nextCompletionDecision(deadlineMs);
+        }
         if (this.onWait) {
             return this.onWait(reason, {
                 runId: this.activeRunId,

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -6573,7 +6573,257 @@ async function runWorkflowBodyLegacy(workflow, opts) {
                 .filter((task) => !schedulerTaskKeys.has(makeSchedulerTaskKey(task)))
                 .slice(0, localCapacity);
             void Effect.runPromise(Metric.set(schedulerQueueDepth, schedule.runnable.length - runnable.length));
+            const advanceReadyRalphs = async ({ allowContinueAsNew }) => {
+                    // Re-evaluate each ralph's `until` with the correct per-ralph
+                    // iteration context.  The plan tree's `until` was rendered with
+                    // `defaultIteration` which may not reflect each ralph's own
+                    // iteration (especially with multiple parallel loops).  When
+                    // there is a single ralph, `defaultIteration` already tracks
+                    // it correctly, so skip the extra work.
+                    const freshUntilMap = new Map();
+                    if (!singleRalphId) {
+                        const freshOutputs = await loadOutputs(db, schema, runId);
+                        const evalRenderer = new SmithersRenderer();
+                        for (const ralph of schedule.readyRalphs) {
+                            const rState = ralphState.get(ralph.id);
+                            const ralphIteration = rState?.iteration ?? 0;
+                            const perRalphCtx = new SmithersCtx({
+                                runId,
+                                iteration: ralphIteration,
+                                iterations: ralphIterationsObject(ralphState),
+                                input: inputRow,
+                                auth: runAuth,
+                                outputs: freshOutputs,
+                                zodToKeyName: workflow.zodToKeyName,
+                            });
+                            const { xml: freshXml } = await evalRenderer.render(workflowRef.build(perRalphCtx), {
+                                ralphIterations: ralphIterationsFromState(ralphState),
+                                defaultIteration: ralphIteration,
+                                baseRootDir: rootDir,
+                                workflowPath: resolvedWorkflowPath,
+                            });
+                            const { ralphs: freshRalphs } = buildPlanTree(freshXml, ralphState);
+                            const freshRalph = freshRalphs.find((r) => r.id === ralph.id);
+                            freshUntilMap.set(ralph.id, freshRalph?.until ?? ralph.until);
+                        }
+                    }
+                    let advancedAnyRalph = false;
+                    for (const ralph of schedule.readyRalphs) {
+                        const state = ralphState.get(ralph.id) ?? {
+                            iteration: defaultIteration,
+                            done: false,
+                        };
+                        const freshUntil = freshUntilMap.get(ralph.id) ?? ralph.until;
+                        if (state.done || freshUntil) {
+                            // Fresh re-evaluation says the condition is now met — mark done.
+                            if (freshUntil && !state.done) {
+                                ralphState.set(ralph.id, { ...state, done: true });
+                                advancedAnyRalph = true;
+                                await Effect.runPromise(adapter.insertOrUpdateRalph({
+                                    runId,
+                                    ralphId: ralph.id,
+                                    iteration: state.iteration,
+                                    done: true,
+                                    updatedAtMs: nowMs(),
+                                }));
+                            }
+                            continue;
+                        }
+                        const continueAsNewEvery = ralph.continueAsNewEvery;
+                        const nextIteration = state.iteration + 1;
+                        const shouldContinueAsNew = typeof continueAsNewEvery === "number" &&
+                            continueAsNewEvery > 0 &&
+                            nextIteration % continueAsNewEvery === 0;
+                        if (shouldContinueAsNew) {
+                            if (!allowContinueAsNew) {
+                                // Defer the run-level loop-threshold handoff until
+                                // the run is quiescent (#267).
+                                continue;
+                            }
+                            if (continueAsNewEvery === 1) {
+                                logWarning("continue-as-new threshold is 1; this can create high handoff overhead", {
+                                    runId,
+                                    ralphId: ralph.id,
+                                    continueAsNewEvery,
+                                    iteration: state.iteration,
+                                }, "engine:continue-as-new");
+                            }
+                            if (runAbortController.signal.aborted) {
+                                continue;
+                            }
+                            const latestRun = await Effect.runPromise(adapter.getRun(runId));
+                            if (latestRun?.cancelRequestedAtMs) {
+                                runAbortController.abort();
+                                continue;
+                            }
+                            const nextRalphState = cloneRalphStateMap(ralphState);
+                            nextRalphState.set(ralph.id, {
+                                iteration: nextIteration,
+                                done: false,
+                            });
+                            const continuationIteration = state.iteration;
+                            let transition;
+                            try {
+                                transition = await Effect.runPromise(Effect.tryPromise({
+                                    try: () => continueRunAsNew({
+                                        db,
+                                        adapter,
+                                        schema,
+                                        inputTable,
+                                        runId,
+                                        workflowPath: resolvedWorkflowPath ??
+                                            opts.workflowPath ??
+                                            latestRun?.workflowPath ??
+                                            null,
+                                        runMetadata,
+                                        currentFrameNo: frameNo,
+                                        continuation: {
+                                            reason: "loop-threshold",
+                                            iteration: continuationIteration,
+                                            loopId: ralph.id,
+                                            continueAsNewEvery,
+                                            statePayload: {
+                                                loopId: ralph.id,
+                                                continueAsNewEvery,
+                                                nextIteration,
+                                            },
+                                            nextRalphState,
+                                        },
+                                        ralphState,
+                                    }),
+                                    catch: (cause) => toSmithersError(cause, "continue-as-new loop transition"),
+                                }).pipe(Effect.annotateLogs({
+                                    runId,
+                                    ralphId: ralph.id,
+                                    iteration: continuationIteration,
+                                    continueAsNewEvery,
+                                }), Effect.withLogSpan("engine:continue-as-new")));
+                            }
+                            catch (error) {
+                                if (error?.code === "RUN_CANCELLED") {
+                                    runAbortController.abort();
+                                    continue;
+                                }
+                                throw error;
+                            }
+                            const continuationEvent = {
+                                type: "RunContinuedAsNew",
+                                runId,
+                                newRunId: transition.newRunId,
+                                iteration: continuationIteration,
+                                carriedStateSize: transition.carriedStateBytes,
+                                ancestryDepth: transition.ancestryDepth,
+                                timestampMs: nowMs(),
+                            };
+                            eventBus.emit("event", continuationEvent);
+                            Effect.runSync(trackEvent(continuationEvent));
+                            logInfo(`Continuing run ${runId} as ${transition.newRunId} at iteration ${continuationIteration}`, {
+                                runId,
+                                newRunId: transition.newRunId,
+                                iteration: continuationIteration,
+                                carriedStateBytes: transition.carriedStateBytes,
+                            }, "engine:continue-as-new");
+                            void Effect.runPromise(Metric.update(runDuration, performance.now() - runStartPerformanceMs));
+                            await annotateRunSpan({
+                                status: "continued",
+                            });
+                            return {
+                                type: "return",
+                                result: {
+                                    runId,
+                                    status: "continued",
+                                    nextRunId: transition.newRunId,
+                                },
+                            };
+                        }
+                        if (state.iteration + 1 < ralph.maxIterations) {
+                            state.iteration += 1;
+                            advancedAnyRalph = true;
+                            ralphState.set(ralph.id, { ...state, done: false });
+                            if (singleRalphId && ralph.id === singleRalphId) {
+                                defaultIteration = state.iteration;
+                            }
+                            await Effect.runPromise(adapter.insertOrUpdateRalph({
+                                runId,
+                                ralphId: ralph.id,
+                                iteration: state.iteration,
+                                done: false,
+                                updatedAtMs: nowMs(),
+                            }));
+                            continue;
+                        }
+                        if (ralph.onMaxReached === "fail") {
+                            await Effect.runPromise(adapter.updateRun(runId, {
+                                status: "failed",
+                                finishedAtMs: nowMs(),
+                                heartbeatAtMs: null,
+                                runtimeOwnerId: null,
+                                cancelRequestedAtMs: null,
+                                hijackRequestedAtMs: null,
+                                hijackTarget: null,
+                                errorJson: JSON.stringify({
+                                    code: "RALPH_MAX_REACHED",
+                                    ralphId: ralph.id,
+                                }),
+                            }));
+                            await Effect.runPromise(eventBus.emitEventWithPersist({
+                                type: "RunFailed",
+                                runId,
+                                error: { code: "RALPH_MAX_REACHED", ralphId: ralph.id },
+                                timestampMs: nowMs(),
+                            }));
+                            await annotateRunSpan({
+                                status: "failed",
+                            });
+                            return {
+                                type: "return",
+                                result: {
+                                    runId,
+                                    status: "failed",
+                                    error: { code: "RALPH_MAX_REACHED", ralphId: ralph.id },
+                                },
+                            };
+                        }
+                        ralphState.set(ralph.id, { ...state, done: true });
+                        advancedAnyRalph = true;
+                        await Effect.runPromise(adapter.insertOrUpdateRalph({
+                            runId,
+                            ralphId: ralph.id,
+                            iteration: state.iteration,
+                            done: true,
+                            updatedAtMs: nowMs(),
+                        }));
+                    }
+                    if (!advancedAnyRalph) {
+                        return null;
+                    }
+                    offerSchedulerTrigger({
+                        type: "external-event",
+                        source: "render",
+                    });
+                    return { type: "continue" };
+            };
             if (runnable.length === 0) {
+                if (schedule.readyRalphs.length > 0 && !schedule.fatalError) {
+                    // Advance ready loops even while unrelated work is in flight
+                    // or pending elsewhere — a ralph is ready only when its own
+                    // subtree is terminal, so other pipelines must not starve its
+                    // next iteration (#267). Run-level continue-as-new handoffs
+                    // remain quiescence-only, and an unhandled task failure keeps
+                    // its precedence over further loop iterations.
+                    const hasUnhandledFailedTask = tasks.some((t) => {
+                        const state = stateMap.get(buildStateKey(t.nodeId, t.iteration));
+                        return state === "failed" && !t.continueOnFail;
+                    });
+                    if (!hasUnhandledFailedTask) {
+                        const ralphDecision = await advanceReadyRalphs({
+                            allowContinueAsNew: schedulerTaskKeys.size === 0 && !schedule.pendingExists,
+                        });
+                        if (ralphDecision) {
+                            return ralphDecision;
+                        }
+                    }
+                }
                 if (schedulerTaskKeys.size > 0) {
                     return { type: "await-trigger" };
                 }
@@ -6852,224 +7102,6 @@ async function runWorkflowBodyLegacy(workflow, opts) {
                             waitMs,
                         };
                     }
-                    return { type: "continue" };
-                }
-                if (schedule.readyRalphs.length > 0) {
-                    // Re-evaluate each ralph's `until` with the correct per-ralph
-                    // iteration context.  The plan tree's `until` was rendered with
-                    // `defaultIteration` which may not reflect each ralph's own
-                    // iteration (especially with multiple parallel loops).  When
-                    // there is a single ralph, `defaultIteration` already tracks
-                    // it correctly, so skip the extra work.
-                    const freshUntilMap = new Map();
-                    if (!singleRalphId) {
-                        const freshOutputs = await loadOutputs(db, schema, runId);
-                        const evalRenderer = new SmithersRenderer();
-                        for (const ralph of schedule.readyRalphs) {
-                            const rState = ralphState.get(ralph.id);
-                            const ralphIteration = rState?.iteration ?? 0;
-                            const perRalphCtx = new SmithersCtx({
-                                runId,
-                                iteration: ralphIteration,
-                                iterations: ralphIterationsObject(ralphState),
-                                input: inputRow,
-                                auth: runAuth,
-                                outputs: freshOutputs,
-                                zodToKeyName: workflow.zodToKeyName,
-                            });
-                            const { xml: freshXml } = await evalRenderer.render(workflowRef.build(perRalphCtx), {
-                                ralphIterations: ralphIterationsFromState(ralphState),
-                                defaultIteration: ralphIteration,
-                                baseRootDir: rootDir,
-                                workflowPath: resolvedWorkflowPath,
-                            });
-                            const { ralphs: freshRalphs } = buildPlanTree(freshXml, ralphState);
-                            const freshRalph = freshRalphs.find((r) => r.id === ralph.id);
-                            freshUntilMap.set(ralph.id, freshRalph?.until ?? ralph.until);
-                        }
-                    }
-                    for (const ralph of schedule.readyRalphs) {
-                        const state = ralphState.get(ralph.id) ?? {
-                            iteration: defaultIteration,
-                            done: false,
-                        };
-                        const freshUntil = freshUntilMap.get(ralph.id) ?? ralph.until;
-                        if (state.done || freshUntil) {
-                            // Fresh re-evaluation says the condition is now met — mark done.
-                            if (freshUntil && !state.done) {
-                                ralphState.set(ralph.id, { ...state, done: true });
-                                await Effect.runPromise(adapter.insertOrUpdateRalph({
-                                    runId,
-                                    ralphId: ralph.id,
-                                    iteration: state.iteration,
-                                    done: true,
-                                    updatedAtMs: nowMs(),
-                                }));
-                            }
-                            continue;
-                        }
-                        const continueAsNewEvery = ralph.continueAsNewEvery;
-                        const nextIteration = state.iteration + 1;
-                        const shouldContinueAsNew = typeof continueAsNewEvery === "number" &&
-                            continueAsNewEvery > 0 &&
-                            nextIteration % continueAsNewEvery === 0;
-                        if (shouldContinueAsNew) {
-                            if (continueAsNewEvery === 1) {
-                                logWarning("continue-as-new threshold is 1; this can create high handoff overhead", {
-                                    runId,
-                                    ralphId: ralph.id,
-                                    continueAsNewEvery,
-                                    iteration: state.iteration,
-                                }, "engine:continue-as-new");
-                            }
-                            if (runAbortController.signal.aborted) {
-                                continue;
-                            }
-                            const latestRun = await Effect.runPromise(adapter.getRun(runId));
-                            if (latestRun?.cancelRequestedAtMs) {
-                                runAbortController.abort();
-                                continue;
-                            }
-                            const nextRalphState = cloneRalphStateMap(ralphState);
-                            nextRalphState.set(ralph.id, {
-                                iteration: nextIteration,
-                                done: false,
-                            });
-                            const continuationIteration = state.iteration;
-                            let transition;
-                            try {
-                                transition = await Effect.runPromise(Effect.tryPromise({
-                                    try: () => continueRunAsNew({
-                                        db,
-                                        adapter,
-                                        schema,
-                                        inputTable,
-                                        runId,
-                                        workflowPath: resolvedWorkflowPath ??
-                                            opts.workflowPath ??
-                                            latestRun?.workflowPath ??
-                                            null,
-                                        runMetadata,
-                                        currentFrameNo: frameNo,
-                                        continuation: {
-                                            reason: "loop-threshold",
-                                            iteration: continuationIteration,
-                                            loopId: ralph.id,
-                                            continueAsNewEvery,
-                                            statePayload: {
-                                                loopId: ralph.id,
-                                                continueAsNewEvery,
-                                                nextIteration,
-                                            },
-                                            nextRalphState,
-                                        },
-                                        ralphState,
-                                    }),
-                                    catch: (cause) => toSmithersError(cause, "continue-as-new loop transition"),
-                                }).pipe(Effect.annotateLogs({
-                                    runId,
-                                    ralphId: ralph.id,
-                                    iteration: continuationIteration,
-                                    continueAsNewEvery,
-                                }), Effect.withLogSpan("engine:continue-as-new")));
-                            }
-                            catch (error) {
-                                if (error?.code === "RUN_CANCELLED") {
-                                    runAbortController.abort();
-                                    continue;
-                                }
-                                throw error;
-                            }
-                            const continuationEvent = {
-                                type: "RunContinuedAsNew",
-                                runId,
-                                newRunId: transition.newRunId,
-                                iteration: continuationIteration,
-                                carriedStateSize: transition.carriedStateBytes,
-                                ancestryDepth: transition.ancestryDepth,
-                                timestampMs: nowMs(),
-                            };
-                            eventBus.emit("event", continuationEvent);
-                            Effect.runSync(trackEvent(continuationEvent));
-                            logInfo(`Continuing run ${runId} as ${transition.newRunId} at iteration ${continuationIteration}`, {
-                                runId,
-                                newRunId: transition.newRunId,
-                                iteration: continuationIteration,
-                                carriedStateBytes: transition.carriedStateBytes,
-                            }, "engine:continue-as-new");
-                            void Effect.runPromise(Metric.update(runDuration, performance.now() - runStartPerformanceMs));
-                            await annotateRunSpan({
-                                status: "continued",
-                            });
-                            return {
-                                type: "return",
-                                result: {
-                                    runId,
-                                    status: "continued",
-                                    nextRunId: transition.newRunId,
-                                },
-                            };
-                        }
-                        if (state.iteration + 1 < ralph.maxIterations) {
-                            state.iteration += 1;
-                            ralphState.set(ralph.id, { ...state, done: false });
-                            if (singleRalphId && ralph.id === singleRalphId) {
-                                defaultIteration = state.iteration;
-                            }
-                            await Effect.runPromise(adapter.insertOrUpdateRalph({
-                                runId,
-                                ralphId: ralph.id,
-                                iteration: state.iteration,
-                                done: false,
-                                updatedAtMs: nowMs(),
-                            }));
-                            continue;
-                        }
-                        if (ralph.onMaxReached === "fail") {
-                            await Effect.runPromise(adapter.updateRun(runId, {
-                                status: "failed",
-                                finishedAtMs: nowMs(),
-                                heartbeatAtMs: null,
-                                runtimeOwnerId: null,
-                                cancelRequestedAtMs: null,
-                                hijackRequestedAtMs: null,
-                                hijackTarget: null,
-                                errorJson: JSON.stringify({
-                                    code: "RALPH_MAX_REACHED",
-                                    ralphId: ralph.id,
-                                }),
-                            }));
-                            await Effect.runPromise(eventBus.emitEventWithPersist({
-                                type: "RunFailed",
-                                runId,
-                                error: { code: "RALPH_MAX_REACHED", ralphId: ralph.id },
-                                timestampMs: nowMs(),
-                            }));
-                            await annotateRunSpan({
-                                status: "failed",
-                            });
-                            return {
-                                type: "return",
-                                result: {
-                                    runId,
-                                    status: "failed",
-                                    error: { code: "RALPH_MAX_REACHED", ralphId: ralph.id },
-                                },
-                            };
-                        }
-                        ralphState.set(ralph.id, { ...state, done: true });
-                        await Effect.runPromise(adapter.insertOrUpdateRalph({
-                            runId,
-                            ralphId: ralph.id,
-                            iteration: state.iteration,
-                            done: true,
-                            updatedAtMs: nowMs(),
-                        }));
-                    }
-                    offerSchedulerTrigger({
-                        type: "external-event",
-                        source: "render",
-                    });
                     return { type: "continue" };
                 }
                 // Guard against premature completion when conditional children

--- a/packages/engine/tests/parallel-loop-advancement.test.jsx
+++ b/packages/engine/tests/parallel-loop-advancement.test.jsx
@@ -1,0 +1,97 @@
+/** @jsxImportSource smithers-orchestrator */
+/**
+ * Regression test for https://github.com/smithersai/smithers/issues/267
+ *
+ * Loop iteration advancement used to require total quiescence: with any task
+ * in flight (or pending) anywhere in the graph, the engine returned
+ * await-trigger / schedule-retry before ever reaching the readyRalphs branch,
+ * so independent parallel loops starved behind unrelated pipelines.
+ */
+import { describe, expect, test } from "bun:test";
+import { Loop, Parallel, Task, Workflow, runWorkflow } from "smithers-orchestrator";
+import { createTestSmithers } from "../../smithers/tests/helpers.js";
+import { z } from "zod";
+import { Effect } from "effect";
+
+describe("issue #267 – parallel loop advancement without quiescence", () => {
+    test(
+        "a ready loop keeps iterating while a sibling task is still in flight",
+        async () => {
+            const { smithers, outputs, tables, db, cleanup } = createTestSmithers({
+                tick: z.object({ n: z.number(), atMs: z.number() }),
+                slow: z.object({ finishedAtMs: z.number() }),
+            });
+            const SLOW_MS = 4_000;
+            const workflow = smithers((ctx) => {
+                const ticks = ctx.outputs.tick ?? [];
+                return (<Workflow name="parallel-loop-starvation-mre">
+            <Parallel>
+              <Loop id="fast-loop" until={ticks.length >= 3} maxIterations={5}>
+                <Task id="tick" output={outputs.tick}>
+                  {() => ({ n: (ctx.outputs.tick ?? []).length, atMs: Date.now() })}
+                </Task>
+              </Loop>
+              <Task id="slow" output={outputs.slow}>
+                {async () => {
+                    await new Promise((resolve) => setTimeout(resolve, SLOW_MS));
+                    return { finishedAtMs: Date.now() };
+                }}
+              </Task>
+            </Parallel>
+          </Workflow>);
+            });
+            await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "parallel-loop-starvation-mre" }));
+            const ticks = await db.select().from(tables.tick);
+            const slowRows = await db.select().from(tables.slow);
+            expect(slowRows.length).toBe(1);
+            expect(ticks.length).toBeGreaterThanOrEqual(3);
+            // Without the fix, tick iterations 1+ only run after `slow`
+            // completes; with it, every iteration lands while `slow` is still
+            // sleeping.
+            const lastTickAtMs = Math.max(...ticks.map((row) => row.atMs));
+            expect(lastTickAtMs).toBeLessThan(slowRows[0].finishedAtMs);
+            cleanup();
+        },
+        30_000,
+    );
+
+    test(
+        "an unhandled task failure keeps precedence over further loop iterations (legacy engine)",
+        async () => {
+            const { smithers, outputs, tables, db, cleanup } = createTestSmithers({
+                tick: z.object({ n: z.number() }),
+                boom: z.object({ ok: z.boolean() }),
+            });
+            const workflow = smithers((ctx) => (<Workflow name="loop-vs-failure-mre">
+          <Parallel>
+            <Loop id="fast-loop" until={false} maxIterations={5}>
+              <Task id="tick" output={outputs.tick}>
+                {() => ({ n: (ctx.outputs.tick ?? []).length })}
+              </Task>
+            </Loop>
+            <Task id="boom" output={outputs.boom} noRetry>
+              {() => {
+                  throw new Error("boom");
+              }}
+            </Task>
+          </Parallel>
+        </Workflow>));
+            process.env.SMITHERS_LEGACY_ENGINE = "1";
+            let result;
+            try {
+                result = await Effect.runPromise(runWorkflow(workflow, { input: {}, runId: "loop-vs-failure-mre" }));
+            }
+            finally {
+                delete process.env.SMITHERS_LEGACY_ENGINE;
+            }
+            expect(result.status).toBe("failed");
+            // The ready loop must not keep iterating ahead of the failed task:
+            // at most the iteration that was already in flight when `boom`
+            // failed may land.
+            const ticks = await db.select().from(tables.tick);
+            expect(ticks.length).toBeLessThanOrEqual(2);
+            cleanup();
+        },
+        30_000,
+    );
+});

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -477,6 +477,63 @@ export function makeWorkflowSession(options = {}) {
         if (existingWait) {
             return { _tag: "Wait", reason: existingWait };
         }
+        if (schedule.readyRalphs.length > 0 && !unhandledFailureDecision(recoveryKeys)) {
+            // A ralph is ready only when every task in its own subtree is
+            // terminal, so pending or in-flight work elsewhere in the graph must
+            // not starve its next iteration (#267). Run-level continue-as-new
+            // handoffs stay quiescence-only: tearing down the run while sibling
+            // tasks are mid-flight is not safe, so those ralphs are deferred.
+            // An unhandled task failure keeps its precedence over further loop
+            // iterations (decide() already returns it at the top; this guard
+            // makes the ordering explicit).
+            const hasInProgress = [...state.states.values()].some((taskState) => taskState === "in-progress");
+            let advanced = false;
+            for (const ralph of schedule.readyRalphs) {
+                const current = state.ralphState.get(ralph.id) ?? {
+                    iteration: 0,
+                    done: false,
+                };
+                if (ralph.until) {
+                    state.ralphState.set(ralph.id, { ...current, done: true });
+                    advanced = true;
+                    continue;
+                }
+                const nextIteration = current.iteration + 1;
+                if (nextIteration >= ralph.maxIterations) {
+                    if (ralph.onMaxReached === "fail") {
+                        return {
+                            _tag: "Failed",
+                            error: new SmithersError("RALPH_MAX_REACHED", `Ralph ${ralph.id} reached maxIterations ${ralph.maxIterations}.`, { ralphId: ralph.id, maxIterations: ralph.maxIterations }),
+                        };
+                    }
+                    state.ralphState.set(ralph.id, { iteration: current.iteration, done: true });
+                    advanced = true;
+                    continue;
+                }
+                const wantsContinueAsNew = ralph.continueAsNewEvery != null &&
+                    ralph.continueAsNewEvery > 0 &&
+                    nextIteration > 0 &&
+                    nextIteration % ralph.continueAsNewEvery === 0;
+                if (wantsContinueAsNew && (hasInProgress || schedule.pendingExists)) {
+                    continue;
+                }
+                state.ralphState.set(ralph.id, { iteration: nextIteration, done: false });
+                if (wantsContinueAsNew) {
+                    return {
+                        _tag: "ContinueAsNew",
+                        transition: {
+                            reason: "loop-threshold",
+                            iteration: nextIteration,
+                            statePayload: ralphStatePayload(),
+                        },
+                    };
+                }
+                advanced = true;
+            }
+            if (advanced) {
+                return { _tag: "ReRender", context: renderContext(state) };
+            }
+        }
         if (schedule.pendingExists) {
             if (schedule.nextRetryAtMs != null) {
                 return {
@@ -495,44 +552,6 @@ export function makeWorkflowSession(options = {}) {
         failure = unhandledFailureDecision(recoveryKeys);
         if (failure) {
             return failure;
-        }
-        if (schedule.readyRalphs.length > 0) {
-            for (const ralph of schedule.readyRalphs) {
-                const current = state.ralphState.get(ralph.id) ?? {
-                    iteration: 0,
-                    done: false,
-                };
-                if (ralph.until) {
-                    state.ralphState.set(ralph.id, { ...current, done: true });
-                    continue;
-                }
-                const nextIteration = current.iteration + 1;
-                if (nextIteration >= ralph.maxIterations) {
-                    if (ralph.onMaxReached === "fail") {
-                        return {
-                            _tag: "Failed",
-                            error: new SmithersError("RALPH_MAX_REACHED", `Ralph ${ralph.id} reached maxIterations ${ralph.maxIterations}.`, { ralphId: ralph.id, maxIterations: ralph.maxIterations }),
-                        };
-                    }
-                    state.ralphState.set(ralph.id, { iteration: current.iteration, done: true });
-                    continue;
-                }
-                state.ralphState.set(ralph.id, { iteration: nextIteration, done: false });
-                if (ralph.continueAsNewEvery != null &&
-                    ralph.continueAsNewEvery > 0 &&
-                    nextIteration > 0 &&
-                    nextIteration % ralph.continueAsNewEvery === 0) {
-                    return {
-                        _tag: "ContinueAsNew",
-                        transition: {
-                            reason: "loop-threshold",
-                            iteration: nextIteration,
-                            statePayload: ralphStatePayload(),
-                        },
-                    };
-                }
-            }
-            return { _tag: "ReRender", context: renderContext(state) };
         }
         if (options.requireStableFinish && state.graph) {
             const signature = mountedSignature(state.graph);


### PR DESCRIPTION
Closes #267

Loop iteration advancement starved behind unrelated work in all three scheduling paths:

- **Legacy engine** (`packages/engine/src/engine.js`): the decision ladder returned `await-trigger` (any in-flight task) or `schedule-retry` (any pending task) before ever reaching the `readyRalphs` branch. The block is now extracted into `advanceReadyRalphs()` and called at the top of the runnable-empty ladder.
- **Workflow session** (`packages/scheduler/src/makeWorkflowSession.js`): `decide()` returned `Wait` on `pendingExists` / in-progress before its readyRalphs handling. The block is hoisted above those waits.
- **Driver** (`packages/driver/src/WorkflowDriver.js`): `executeTasks` barriered each Execute batch behind `Promise.all`, parking a fast task's completion decision until the slowest sibling finished. Replaced with incremental completion processing (`startInflightTask` / `nextCompletionDecision`): completions are reported to the session one at a time at pop time, so every decision is computed against fresh state (no stale-decision double dispatch), and deadline waits (retry backoff / timer) race against the in-flight set.

Safety properties preserved:
- A ralph advances only when every task in its own subtree is terminal.
- **Failure precedence**: an unhandled (non-`continueOnFail`) task failure still beats further loop iterations in both scheduler paths (explicit guards; pinned by test).
- **Continue-as-new stays quiescence-only** in both paths (no run handoff while siblings are in flight or pending retry).
- `drainInflight()` before run-level failure/continue-as-new exits preserves the pre-existing barrier invariant that no task executor writes after the run is terminal (failure-reporting latency is bounded by task/heartbeat timeouts — same as before this change).

Tests: `packages/engine/tests/parallel-loop-advancement.test.jsx` pins both behaviors (a ready loop completes all iterations while a 4s sibling sleeps; a failed sibling stops further iterations on the legacy path). Full `engine` (608), `scheduler` (100), and `driver` (86) suites pass; engine + scheduler + driver typechecks clean.

Review: Codex (`codex review --base main`, reasoning=high) ran 3 rounds — 2 P1s (failure precedence) fixed, 1 P2 (session CAN gate vs pending retry) fixed, 1 P2 (drain-before-fail latency) acknowledged as the pre-existing semantic, documented in code.

Found while orchestrating six parallel issue-fix pipelines (run `fix6-a`): loops with split review verdicts could not start their second iteration until every other pipeline went quiescent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)