### PR TITLE
🐛 fix(agents): update OpenCode Opus JSDoc model ID

### DIFF
--- a/packages/agents/src/OpenCodeAgent.js
+++ b/packages/agents/src/OpenCodeAgent.js
@@ -80,7 +80,7 @@ export function createOpenCodeCapabilityRegistry(opts = {}) {
  *
  * Usage:
  *   const agent = new OpenCodeAgent({
- *     model: "anthropic/claude-opus-4-20250514",
+ *     model: "anthropic/claude-opus-4-8",
  *     yolo: true,
  *   });
  *   const result = await agent.generate({

--- a/packages/agents/src/OpenCodeAgent.ts
+++ b/packages/agents/src/OpenCodeAgent.ts
@@ -3,7 +3,7 @@ import type { BaseCliAgentOptions } from "./BaseCliAgent";
 import { type AgentCapabilityRegistry } from "./capability-registry";
 
 export type OpenCodeAgentOptions = BaseCliAgentOptions & {
-  /** Model identifier (e.g., "anthropic/claude-opus-4-20250514", "openai/gpt-5.4") */
+  /** Model identifier (e.g., "anthropic/claude-opus-4-8", "openai/gpt-5.4") */
   model?: string;
   /** OpenCode agent name (maps to --agent flag, selects predefined agent config) */
   agentName?: string;

--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -275,7 +275,7 @@ type BaseCliAgentOptions = BaseCliAgentOptions$2;
 type CliOutputInterpreter$8 = CliOutputInterpreter$a;
 
 type OpenCodeAgentOptions$1 = BaseCliAgentOptions & {
-    /** Model identifier (e.g., "anthropic/claude-opus-4-20250514", "openai/gpt-5.4") */
+    /** Model identifier (e.g., "anthropic/claude-opus-4-8", "openai/gpt-5.4") */
     model?: string;
     /** OpenCode agent name (maps to --agent flag, selects predefined agent config) */
     agentName?: string;

--- a/packages/agents/tests/opencode-jsdoc.test.js
+++ b/packages/agents/tests/opencode-jsdoc.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("OpenCodeAgent JSDoc", () => {
+  test("documents the current Opus model ID", async () => {
+    const source = await readFile(
+      resolve(__dirname, "../src/OpenCodeAgent.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("anthropic/claude-opus-4-8");
+    expect(source).not.toContain("anthropic/claude-opus-4-20250514");
+  });
+});


### PR DESCRIPTION
Relates to #304

## What was fixed

The JSDoc usage example in `OpenCodeAgent.js` and the model option comment in `OpenCodeAgent.ts` (and its generated type declaration `index.d.ts`) referenced the old date-suffixed Opus model ID `anthropic/claude-opus-4-20250514` instead of the current canonical ID `anthropic/claude-opus-4-8`.

## Root cause & approach

The model ID was set when the date-suffix format was in use and was never updated after Anthropic standardized to the shorter `claude-opus-4-8` identifier. The fix updates all three documentation locations to use the correct model ID and adds a TDD test (`packages/agents/tests/opencode-jsdoc.test.js`) that pins the correct string and guards against future drift.

## Key files changed

- `packages/agents/src/OpenCodeAgent.js` — JSDoc `@example` usage snippet
- `packages/agents/src/OpenCodeAgent.ts` — `model?` option JSDoc comment
- `packages/agents/src/index.d.ts` — generated type declaration comment
- `packages/agents/tests/opencode-jsdoc.test.js` — new TDD test (added by Codex)

## Review

Codex implemented the fix via TDD; both Codex and Claude Opus approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)