### PR TITLE
🐛 fix(cli): broker scoped action tokens without breaking gateway auth

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -12281,6 +12281,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -1440,7 +1440,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[72]:
+commands[73]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1985,11 +1985,21 @@ commands[72]:
       specPath,string,true,File path or URL to OpenAPI spec
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
-    flags[4]{name,short,type,default,desc}:
+    flags[6]{name,short,type,default,desc}:
       scopes,,string,run:read,Comma or space separated Gateway scopes
       role,,string,operator,Role recorded on the token grant
       user-id,,string,,User ID recorded on the token grant
       ttl,,string,1h,Token lifetime such as 15m or 1h
+      action-id,,string,gateway,Action id allowed to resolve the brokered action token
+      reveal-token,,boolean,false,Include the raw bearer token in CLI output
+  - name: token.exec
+    purpose: Resolve an action token locally and inject the bearer into a child process environment
+    flags[5]{name,short,type,default,desc}:
+      handle,,string,,Brokered action token handle
+      action-id,,string,gateway,Action id expected by the brokered token
+      scopes,,string,,Comma or space separated scopes required for this action
+      env,,string,SMITHERS_API_KEY,Environment variable that receives the bearer token
+      command,,string,,Shell command to run with the injected token
   - name: token.revoke
     purpose: Revoke a locally issued Gateway bearer token
     args[1]{name,type,required,desc}:

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -7928,6 +7928,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -70,7 +70,7 @@ import { formatCliAgentCapabilityDoctorReport, getCliAgentCapabilityDoctorReport
 import { parseDurationMs, supervisorLoopEffect, } from "./supervisor.js";
 import { WATCH_MIN_INTERVAL_MS, runWatchLoop, watchIntervalSecondsToMs, } from "./watch.js";
 import { createSemanticMcpServer } from "./mcp/semantic-server.js";
-import { parseTokenScopes, readSmithersTokenStore, smithersTokenStorePath, writeSmithersTokenStore, } from "./token-store.js";
+import { issueSmithersBrokerToken, parseTokenScopes, readSmithersTokenStore, resolveSmithersActionTokenFromStore, revokeSmithersToken, smithersTokenStorePath, writeSmithersTokenStore, } from "./token-store.js";
 import { resolveSmithersDocsSource } from "./docs-command.js";
 import pc from "picocolors";
 import crypto from "node:crypto";
@@ -2521,6 +2521,8 @@ const tokenCli = Cli.create({
         role: z.string().default("operator").describe("Role recorded on the token grant"),
         userId: z.string().optional().describe("User id recorded on the token grant"),
         ttl: z.string().default("1h").describe("Token lifetime, such as 15m or 1h"),
+        actionId: z.string().default("gateway").describe("Action id allowed to resolve the brokered action token"),
+        revealToken: z.boolean().default(false).describe("Include the raw bearer token in CLI output"),
     }),
     run(c) {
         const fail = (opts) => {
@@ -2529,29 +2531,75 @@ const tokenCli = Cli.create({
         };
         try {
             const ttlMs = parseDurationMs(c.options.ttl, "ttl");
-            const now = Date.now();
-            const token = `smithers_${crypto.randomBytes(32).toString("base64url")}`;
-            const tokenId = crypto.createHash("sha256").update(token).digest("hex").slice(0, 16);
-            const grant = {
-                tokenId,
+            const issued = issueSmithersBrokerToken({
+                store: readSmithersTokenStore(),
                 role: c.options.role,
                 scopes: parseTokenScopes(c.options.scopes),
                 ...(c.options.userId ? { userId: c.options.userId } : {}),
-                issuedAtMs: now,
-                expiresAtMs: now + ttlMs,
-            };
-            const store = readSmithersTokenStore();
-            store.tokens[token] = grant;
-            writeSmithersTokenStore(store);
+                actionId: c.options.actionId,
+                ttlMs,
+            });
+            writeSmithersTokenStore(issued.store);
             return c.ok({
-                token,
-                grant,
+                ...(c.options.revealToken ? { token: issued.token } : {}),
+                grant: c.options.revealToken ? issued.grant : { ...issued.grant, secret: undefined },
+                actionToken: issued.actionToken,
                 storePath: smithersTokenStorePath(),
             });
         }
         catch (err) {
             return fail({
                 code: err instanceof SmithersError ? err.code : "TOKEN_ISSUE_FAILED",
+                message: err?.message ?? String(err),
+                exitCode: 1,
+            });
+        }
+    },
+})
+    .command("exec", {
+    description: "Resolve an action token locally and inject the bearer into a child process environment.",
+    options: z.object({
+        handle: z.string().describe("Brokered action token handle"),
+        actionId: z.string().default("gateway").describe("Action id expected by the brokered token"),
+        scopes: z.string().default("").describe("Comma or space separated scopes required for this action"),
+        env: z.string().default("SMITHERS_API_KEY").describe("Environment variable that receives the bearer token"),
+        command: z.string().describe("Shell command to run with the injected token"),
+    }),
+    async run(c) {
+        const fail = (opts) => {
+            commandExitOverride = opts.exitCode ?? 1;
+            return c.error(opts);
+        };
+        try {
+            const resolved = resolveSmithersActionTokenFromStore(c.options.handle, {
+                actionId: c.options.actionId,
+                scopes: parseTokenScopes(c.options.scopes),
+            });
+            const child = spawn(c.options.command, {
+                shell: true,
+                stdio: "inherit",
+                env: {
+                    ...process.env,
+                    [c.options.env]: resolved.token,
+                },
+            });
+            const exitCode = await new Promise((resolveExit) => {
+                child.on("error", () => resolveExit(1));
+                child.on("exit", (code, signal) => {
+                    if (typeof code === "number")
+                        resolveExit(code);
+                    else
+                        resolveExit(signal ? 1 : 0);
+                });
+            });
+            commandExitOverride = exitCode;
+            return exitCode === 0
+                ? c.ok({ ok: true, tokenId: resolved.grant.tokenId, actionId: resolved.actionToken.actionId })
+                : fail({ code: "TOKEN_EXEC_FAILED", message: `Command exited with status ${exitCode}`, exitCode });
+        }
+        catch (err) {
+            return fail({
+                code: err instanceof SmithersError ? err.code : "TOKEN_EXEC_FAILED",
                 message: err?.message ?? String(err),
                 exitCode: 1,
             });
@@ -2565,7 +2613,7 @@ const tokenCli = Cli.create({
     }),
     run(c) {
         const store = readSmithersTokenStore();
-        const grant = store.tokens[c.args.token];
+        const grant = revokeSmithersToken(store, c.args.token);
         if (!grant) {
             commandExitOverride = 1;
             return c.error({
@@ -2574,11 +2622,10 @@ const tokenCli = Cli.create({
                 exitCode: 1,
             });
         }
-        grant.revokedAtMs = Date.now();
         writeSmithersTokenStore(store);
         return c.ok({
             revoked: true,
-            tokenId: grant.tokenId ?? crypto.createHash("sha256").update(c.args.token).digest("hex").slice(0, 16),
+            tokenId: grant.tokenId,
             storePath: smithersTokenStorePath(),
         });
     },

--- a/apps/cli/src/token-store.js
+++ b/apps/cli/src/token-store.js
@@ -1,5 +1,86 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import crypto from "node:crypto";
 import { dirname, resolve } from "node:path";
+
+const STORE_VERSION = 2;
+const MAX_AUDIT_ENTRIES = 1_000;
+
+function tokenIdFor(token) {
+    return crypto.createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+function tokenHashFor(token) {
+    return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+function defaultStore() {
+    return { version: STORE_VERSION, tokens: {}, actionTokens: {}, audit: [] };
+}
+
+function asRecord(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function normalizeAuditEntry(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry) || typeof entry.type !== "string") {
+        return null;
+    }
+    return entry;
+}
+
+function normalizeStore(parsed) {
+    const store = defaultStore();
+    const raw = asRecord(parsed);
+    const rawTokens = asRecord(raw.tokens);
+    for (const [key, value] of Object.entries(rawTokens)) {
+        const grant = asRecord(value);
+        const tokenId = typeof grant.tokenId === "string" && grant.tokenId.length > 0 ? grant.tokenId : tokenIdFor(key);
+        const secret = typeof grant.secret === "string" ? grant.secret : key.startsWith("smithers_") ? key : undefined;
+        const storeKey = secret && key === tokenId ? secret : key;
+        store.tokens[storeKey] = {
+            ...grant,
+            tokenId,
+            ...(secret ? { secret, tokenHash: typeof grant.tokenHash === "string" ? grant.tokenHash : tokenHashFor(secret) } : {}),
+            scopes: Array.isArray(grant.scopes) ? grant.scopes.filter((scope) => typeof scope === "string") : [],
+        };
+    }
+    store.actionTokens = asRecord(raw.actionTokens);
+    store.audit = Array.isArray(raw.audit) ? raw.audit.map(normalizeAuditEntry).filter(Boolean) : [];
+    return store;
+}
+
+function appendAudit(store, entry) {
+    store.audit.push(entry);
+    if (store.audit.length > MAX_AUDIT_ENTRIES) {
+        store.audit.splice(0, store.audit.length - MAX_AUDIT_ENTRIES);
+    }
+}
+
+function findTokenEntryById(store, tokenId) {
+    for (const [token, grant] of Object.entries(store.tokens)) {
+        if (grant?.tokenId === tokenId) {
+            return { token, grant };
+        }
+    }
+    return null;
+}
+
+function assertScopes(grant, requiredScopes) {
+    const granted = new Set(Array.isArray(grant.scopes) ? grant.scopes : []);
+    const missing = requiredScopes.filter((scope) => !granted.has(scope));
+    if (missing.length > 0) {
+        throw new Error(`Token is missing required scope(s): ${missing.join(", ")}`);
+    }
+}
+
+function assertGrantActive(grant, nowMs) {
+    if (typeof grant.revokedAtMs === "number") {
+        throw new Error("Token grant has been revoked");
+    }
+    if (typeof grant.expiresAtMs === "number" && grant.expiresAtMs <= nowMs) {
+        throw new Error("Token grant has expired");
+    }
+}
 
 export function smithersTokenStorePath() {
     return process.env.SMITHERS_TOKEN_STORE ?? resolve(process.env.HOME ?? process.cwd(), ".smithers", "tokens.json");
@@ -8,20 +89,14 @@ export function smithersTokenStorePath() {
 export function readSmithersTokenStore() {
     const path = smithersTokenStorePath();
     if (!existsSync(path)) {
-        return { tokens: {} };
+        return defaultStore();
     }
     try {
         const parsed = JSON.parse(readFileSync(path, "utf8"));
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-            return { tokens: {} };
-        }
-        const tokens = parsed.tokens && typeof parsed.tokens === "object" && !Array.isArray(parsed.tokens)
-            ? parsed.tokens
-            : {};
-        return { tokens };
+        return normalizeStore(parsed);
     }
     catch {
-        return { tokens: {} };
+        return defaultStore();
     }
 }
 
@@ -36,4 +111,130 @@ export function parseTokenScopes(raw) {
         .split(/[,\s]+/)
         .map((scope) => scope.trim())
         .filter(Boolean);
+}
+
+export function issueSmithersBrokerToken(options) {
+    const nowMs = options.nowMs ?? Date.now();
+    const randomBytes = options.randomBytes ?? ((size) => crypto.randomBytes(size));
+    const token = options.token ?? `smithers_${randomBytes(32).toString("base64url")}`;
+    const tokenId = tokenIdFor(token);
+    const grant = {
+        tokenId,
+        role: options.role,
+        scopes: Array.isArray(options.scopes) ? options.scopes : [],
+        ...(options.userId ? { userId: options.userId } : {}),
+        issuedAtMs: nowMs,
+        expiresAtMs: nowMs + options.ttlMs,
+        secret: token,
+        tokenHash: tokenHashFor(token),
+    };
+    const store = options.store ?? defaultStore();
+    Object.assign(store, normalizeStore(store));
+    store.tokens[token] = grant;
+    appendAudit(store, {
+        type: "issued",
+        tokenId,
+        role: grant.role,
+        scopes: grant.scopes,
+        ...(grant.userId ? { userId: grant.userId } : {}),
+        atMs: nowMs,
+        expiresAtMs: grant.expiresAtMs,
+    });
+    const actionToken = mintSmithersActionToken(store, {
+        tokenId,
+        actionId: options.actionId ?? "gateway",
+        scopes: grant.scopes,
+        nowMs,
+        expiresAtMs: grant.expiresAtMs,
+        randomBytes,
+    });
+    return { token, grant, actionToken, store };
+}
+
+export function mintSmithersActionToken(store, options) {
+    const normalized = normalizeStore(store);
+    Object.assign(store, normalized);
+    const handle = options.handle ?? `smithers_action_${(options.randomBytes ?? ((size) => crypto.randomBytes(size)))(24).toString("base64url")}`;
+    const actionToken = {
+        handle,
+        tokenId: options.tokenId,
+        actionId: options.actionId,
+        scopes: Array.isArray(options.scopes) ? options.scopes : [],
+        issuedAtMs: options.nowMs ?? Date.now(),
+        expiresAtMs: options.expiresAtMs,
+    };
+    store.actionTokens[handle] = actionToken;
+    appendAudit(store, {
+        type: "action_issued",
+        tokenId: options.tokenId,
+        actionId: options.actionId,
+        scopes: actionToken.scopes,
+        atMs: actionToken.issuedAtMs,
+        expiresAtMs: actionToken.expiresAtMs,
+    });
+    return actionToken;
+}
+
+export function resolveSmithersActionToken(store, handle, options = {}) {
+    const normalized = normalizeStore(store);
+    Object.assign(store, normalized);
+    const nowMs = options.nowMs ?? Date.now();
+    const actionToken = store.actionTokens[handle];
+    if (!actionToken) {
+        throw new Error("Action token handle was not found");
+    }
+    if (options.actionId && actionToken.actionId !== options.actionId) {
+        throw new Error("Action token is not valid for this action");
+    }
+    if (typeof actionToken.revokedAtMs === "number") {
+        throw new Error("Action token handle has been revoked");
+    }
+    if (typeof actionToken.expiresAtMs === "number" && actionToken.expiresAtMs <= nowMs) {
+        throw new Error("Action token handle has expired");
+    }
+    const entry = findTokenEntryById(store, actionToken.tokenId);
+    const grant = entry?.grant;
+    if (!grant || typeof grant.secret !== "string") {
+        throw new Error("Backing token grant was not found");
+    }
+    assertGrantActive(grant, nowMs);
+    const requiredScopes = Array.isArray(options.scopes) ? options.scopes : [];
+    assertScopes(actionToken, requiredScopes);
+    assertScopes(grant, requiredScopes);
+    appendAudit(store, {
+        type: "action_used",
+        tokenId: actionToken.tokenId,
+        actionId: actionToken.actionId,
+        scopes: requiredScopes,
+        atMs: nowMs,
+    });
+    return { token: grant.secret, grant, actionToken };
+}
+
+export function resolveSmithersActionTokenFromStore(handle, options = {}) {
+    const store = readSmithersTokenStore();
+    const resolved = resolveSmithersActionToken(store, handle, options);
+    writeSmithersTokenStore(store);
+    return resolved;
+}
+
+export function revokeSmithersToken(store, tokenOrId, nowMs = Date.now()) {
+    const normalized = normalizeStore(store);
+    Object.assign(store, normalized);
+    const entry = store.tokens[tokenOrId]
+        ? { token: tokenOrId, grant: store.tokens[tokenOrId] }
+        : findTokenEntryById(store, tokenOrId) ?? findTokenEntryById(store, tokenIdFor(tokenOrId));
+    if (!entry?.grant) {
+        return null;
+    }
+    const grant = entry.grant;
+    const tokenId = grant.tokenId ?? tokenIdFor(entry.token);
+    grant.revokedAtMs = nowMs;
+    for (const actionToken of Object.values(store.actionTokens)) {
+        if (actionToken.tokenId === tokenId && typeof actionToken.revokedAtMs !== "number") {
+            actionToken.revokedAtMs = nowMs;
+        }
+    }
+    appendAudit(store, { type: "revoked", tokenId, atMs: nowMs });
+    return grant;
 }

--- a/apps/cli/tests/docs-public-surface-coverage.test.js
+++ b/apps/cli/tests/docs-public-surface-coverage.test.js
@@ -446,6 +446,46 @@ test("community connector spec documents the long-tail package contract", () => 
     for (const key of manifestKeys) expect(doc).toContain(key);
     for (const term of loaderTerms) expect(doc).toContain(term);
 });
+test("community connector spec documents the long-tail package contract", () => {
+    const docsConfig = readRepoFile("docs/docs.json");
+    expect(docsConfig).toContain("integrations/community-connectors");
+
+    const doc = readRepoFile("docs/integrations/community-connectors.mdx");
+    const requiredSections = [
+        "## Package Layout",
+        "## Manifest Format",
+        "## Loader Contract",
+        "## Tool Declarations",
+        "## Trigger Declarations",
+        "## Auth Requirements",
+        "## Tier 0 Integration Points",
+        "## Anti-Patterns",
+    ];
+    const manifestKeys = [
+        "smithers.connector.v1",
+        "tools",
+        "triggers",
+        "auth",
+        "surfaces",
+        "oauth",
+        "tokenBroker",
+        "mcp",
+        "openapi",
+        "webhooks",
+    ];
+    const loaderTerms = [
+        "validate the manifest",
+        "project tools",
+        "register triggers",
+        "resolve auth",
+        "enforce scopes",
+        "idempotency",
+    ];
+
+    for (const section of requiredSections) expect(doc).toContain(section);
+    for (const key of manifestKeys) expect(doc).toContain(key);
+    for (const term of loaderTerms) expect(doc).toContain(term);
+});
 
 test("memory docs cover current MemoryStore method names", () => {
     const memoryStoreSource = readRepoFile("packages/memory/src/store/MemoryStore.ts");

--- a/apps/cli/tests/token-store.test.js
+++ b/apps/cli/tests/token-store.test.js
@@ -2,7 +2,17 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { parseTokenScopes, readSmithersTokenStore, smithersTokenStorePath, writeSmithersTokenStore } from "../src/token-store.js";
+import {
+    issueSmithersBrokerToken,
+    parseTokenScopes,
+    readSmithersTokenStore,
+    resolveSmithersActionToken,
+    resolveSmithersActionTokenFromStore,
+    revokeSmithersToken,
+    smithersTokenStorePath,
+    writeSmithersTokenStore,
+} from "../src/token-store.js";
+import { Gateway } from "../../../packages/server/src/gateway.js";
 
 const originalTokenStore = process.env.SMITHERS_TOKEN_STORE;
 
@@ -38,11 +48,175 @@ describe("CLI token store helpers", () => {
             });
 
             expect(smithersTokenStorePath()).toBe(join(dir, "tokens.json"));
-            expect(readSmithersTokenStore().tokens.secret.role).toBe("operator");
+            expect(Object.values(readSmithersTokenStore().tokens)[0].role).toBe("operator");
             expect(readFileSync(join(dir, "tokens.json"), "utf8")).toContain('"run:read"');
         }
         finally {
             rmSync(dir, { recursive: true, force: true });
         }
+    });
+
+    test("brokers scoped per-action handles without breaking bearer-keyed gateway auth", () => {
+        const issued = issueSmithersBrokerToken({
+            role: "operator",
+            scopes: ["run:read", "approval:submit"],
+            userId: "user_123",
+            actionId: "approve:run_1",
+            ttlMs: 60_000,
+            nowMs: 1_000,
+            randomBytes: () => Buffer.alloc(32, 7),
+        });
+
+        expect(issued.token).toStartWith("smithers_");
+        expect(issued.actionToken.handle).toStartWith("smithers_action_");
+        expect(JSON.stringify(issued.actionToken)).not.toContain(issued.token);
+        expect(issued.store.audit.map((entry) => entry.type)).toEqual(["issued", "action_issued"]);
+        expect(issued.store.tokens[issued.token]).toMatchObject({
+            tokenId: issued.grant.tokenId,
+            role: "operator",
+            scopes: ["run:read", "approval:submit"],
+        });
+        expect(issued.store.tokens[issued.grant.tokenId]).toBeUndefined();
+
+        const resolved = resolveSmithersActionToken(issued.store, issued.actionToken.handle, {
+            actionId: "approve:run_1",
+            scopes: ["approval:submit"],
+            nowMs: 2_000,
+        });
+        expect(resolved.token).toBe(issued.token);
+        expect(resolved.grant.userId).toBe("user_123");
+        expect(issued.store.audit.at(-1)).toMatchObject({
+            type: "action_used",
+            actionId: "approve:run_1",
+            tokenId: issued.grant.tokenId,
+            atMs: 2_000,
+        });
+
+        expect(() => resolveSmithersActionToken(issued.store, issued.actionToken.handle, {
+            actionId: "approve:run_1",
+            scopes: ["run:write"],
+            nowMs: 2_000,
+        })).toThrow("scope");
+
+        revokeSmithersToken(issued.store, issued.token, 3_000);
+        expect(() => resolveSmithersActionToken(issued.store, issued.actionToken.handle, {
+            actionId: "approve:run_1",
+            scopes: ["approval:submit"],
+            nowMs: 4_000,
+        })).toThrow("revoked");
+        expect(issued.store.tokens[issued.token].secret).toBe(issued.token);
+    });
+
+    test("write preserves operator-authored bearer keys on round trip", () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-token-store-"));
+        try {
+            process.env.SMITHERS_TOKEN_STORE = join(dir, "tokens.json");
+            writeSmithersTokenStore({
+                version: 2,
+                tokens: {
+                    "replace-me": {
+                        role: "operator",
+                        scopes: ["run:read"],
+                        expiresAtMs: 4_102_444_800_000,
+                    },
+                },
+                actionTokens: {},
+                audit: [],
+            });
+
+            const raw = JSON.parse(readFileSync(join(dir, "tokens.json"), "utf8"));
+            expect(raw.tokens["replace-me"]).toMatchObject({ role: "operator" });
+            expect(raw.tokens[Object.keys(raw.tokens)[0]].secret).toBeUndefined();
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("read migrates token-id-keyed grants with secrets back to bearer keys", () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-token-store-"));
+        try {
+            process.env.SMITHERS_TOKEN_STORE = join(dir, "tokens.json");
+            const issued = issueSmithersBrokerToken({
+                role: "operator",
+                scopes: ["run:read"],
+                actionId: "gateway",
+                ttlMs: 60_000,
+                nowMs: 1_000,
+                token: "smithers_old_store_secret",
+            });
+            writeSmithersTokenStore({
+                version: 2,
+                tokens: {
+                    [issued.grant.tokenId]: issued.grant,
+                },
+                actionTokens: issued.store.actionTokens,
+                audit: issued.store.audit,
+            });
+
+            const store = readSmithersTokenStore();
+            expect(store.tokens[issued.token]).toMatchObject({ tokenId: issued.grant.tokenId });
+            expect(store.tokens[issued.grant.tokenId]).toBeUndefined();
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("resolving an action token from disk persists the use audit", () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-token-store-"));
+        try {
+            process.env.SMITHERS_TOKEN_STORE = join(dir, "tokens.json");
+            const issued = issueSmithersBrokerToken({
+                role: "operator",
+                scopes: ["run:read"],
+                actionId: "gateway",
+                ttlMs: 60_000,
+                nowMs: 1_000,
+                randomBytes: () => Buffer.alloc(32, 9),
+            });
+            writeSmithersTokenStore(issued.store);
+
+            const resolved = resolveSmithersActionTokenFromStore(issued.actionToken.handle, {
+                actionId: "gateway",
+                scopes: ["run:read"],
+                nowMs: 2_000,
+            });
+
+            expect(resolved.token).toBe(issued.token);
+            expect(readSmithersTokenStore().audit.at(-1)).toMatchObject({
+                type: "action_used",
+                actionId: "gateway",
+                tokenId: issued.grant.tokenId,
+                atMs: 2_000,
+            });
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("issued broker tokens authenticate through the gateway bearer lookup", async () => {
+        const issued = issueSmithersBrokerToken({
+            role: "operator",
+            scopes: ["run:read"],
+            actionId: "gateway",
+            ttlMs: 60_000,
+            nowMs: Date.now(),
+            randomBytes: () => Buffer.alloc(32, 11),
+        });
+        const gateway = new Gateway({
+            auth: {
+                mode: "token",
+                tokens: issued.store.tokens,
+            },
+        });
+
+        await expect(gateway.authenticateRequest(new Request("http://localhost"), issued.token)).resolves.toMatchObject({
+            ok: true,
+            role: "operator",
+            scopes: ["run:read"],
+            tokenId: issued.grant.tokenId,
+        });
     });
 });

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -56,7 +56,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[72]:
+commands[73]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -601,11 +601,21 @@ commands[72]:
       specPath,string,true,File path or URL to OpenAPI spec
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
-    flags[4]{name,short,type,default,desc}:
+    flags[6]{name,short,type,default,desc}:
       scopes,,string,run:read,Comma or space separated Gateway scopes
       role,,string,operator,Role recorded on the token grant
       user-id,,string,,User ID recorded on the token grant
       ttl,,string,1h,Token lifetime such as 15m or 1h
+      action-id,,string,gateway,Action id allowed to resolve the brokered action token
+      reveal-token,,boolean,false,Include the raw bearer token in CLI output
+  - name: token.exec
+    purpose: Resolve an action token locally and inject the bearer into a child process environment
+    flags[5]{name,short,type,default,desc}:
+      handle,,string,,Brokered action token handle
+      action-id,,string,gateway,Action id expected by the brokered token
+      scopes,,string,,Comma or space separated scopes required for this action
+      env,,string,SMITHERS_API_KEY,Environment variable that receives the bearer token
+      command,,string,,Shell command to run with the injected token
   - name: token.revoke
     purpose: Revoke a locally issued Gateway bearer token
     args[1]{name,type,required,desc}:

--- a/docs/concepts/openapi-tools.mdx
+++ b/docs/concepts/openapi-tools.mdx
@@ -100,6 +100,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/docs/deployment/reference.mdx
+++ b/docs/deployment/reference.mdx
@@ -17,16 +17,22 @@ docker compose -f deploy/reference/docker-compose.yml up
 
 The Gateway listens on `7331` inside the compose network and Caddy exposes HTTP/TLS. The compose file mounts a SQLite volume at `/data` and reads short-lived bearer grants from `/data/tokens.json`. If `/data/tokens.json` does not exist, the Gateway starts with an empty in-memory token set and denies token auth until you mount or write a token store.
 
-Issue a local token grant:
+Issue a local token grant. By default, the command returns a scoped action handle and writes the bearer-keyed grant to the local token store without printing the bearer token. Use `--reveal-token` only for manual operator workflows that need to copy the raw bearer.
 
 ```bash
-bunx smithers-orchestrator token issue --scopes run:read,run:write,approval:submit --ttl 1h
+bunx smithers-orchestrator token issue --scopes run:read,run:write,approval:submit --ttl 1h --action-id gateway
 ```
 
-Copy the resulting grant into the token store used by the deployment. Revoke it with:
+Copy the resulting grant store entry into the token store used by the deployment. Revoking the bearer token also revokes its action handles and records the revocation in the audit trail:
 
 ```bash
 bunx smithers-orchestrator token revoke <token>
+```
+
+Automation can hand a broker handle to an action without exposing the bearer in model-visible context by resolving it locally and injecting the bearer only into the child process environment:
+
+```bash
+bunx smithers-orchestrator token exec --handle <action-handle> --action-id gateway --scopes run:read --command 'curl -H "Authorization: Bearer $SMITHERS_API_KEY" http://localhost:7331/v1/runs'
 ```
 
 ## Single Host

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1419,7 +1419,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[72]:
+commands[73]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1964,11 +1964,21 @@ commands[72]:
       specPath,string,true,File path or URL to OpenAPI spec
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
-    flags[4]{name,short,type,default,desc}:
+    flags[6]{name,short,type,default,desc}:
       scopes,,string,run:read,Comma or space separated Gateway scopes
       role,,string,operator,Role recorded on the token grant
       user-id,,string,,User ID recorded on the token grant
       ttl,,string,1h,Token lifetime such as 15m or 1h
+      action-id,,string,gateway,Action id allowed to resolve the brokered action token
+      reveal-token,,boolean,false,Include the raw bearer token in CLI output
+  - name: token.exec
+    purpose: Resolve an action token locally and inject the bearer into a child process environment
+    flags[5]{name,short,type,default,desc}:
+      handle,,string,,Brokered action token handle
+      action-id,,string,gateway,Action id expected by the brokered token
+      scopes,,string,,Comma or space separated scopes required for this action
+      env,,string,SMITHERS_API_KEY,Environment variable that receives the bearer token
+      command,,string,,Shell command to run with the injected token
   - name: token.revoke
     purpose: Revoke a locally issued Gateway bearer token
     args[1]{name,type,required,desc}:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12281,6 +12281,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1440,7 +1440,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[72]:
+commands[73]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1985,11 +1985,21 @@ commands[72]:
       specPath,string,true,File path or URL to OpenAPI spec
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
-    flags[4]{name,short,type,default,desc}:
+    flags[6]{name,short,type,default,desc}:
       scopes,,string,run:read,Comma or space separated Gateway scopes
       role,,string,operator,Role recorded on the token grant
       user-id,,string,,User ID recorded on the token grant
       ttl,,string,1h,Token lifetime such as 15m or 1h
+      action-id,,string,gateway,Action id allowed to resolve the brokered action token
+      reveal-token,,boolean,false,Include the raw bearer token in CLI output
+  - name: token.exec
+    purpose: Resolve an action token locally and inject the bearer into a child process environment
+    flags[5]{name,short,type,default,desc}:
+      handle,,string,,Brokered action token handle
+      action-id,,string,gateway,Action id expected by the brokered token
+      scopes,,string,,Comma or space separated scopes required for this action
+      env,,string,SMITHERS_API_KEY,Environment variable that receives the bearer token
+      command,,string,,Shell command to run with the injected token
   - name: token.revoke
     purpose: Revoke a locally issued Gateway bearer token
     args[1]{name,type,required,desc}:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7928,6 +7928,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -2525,6 +2525,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/docs/llms-openapi.txt
+++ b/docs/llms-openapi.txt
@@ -105,6 +105,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -12281,6 +12281,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -1440,7 +1440,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[72]:
+commands[73]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1985,11 +1985,21 @@ commands[72]:
       specPath,string,true,File path or URL to OpenAPI spec
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
-    flags[4]{name,short,type,default,desc}:
+    flags[6]{name,short,type,default,desc}:
       scopes,,string,run:read,Comma or space separated Gateway scopes
       role,,string,operator,Role recorded on the token grant
       user-id,,string,,User ID recorded on the token grant
       ttl,,string,1h,Token lifetime such as 15m or 1h
+      action-id,,string,gateway,Action id allowed to resolve the brokered action token
+      reveal-token,,boolean,false,Include the raw bearer token in CLI output
+  - name: token.exec
+    purpose: Resolve an action token locally and inject the bearer into a child process environment
+    flags[5]{name,short,type,default,desc}:
+      handle,,string,,Brokered action token handle
+      action-id,,string,gateway,Action id expected by the brokered token
+      scopes,,string,,Comma or space separated scopes required for this action
+      env,,string,SMITHERS_API_KEY,Environment variable that receives the bearer token
+      command,,string,,Shell command to run with the injected token
   - name: token.revoke
     purpose: Revoke a locally issued Gateway bearer token
     args[1]{name,type,required,desc}:

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -7928,6 +7928,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.


### PR DESCRIPTION
Relates to #222

## What was fixed

Gateway auth was broken when callers tried to issue scoped action tokens: the token store had no concept of brokered handles, so the full bearer secret was exposed at rest and there was no way to scope a token to a single action without granting broad API access.

## Root cause & approach

**Root cause:** `token-store.js` stored the raw bearer as the map key and had no handle/broker layer, no scope enforcement, no expiry/revocation checks, and no audit trail. `index.js` duplicated the token-generation logic inline and returned the plaintext secret unconditionally.

**Fix (key files: `apps/cli/src/token-store.js`, `apps/cli/src/index.js`):**
- Added `issueSmithersBrokerToken()` — generates a main bearer plus an opaque brokered action-token handle scoped to a single `actionId`; the handle is stored separately from the bearer.
- Added `resolveSmithersActionTokenFromStore()` — validates the handle against `actionId`, checks scopes, expiry, and revocation, then returns the raw bearer only at resolution time (never stored in plaintext in the action-token map).
- Added `revokeSmithersToken()` with an append-only audit trail (capped at 1 000 entries) and `assertGrantActive()` / `assertScopes()` helpers.
- Bumped store to version 2 with `normalizeStore()` for safe forward/backward reads.
- Wired into the CLI: `smithers token issue` gains `--actionId` and `--revealToken`; new `smithers token exec` subcommand resolves a handle and injects the bearer into a child process environment variable without leaking it to stdout.

## Review

Codex implemented this via TDD; Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)