### PR TITLE
📝 docs(components): mark Aspects budgets as not yet enforced

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -3600,7 +3600,7 @@ type SuperSmithersProps = {
 
 ## <Aspects>
 
-> Propagate token, latency, and cost budgets to descendant tasks.
+> Declare token, latency, and cost budgets for descendant tasks.
 
 ```ts
 import { Aspects } from "smithers-orchestrator";
@@ -3653,7 +3653,8 @@ type AspectsProps = {
 ## Notes
 
 - Nested `<Aspects>` inherit outer budget configs wholesale. If an inner `<Aspects>` sets `tokenBudget`, `latencySlo`, or `costBudget`, that field's entire parent config object is replaced (no per-field merge). The `tracking` config is the exception: `tokens`, `latency`, and `cost` each fall back to the parent value independently.
-- Budgets enforce regardless of `tracking`; `tracking` controls metric emission only.
+- Budget props are not enforced by the runtime yet. They are currently declarative metadata reserved for future token, latency, and cost enforcement.
+- `tracking` controls metric emission only.
 - Accumulator is per-run and resets on resume.
 
 ---
@@ -6618,7 +6619,7 @@ try {
 | `CONTEXT_OUTSIDE_WORKFLOW` | Workflow context access happens outside an active Smithers workflow render. | -- |
 | `MISSING_OUTPUT` | Code calls `ctx.output()` for a node result that does not exist. | `{ nodeId, iteration }` |
 | `DEP_NOT_SATISFIED` | A typed dep on `<Task>` references an upstream output that has not been produced yet. | `{ taskId, depKey, resolvedNodeId }` |
-| `ASPECT_BUDGET_EXCEEDED` | An Aspects budget (tokens, latency, or cost) has been exceeded. | `{ kind, limit, current }` |
+| `ASPECT_BUDGET_EXCEEDED` | Reserved for future Aspects budget enforcement; the runtime does not emit this code yet. | `{ kind, limit, current }` |
 | `APPROVAL_OUTSIDE_TASK` | `<Approval>` is resolved outside the active task runtime. | -- |
 | `APPROVAL_OPTIONS_REQUIRED` | An approval mode that requires explicit options is missing them. | -- |
 | `WORKFLOW_MISSING_DEFAULT` | A workflow module does not export a default Smithers workflow. | -- |

--- a/docs/components/aspects.mdx
+++ b/docs/components/aspects.mdx
@@ -1,6 +1,6 @@
 ---
 title: <Aspects>
-description: Propagate token, latency, and cost budgets to descendant tasks.
+description: Declare token, latency, and cost budgets for descendant tasks.
 ---
 
 ```ts
@@ -54,5 +54,6 @@ type AspectsProps = {
 ## Notes
 
 - Nested `<Aspects>` inherit outer budget configs wholesale. If an inner `<Aspects>` sets `tokenBudget`, `latencySlo`, or `costBudget`, that field's entire parent config object is replaced (no per-field merge). The `tracking` config is the exception: `tokens`, `latency`, and `cost` each fall back to the parent value independently.
-- Budgets enforce regardless of `tracking`; `tracking` controls metric emission only.
+- Budget props are not enforced by the runtime yet. They are currently declarative metadata reserved for future token, latency, and cost enforcement.
+- `tracking` controls metric emission only.
 - Accumulator is per-run and resets on resume.

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -3580,7 +3580,7 @@ type SuperSmithersProps = {
 
 ## <Aspects>
 
-> Propagate token, latency, and cost budgets to descendant tasks.
+> Declare token, latency, and cost budgets for descendant tasks.
 
 ```ts
 import { Aspects } from "smithers-orchestrator";
@@ -3633,7 +3633,8 @@ type AspectsProps = {
 ## Notes
 
 - Nested `<Aspects>` inherit outer budget configs wholesale. If an inner `<Aspects>` sets `tokenBudget`, `latencySlo`, or `costBudget`, that field's entire parent config object is replaced (no per-field merge). The `tracking` config is the exception: `tokens`, `latency`, and `cost` each fall back to the parent value independently.
-- Budgets enforce regardless of `tracking`; `tracking` controls metric emission only.
+- Budget props are not enforced by the runtime yet. They are currently declarative metadata reserved for future token, latency, and cost enforcement.
+- `tracking` controls metric emission only.
 - Accumulator is per-run and resets on resume.
 
 ---
@@ -6598,7 +6599,7 @@ try {
 | `CONTEXT_OUTSIDE_WORKFLOW` | Workflow context access happens outside an active Smithers workflow render. | -- |
 | `MISSING_OUTPUT` | Code calls `ctx.output()` for a node result that does not exist. | `{ nodeId, iteration }` |
 | `DEP_NOT_SATISFIED` | A typed dep on `<Task>` references an upstream output that has not been produced yet. | `{ taskId, depKey, resolvedNodeId }` |
-| `ASPECT_BUDGET_EXCEEDED` | An Aspects budget (tokens, latency, or cost) has been exceeded. | `{ kind, limit, current }` |
+| `ASPECT_BUDGET_EXCEEDED` | Reserved for future Aspects budget enforcement; the runtime does not emit this code yet. | `{ kind, limit, current }` |
 | `APPROVAL_OUTSIDE_TASK` | `<Approval>` is resolved outside the active task runtime. | -- |
 | `APPROVAL_OPTIONS_REQUIRED` | An approval mode that requires explicit options is missing them. | -- |
 | `WORKFLOW_MISSING_DEFAULT` | A workflow module does not export a default Smithers workflow. | -- |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3600,7 +3600,7 @@ type SuperSmithersProps = {
 
 ## <Aspects>
 
-> Propagate token, latency, and cost budgets to descendant tasks.
+> Declare token, latency, and cost budgets for descendant tasks.
 
 ```ts
 import { Aspects } from "smithers-orchestrator";
@@ -3653,7 +3653,8 @@ type AspectsProps = {
 ## Notes
 
 - Nested `<Aspects>` inherit outer budget configs wholesale. If an inner `<Aspects>` sets `tokenBudget`, `latencySlo`, or `costBudget`, that field's entire parent config object is replaced (no per-field merge). The `tracking` config is the exception: `tokens`, `latency`, and `cost` each fall back to the parent value independently.
-- Budgets enforce regardless of `tracking`; `tracking` controls metric emission only.
+- Budget props are not enforced by the runtime yet. They are currently declarative metadata reserved for future token, latency, and cost enforcement.
+- `tracking` controls metric emission only.
 - Accumulator is per-run and resets on resume.
 
 ---
@@ -6618,7 +6619,7 @@ try {
 | `CONTEXT_OUTSIDE_WORKFLOW` | Workflow context access happens outside an active Smithers workflow render. | -- |
 | `MISSING_OUTPUT` | Code calls `ctx.output()` for a node result that does not exist. | `{ nodeId, iteration }` |
 | `DEP_NOT_SATISFIED` | A typed dep on `<Task>` references an upstream output that has not been produced yet. | `{ taskId, depKey, resolvedNodeId }` |
-| `ASPECT_BUDGET_EXCEEDED` | An Aspects budget (tokens, latency, or cost) has been exceeded. | `{ kind, limit, current }` |
+| `ASPECT_BUDGET_EXCEEDED` | Reserved for future Aspects budget enforcement; the runtime does not emit this code yet. | `{ kind, limit, current }` |
 | `APPROVAL_OUTSIDE_TASK` | `<Approval>` is resolved outside the active task runtime. | -- |
 | `APPROVAL_OPTIONS_REQUIRED` | An approval mode that requires explicit options is missing them. | -- |
 | `WORKFLOW_MISSING_DEFAULT` | A workflow module does not export a default Smithers workflow. | -- |

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -128,7 +128,7 @@ try {
 | `CONTEXT_OUTSIDE_WORKFLOW` | Workflow context access happens outside an active Smithers workflow render. | -- |
 | `MISSING_OUTPUT` | Code calls `ctx.output()` for a node result that does not exist. | `{ nodeId, iteration }` |
 | `DEP_NOT_SATISFIED` | A typed dep on `<Task>` references an upstream output that has not been produced yet. | `{ taskId, depKey, resolvedNodeId }` |
-| `ASPECT_BUDGET_EXCEEDED` | An Aspects budget (tokens, latency, or cost) has been exceeded. | `{ kind, limit, current }` |
+| `ASPECT_BUDGET_EXCEEDED` | Reserved for future Aspects budget enforcement; the runtime does not emit this code yet. | `{ kind, limit, current }` |
 | `APPROVAL_OUTSIDE_TASK` | `<Approval>` is resolved outside the active task runtime. | -- |
 | `APPROVAL_OPTIONS_REQUIRED` | An approval mode that requires explicit options is missing them. | -- |
 | `WORKFLOW_MISSING_DEFAULT` | A workflow module does not export a default Smithers workflow. | -- |

--- a/packages/components/src/aspects/AspectContext.js
+++ b/packages/components/src/aspects/AspectContext.js
@@ -10,7 +10,7 @@
 import React from "react";
 /**
  * React context that propagates Aspects configuration down the component tree.
- * Tasks read from this context to enforce budgets and track metrics.
+ * Budget configuration is declarative metadata and is not enforced yet.
  * @type {React.Context<AspectContextValue | null>}
  */
 export const AspectContext = React.createContext(/** @type {AspectContextValue | null} */ (null));

--- a/packages/components/src/aspects/CostBudgetConfig.ts
+++ b/packages/components/src/aspects/CostBudgetConfig.ts
@@ -1,9 +1,11 @@
 /**
  * Cost budget configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 export type CostBudgetConfig = {
 	/** Maximum total cost in USD across all tasks within the Aspects scope. */
 	maxUsd: number;
-	/** Behavior when the budget is exceeded. Default: "fail". */
+	/** Requested future behavior when the budget is exceeded. Default: "fail". */
 	onExceeded?: "fail" | "warn" | "skip-remaining";
 };

--- a/packages/components/src/aspects/LatencySloConfig.ts
+++ b/packages/components/src/aspects/LatencySloConfig.ts
@@ -1,11 +1,13 @@
 /**
  * Latency SLO configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 export type LatencySloConfig = {
 	/** Maximum total latency in milliseconds across all tasks. */
 	maxMs: number;
 	/** Optional per-task latency limit in milliseconds. */
 	perTask?: number;
-	/** Behavior when the SLO is exceeded. Default: "fail". */
+	/** Requested future behavior when the SLO is exceeded. Default: "fail". */
 	onExceeded?: "fail" | "warn";
 };

--- a/packages/components/src/aspects/TokenBudgetConfig.ts
+++ b/packages/components/src/aspects/TokenBudgetConfig.ts
@@ -1,11 +1,13 @@
 /**
  * Token budget configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 export type TokenBudgetConfig = {
 	/** Maximum total tokens across all tasks within the Aspects scope. */
 	max: number;
 	/** Optional per-task token limit. */
 	perTask?: number;
-	/** Behavior when the budget is exceeded. Default: "fail". */
+	/** Requested future behavior when the budget is exceeded. Default: "fail". */
 	onExceeded?: "fail" | "warn" | "skip-remaining";
 };

--- a/packages/components/src/components/Aspects.js
+++ b/packages/components/src/components/Aspects.js
@@ -9,7 +9,8 @@ import { AspectContext, createAccumulator, } from "../aspects/AspectContext.js";
  *
  * Wraps a section of the workflow tree and propagates token budgets,
  * latency SLOs, and cost budgets to all descendant Task components
- * without modifying individual tasks.
+ * without modifying individual tasks. Runtime budget enforcement is not
+ * implemented yet.
  *
  * ```tsx
  * <Aspects tokenBudget={{ max: 100_000, perTask: 20_000, onExceeded: "warn" }}>

--- a/packages/components/src/components/AspectsProps.ts
+++ b/packages/components/src/components/AspectsProps.ts
@@ -5,11 +5,11 @@ import type { CostBudgetConfig } from "../aspects/CostBudgetConfig.ts";
 import type { TrackingConfig } from "../aspects/TrackingConfig.ts";
 
 export type AspectsProps = {
-	/** Token budget — max total tokens, optional per-task limit, and exceeded behavior. */
+	/** Token budget metadata. Runtime enforcement is not implemented yet. */
 	tokenBudget?: TokenBudgetConfig;
-	/** Latency SLO — max total latency, optional per-task limit, and exceeded behavior. */
+	/** Latency SLO metadata. Runtime enforcement is not implemented yet. */
 	latencySlo?: LatencySloConfig;
-	/** Cost budget — max total USD, and exceeded behavior. */
+	/** Cost budget metadata. Runtime enforcement is not implemented yet. */
 	costBudget?: CostBudgetConfig;
 	/** Which metrics to track. Defaults to all enabled. */
 	tracking?: TrackingConfig;

--- a/packages/components/src/components/Task.js
+++ b/packages/components/src/components/Task.js
@@ -218,8 +218,8 @@ export function Task(props) {
         // This is normal reactive behavior; the task will re-render once deps are ready.
         return null;
     }
-    // Build aspect metadata to attach to the task element so the engine can
-    // enforce budgets and tracking at execution time.
+    // Build aspect metadata to attach to the task element. Budget metadata is
+    // declarative only until runtime enforcement is implemented.
     const aspectMeta = aspectCtx ? buildAspectMeta(aspectCtx) : undefined;
     const agentChain = Array.isArray(agent)
         ? fallbackAgent
@@ -282,8 +282,8 @@ export function Task(props) {
 }
 /**
  * Build the __aspects metadata object from the current AspectContext.
- * This is attached to the smithers:task element props so the engine
- * can read budgets and tracking config at execution time.
+ * This is attached to the smithers:task element props. Budget metadata is not
+ * enforced by the runtime yet.
  * @param {{
  *     tokenBudget?: unknown;
  *     latencySlo?: unknown;

--- a/packages/components/src/index.d.ts
+++ b/packages/components/src/index.d.ts
@@ -799,35 +799,41 @@ type BranchProps$2 = {
 
 /**
  * Token budget configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 type TokenBudgetConfig = {
     /** Maximum total tokens across all tasks within the Aspects scope. */
     max: number;
     /** Optional per-task token limit. */
     perTask?: number;
-    /** Behavior when the budget is exceeded. Default: "fail". */
+    /** Requested future behavior when the budget is exceeded. Default: "fail". */
     onExceeded?: "fail" | "warn" | "skip-remaining";
 };
 
 /**
  * Latency SLO configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 type LatencySloConfig = {
     /** Maximum total latency in milliseconds across all tasks. */
     maxMs: number;
     /** Optional per-task latency limit in milliseconds. */
     perTask?: number;
-    /** Behavior when the SLO is exceeded. Default: "fail". */
+    /** Requested future behavior when the SLO is exceeded. Default: "fail". */
     onExceeded?: "fail" | "warn";
 };
 
 /**
  * Cost budget configuration for Aspects.
+ *
+ * Runtime enforcement is not implemented yet; this is declarative metadata.
  */
 type CostBudgetConfig = {
     /** Maximum total cost in USD across all tasks within the Aspects scope. */
     maxUsd: number;
-    /** Behavior when the budget is exceeded. Default: "fail". */
+    /** Requested future behavior when the budget is exceeded. Default: "fail". */
     onExceeded?: "fail" | "warn" | "skip-remaining";
 };
 
@@ -844,11 +850,11 @@ type TrackingConfig = {
 };
 
 type AspectsProps$2 = {
-    /** Token budget — max total tokens, optional per-task limit, and exceeded behavior. */
+    /** Token budget metadata. Runtime enforcement is not implemented yet. */
     tokenBudget?: TokenBudgetConfig;
-    /** Latency SLO — max total latency, optional per-task limit, and exceeded behavior. */
+    /** Latency SLO metadata. Runtime enforcement is not implemented yet. */
     latencySlo?: LatencySloConfig;
-    /** Cost budget — max total USD, and exceeded behavior. */
+    /** Cost budget metadata. Runtime enforcement is not implemented yet. */
     costBudget?: CostBudgetConfig;
     /** Which metrics to track. Defaults to all enabled. */
     tracking?: TrackingConfig;
@@ -1414,7 +1420,8 @@ type AspectContextValue = {
  *
  * Wraps a section of the workflow tree and propagates token budgets,
  * latency SLOs, and cost budgets to all descendant Task components
- * without modifying individual tasks.
+ * without modifying individual tasks. Runtime budget enforcement is not
+ * implemented yet.
  *
  * ```tsx
  * <Aspects tokenBudget={{ max: 100_000, perTask: 20_000, onExceeded: "warn" }}>

--- a/packages/errors/src/smithersErrorDefinitions.js
+++ b/packages/errors/src/smithersErrorDefinitions.js
@@ -231,7 +231,7 @@ export const smithersErrorDefinitions = {
     },
     ASPECT_BUDGET_EXCEEDED: {
         category: "components",
-        when: "An Aspects budget has been exceeded.",
+        when: "Reserved for future Aspects budget enforcement; the runtime does not emit this code yet.",
         details: "{ kind, limit, current }",
     },
     APPROVAL_OUTSIDE_TASK: {

--- a/skills/smithers/SKILL.md
+++ b/skills/smithers/SKILL.md
@@ -226,7 +226,7 @@ below).
 The same substrate carries the concerns you'd otherwise bolt on later:
 
 - **Isolation**: `<Worktree>` (per-agent git worktrees), `<Sandbox>` (freestyle / docker / process), `<Subflow>` & `<SuperSmithers>` (nest a workflow as a node).
-- **Budgets**: `<Aspects>` propagates token / latency / cost budgets to a subtree (`fail` | `warn` | `skip-remaining`).
+- **Budgets**: `<Aspects>` propagates token / latency / cost budget metadata to a subtree, but runtime enforcement is not implemented yet.
 - **Scorers / evals**: attach `faithfulness`, `relevancy`, `schemaAdherence`, or `llmJudge(...)` to any `<Task>`; inspect with `smithers scores <run>`.
 - **Memory**: cross-run facts + history per namespace; `memory={{ recall, save }}` auto-injects the top-K relevant facts; query with `smithers memory`.
 - **Hot mode**: `--hot true` re-renders against persisted state when you edit the workflow or an `.mdx` prompt mid-run; finished tasks stay put.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -3600,7 +3600,7 @@ type SuperSmithersProps = {
 
 ## <Aspects>
 
-> Propagate token, latency, and cost budgets to descendant tasks.
+> Declare token, latency, and cost budgets for descendant tasks.
 
 ```ts
 import { Aspects } from "smithers-orchestrator";
@@ -3653,7 +3653,8 @@ type AspectsProps = {
 ## Notes
 
 - Nested `<Aspects>` inherit outer budget configs wholesale. If an inner `<Aspects>` sets `tokenBudget`, `latencySlo`, or `costBudget`, that field's entire parent config object is replaced (no per-field merge). The `tracking` config is the exception: `tokens`, `latency`, and `cost` each fall back to the parent value independently.
-- Budgets enforce regardless of `tracking`; `tracking` controls metric emission only.
+- Budget props are not enforced by the runtime yet. They are currently declarative metadata reserved for future token, latency, and cost enforcement.
+- `tracking` controls metric emission only.
 - Accumulator is per-run and resets on resume.
 
 ---
@@ -6618,7 +6619,7 @@ try {
 | `CONTEXT_OUTSIDE_WORKFLOW` | Workflow context access happens outside an active Smithers workflow render. | -- |
 | `MISSING_OUTPUT` | Code calls `ctx.output()` for a node result that does not exist. | `{ nodeId, iteration }` |
 | `DEP_NOT_SATISFIED` | A typed dep on `<Task>` references an upstream output that has not been produced yet. | `{ taskId, depKey, resolvedNodeId }` |
-| `ASPECT_BUDGET_EXCEEDED` | An Aspects budget (tokens, latency, or cost) has been exceeded. | `{ kind, limit, current }` |
+| `ASPECT_BUDGET_EXCEEDED` | Reserved for future Aspects budget enforcement; the runtime does not emit this code yet. | `{ kind, limit, current }` |
 | `APPROVAL_OUTSIDE_TASK` | `<Approval>` is resolved outside the active task runtime. | -- |
 | `APPROVAL_OPTIONS_REQUIRED` | An approval mode that requires explicit options is missing them. | -- |
 | `WORKFLOW_MISSING_DEFAULT` | A workflow module does not export a default Smithers workflow. | -- |


### PR DESCRIPTION
Closes #265

Takes the issue's explicitly-permitted fallback path: every surface that claimed Aspects budgets are enforced now says they are declarative metadata pending runtime enforcement —
- `docs/components/aspects.mdx` (drops the false "Budgets enforce regardless of `tracking`" note),
- `docs/reference/errors.mdx` + `packages/errors` registry (`ASPECT_BUDGET_EXCEEDED` marked reserved/unreachable),
- the aspects config types' and `AspectsProps`' JSDoc plus `index.d.ts`,
- comment-level corrections in `Aspects.js` / `Task.js` / `AspectContext.js` (no behavior change anywhere — verified comment-only),
- skill docs and regenerated llms bundles, so generated agent-facing docs stop promising false spend protection.

Real enforcement is tracked in the follow-up issue (implementation sketch included there): thread `__aspects` through graph extraction into TaskDescriptors, accumulate per-run token/cost from `TokenUsageReported`, apply `onExceeded` at dispatch, surface `ASPECT_BUDGET_EXCEEDED`.

Pipeline: Opus investigated, Codex implemented; Codex's strict review approved this state ("did not find remaining claims" of enforcement); the Opus reviewer's rejection was a context-truncation honesty refusal, not a substantive finding — human-verified instead. packages/components typecheck clean; docs gates (em-dash, bare-command, llms freshness) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)