### PR TITLE
🐛 fix(vcs): remove bare require from jj workspace cleanup

### DIFF
--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -14,6 +14,8 @@
 // @smithers-type-exports-end
 
 import * as Command from "@effect/platform/Command";
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
 import { Duration, Effect, Fiber, Metric, Stream } from "effect";
 import { vcsDuration } from "@smithers-orchestrator/observability/metrics";
 import { resolveJjBinary } from "./resolveJjBinary.js";
@@ -194,8 +196,6 @@ export function workspaceAdd(name, path, opts = {}) {
             yield* runJj(["workspace", "forget", name], { cwd: opts.cwd });
         }
         try {
-            const fs = require("node:fs");
-            const nodePath = require("node:path");
             if (fs.existsSync(path)) {
                 fs.rmSync(path, { recursive: true, force: true });
             }

--- a/packages/vcs/tests/jj-workspace.test.js
+++ b/packages/vcs/tests/jj-workspace.test.js
@@ -154,6 +154,11 @@ exit 1
     });
 });
 describe("workspaceAdd", () => {
+    test("does not use CommonJS require in the ESM cleanup path", async () => {
+        const source = await fs.readFile(new URL("../src/jj.js", import.meta.url), "utf8");
+        expect(source).not.toMatch(/\brequire\(/);
+    });
+
     test("uses primary syntax: path then --name", async () => {
         const script = `
 if [[ "$1" = "workspace" && "$2" = "add" && "$4" = "--name" && "$6" = "-r" ]]; then


### PR DESCRIPTION
Relates to #303

## What was fixed

`workspaceAdd` in `packages/vcs/src/jj.js` used bare `require('node:fs')` and `require('node:path')` calls inline inside the cleanup block — CJS holdovers that throw at runtime because the `vcs` package is ESM-only.

## Root cause & approach

The two `require()` calls were inserted directly inside an `Effect.gen` generator rather than imported at the top of the module.  The fix moves them to static ESM `import * as fs from "node:fs"` / `import * as nodePath from "node:path"` declarations at the top of `jj.js`, matching the rest of the file's import style.

A regression test was added to `packages/vcs/tests/jj-workspace.test.js` that reads the source of `jj.js` and asserts no `require(` call appears anywhere in the file, preventing the pattern from silently creeping back in.

## Review

Codex implemented the fix via TDD; both Codex and Claude Opus approved the implementation in code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)