### PR TITLE
✨ feat(cli): render workflow input schemas in inspect and generated skills

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -46,7 +46,7 @@ import { getUsageForAccounts, formatUsageReports } from "@smithers-orchestrator/
 import { runAgentAdd, pingAccount } from "./agent-commands/runAgentAdd.js";
 import { agentAddWizard } from "./agent-commands/agentAddWizard.js";
 import { getWorkflowFollowUpCtas } from "./workflow-pack.js";
-import { discoverWorkflows, resolveWorkflow, createWorkflowFile, renderWorkflowSkill, writeWorkflowSkillFiles, resolvePackDirs } from "./workflows.js";
+import { discoverWorkflows, resolveWorkflow, createWorkflowFile, renderWorkflowSkill, writeWorkflowSkillFiles, resolvePackDirs, summarizeWorkflowInputSchema, workflowInputJsonSchema } from "./workflows.js";
 import {
     assertEvalRunIdsAvailable,
     assertEvalReportWritable,
@@ -1982,11 +1982,14 @@ const workflowCli = Cli.create({
     .command("inspect", {
     description: "Show workflow metadata and an agent-facing skill preview.",
     args: workflowPathArgs,
-    run(c) {
+    async run(c) {
         const workflow = resolveWorkflow(c.args.name, process.cwd());
+        const loaded = await loadWorkflow(workflow.entryFile);
+        const inputSchema = summarizeWorkflowInputSchema(workflowInputJsonSchema(loaded.inputSchema));
         return c.ok({
             workflow,
-            skillPreview: renderWorkflowSkill(workflow, { root: process.cwd() }),
+            inputSchema,
+            skillPreview: renderWorkflowSkill(workflow, { root: process.cwd(), inputSchema }),
         });
     },
 })
@@ -1994,17 +1997,27 @@ const workflowCli = Cli.create({
     description: "Generate agent-facing skill docs for local workflows.",
     args: workflowSkillArgs,
     options: workflowSkillOptions,
-    run(c) {
+    async run(c) {
         const fail = (opts) => {
             commandExitOverride = opts.exitCode ?? 1;
             return c.error(opts);
         };
         try {
+            const workflowId = c.args.name ?? "all";
+            const workflows = workflowId === "all"
+                ? discoverWorkflows(process.cwd()).filter((workflow) => workflow.id !== "workflow-skill")
+                : [resolveWorkflow(workflowId, process.cwd())];
+            const inputSchemas = new Map();
+            for (const workflow of workflows) {
+                const loaded = await loadWorkflow(workflow.entryFile);
+                inputSchemas.set(workflow.id, summarizeWorkflowInputSchema(workflowInputJsonSchema(loaded.inputSchema)));
+            }
             return c.ok(writeWorkflowSkillFiles(process.cwd(), {
-                workflowId: c.args.name ?? "all",
+                workflowId,
                 output: c.options.output,
                 force: c.options.force,
                 global: c.options.global,
+                inputSchemas,
             }));
         }
         catch (err) {

--- a/apps/cli/src/workflows.js
+++ b/apps/cli/src/workflows.js
@@ -123,6 +123,121 @@ function yamlString(value) {
     return JSON.stringify(value);
 }
 /**
+ * @param {unknown} schema
+ * @returns {Record<string, unknown> | undefined}
+ */
+export function workflowInputJsonSchema(schema) {
+    if (!schema || typeof schema !== "object") return undefined;
+    const candidate = /** @type {{ toJSONSchema?: () => unknown }} */ (schema);
+    if (typeof candidate.toJSONSchema !== "function") return undefined;
+    const jsonSchema = candidate.toJSONSchema();
+    return jsonSchema && typeof jsonSchema === "object" && !Array.isArray(jsonSchema)
+        ? /** @type {Record<string, unknown>} */ (jsonSchema)
+        : undefined;
+}
+/**
+ * @param {unknown} value
+ * @returns {Record<string, unknown> | undefined}
+ */
+function objectSchema(value) {
+    return value && typeof value === "object" && !Array.isArray(value)
+        ? /** @type {Record<string, unknown>} */ (value)
+        : undefined;
+}
+/**
+ * @param {unknown[]} values
+ * @returns {unknown[]}
+ */
+function uniqueValues(values) {
+    const seen = new Set();
+    return values.filter((value) => {
+        const key = JSON.stringify(value);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+    });
+}
+/**
+ * @param {Record<string, unknown>} field
+ * @returns {{ types: string[]; enumValues: unknown[] }}
+ */
+function summarizeJsonSchemaField(field) {
+    const types = [];
+    const enumValues = Array.isArray(field.enum) ? [...field.enum] : [];
+    if (typeof field.type === "string") {
+        types.push(field.type);
+    }
+    else if (Array.isArray(field.type)) {
+        types.push(...field.type.filter((type) => typeof type === "string"));
+    }
+    for (const key of ["anyOf", "oneOf", "allOf"]) {
+        const members = field[key];
+        if (!Array.isArray(members)) continue;
+        for (const member of members) {
+            const schema = objectSchema(member);
+            if (!schema) continue;
+            const summary = summarizeJsonSchemaField(schema);
+            types.push(...summary.types);
+            enumValues.push(...summary.enumValues);
+        }
+    }
+    return {
+        types: [...new Set(types)],
+        enumValues: uniqueValues(enumValues),
+    };
+}
+/**
+ * @param {Record<string, unknown> | undefined} jsonSchema
+ * @returns {{ name: string; type: string; required: boolean; default?: unknown; enum?: unknown[]; description?: string }[]}
+ */
+export function workflowInputSchemaFields(jsonSchema) {
+    const properties = jsonSchema?.properties;
+    if (!properties || typeof properties !== "object" || Array.isArray(properties)) return [];
+    const required = new Set(Array.isArray(jsonSchema.required) ? jsonSchema.required.filter((key) => typeof key === "string") : []);
+    return Object.entries(/** @type {Record<string, Record<string, unknown>>} */ (properties)).map(([name, field]) => {
+        const summary = summarizeJsonSchemaField(field);
+        return {
+            name,
+            type: summary.types.length > 0 ? summary.types.join(" | ") : "unknown",
+            required: required.has(name),
+            ...(Object.prototype.hasOwnProperty.call(field, "default") ? { default: field.default } : {}),
+            ...(summary.enumValues.length > 0 ? { enum: summary.enumValues } : {}),
+            ...(typeof field.description === "string" ? { description: field.description } : {}),
+        };
+    });
+}
+/**
+ * @param {Record<string, unknown> | undefined} jsonSchema
+ * @returns {{ jsonSchema?: Record<string, unknown>; fields: ReturnType<typeof workflowInputSchemaFields> }}
+ */
+export function summarizeWorkflowInputSchema(jsonSchema) {
+    return {
+        ...(jsonSchema ? { jsonSchema } : {}),
+        fields: workflowInputSchemaFields(jsonSchema),
+    };
+}
+/**
+ * @param {{ jsonSchema?: Record<string, unknown>; fields: ReturnType<typeof workflowInputSchemaFields> } | undefined} inputSchema
+ * @returns {string}
+ */
+export function renderWorkflowInputSchemaMarkdown(inputSchema) {
+    const fields = inputSchema?.fields ?? [];
+    if (fields.length === 0) return "No structured input fields declared.";
+    return [
+        "| Field | Type | Required / Default | Enum | Description |",
+        "| --- | --- | --- | --- | --- |",
+        ...fields.map((field) => {
+            const status = Object.prototype.hasOwnProperty.call(field, "default")
+                ? `default: \`${JSON.stringify(field.default)}\``
+                : field.required
+                    ? "required"
+                    : "optional";
+            const enumValues = field.enum?.length ? field.enum.map((value) => `\`${String(value)}\``).join(", ") : "-";
+            return `| \`${field.name}\` | \`${field.type}\` | ${status} | ${enumValues} | ${field.description ?? "-"} |`;
+        }),
+    ].join("\n");
+}
+/**
  * @param {string} source
  * @param {string} id
  */
@@ -307,7 +422,7 @@ function assertSkillFileName(id) {
 }
 /**
  * @param {DiscoveredWorkflow} workflow
- * @param {{ root?: string }} [options]
+ * @param {{ root?: string; inputSchema?: ReturnType<typeof summarizeWorkflowInputSchema> }} [options]
  * @returns {string}
  */
 export function renderWorkflowSkill(workflow, options = {}) {
@@ -318,6 +433,13 @@ export function renderWorkflowSkill(workflow, options = {}) {
     const workflowAliases = workflow.aliases ?? [];
     const tags = workflowTags.length > 0 ? workflowTags.join(", ") : "workflow";
     const aliases = workflowAliases.length > 0 ? workflowAliases.join(", ") : "none";
+    const inputFields = options.inputSchema?.fields ?? [];
+    const runCommand = inputFields.length === 0
+        ? `smithers workflow run ${workflow.id} --prompt "<request>"`
+        : `smithers workflow run ${workflow.id} --input '${JSON.stringify(Object.fromEntries(inputFields.map((field) => [
+        field.name,
+        Object.prototype.hasOwnProperty.call(field, "default") ? field.default : `<${field.type}>`,
+    ])))}'`;
     return [
         "---",
         `name: ${workflow.id}`,
@@ -336,16 +458,20 @@ export function renderWorkflowSkill(workflow, options = {}) {
         `- Tags: ${tags}`,
         `- Aliases: ${aliases}`,
         "",
+        "## Input Schema",
+        "",
+        renderWorkflowInputSchemaMarkdown(options.inputSchema),
+        "",
         "## Run",
         "",
         "```bash",
-        `smithers workflow run ${workflow.id} --prompt "<request>"`,
+        runCommand,
         "```",
         "",
-        "For structured inputs, pass JSON explicitly:",
+        "If the workflow defines a `prompt` field, `--prompt` is shorthand for `--input '{\"prompt\":\"...\"}'`.",
         "",
         "```bash",
-        `smithers workflow run ${workflow.id} --input '{"prompt":"<request>"}'`,
+        `smithers workflow inspect ${workflow.id} --format json`,
         "```",
         "",
         "## Operating Notes",
@@ -359,7 +485,7 @@ export function renderWorkflowSkill(workflow, options = {}) {
 }
 /**
  * @param {string} root
- * @param {{ workflowId?: string; output?: string; force?: boolean; global?: boolean }} [options]
+ * @param {{ workflowId?: string; output?: string; force?: boolean; global?: boolean; inputSchemas?: Map<string, ReturnType<typeof summarizeWorkflowInputSchema>> }} [options]
  */
 export function writeWorkflowSkillFiles(root, options = {}) {
     const workflowId = options.workflowId ?? "all";
@@ -393,7 +519,7 @@ export function writeWorkflowSkillFiles(root, options = {}) {
             continue;
         }
         mkdirSync(dirname(target), { recursive: true });
-        writeFileSync(target, renderWorkflowSkill(workflow, { root }));
+        writeFileSync(target, renderWorkflowSkill(workflow, { root, inputSchema: options.inputSchemas?.get(workflow.id) }));
         writtenFiles.push(target);
     }
     return {

--- a/apps/cli/tests/init.e2e.test.js
+++ b/apps/cli/tests/init.e2e.test.js
@@ -380,6 +380,13 @@ test("workflow inspect and skills use seeded workflow metadata", () => {
         tags: ["coding", "implementation", "review"],
     });
     expect(inspect.json.skillPreview).toContain("smithers workflow run implement");
+    expect(inspect.json.inputSchema.fields).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            name: "prompt",
+            type: "string",
+            default: "Implement the requested change.",
+        }),
+    ]));
 
     const skills = runSmithers(["workflow", "skills", "implement", "--output", "docs/implement-skill.md"], {
         cwd: repo.dir,
@@ -389,6 +396,27 @@ test("workflow inspect and skills use seeded workflow metadata", () => {
     expect(skills.json.writtenFiles).toHaveLength(1);
     expect(repo.read("docs/implement-skill.md")).toContain("name: implement");
     expect(repo.read("docs/implement-skill.md")).toContain("Implement a focused change");
+    expect(repo.read("docs/implement-skill.md")).toContain("| `prompt` | `string` |");
+
+    const reportInspect = runSmithers(["workflow", "inspect", "report-slideshow"], {
+        cwd: repo.dir,
+        format: "json",
+    });
+    expect(reportInspect.exitCode).toBe(0);
+    expect(reportInspect.json.inputSchema.fields).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+            name: "runId",
+            type: "string",
+            required: true,
+        }),
+        expect.objectContaining({
+            name: "title",
+            type: "string | null",
+            default: null,
+        }),
+    ]));
+    expect(reportInspect.json.skillPreview).toContain("| `runId` | `string` | required |");
+    expect(reportInspect.json.skillPreview).toContain("| `title` | `string | null` | default: `null` |");
 }, 15_000);
 test("seeded workflows reuse the shared review substrate", () => {
     const repo = createTempRepo();

--- a/docs/workflows/overview.mdx
+++ b/docs/workflows/overview.mdx
@@ -38,6 +38,6 @@ Most prompt-driven workflows accept `--prompt` as shorthand for `--input '{"prom
 
 - Default workflow files are user-owned after scaffold. `bunx smithers-orchestrator init` will not overwrite edited files unless you pass `--force`.
 - Agent pools are defined in `.smithers/agents.ts`; edit that file to change which models each workflow uses.
-- Run `bunx smithers-orchestrator workflow list` to see the workflows in the current repo, `bunx smithers-orchestrator workflow inspect WORKFLOW_ID` to see metadata, and `bunx smithers-orchestrator workflow skills` to generate agent-facing docs under `.smithers/skills/`.
+- Run `bunx smithers-orchestrator workflow list` to see the workflows in the current repo, `bunx smithers-orchestrator workflow inspect WORKFLOW_ID` to see metadata and the workflow input schema, and `bunx smithers-orchestrator workflow skills` to generate agent-facing docs under `.smithers/skills/`.
 - Workflows can carry optional metadata comments (`smithers-display-name`, `smithers-description`, `smithers-tags`, `smithers-aliases`) that `bunx smithers-orchestrator workflow list` and `workflow-skill` use for display and discovery.
 - Inspect and resume runs with the normal CLI: `inspect`, `logs`, `chat`, `events`, `why`, `approve`, and `up --resume`.

--- a/docs/workflows/workflow-skill.mdx
+++ b/docs/workflows/workflow-skill.mdx
@@ -5,10 +5,16 @@ description: Create or update agent-facing skill docs from local workflows.
 
 `workflow-skill` reads local Smithers workflow metadata and asks an agent to write concise skill documentation for selected workflows. It passes each workflow's ID, display name, source type, entry file path, and full source to the agent. The agent infers descriptions, inputs, and other workflow-specific fields directly from the source.
 
-For deterministic, no-agent generation, use the CLI command:
+For deterministic, no-agent generation, use the CLI command. The generated skill includes the workflow's real input schema: field names, types, required/default status, enum values, and descriptions when the Zod schema provides them.
 
 ```bash
 bunx smithers-orchestrator workflow skills
+```
+
+Inspect the same machine-readable contract without writing files:
+
+```bash
+bunx smithers-orchestrator workflow inspect mission --format json
 ```
 
 To generate skill docs through the agent (with prompt-driven customization), use:

--- a/packages/smithers/src/create.js
+++ b/packages/smithers/src/create.js
@@ -224,10 +224,11 @@ function prepareSmithersTables(schemas) {
  *   zodToKeyName: Map<unknown, string>;
  *   ambiguousZodSchemas: Set<unknown>;
  *   opts?: CreateSmithersOptions;
+ *   inputSchema?: unknown;
  * }} config
  */
 function buildSmithersApi(config) {
-    const { db, tables, schemaRegistry, outputs, zodToKeyName, ambiguousZodSchemas, opts } = config;
+    const { db, tables, schemaRegistry, outputs, zodToKeyName, ambiguousZodSchemas, opts, inputSchema } = config;
     const { SmithersContext: RuntimeSmithersContext, useCtx } = createSmithersContext();
     const ctxRef = { current: null };
     let moduleAlertPolicy = opts?.alertPolicy;
@@ -306,6 +307,7 @@ function buildSmithersApi(config) {
                 return React.createElement(RuntimeSmithersContext.Provider, { value: ctxRef.current }, React.createElement(GlobalSmithersContext.Provider, { value: ctxRef.current }, build(ctx)));
             },
             opts: workflowOpts,
+            inputSchema,
             schemaRegistry,
             zodToKeyName,
             ambiguousZodSchemas,
@@ -450,6 +452,7 @@ export function createSmithers(schemas, opts) {
         zodToKeyName,
         ambiguousZodSchemas,
         opts,
+        inputSchema: schemas.input,
     });
     if (process.env.SMITHERS_HOT === "1") {
         const sig = computeSchemaSig(schemas, absDbPath);
@@ -538,6 +541,7 @@ export async function createSmithersPostgres(schemas, opts) {
             zodToKeyName,
             ambiguousZodSchemas,
             opts,
+            inputSchema: schemas.input,
         });
     }
     catch (e) {


### PR DESCRIPTION
Closes #258

`smithers workflow inspect <workflow>` now returns the workflow's real `inputSchema` — both the machine-readable JSON schema and a summarized `fields` list (name, type incl. unions, required/default, enum values, description) — and threads it into the human skill preview. Generated skill docs (`workflow skills`) render the same real schema as a markdown table and derive the run-command example from actual fields (falling back to `--prompt` only when no structured fields exist). `createSmithers` exposes the input zod schema on the workflow object (`packages/smithers/src/create.js`, additive).

Acceptance criteria from the issue:
- Inspecting a workflow shows its real input schema without opening source (human + JSON output).
- Generated skills document real workflow inputs; a workflow with a non-`prompt` field (e2e: `report-slideshow`'s required `runId`, nullable `title`) produces skill docs naming those fields.
- JSON output is machine-readable for IDE/agent integrations.

Tests: extended `apps/cli/tests/init.e2e.test.js` (real CLI subprocess; 11 pass) asserting schema fields and markdown tables for seeded workflows; `cli-workflows.test.js` 41 pass. apps/cli + packages/smithers typecheck clean. llms bundles regenerated (no diff).

Pipeline: Opus investigated, Codex implemented across 3 review iterations (Opus + Codex reviewers); final Codex objection was unrelated worktree artifacts (a stray `bun.lock` rewrite and scratch `.smithers/` files from test runs) — removed in this cleaned PR; the dependency-drift test failure it caused disappears with lockfile-true installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)