### PR TITLE
🐛 fix(server): rerun via portable input loading

### DIFF
--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -13,12 +13,13 @@ import { resolve } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { Effect, Metric } from "effect";
 import { WebSocketServer } from "ws";
-import { runWorkflow } from "@smithers-orchestrator/engine";
+import { resolveSchema, runWorkflow } from "@smithers-orchestrator/engine";
 import { approveNode, denyNode } from "@smithers-orchestrator/engine/approvals";
 import { signalRun } from "@smithers-orchestrator/engine/signals";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
 import { computeRunStateFromRow } from "@smithers-orchestrator/db/runState";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { loadInput } from "@smithers-orchestrator/db/snapshot";
 import { devtoolsActiveSubscribers, devtoolsBackpressureDisconnectTotal, devtoolsDeltaBuildMs, devtoolsEventBytes, devtoolsEventTotal, devtoolsSnapshotBuildMs, devtoolsSubscribeTotal, gatewayApprovalDecisionsTotal, gatewayAuthEventsTotal, gatewayConnectionsActive, gatewayConnectionsClosedTotal, gatewayConnectionsTotal, gatewayCronTriggersTotal, gatewayErrorsTotal, gatewayHeartbeatTicksTotal, gatewayMessagesReceivedTotal, gatewayMessagesSentTotal, gatewayRpcCallsTotal, gatewayRpcDuration, gatewayRunsCompletedTotal, gatewayRunsStartedTotal, gatewaySignalsTotal, gatewayWebhooksReceivedTotal, gatewayWebhooksRejectedTotal, gatewayWebhooksVerifiedTotal, } from "@smithers-orchestrator/observability/metrics";
 import { runFork, runPromise } from "./smithersRuntime.js";
 import { prometheusContentType, renderPrometheusMetrics } from "@smithers-orchestrator/observability";
@@ -298,6 +299,24 @@ function parseJson(value) {
     catch {
         return null;
     }
+}
+/**
+ * @param {Record<string, unknown> | undefined} row
+ * @returns {Record<string, unknown>}
+ */
+function normalizeRerunInput(row) {
+    if (!row || typeof row !== "object") {
+        return {};
+    }
+    if ("payload" in row) {
+        const { runId: _runId, payload, ...rest } = row;
+        if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+            return { ...payload, ...rest };
+        }
+        return rest;
+    }
+    const { runId: _runId, ...rest } = row;
+    return rest;
 }
 /**
  * @param {unknown} run
@@ -4539,11 +4558,11 @@ export class Gateway {
                 if (!resolved) {
                     return responseError(frame.id, "NOT_FOUND", `Run not found: ${runId}`);
                 }
-                const client = (resolved.workflow.db.session?.client ?? resolved.workflow.db.$client);
-                const row = client?.query?.("SELECT payload FROM input WHERE run_id = ? LIMIT 1").get(runId);
-                const input = typeof row?.payload === "string"
-                    ? parseJson(row.payload) ?? {}
-                    : row?.payload ?? {};
+                const inputTable = resolveSchema(resolved.workflow.db).input;
+                if (!inputTable) {
+                    return responseError(frame.id, "MISSING_INPUT_TABLE", "Schema must include input table");
+                }
+                const input = normalizeRerunInput(await loadInput(resolved.workflow.db, inputTable, runId));
                 return this.routeRequest(connection, {
                     type: "req",
                     id: frame.id,

--- a/packages/server/tests/gateway.test.jsx
+++ b/packages/server/tests/gateway.test.jsx
@@ -62,6 +62,20 @@ function createValueWorkflow(dbPath) {
 /**
  * @param {string} dbPath
  */
+function createSchemaInputValueWorkflow(dbPath) {
+    const { smithers, Workflow, Task, outputs } = createSmithers({
+        input: z.object({ value: z.number().optional() }),
+        outputA: z.object({ value: z.number() }),
+    }, { dbPath });
+    return smithers((ctx) => (<Workflow name="gateway-basic">
+      <Task id="task1" output={outputs.outputA}>
+        {{ value: Number(ctx.input.value ?? 1) }}
+      </Task>
+    </Workflow>));
+}
+/**
+ * @param {string} dbPath
+ */
 function createApprovalWorkflow(dbPath) {
     const api = createSmithers({
         selection: z.object({
@@ -488,6 +502,50 @@ describe("Gateway", () => {
         });
         expect(diff.ok).toBe(true);
         expect(diff.payload.outputsChanged.length).toBeGreaterThan(0);
+        await client.close();
+    });
+    test("reruns with the original schema-backed input row", async () => {
+        const dbPath = makeDbPath("rerun-input");
+        dbPaths.push(dbPath);
+        gateway = new Gateway({
+            protocol: 1,
+            features: ["runs"],
+            heartbeatMs: 100,
+            auth: {
+                mode: "token",
+                tokens: {
+                    "op-token": {
+                        role: "operator",
+                        scopes: ["*"],
+                        userId: "user:will",
+                    },
+                },
+            },
+        });
+        gateway.register("basic", createSchemaInputValueWorkflow(dbPath));
+        server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+        const port = getPort(server);
+        const { client } = await connectGateway(port, "op-token");
+        const first = await client.request("runs.create", {
+            workflow: "basic",
+            input: { value: 42 },
+        });
+        expect(first.ok).toBe(true);
+        const sourceRunId = first.payload.runId;
+        await waitForRunStatus(client, sourceRunId, ["finished"]);
+        const rerun = await client.request("runs.rerun", {
+            runId: sourceRunId,
+            newRunId: "rerun-schema-input",
+        });
+        expect(rerun.ok).toBe(true);
+        await waitForRunStatus(client, "rerun-schema-input", ["finished"]);
+        const output = await client.request("getNodeOutput", {
+            runId: "rerun-schema-input",
+            nodeId: "task1",
+            iteration: 0,
+        });
+        expect(output.ok).toBe(true);
+        expect(output.payload.row).toMatchObject({ value: 42 });
         await client.close();
     });
     test("enforces approval-level scopes/users and returns rich pending approval metadata", async () => {


### PR DESCRIPTION
Relates to #303

## What was fixed

The `runs.rerun` RPC handler in `packages/server/src/gateway.js` was fetching the original run's input via a hardcoded raw SQL query (`SELECT payload FROM input WHERE run_id = ?`) executed directly against the better-sqlite3 client. This broke for schema-backed workflows where the input table name is derived from the workflow's Effect schema, and it also failed to correctly unwrap the payload envelope before forwarding the input to the new run.

## How it was fixed

**Root cause:** direct raw SQL bypassed the schema-aware table resolution and the db/snapshot abstraction layer.

**Approach:**
1. Import `resolveSchema` from `@smithers-orchestrator/engine` to derive the actual input table name from the registered workflow schema.
2. Import `loadInput` from `@smithers-orchestrator/db/snapshot` to fetch the row portably (no raw SQL).
3. Add `normalizeRerunInput()` to strip the `run_id` and unwrap any `payload` envelope before the input object is forwarded to the new run.

**Key files changed:**
- `packages/server/src/gateway.js` — replace raw SQL with `resolveSchema` + `loadInput` + `normalizeRerunInput`
- `packages/server/tests/gateway.test.jsx` — new real-backend test (`reruns with the original schema-backed input row`) exercising schema-backed rerun end-to-end

Codex implemented the fix via TDD, and both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)