### PR TITLE
👷 ci(review): dogfood the zero-secret review action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,109 +1,22 @@
-name: PR review walkthrough
-
-# Runs `smithers review` (apps/review) on every PR: agent code review plus a
-# story-form HTML walkthrough, published to the share service and posted onto
-# the PR as a review with inline findings.
-#
-# Secrets:
-#   CLAUDE_CODE_OAUTH_TOKEN        from `claude setup-token` (or ANTHROPIC_API_KEY).
-#                                  Without either the job skips with a notice.
-#   SMITHERS_REVIEW_PUBLISH_TOKEN  optional; without it the review still posts,
-#                                  just without a hosted walkthrough link.
-#
-# Safety scoping: this stays on `pull_request` (never `pull_request_target`)
-# because the review agents execute with the PR's code checked out. Fork PRs
-# therefore run without secrets and a read-only token, so the job skips them.
-# The GITHUB_TOKEN granted below cannot push code or touch other scopes.
-
+name: smithers review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
-permissions: {}
+permissions:
+  id-token: write       # proves your repo's identity to the review service
+  contents: read        # check out the PR
+  pull-requests: write  # post the review
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: smithers-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # Fork PRs have no secrets and a read-only token; drafts are not ready.
-    if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
-    permissions:
-      contents: read # checkout + fetching the PR head sha
-      pull-requests: write # post the review (summary + inline findings)
-
     steps:
-      - name: Check Claude credentials
-        id: creds
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::notice::Neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is configured; skipping PR review."
-            echo "have=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "have=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - if: steps.creds.outputs.have == 'true'
-        uses: actions/checkout@v6.0.2
-        with:
-          # The review diffs origin/<base>..<head sha>; merge-base needs history.
-          fetch-depth: 0
-
-      - if: steps.creds.outputs.have == 'true'
-        uses: pnpm/action-setup@v6.0.8
-        with:
-          version: 10.10.0
-          run_install: false
-
-      - if: steps.creds.outputs.have == 'true'
-        uses: actions/setup-node@v6.4.0
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - if: steps.creds.outputs.have == 'true'
-        uses: oven-sh/setup-bun@v2.2.0
-        with:
-          bun-version: 1.3.13
-
-      - if: steps.creds.outputs.have == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - if: steps.creds.outputs.have == 'true'
-        name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code
-
-      - if: steps.creds.outputs.have == 'true'
-        name: Review the PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          # review.smithers.sh is pre-wired but blocked on credentials; the
-          # live publish service is review.jjhub.tech (see apps/review/README.md).
-          SMITHERS_REVIEW_PUBLISH_URL: https://review.jjhub.tech
-          SMITHERS_REVIEW_PUBLISH_TOKEN: ${{ secrets.SMITHERS_REVIEW_PUBLISH_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          args=(--pr "$PR_NUMBER")
-          if [ -n "$SMITHERS_REVIEW_PUBLISH_TOKEN" ]; then
-            args+=(--publish)
-          else
-            echo "::notice::SMITHERS_REVIEW_PUBLISH_TOKEN is not configured; posting the review without a hosted walkthrough link."
-          fi
-          bun apps/review/src/cli/main.ts "${args[@]}"
-
-      - if: always() && steps.creds.outputs.have == 'true'
-        name: Upload walkthrough artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: walkthrough
-          path: .smithers-review/walkthrough.html
-          if-no-files-found: ignore
+      - uses: smithersai/smithers/apps/review/action@main


### PR DESCRIPTION
## Summary
Replaces `.github/workflows/pr-review.yml` with the zero-secret template
documented in `apps/review/README.md` ("Add it to your repo"):

- `pull_request` + `issue_comment` triggers
- `id-token: write` so the action can mint a review session via OIDC
- single `uses: smithersai/smithersai/apps/review/action@main` step
- concurrency group keyed on the PR/issue number

Implements `.smithers/specs/smithers-review-cloud.md`.

## Why
End-to-end dogfood of the smithers review cloud contract: prove that the
repo can drop secrets, route through `https://review.jjhub.tech`, and
still get reviews + a hosted walkthrough on every PR.

## Test plan
- [ ] PR opens; GitHub runs the workflow that lives on `main` for this PR
      push (the old credentials-based job).
- [ ] After merge, a follow-up PR triggers the new composite action and
      authenticates with `/api/sessions` — no secrets — then posts the
      review and links the walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)