### PR TITLE
📝 docs(review): dogfood the Codex-subscription review action

### DIFF
--- a/apps/review/CONTRIBUTING.md
+++ b/apps/review/CONTRIBUTING.md
@@ -154,3 +154,7 @@ failover). Override with `SMITHERS_REVIEW_MODEL` /
 pnpm -C apps/review test        # bun test: real git fixtures + agentless engine e2e
 pnpm -C apps/review typecheck
 ```
+
+## smithers review
+
+This repo dogfoods `apps/review` on every PR via `.github/workflows/pr-review.yml`, running the agents on a ChatGPT (Codex) subscription. See `apps/review/README.md`.


### PR DESCRIPTION
Small doc change to drive a live e2e of the review action running on a ChatGPT (Codex) subscription (CODEX_AUTH_JSON), not the metered proxy.

Expected: the action mints an OIDC session, runs the review on gpt-5.5, and posts a walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)