### PR TITLE
🐛 fix(agents): run pi json mode non-interactively + capture pi usage (#284)

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -11092,7 +11092,7 @@ const pi = new PiAgent({
 </Task>
 ```
 
-`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text mode uses `--print` by default; JSON/RPC modes set `--mode` and omit `--print`.
+`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text and JSON modes both run non-interactively with `--print` (pi's `--mode` only selects the output format, so JSON also needs `--print` to process one prompt and exit instead of idling until the task timeout); JSON mode adds `--mode json`. RPC mode drives its own persistent stdin/stdout transport, so it sets `--mode rpc` and omits `--print`. Pass `print: false` to opt back into interactive behavior.
 
 PI sessions are first-class hijack targets. `bunx smithers-orchestrator hijack RUN_ID --target pi` reopens the PI session for local steering.
 

--- a/docs/integrations/pi-integration.mdx
+++ b/docs/integrations/pi-integration.mdx
@@ -24,7 +24,7 @@ const pi = new PiAgent({
 </Task>
 ```
 
-`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text mode uses `--print` by default; JSON/RPC modes set `--mode` and omit `--print`.
+`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text and JSON modes both run non-interactively with `--print` (pi's `--mode` only selects the output format, so JSON also needs `--print` to process one prompt and exit instead of idling until the task timeout); JSON mode adds `--mode json`. RPC mode drives its own persistent stdin/stdout transport, so it sets `--mode rpc` and omits `--print`. Pass `print: false` to opt back into interactive behavior.
 
 PI sessions are first-class hijack targets. `bunx smithers-orchestrator hijack RUN_ID --target pi` reopens the PI session for local steering.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11092,7 +11092,7 @@ const pi = new PiAgent({
 </Task>
 ```
 
-`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text mode uses `--print` by default; JSON/RPC modes set `--mode` and omit `--print`.
+`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text and JSON modes both run non-interactively with `--print` (pi's `--mode` only selects the output format, so JSON also needs `--print` to process one prompt and exit instead of idling until the task timeout); JSON mode adds `--mode json`. RPC mode drives its own persistent stdin/stdout transport, so it sets `--mode rpc` and omits `--print`. Pass `print: false` to opt back into interactive behavior.
 
 PI sessions are first-class hijack targets. `bunx smithers-orchestrator hijack RUN_ID --target pi` reopens the PI session for local steering.
 

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -1205,7 +1205,7 @@ const pi = new PiAgent({
 </Task>
 ```
 
-`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text mode uses `--print` by default; JSON/RPC modes set `--mode` and omit `--print`.
+`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text and JSON modes both run non-interactively with `--print` (pi's `--mode` only selects the output format, so JSON also needs `--print` to process one prompt and exit instead of idling until the task timeout); JSON mode adds `--mode json`. RPC mode drives its own persistent stdin/stdout transport, so it sets `--mode rpc` and omits `--print`. Pass `print: false` to opt back into interactive behavior.
 
 PI sessions are first-class hijack targets. `bunx smithers-orchestrator hijack RUN_ID --target pi` reopens the PI session for local steering.
 

--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -506,6 +506,42 @@ export function extractUsageFromOutput(raw) {
             countedIncremental = true;
             continue;
         }
+        // pi (@mariozechner/pi) reports final per-message token usage under
+        // message.usage on the assistant's message_end, with its own field
+        // names (input/output/cacheRead/cacheWrite/totalTokens) rather than
+        // Anthropic's input_tokens/output_tokens. Without this branch the only
+        // pi usage captured is the all-zero message_start, so completed runs
+        // report zero tokens. Sum across assistant message_end events so
+        // multi-step tool loops total correctly; turn_end mirrors the last
+        // message, so it is intentionally not counted here to avoid double
+        // counting. (#284)
+        if (parsed.type === "message_end" &&
+            parsed.message?.role === "assistant" &&
+            parsed.message.usage &&
+            typeof parsed.message.usage === "object" &&
+            typeof parsed.message.usage.input_tokens !== "number" &&
+            (typeof parsed.message.usage.input === "number" ||
+                typeof parsed.message.usage.output === "number" ||
+                typeof parsed.message.usage.totalTokens === "number")) {
+            const u = parsed.message.usage;
+            if (typeof u.input === "number") {
+                usage.inputTokens = (usage.inputTokens ?? 0) + u.input;
+            }
+            if (typeof u.output === "number") {
+                usage.outputTokens = (usage.outputTokens ?? 0) + u.output;
+            }
+            if (typeof u.cacheRead === "number" && u.cacheRead) {
+                usage.cacheReadTokens = (usage.cacheReadTokens ?? 0) + u.cacheRead;
+            }
+            if (typeof u.cacheWrite === "number" && u.cacheWrite) {
+                usage.cacheWriteTokens = (usage.cacheWriteTokens ?? 0) + u.cacheWrite;
+            }
+            if (typeof u.totalTokens === "number") {
+                usage.totalTokens = (usage.totalTokens ?? 0) + u.totalTokens;
+            }
+            found = true;
+            continue;
+        }
         if (parsed.type === "message_delta" && parsed.usage) {
             if (parsed.usage.output_tokens) {
                 usage.outputTokens =

--- a/packages/agents/src/PiAgent.js
+++ b/packages/agents/src/PiAgent.js
@@ -104,12 +104,22 @@ export class PiAgent extends BaseCliAgent {
             : undefined;
         const effectiveSession = resumeSession ?? this.opts.session;
         this.issuedSessionRef = effectiveSession;
-        if (params.mode === "text") {
-            if (this.opts.print !== false)
-                args.push("--print");
+        // pi's `--mode` only selects the output format (text|json|rpc); it does
+        // NOT make pi process a single prompt and exit. `--print` is the
+        // non-interactive switch. Without it, a json/stream-json task can emit
+        // its complete result (agent_end) and then sit as an open interactive
+        // session until Smithers kills it at the task timeout, discarding the
+        // finished output as PROCESS_TIMEOUT. So `--print` applies to every
+        // non-interactive mode, not just text. RPC mode drives its own
+        // persistent stdin/stdout transport, so `--print` does not apply. (#284)
+        if (params.mode === "rpc") {
+            args.push("--mode", "rpc");
         }
         else {
-            args.push("--mode", params.mode);
+            if (this.opts.print !== false)
+                args.push("--print");
+            if (params.mode !== "text")
+                args.push("--mode", params.mode);
         }
         pushFlag(args, "--provider", this.opts.provider);
         pushFlag(args, "--model", this.opts.model ?? this.model);

--- a/packages/agents/tests/extract-usage.test.js
+++ b/packages/agents/tests/extract-usage.test.js
@@ -108,6 +108,41 @@ describe("extractUsageFromOutput", () => {
     expect(usage.outputTokens).toBe(50);
   });
 
+  test("extracts tokens from pi json NDJSON (assistant message_end), ignoring zero message_start and mirrored turn_end (#284)", () => {
+    const piUsage = { input: 1228, output: 2, cacheRead: 0, cacheWrite: 0, totalTokens: 1230 };
+    const lines = [
+      JSON.stringify({ type: "session", id: "s1", version: 3 }),
+      JSON.stringify({ type: "agent_start" }),
+      JSON.stringify({ type: "turn_start" }),
+      JSON.stringify({ type: "message_start", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+      JSON.stringify({ type: "message_end", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+      // assistant message_start carries an all-zero usage up front; must not win.
+      JSON.stringify({ type: "message_start", message: { role: "assistant", content: [], usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 } } }),
+      JSON.stringify({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "hi" }], usage: piUsage } }),
+      // turn_end mirrors the last assistant message; counting it would double.
+      JSON.stringify({ type: "turn_end", message: { role: "assistant", usage: piUsage } }),
+      JSON.stringify({ type: "agent_end", messages: [] }),
+    ];
+    const usage = extractUsageFromOutput(lines.join("\n"));
+    expect(usage).toBeDefined();
+    expect(usage.inputTokens).toBe(1228);
+    expect(usage.outputTokens).toBe(2);
+    expect(usage.totalTokens).toBe(1230);
+  });
+
+  test("sums pi usage across multiple assistant message_end events (tool loop) (#284)", () => {
+    const lines = [
+      JSON.stringify({ type: "message_end", message: { role: "assistant", usage: { input: 100, output: 10, totalTokens: 110 } } }),
+      JSON.stringify({ type: "message_end", message: { role: "assistant", usage: { input: 200, output: 20, cacheRead: 5, totalTokens: 220 } } }),
+    ];
+    const usage = extractUsageFromOutput(lines.join("\n"));
+    expect(usage).toBeDefined();
+    expect(usage.inputTokens).toBe(300);
+    expect(usage.outputTokens).toBe(30);
+    expect(usage.totalTokens).toBe(330);
+    expect(usage.cacheReadTokens).toBe(5);
+  });
+
   test("returns undefined for plain text output with no usage data", () => {
     const raw = "Hello, I am a helpful assistant.\nHow can I help you today?";
     const usage = extractUsageFromOutput(raw);

--- a/packages/agents/tests/pi-support.test.js
+++ b/packages/agents/tests/pi-support.test.js
@@ -21,6 +21,34 @@ afterEach(() => {
     delete process.env.PI_RESPONSE_FILE;
 });
 describe("PI CLI agent", () => {
+    test("buildArgs adds --print for every non-interactive mode, not just text (#284)", async () => {
+        // text mode: --print, no --mode (text is pi's default output mode)
+        const textArgs = await (new PiAgent({ mode: "text" })).buildArgs({ prompt: "hi", cwd: "/tmp", options: {}, mode: "text" });
+        expect(textArgs).toContain("--print");
+        expect(textArgs).not.toContain("--mode");
+
+        // json mode: --print AND --mode json (so pi exits after emitting NDJSON)
+        const jsonArgs = await (new PiAgent({ mode: "json" })).buildArgs({ prompt: "hi", cwd: "/tmp", options: {}, mode: "json" });
+        expect(jsonArgs).toContain("--print");
+        expect(jsonArgs.indexOf("--mode")).toBeGreaterThanOrEqual(0);
+        expect(jsonArgs[jsonArgs.indexOf("--mode") + 1]).toBe("json");
+
+        // onEvent forces json mode (resolveMode) and must still be non-interactive
+        const evAgent = new PiAgent({});
+        const evArgs = await evAgent.buildArgs({ prompt: "hi", cwd: "/tmp", options: { onEvent: () => {} }, mode: evAgent.resolveMode({ onEvent: () => {} }) });
+        expect(evArgs).toContain("--print");
+        expect(evArgs).toContain("json");
+
+        // rpc mode drives its own persistent transport: --mode rpc, never --print
+        const rpcArgs = await (new PiAgent({ mode: "rpc" })).buildArgs({ prompt: "hi", cwd: "/tmp", options: {}, mode: "rpc" });
+        expect(rpcArgs[rpcArgs.indexOf("--mode") + 1]).toBe("rpc");
+        expect(rpcArgs).not.toContain("--print");
+
+        // print:false opts out even in json mode (explicit interactive override)
+        const noPrintArgs = await (new PiAgent({ mode: "json", print: false })).buildArgs({ prompt: "hi", cwd: "/tmp", options: {}, mode: "json" });
+        expect(noPrintArgs).not.toContain("--print");
+        expect(noPrintArgs).toContain("--mode");
+    });
     test("PiAgent emits resumable session and tool lifecycle events when hijack hooks are enabled", async () => {
         const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-events-"));
         const argsFile = join(argsFileDir, "args.json");
@@ -141,6 +169,9 @@ process.stdout.write(lines.join("\\n") + "\\n");
             expect(Array.isArray(payload.args)).toBe(true);
             expect(payload.args).toContain("--mode");
             expect(payload.args).toContain("json");
+            // json mode must be non-interactive: --print makes pi process the
+            // prompt and exit instead of idling until the task timeout (#284).
+            expect(payload.args).toContain("--print");
             expect(payload.args).toContain("--continue");
             expect(payload.args).toContain("--resume");
             expect(payload.args).toContain("--provider");

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -11092,7 +11092,7 @@ const pi = new PiAgent({
 </Task>
 ```
 
-`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text mode uses `--print` by default; JSON/RPC modes set `--mode` and omit `--print`.
+`PiAgent` supports all PI CLI flags: provider/model, tools, extensions, skills, prompt templates, themes, sessions. Text and JSON modes both run non-interactively with `--print` (pi's `--mode` only selects the output format, so JSON also needs `--print` to process one prompt and exit instead of idling until the task timeout); JSON mode adds `--mode json`. RPC mode drives its own persistent stdin/stdout transport, so it sets `--mode rpc` and omits `--print`. Pass `print: false` to opt back into interactive behavior.
 
 PI sessions are first-class hijack targets. `bunx smithers-orchestrator hijack RUN_ID --target pi` reopens the PI session for local steering.
 


### PR DESCRIPTION
Fixes #284.

## Problem

`PiAgent` switches to pi's JSON output mode whenever Smithers passes `onEvent`, but `buildArgs` added pi's `--print` flag **only in text mode**. pi documents `--mode` and `--print` as independent concerns:

```
--mode <mode>    Output mode: text (default), json, or rpc
--print, -p      Non-interactive mode: process prompt and exit
```

So `--mode json` selects NDJSON output but does **not** make pi process one prompt and exit. A json-mode Pi task could emit a complete `agent_end`, then sit as an open interactive session until Smithers killed it at the task timeout, and the finished output got discarded as `PROCESS_TIMEOUT`. Separately, completed pi runs reported **zero token usage**.

## What I verified against real pi (0.60.0)

- `--print` and `--mode` are independent flags (confirmed in `pi --help`).
- A json-mode run **with `--print`** exits cleanly (exit 0); the same path drives `PiAgent.generate({ onEvent })` to completion in ~2.5s instead of hanging.
- pi reports final usage under `message.usage` on the assistant's `message_end` with its own field names: `{input, output, cacheRead, cacheWrite, totalTokens}` — not Anthropic's `input_tokens`. The shared `extractUsageFromOutput` only understood Anthropic/Codex shapes, so it returned the all-zero `message_start` and reported 0 tokens.
- pi emits **one `agent_end` per auto-retry attempt** (saw 4 on a rate-limited run) — see "Deliberately not done" below.

## Fixes

1. **`--print` for every non-interactive mode** (`PiAgent.buildArgs`). Text and json/stream-json now both run non-interactively; RPC keeps its own persistent transport (`--mode rpc`, no `--print`). `print: false` still opts out.
2. **pi usage extraction** (`extractUsageFromOutput`) — additive branch that sums usage across assistant `message_end` events; intentionally skips `turn_end` (mirrors the last message → would double count). Claude/Codex extraction unchanged.
3. **Docs** — the pi integration doc literally described the buggy behavior ("JSON/RPC modes set `--mode` and omit `--print`"); corrected + llms bundles regenerated.

End-to-end after the fix: `generate({ onEvent })` → text `"hi"`, events fire, `usage = {inputTokens: 1228, outputTokens: 2, totalTokens: 1230}`, no timeout.

## Deliberately not done (with reasoning)

- **"Treat `agent_end` as terminal / force-close after it."** pi emits one `agent_end` per retry attempt, so completing on the first would truncate a run mid-retry and capture an error result. With `--print`, **process exit** is the correct terminal signal and the existing `onExit` harvesting works. Forcing early completion would regress retried runs.
- **Provider-aware pi diagnostics** (the issue's lower-priority cleanup #1). The pi strategy hardcodes Google auth/rate-limit checks regardless of `--provider`. Fixing it well needs provider plumbing through `launchDiagnostics` + a provider→check mapping across all pi-supported providers — a separate, lower-confidence change best done on its own. Left out to keep this PR focused and low-risk. Happy to follow up.

## Verification

`pnpm -C packages/agents typecheck` ✓ · full agents suite **236 pass / 0 fail** (incl. new pi `--print` matrix + pi usage cases) ✓ · `check:docs` ✓ · llms bundles regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
