### PR TITLE
🐛 fix(review): stop naming review.smithers.sh in --publish help text

### DIFF
--- a/apps/review/src/cli/main.ts
+++ b/apps/review/src/cli/main.ts
@@ -52,7 +52,7 @@ Usage: smithers-review [repo] [options]
   --concurrency <n>         parallel file reviews (default 8)
   --timeout <min>           per-agent-task timeout in minutes (default 10)
   --split                   side-by-side diffs instead of unified
-  --publish                 upload to review.smithers.sh and print the share URL
+  --publish                 upload to the share service and print the share URL
   --pr <number|url>         review a GitHub PR and post the review onto it (via gh)
   --open                    open the walkthrough in the default browser
   -h, --help                show this help`;


### PR DESCRIPTION
The publish URL comes from `SMITHERS_REVIEW_PUBLISH_URL` or `~/.smithers-review.json`; the live service is review.jjhub.tech, so the help line now describes the behavior instead of hardcoding a domain.

Also serves as the end-to-end check for the new PR review walkthrough workflow (secrets were just configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)