### PR TITLE
🐛 fix(agents): make PiAgent JSON mode non-interactive and complete on agent_end (#284)

### DIFF
--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -862,7 +862,7 @@ export class BaseCliAgent {
                 }
                 flushBufferedLines(stream, false);
             };
-            diagnosticsPromise = launchDiagnostics(commandSpec.command, commandEnv, cwd);
+            diagnosticsPromise = launchDiagnostics(commandSpec.command, commandEnv, cwd, this.diagnosticHints?.());
             return Effect.gen(this, function* () {
                 const result = yield* runCommandEffect(commandSpec.command, commandSpec.args, {
                     cwd,
@@ -1086,6 +1086,12 @@ export class BaseCliAgent {
    * @returns {CliOutputInterpreter | undefined}
    */
     createOutputInterpreter() {
+        return undefined;
+    }
+    /**
+   * @returns {{ provider?: string; model?: string } | undefined}
+   */
+    diagnosticHints() {
         return undefined;
     }
 }

--- a/packages/agents/src/PiAgent.js
+++ b/packages/agents/src/PiAgent.js
@@ -104,11 +104,14 @@ export class PiAgent extends BaseCliAgent {
             : undefined;
         const effectiveSession = resumeSession ?? this.opts.session;
         this.issuedSessionRef = effectiveSession;
-        if (params.mode === "text") {
-            if (this.opts.print !== false)
-                args.push("--print");
+        // pi's --print (non-interactive: process prompt and exit) and --mode
+        // are independent. Apply --print to every non-RPC mode so json task
+        // executions also process one prompt and exit instead of lingering as
+        // an interactive session (#284).
+        if (params.mode !== "rpc" && this.opts.print !== false) {
+            args.push("--print");
         }
-        else {
+        if (params.mode !== "text") {
             args.push("--mode", params.mode);
         }
         pushFlag(args, "--provider", this.opts.provider);
@@ -197,7 +200,9 @@ export class PiAgent extends BaseCliAgent {
     createOutputInterpreter() {
         let sessionId = this.issuedSessionRef;
         let emittedStarted = false;
+        let emittedCompleted = false;
         let finalAnswer = "";
+        let finalUsage;
         /**
      * @param {unknown} value
      */
@@ -229,6 +234,17 @@ export class PiAgent extends BaseCliAgent {
                     resume: sessionId,
                     detail,
                 }];
+        };
+        /**
+     * @param {Record<string, unknown>} payload
+     */
+        const captureUsage = (payload) => {
+            const candidate = (payload && typeof payload.usage === "object" && payload.usage) ||
+                (payload && typeof payload.message === "object" && payload.message && typeof payload.message.usage === "object" && payload.message.usage) ||
+                undefined;
+            if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+                finalUsage = candidate;
+            }
         };
         /**
      * @param {string} line
@@ -267,6 +283,7 @@ export class PiAgent extends BaseCliAgent {
                 return startedEvents();
             }
             if (type === "message_end" || type === "turn_end") {
+                captureUsage(payload);
                 const message = payload.message;
                 if (message?.role === "assistant") {
                     const extracted = extractTextFromJsonValue(message);
@@ -275,6 +292,33 @@ export class PiAgent extends BaseCliAgent {
                     }
                 }
                 return startedEvents();
+            }
+            if (type === "agent_end") {
+                captureUsage(payload);
+                if (Array.isArray(payload.messages)) {
+                    for (let i = payload.messages.length - 1; i >= 0; i--) {
+                        const message = payload.messages[i];
+                        if (message?.role === "assistant") {
+                            const extracted = extractTextFromJsonValue(message);
+                            if (extracted) {
+                                finalAnswer = extracted;
+                            }
+                            break;
+                        }
+                    }
+                }
+                emittedCompleted = true;
+                return [
+                    ...startedEvents(),
+                    {
+                        type: "completed",
+                        engine: this.cliEngine,
+                        ok: true,
+                        answer: finalAnswer || undefined,
+                        usage: finalUsage,
+                        resume: sessionId,
+                    },
+                ];
             }
             if (type === "tool_execution_start") {
                 const toolName = asString(payload.toolName) ?? "tool";
@@ -355,6 +399,9 @@ export class PiAgent extends BaseCliAgent {
                 const started = !emittedStarted && sessionId
                     ? startedEvents()
                     : [];
+                if (emittedCompleted) {
+                    return started;
+                }
                 return [
                     ...started,
                     {
@@ -362,6 +409,7 @@ export class PiAgent extends BaseCliAgent {
                         engine: this.cliEngine,
                         ok: !result.exitCode || result.exitCode === 0,
                         answer: finalAnswer || undefined,
+                        usage: finalUsage,
                         error: result.exitCode && result.exitCode !== 0
                             ? result.stderr.trim() || `PI exited with code ${result.exitCode}`
                             : undefined,
@@ -394,7 +442,7 @@ export class PiAgent extends BaseCliAgent {
         const cwd = this.cwd ?? options?.rootDir ?? process.cwd();
         const env = { ...process.env, ...this.env };
         const args = this.buildArgs({ prompt, cwd, options, mode });
-        const diagnosticsPromise = launchDiagnostics("pi", env, cwd);
+        const diagnosticsPromise = launchDiagnostics("pi", env, cwd, this.diagnosticHints());
         const interpreter = this.createOutputInterpreter();
         /**
      * @param {AgentCliEvent[] | AgentCliEvent | null | undefined} payload
@@ -463,6 +511,16 @@ export class PiAgent extends BaseCliAgent {
                 mode,
             }),
             outputFormat: mode,
+        };
+    }
+    /**
+   * @returns {{ provider?: string; model?: string; apiKey?: string }}
+   */
+    diagnosticHints() {
+        return {
+            provider: this.opts.provider,
+            model: this.opts.model ?? this.model,
+            apiKey: this.opts.apiKey,
         };
     }
 }

--- a/packages/agents/src/diagnostics/getDiagnosticStrategy.js
+++ b/packages/agents/src/diagnostics/getDiagnosticStrategy.js
@@ -9,6 +9,9 @@ import { spawnSync } from "node:child_process";
 /**
  * @typedef {{ id: DiagnosticCheckId; run: (ctx: DiagnosticContext) => Promise<DiagnosticCheck>; }} DiagnosticCheckDef
  */
+/**
+ * @typedef {{ provider?: string; model?: string; apiKey?: string }} DiagnosticHints
+ */
 
 // ---------------------------------------------------------------------------
 // Shared check helpers
@@ -472,15 +475,75 @@ const antigravityStrategy = {
 // ---------------------------------------------------------------------------
 // Pi strategy
 // ---------------------------------------------------------------------------
-const piStrategy = {
-    agentId: "pi",
-    command: "pi",
-    checks: [
-        checkCliInstalled("pi", "Pi"),
-        googleAuthCheck,
-        googleRateLimitCheck,
-    ],
-};
+/**
+ * Resolve the effective pi provider family from an explicit `--provider`, a
+ * `provider/model` prefix, or a bare model id's well-known prefix. Returns ""
+ * when undeterminable so callers fall back to pi's default (google) (#284).
+ * @param {DiagnosticHints | undefined} hints
+ * @returns {string}
+ */
+function resolvePiProvider(hints) {
+    const explicit = (hints?.provider || "").trim().toLowerCase();
+    if (explicit) {
+        return explicit;
+    }
+    const model = typeof hints?.model === "string" ? hints.model.trim().toLowerCase() : "";
+    if (!model) {
+        return "";
+    }
+    if (model.includes("/")) {
+        return model.split("/")[0];
+    }
+    // Bare model id (no provider prefix) — infer the provider family from
+    // common id prefixes so diagnostics probe the right backend.
+    if (model.startsWith("gpt-") || model.startsWith("o1-") || model.startsWith("o3-") || model.startsWith("o4-") || model.startsWith("chatgpt")) {
+        return "openai";
+    }
+    if (model.startsWith("claude")) {
+        return "anthropic";
+    }
+    if (model.startsWith("gemini")) {
+        return "google";
+    }
+    return "";
+}
+/**
+ * @param {DiagnosticHints | undefined} hints
+ * @returns {DiagnosticCheckDef[]}
+ */
+function piProviderChecks(hints) {
+    const raw = resolvePiProvider(hints);
+    if (raw === "openai" || raw === "openai-codex" || raw === "azure" || raw === "azure-openai") {
+        return [...codexApiKeyAndRateLimitCheck];
+    }
+    if (raw === "anthropic" || raw === "claude") {
+        return [claudeApiKeyCheck, claudeRateLimitCheck];
+    }
+    return [googleAuthCheck, googleRateLimitCheck];
+}
+/**
+ * pi accepts credentials via the `--api-key` option instead of an environment
+ * variable. Diagnostics only see the process env, so map an explicit apiKey to
+ * the env var the selected provider's checks read — otherwise an apiKey-only pi
+ * run is misreported as "key missing" (#284). Returns undefined when there is
+ * nothing to inject.
+ * @param {string} command
+ * @param {DiagnosticHints | undefined} hints
+ * @returns {Record<string, string> | undefined}
+ */
+export function diagnosticApiKeyEnv(command, hints) {
+    if (command !== "pi" || !hints?.apiKey) {
+        return undefined;
+    }
+    const raw = resolvePiProvider(hints);
+    if (raw === "openai" || raw === "openai-codex" || raw === "azure" || raw === "azure-openai") {
+        return { OPENAI_API_KEY: hints.apiKey };
+    }
+    if (raw === "anthropic" || raw === "claude") {
+        return { ANTHROPIC_API_KEY: hints.apiKey };
+    }
+    return { GOOGLE_API_KEY: hints.apiKey };
+}
 // ---------------------------------------------------------------------------
 // Amp strategy
 // ---------------------------------------------------------------------------
@@ -524,13 +587,20 @@ const strategies = {
     antigravity: antigravityStrategy,
     agy: antigravityStrategy,
     gemini: geminiStrategy,
-    pi: piStrategy,
     amp: ampStrategy,
 };
 /**
  * @param {string} command
+ * @param {DiagnosticHints} [hints]
  * @returns {AgentDiagnosticStrategy | null}
  */
-export function getDiagnosticStrategy(command) {
+export function getDiagnosticStrategy(command, hints) {
+    if (command === "pi") {
+        return {
+            agentId: "pi",
+            command: "pi",
+            checks: [checkCliInstalled("pi", "Pi"), ...piProviderChecks(hints)],
+        };
+    }
     return strategies[command] ?? null;
 }

--- a/packages/agents/src/diagnostics/launchDiagnostics.js
+++ b/packages/agents/src/diagnostics/launchDiagnostics.js
@@ -1,4 +1,4 @@
-import { getDiagnosticStrategy } from "./getDiagnosticStrategy.js";
+import { diagnosticApiKeyEnv, getDiagnosticStrategy } from "./getDiagnosticStrategy.js";
 import { runDiagnostics } from "./runDiagnostics.js";
 /** @typedef {import("./DiagnosticReport.ts").DiagnosticReport} DiagnosticReport */
 
@@ -6,11 +6,14 @@ import { runDiagnostics } from "./runDiagnostics.js";
  * @param {string} command
  * @param {Record<string, string>} env
  * @param {string} cwd
+ * @param {{ provider?: string; model?: string; apiKey?: string }} [hints]
  * @returns {Promise<DiagnosticReport> | null}
  */
-export function launchDiagnostics(command, env, cwd) {
-    const strategy = getDiagnosticStrategy(command);
+export function launchDiagnostics(command, env, cwd, hints) {
+    const strategy = getDiagnosticStrategy(command, hints);
     if (!strategy)
         return null;
-    return runDiagnostics(strategy, { env, cwd }).catch(() => null);
+    const apiKeyEnv = diagnosticApiKeyEnv(command, hints);
+    const effectiveEnv = apiKeyEnv ? { ...env, ...apiKeyEnv } : env;
+    return runDiagnostics(strategy, { env: effectiveEnv, cwd }).catch(() => null);
 }

--- a/packages/agents/tests/pi-diagnostics.test.js
+++ b/packages/agents/tests/pi-diagnostics.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { diagnosticApiKeyEnv, getDiagnosticStrategy } from "../src/diagnostics/getDiagnosticStrategy.js";
+
+/**
+ * @param {ReturnType<typeof getDiagnosticStrategy>} strategy
+ */
+function apiKeyCheck(strategy) {
+    return strategy?.checks.find((check) => check.id === "api_key_valid");
+}
+
+describe("Pi diagnostics provider mapping", () => {
+    test("defaults to Google checks", () => {
+        const strategy = getDiagnosticStrategy("pi");
+        expect(strategy).not.toBeNull();
+        expect(strategy.checks).toHaveLength(3);
+        expect(strategy.checks.map((check) => check.id)).toEqual([
+            "cli_installed",
+            "api_key_valid",
+            "rate_limit_status",
+        ]);
+    });
+    test("uses OpenAI checks for provider hint", async () => {
+        const check = apiKeyCheck(getDiagnosticStrategy("pi", { provider: "openai" }));
+        const result = await check.run({ env: {}, cwd: "/tmp" });
+        expect(result.message).toContain("OPENAI_API_KEY");
+    });
+    test("uses Anthropic checks for provider hint", async () => {
+        const check = apiKeyCheck(getDiagnosticStrategy("pi", { provider: "anthropic" }));
+        const result = await check.run({ env: {}, cwd: "/tmp" });
+        expect(result.message).toContain("ANTHROPIC_API_KEY");
+    });
+    test("infers OpenAI checks from provider/model prefix", async () => {
+        const check = apiKeyCheck(getDiagnosticStrategy("pi", { model: "openai/gpt-4o" }));
+        const result = await check.run({ env: {}, cwd: "/tmp" });
+        expect(result.message).toContain("OPENAI_API_KEY");
+    });
+    test("infers OpenAI checks from a bare gpt- model id", async () => {
+        const check = apiKeyCheck(getDiagnosticStrategy("pi", { model: "gpt-4o" }));
+        const result = await check.run({ env: {}, cwd: "/tmp" });
+        expect(result.message).toContain("OPENAI_API_KEY");
+    });
+    test("infers Anthropic checks from a bare claude- model id", async () => {
+        const check = apiKeyCheck(getDiagnosticStrategy("pi", { model: "claude-3-5-sonnet" }));
+        const result = await check.run({ env: {}, cwd: "/tmp" });
+        expect(result.message).toContain("ANTHROPIC_API_KEY");
+    });
+    test("keeps Google checks for a bare gemini- model id", () => {
+        const strategy = getDiagnosticStrategy("pi", { model: "gemini-2.5-flash" });
+        expect(strategy.checks.map((check) => check.id)).toEqual([
+            "cli_installed",
+            "api_key_valid",
+            "rate_limit_status",
+        ]);
+        // The Google api_key check is the one that reads GOOGLE_API_KEY/GEMINI_API_KEY.
+        expect(diagnosticApiKeyEnv("pi", { model: "gemini-2.5-flash", apiKey: "g" }))
+            .toEqual({ GOOGLE_API_KEY: "g" });
+    });
+    test("maps a bare gpt- model id apiKey to OPENAI_API_KEY", () => {
+        expect(diagnosticApiKeyEnv("pi", { model: "gpt-4o", apiKey: "sk-x" }))
+            .toEqual({ OPENAI_API_KEY: "sk-x" });
+    });
+    test("maps the pi --api-key option to the provider's env var", () => {
+        expect(diagnosticApiKeyEnv("pi", { provider: "openai", apiKey: "sk-openai" }))
+            .toEqual({ OPENAI_API_KEY: "sk-openai" });
+        expect(diagnosticApiKeyEnv("pi", { provider: "anthropic", apiKey: "sk-anthropic" }))
+            .toEqual({ ANTHROPIC_API_KEY: "sk-anthropic" });
+        expect(diagnosticApiKeyEnv("pi", { model: "openai/gpt-4o", apiKey: "sk-x" }))
+            .toEqual({ OPENAI_API_KEY: "sk-x" });
+        expect(diagnosticApiKeyEnv("pi", { provider: "google", apiKey: "g-key" }))
+            .toEqual({ GOOGLE_API_KEY: "g-key" });
+        // No apiKey, non-pi command, or undefined hints → nothing to inject.
+        expect(diagnosticApiKeyEnv("pi", { provider: "openai" })).toBeUndefined();
+        expect(diagnosticApiKeyEnv("claude", { apiKey: "x" })).toBeUndefined();
+    });
+});

--- a/packages/agents/tests/pi-support.test.js
+++ b/packages/agents/tests/pi-support.test.js
@@ -198,11 +198,114 @@ process.stdout.write(lines.join("\\n") + "\\n");
             await rm(argsFileDir, { recursive: true, force: true });
         }
     }, 15_000);
+    test("PiAgent json mode includes --print", async () => {
+        const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-json-print-"));
+        const argsFile = join(argsFileDir, "args.json");
+        const fake = await makeFakePi(`
+ const fs = require("node:fs");
+ const args = process.argv.slice(2);
+ if (process.env.PI_ARGS_FILE) fs.writeFileSync(process.env.PI_ARGS_FILE, JSON.stringify(args), "utf8");
+ const lines = [
+   JSON.stringify({ type: "session", id: "json-print-session" }),
+   JSON.stringify({ type: "turn_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } })
+ ];
+ process.stdout.write(lines.join("\\n") + "\\n");
+ `);
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            process.env.PI_ARGS_FILE = argsFile;
+            const agent = new PiAgent({
+                mode: "json",
+                env: { PATH: process.env.PATH },
+            });
+            await agent.generate({
+                messages: [{ role: "user", content: "Ping?" }],
+            });
+            const capturedArgs = JSON.parse(await readFile(argsFile, "utf8"));
+            expect(capturedArgs).toContain("--print");
+            expect(capturedArgs).toContain("--mode");
+            expect(capturedArgs).toContain("json");
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+            await rm(argsFileDir, { recursive: true, force: true });
+        }
+    });
+    test("PiAgent onEvent path includes --print and --mode json", async () => {
+        const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-on-event-print-"));
+        const argsFile = join(argsFileDir, "args.json");
+        const fake = await makeFakePi(`
+ const fs = require("node:fs");
+ const args = process.argv.slice(2);
+ if (process.env.PI_ARGS_FILE) fs.writeFileSync(process.env.PI_ARGS_FILE, JSON.stringify(args), "utf8");
+ const lines = [
+   JSON.stringify({ type: "session", id: "on-event-print-session" }),
+   JSON.stringify({ type: "turn_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } })
+ ];
+ process.stdout.write(lines.join("\\n") + "\\n");
+ `);
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            process.env.PI_ARGS_FILE = argsFile;
+            const agent = new PiAgent({
+                env: { PATH: process.env.PATH },
+            });
+            await agent.generate({
+                messages: [{ role: "user", content: "Ping?" }],
+                onEvent: () => undefined,
+            });
+            const capturedArgs = JSON.parse(await readFile(argsFile, "utf8"));
+            expect(capturedArgs).toContain("--print");
+            expect(capturedArgs).toContain("--mode");
+            expect(capturedArgs).toContain("json");
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+            await rm(argsFileDir, { recursive: true, force: true });
+        }
+    });
+    test("PiAgent print false omits --print in json mode", async () => {
+        const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-no-print-"));
+        const argsFile = join(argsFileDir, "args.json");
+        const fake = await makeFakePi(`
+ const fs = require("node:fs");
+ const args = process.argv.slice(2);
+ if (process.env.PI_ARGS_FILE) fs.writeFileSync(process.env.PI_ARGS_FILE, JSON.stringify(args), "utf8");
+ const lines = [
+   JSON.stringify({ type: "session", id: "no-print-session" }),
+   JSON.stringify({ type: "turn_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }] } })
+ ];
+ process.stdout.write(lines.join("\\n") + "\\n");
+ `);
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            process.env.PI_ARGS_FILE = argsFile;
+            const agent = new PiAgent({
+                mode: "json",
+                print: false,
+                env: { PATH: process.env.PATH },
+            });
+            await agent.generate({
+                messages: [{ role: "user", content: "Ping?" }],
+            });
+            const capturedArgs = JSON.parse(await readFile(argsFile, "utf8"));
+            expect(capturedArgs).not.toContain("--print");
+            expect(capturedArgs).toContain("--mode");
+            expect(capturedArgs).toContain("json");
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+            await rm(argsFileDir, { recursive: true, force: true });
+        }
+    });
     test("PiAgent RPC mode sends prompt and returns output", async () => {
         const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-rpc-"));
         const argsFile = join(argsFileDir, "prompt.json");
+        const responseFile = join(argsFileDir, "args.json");
         const fake = await makeFakePi(`
  const fs = require("node:fs");
+ const args = process.argv.slice(2);
+ if (process.env.PI_RESPONSE_FILE) fs.writeFileSync(process.env.PI_RESPONSE_FILE, JSON.stringify(args), "utf8");
  let buffer = "";
  process.stdin.on("data", (chunk) => {
    buffer += chunk.toString("utf8");
@@ -223,6 +326,7 @@ process.stdout.write(lines.join("\\n") + "\\n");
         try {
             process.env.PATH = `${fake.dir}:${originalPath}`;
             process.env.PI_ARGS_FILE = argsFile;
+            process.env.PI_RESPONSE_FILE = responseFile;
             const agent = new PiAgent({
                 mode: "rpc",
                 model: "gpt-4o-mini",
@@ -235,6 +339,10 @@ process.stdout.write(lines.join("\\n") + "\\n");
             const promptPayload = JSON.parse(await readFile(argsFile, "utf8"));
             expect(promptPayload.type).toBe("prompt");
             expect(promptPayload.message).toContain("USER: Ping?");
+            const capturedArgs = JSON.parse(await readFile(responseFile, "utf8"));
+            expect(capturedArgs).toContain("--mode");
+            expect(capturedArgs).toContain("rpc");
+            expect(capturedArgs).not.toContain("--print");
         }
         finally {
             await rm(fake.dir, { recursive: true, force: true });
@@ -415,6 +523,85 @@ process.stdout.write(lines.join("\\n") + "\\n");
                 messages: [{ role: "user", content: "Hello" }],
             });
             expect(result.text).toBe("Response from agent_end");
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+        }
+    });
+    test("PiAgent completes once on agent_end with usage", async () => {
+        const fake = await makeFakePi(`
+ const lines = [
+   JSON.stringify({ type: "session", version: 3, id: "agent-end-usage-session" }),
+   JSON.stringify({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "partial" } }),
+   JSON.stringify({ type: "agent_end", messages: [
+     { role: "user", content: [{ type: "text", text: "Hello" }] },
+     { role: "assistant", content: [{ type: "text", text: "Final from agent_end" }] }
+   ], usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } })
+ ];
+ process.stdout.write(lines.join("\\n") + "\\n");
+ `);
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            const events = [];
+            const agent = new PiAgent({
+                mode: "json",
+                model: "test-model",
+                env: { PATH: process.env.PATH },
+            });
+            const result = await agent.generate({
+                messages: [{ role: "user", content: "Hello" }],
+                onEvent: (event) => {
+                    events.push(event);
+                },
+            });
+            const completedEvents = events.filter((event) => event.type === "completed");
+            expect(completedEvents).toHaveLength(1);
+            expect(completedEvents[0].answer).toBe("Final from agent_end");
+            expect(completedEvents[0].usage).toEqual({
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+            });
+            expect(result.text).toBe("Final from agent_end");
+            expect(result.usage.inputTokens).toBe(10);
+            expect(result.usage.outputTokens).toBe(5);
+        }
+        finally {
+            await rm(fake.dir, { recursive: true, force: true });
+        }
+    });
+    test("PiAgent surfaces usage via the completed-event fallback when stdout extraction misses it", async () => {
+        // usage is nested under message.usage (NOT a top-level `usage` field),
+        // which BaseCliAgent.extractUsageFromOutput ignores. result.usage must
+        // therefore come from the interpreter's completed event via
+        // usageFromCompletedEvent — exercising the fallback path (#284).
+        const fake = await makeFakePi(`
+ const lines = [
+   JSON.stringify({ type: "session", version: 3, id: "usage-fallback-session" }),
+   JSON.stringify({ type: "turn_end", message: { role: "assistant", content: [{ type: "text", text: "ok" }], stopReason: "stop", usage: { input_tokens: 7, output_tokens: 3 } } })
+ ];
+ process.stdout.write(lines.join("\\n") + "\\n");
+ `);
+        try {
+            process.env.PATH = `${fake.dir}:${originalPath}`;
+            const events = [];
+            const agent = new PiAgent({
+                mode: "json",
+                model: "test-model",
+                env: { PATH: process.env.PATH },
+            });
+            const result = await agent.generate({
+                messages: [{ role: "user", content: "Hello" }],
+                onEvent: (event) => {
+                    events.push(event);
+                },
+            });
+            const completed = events.find((event) => event.type === "completed");
+            expect(completed?.usage).toEqual({ input_tokens: 7, output_tokens: 3 });
+            // The fallback (usageFromCompletedEvent) populated result.usage even
+            // though the stdout extractor found no top-level usage.
+            expect(result.usage.inputTokens).toBe(7);
+            expect(result.usage.outputTokens).toBe(3);
         }
         finally {
             await rm(fake.dir, { recursive: true, force: true });


### PR DESCRIPTION
Closes #284.

## Problem
`PiAgent.resolveMode()` returns `json` whenever Smithers passes `onEvent`, but `buildArgs()` only added pi's `--print` flag in `text` mode. Per `pi --help`, `--print` (*non-interactive: process prompt and exit*) and `--mode` (text|json|rpc) are **independent** flags, so the normal event-capture path built `pi --mode json …` with no `--print`. pi then emitted a complete, schema-valid answer and **stayed open as an interactive session** until Smithers killed it at the task timeout — and because `BaseCliAgent` only harvests the final result on process exit, the finished output was discarded as `PROCESS_TIMEOUT`. The Pi interpreter also only emitted its `completed` event from `onExit` (never on pi's terminal `agent_end` event) and never attached token usage (telemetry showed 0 tokens / `eventCount: 0`). Finally, pi diagnostics always probed Google/Gemini even when pi ran with `--provider openai`.

## Fix (matches the issue's "Suggested direction")
- **`buildArgs`** — apply `--print` to every non-RPC mode when `print !== false`; `--mode` to every non-text mode. The `onEvent`/json path now builds `pi --print --mode json …` and exits cleanly. RPC keeps its own stdin/stdout JSON-RPC lifecycle and gets **no** `--print`.
- **`createOutputInterpreter`** — recognize `agent_end` as a terminal event: harvest the final assistant answer + usage from it and emit the `completed` event *during streaming* (the established `CodexAgent`/`ClaudeCodeAgent` pattern); `onExit` now dedupes and only completes if a terminal event didn't already.
- **Usage telemetry** — capture pi `usage` (per-message / `turn_end` / `agent_end`) and attach it to the `completed` event, so `BaseCliAgent.usageFromCompletedEvent` surfaces token usage.
- **Provider-aware diagnostics** — the pi strategy now selects Google/OpenAI/Anthropic auth + rate-limit checks from the effective `--provider`, a `provider/model` prefix, or a bare model id (`gpt-`/`o1-`/`claude-`/`gemini-`…), defaulting to Google (pi's default), threaded via a new `diagnosticHints()` agent hook. An explicit `apiKey` option is mapped to the selected provider's env var so apiKey-configured runs aren't misreported as "key missing".

## Review
- **`codex review`** (GPT-5.x): flagged that apiKey-via-option runs would misreport "key missing" → fixed (apiKey now mapped into the diagnostics env).
- **Claude multi-agent adversarial review** (correctness / regression / edge-cases, each finding independently verified): core fix verdict **correct**; two minor findings confirmed and addressed — bare-model-prefix provider inference, and a test that genuinely exercises the `usageFromCompletedEvent` fallback (not just the stdout extractor).

## Tests
`bun test` in `packages/agents`: **247 pass, 0 fail** (14 skip). New coverage: `--print` present in json / omitted with `print:false` / absent in rpc; single completion + usage on `agent_end`; the completed-event usage fallback path; provider-aware diagnostics mapping (explicit, `provider/model`, and bare model ids). The existing exact-match Pi lifecycle event test (uses `turn_end`, not `agent_end`) is preserved. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)