### PR TITLE
🐛 fix(cli): detect Smithers GUI launch failures

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -5781,17 +5781,40 @@ const cli = Cli.create({
             return c.error({ code: "PATH_NOT_FOUND", message: `Path does not exist: ${target}`, exitCode: 1 });
         }
         try {
-            const proc = spawn("open", ["-b", c.options.bundleId, target], {
-                stdio: "ignore",
-                detached: true,
+            const launch = await new Promise((resolveLaunch) => {
+                const proc = spawn("open", ["-b", c.options.bundleId, target], {
+                    stdio: ["ignore", "ignore", "pipe"],
+                });
+                let stderr = "";
+                proc.stderr?.setEncoding("utf8");
+                proc.stderr?.on("data", (chunk) => {
+                    stderr += chunk;
+                });
+                proc.on("error", (err) => {
+                    resolveLaunch({ ok: false, error: err, stderr });
+                });
+                proc.on("close", (code, signal) => {
+                    resolveLaunch({ ok: code === 0, code, signal, stderr });
+                });
             });
-            proc.unref();
-            proc.on("error", () => {});
+            if (!launch.ok) {
+                const stderr = launch.stderr?.trim() ?? "";
+                const detail = stderr || launch.error?.message || (launch.signal ? `open exited with signal ${launch.signal}` : `open exited with code ${launch.code ?? 1}`);
+                return c.error({
+                    code: "GUI_LAUNCH_FAILED",
+                    message: `Smithers Studio app is not installed or not registered with LaunchServices. Install/register the native app, or pass --bundle-id <actual.bundle.id>. ${detail}`,
+                    exitCode: 1,
+                });
+            }
             console.log(`Opening ${target} in Smithers GUI…`);
             return c.ok({ opened: target, bundleId: c.options.bundleId });
         }
         catch (err) {
-            return c.error({ code: "GUI_LAUNCH_FAILED", message: err?.message ?? String(err), exitCode: 1 });
+            return c.error({
+                code: "GUI_LAUNCH_FAILED",
+                message: `Smithers Studio app is not installed or not registered with LaunchServices. Install/register the native app, or pass --bundle-id <actual.bundle.id>. ${err?.message ?? String(err)}`,
+                exitCode: 1,
+            });
         }
     },
 })

--- a/apps/cli/tests/gui-command.test.js
+++ b/apps/cli/tests/gui-command.test.js
@@ -1,0 +1,53 @@
+import { expect, test } from "bun:test";
+import { createExecutableDir, createTempRepo, prependPath, runSmithers, writeExecutable } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+test("gui reports opened only after macOS open exits successfully", () => {
+    const repo = createTempRepo();
+    repo.write("workspace/.gitkeep", "\n");
+    const binDir = createExecutableDir();
+    writeExecutable(binDir, "open", [
+        "#!/usr/bin/env node",
+        'if (process.argv[2] !== "-b") process.exit(64);',
+        'if (process.argv[3] !== "com.smithers.SmithersGUI") process.exit(65);',
+        'if (!process.argv[4].endsWith("/workspace")) process.exit(66);',
+        "",
+    ].join("\n"));
+
+    const result = runSmithers(["gui", "workspace"], {
+        cwd: repo.dir,
+        format: "json",
+        env: prependPath(binDir),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json).toMatchObject({
+        opened: repo.path("workspace"),
+        bundleId: "com.smithers.SmithersGUI",
+    });
+});
+
+test("gui returns GUI_LAUNCH_FAILED when macOS open cannot resolve the bundle id", () => {
+    const repo = createTempRepo();
+    repo.write("workspace/.gitkeep", "\n");
+    const binDir = createExecutableDir();
+    writeExecutable(binDir, "open", [
+        "#!/usr/bin/env node",
+        'process.stderr.write("LSCopyApplicationURLsForBundleIdentifier() failed for com.smithers.SmithersGUI\\n");',
+        "process.exit(1);",
+        "",
+    ].join("\n"));
+
+    const result = runSmithers(["gui", "workspace"], {
+        cwd: repo.dir,
+        format: "json",
+        env: prependPath(binDir),
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain("Opening ");
+    expect(result.json).toMatchObject({
+        code: "GUI_LAUNCH_FAILED",
+    });
+    expect(result.stdout).toContain("not installed or not registered with LaunchServices");
+    expect(result.stdout).toContain("--bundle-id <actual.bundle.id>");
+});


### PR DESCRIPTION
Closes #249

## What was broken

`smithers gui` launched the macOS `open` process with `stdio: 'ignore'` and `proc.unref()`, immediately detaching from it. This meant any launch failure — including the app not being installed or not registered with LaunchServices — was silently swallowed. The command always exited 0 and printed \"Opening…\" even when the GUI never opened.

## Root cause & fix

**Root cause:** `apps/cli/src/index.js` spawned `open` detached with no stderr capture and no wait for exit, so there was no signal path from `open`'s failure back to the CLI.

**Fix:** Replace the fire-and-forget spawn with a Promise that waits for the `close` event, captures stderr, and resolves with an `ok`/`code`/`stderr` result. If `open` exits non-zero, the command now returns a structured `GUI_LAUNCH_FAILED` error with a human-readable message that includes the raw stderr output and an actionable hint: `--bundle-id <actual.bundle.id>`.

## Tests

Two new TDD tests in `apps/cli/tests/gui-command.test.js` (using a fake `open` stub injected via `PATH`):
1. Happy path: `open` exits 0 → command exits 0 and returns `{ opened, bundleId }`.
2. Failure path: `open` exits 1 with LaunchServices-style stderr → command exits non-zero, returns `{ code: "GUI_LAUNCH_FAILED" }`, and prints the actionable hint.

Codex implemented this fix via TDD. Both Codex and Claude Opus reviewed and approved the implementation before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)