### PR TITLE
📝 docs(worktree): document jj working-copy snapshot footgun

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -3776,6 +3776,14 @@ Both APIs use the graph resolver, so they match the path Smithers gives worker t
 - jj-backed worktrees include colocated git metadata, so git-native CLI agents such as Codex
   resolve the worktree directory as their repository root. Do not compensate by setting an
   agent `cwd`; that defeats the worktree isolation above.
+- **jj continuously snapshots a worktree's working copy onto its bookmark.** A compute
+  `<Task>` (or helper) that detects changes with `git status --porcelain` can see a *clean*
+  tree and skip its work, because jj has already committed the working-copy edits to the
+  bookmark — and `git checkout`/`git restore` of a file in the worktree won't stick for the
+  same reason (jj re-materializes it). Detect a worktree's changes by diffing against its
+  base branch (`jj diff --from <baseBranch> --to @`, or `git diff <baseBranch>...HEAD`), not
+  by git's dirty-state, and let the merge/land step operate on the committed bookmark rather
+  than re-running `git add`/`git commit`.
 - Innermost `<Worktree>` wins when nested; duplicate ids are rejected.
 - Empty/whitespace `path` is rejected at render time.
 

--- a/docs/components/worktree.mdx
+++ b/docs/components/worktree.mdx
@@ -59,5 +59,13 @@ Both APIs use the graph resolver, so they match the path Smithers gives worker t
 - jj-backed worktrees include colocated git metadata, so git-native CLI agents such as Codex
   resolve the worktree directory as their repository root. Do not compensate by setting an
   agent `cwd`; that defeats the worktree isolation above.
+- **jj continuously snapshots a worktree's working copy onto its bookmark.** A compute
+  `<Task>` (or helper) that detects changes with `git status --porcelain` can see a *clean*
+  tree and skip its work, because jj has already committed the working-copy edits to the
+  bookmark — and `git checkout`/`git restore` of a file in the worktree won't stick for the
+  same reason (jj re-materializes it). Detect a worktree's changes by diffing against its
+  base branch (`jj diff --from <baseBranch> --to @`, or `git diff <baseBranch>...HEAD`), not
+  by git's dirty-state, and let the merge/land step operate on the committed bookmark rather
+  than re-running `git add`/`git commit`.
 - Innermost `<Worktree>` wins when nested; duplicate ids are rejected.
 - Empty/whitespace `path` is rejected at render time.

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -3756,6 +3756,14 @@ Both APIs use the graph resolver, so they match the path Smithers gives worker t
 - jj-backed worktrees include colocated git metadata, so git-native CLI agents such as Codex
   resolve the worktree directory as their repository root. Do not compensate by setting an
   agent `cwd`; that defeats the worktree isolation above.
+- **jj continuously snapshots a worktree's working copy onto its bookmark.** A compute
+  `<Task>` (or helper) that detects changes with `git status --porcelain` can see a *clean*
+  tree and skip its work, because jj has already committed the working-copy edits to the
+  bookmark — and `git checkout`/`git restore` of a file in the worktree won't stick for the
+  same reason (jj re-materializes it). Detect a worktree's changes by diffing against its
+  base branch (`jj diff --from <baseBranch> --to @`, or `git diff <baseBranch>...HEAD`), not
+  by git's dirty-state, and let the merge/land step operate on the committed bookmark rather
+  than re-running `git add`/`git commit`.
 - Innermost `<Worktree>` wins when nested; duplicate ids are rejected.
 - Empty/whitespace `path` is rejected at render time.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3776,6 +3776,14 @@ Both APIs use the graph resolver, so they match the path Smithers gives worker t
 - jj-backed worktrees include colocated git metadata, so git-native CLI agents such as Codex
   resolve the worktree directory as their repository root. Do not compensate by setting an
   agent `cwd`; that defeats the worktree isolation above.
+- **jj continuously snapshots a worktree's working copy onto its bookmark.** A compute
+  `<Task>` (or helper) that detects changes with `git status --porcelain` can see a *clean*
+  tree and skip its work, because jj has already committed the working-copy edits to the
+  bookmark — and `git checkout`/`git restore` of a file in the worktree won't stick for the
+  same reason (jj re-materializes it). Detect a worktree's changes by diffing against its
+  base branch (`jj diff --from <baseBranch> --to @`, or `git diff <baseBranch>...HEAD`), not
+  by git's dirty-state, and let the merge/land step operate on the committed bookmark rather
+  than re-running `git add`/`git commit`.
 - Innermost `<Worktree>` wins when nested; duplicate ids are rejected.
 - Empty/whitespace `path` is rejected at render time.
 

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -3776,6 +3776,14 @@ Both APIs use the graph resolver, so they match the path Smithers gives worker t
 - jj-backed worktrees include colocated git metadata, so git-native CLI agents such as Codex
   resolve the worktree directory as their repository root. Do not compensate by setting an
   agent `cwd`; that defeats the worktree isolation above.
+- **jj continuously snapshots a worktree's working copy onto its bookmark.** A compute
+  `<Task>` (or helper) that detects changes with `git status --porcelain` can see a *clean*
+  tree and skip its work, because jj has already committed the working-copy edits to the
+  bookmark — and `git checkout`/`git restore` of a file in the worktree won't stick for the
+  same reason (jj re-materializes it). Detect a worktree's changes by diffing against its
+  base branch (`jj diff --from <baseBranch> --to @`, or `git diff <baseBranch>...HEAD`), not
+  by git's dirty-state, and let the merge/land step operate on the committed bookmark rather
+  than re-running `git add`/`git commit`.
 - Innermost `<Worktree>` wins when nested; duplicate ids are rejected.
 - Empty/whitespace `path` is rejected at render time.
 


### PR DESCRIPTION
While running a multi-agent migration workflow in jj-backed worktrees, a compute `<Task>` that committed each worktree via `git status --porcelain` + `git add`/`git commit` silently no-op'd: jj had already snapshotted the working copy onto the bookmark, so git saw a clean tree. `git checkout -- <file>` / `git restore` also didn't stick (jj re-materializes from `@`).

This adds a note to `docs/components/worktree.mdx` (and the regenerated llms bundles): in jj worktrees, detect changes by diffing against the base branch (`jj diff --from <base> --to @` or `git diff <base>...HEAD`), not git's dirty-state, and let the merge/land step operate on the committed bookmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)