### PR TITLE
🐛 fix(cli): apply tree watch deltas to snapshots

### DIFF
--- a/apps/cli/src/tree.js
+++ b/apps/cli/src/tree.js
@@ -237,8 +237,7 @@ export async function runTreeWatch(input) {
                         attempt = 0;
                     } else if (event.kind === "delta" && snapshot) {
                         try {
-                            const nextRoot = applyDelta(snapshot.root, event.delta);
-                            snapshot = { ...snapshot, root: nextRoot, seq: event.delta.seq };
+                            snapshot = applyDelta(snapshot, event.delta);
                             emit(snapshot);
                             attempt = 0;
                         } catch (err) {

--- a/apps/cli/tests/tree.test.js
+++ b/apps/cli/tests/tree.test.js
@@ -49,11 +49,48 @@ function makeStream() {
     };
 }
 
+function makeStreamWithWriteHook(onWrite) {
+    let out = "";
+    return {
+        write(chunk) {
+            out += String(chunk);
+            onWrite(out);
+        },
+        get value() { return out; },
+    };
+}
+
+function workflowFrameXml(taskState) {
+    return JSON.stringify({
+        kind: "element",
+        tag: "smithers:workflow",
+        props: { name: "watch-delta-fixture" },
+        children: [
+            {
+                kind: "element",
+                tag: "smithers:task",
+                props: { id: "task-a::0", state: taskState },
+                children: [],
+            },
+        ],
+    });
+}
+
 async function openMemoryDb() {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);
     ensureSmithersTables(db);
     return { sqlite, adapter: new SmithersDb(db) };
+}
+
+async function insertFrame(adapter, runId, frameNo, taskState) {
+    await adapter.insertFrame({
+        runId,
+        frameNo,
+        createdAtMs: Date.now(),
+        xmlHash: `hash-${frameNo}`,
+        xmlJson: workflowFrameXml(taskState),
+    });
 }
 
 describe("renderDevToolsTree", () => {
@@ -206,6 +243,53 @@ describe("runTreeOnce", () => {
                 abortSignal: abort.signal,
             });
             expect(result.exitCode).toBe(130);
+        } finally {
+            sqlite.close();
+        }
+    });
+
+    test("--watch applies the first delta to the full snapshot without crashing", async () => {
+        const { sqlite, adapter } = await openMemoryDb();
+        await adapter.insertRun({
+            runId: "watch-delta-run",
+            workflowName: "wf",
+            status: "running",
+            createdAtMs: 1_000,
+            startedAtMs: 1_000,
+            finishedAtMs: null,
+        });
+        await insertFrame(adapter, "watch-delta-run", 0, "pending");
+        const abort = new AbortController();
+        const stderr = makeStream();
+        let insertedDeltaFrame = false;
+        const stdout = makeStreamWithWriteHook((value) => {
+            const lines = value.trim().split("\n").filter(Boolean);
+            if (lines.length >= 1 && !insertedDeltaFrame) {
+                insertedDeltaFrame = true;
+                void insertFrame(adapter, "watch-delta-run", 1, "finished");
+            }
+            if (lines.length >= 2) {
+                abort.abort();
+            }
+        });
+        try {
+            const result = await runTreeWatch({
+                adapter,
+                runId: "watch-delta-run",
+                json: true,
+                watch: true,
+                color: false,
+                stdout,
+                stderr,
+                abortSignal: abort.signal,
+            });
+            expect(result.exitCode).toBe(130);
+            expect(stderr.value).not.toContain("InvalidDelta");
+            const snapshots = stdout.value.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+            expect(snapshots).toHaveLength(2);
+            expect(snapshots[0].seq).toBe(0);
+            expect(snapshots[1].seq).toBe(1);
+            expect(snapshots[1].root.children[0].props.state).toBe("finished");
         } finally {
             sqlite.close();
         }


### PR DESCRIPTION
Relates to #303

## What was fixed

`runTreeWatch` in `apps/cli/src/tree.js` crashed with an `InvalidDelta` error on the very first delta event received during `--watch` mode. The root cause was a signature mismatch: the code was calling `applyDelta(snapshot.root, event.delta)` (passing only the root node) but `applyDelta` expects a full snapshot object and returns a new snapshot. This meant the reconstructed snapshot was malformed, and any subsequent delta application failed immediately.

## How it was fixed

The fix in `apps/cli/src/tree.js` is a one-liner: replace the two-line pattern that extracted the root and rebuilt the snapshot manually with a direct call `snapshot = applyDelta(snapshot, event.delta)`, letting `applyDelta` handle the full snapshot update correctly.

A regression test was added in `apps/cli/tests/tree.test.js` that:
- Boots a real in-memory DB with a running workflow
- Inserts a full frame, starts the watcher, then inserts a delta frame mid-stream
- Asserts no `InvalidDelta` error appears on stderr and that the second emitted snapshot reflects the delta's state change

## Review

Codex implemented the fix via TDD; both Codex and Claude Opus approved the implementation in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)