### PR TITLE
🐛 fix(scorers): correct eval-writer scorer API examples

### DIFF
--- a/packages/scorers/tests/eval-writer-skill-doc.test.js
+++ b/packages/scorers/tests/eval-writer-skill-doc.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const skill = readFileSync(resolve(import.meta.dir, "../../../skills/eval-writer/SKILL.md"), "utf8");
+
+describe("eval-writer skill scorer API examples", () => {
+    test("documents LLM scorer APIs with their real scorer signatures", () => {
+        expect(skill).toContain("faithfulnessScorer(claude)");
+        expect(skill).toContain("relevancyScorer(claude)");
+        expect(skill).toContain("judge: claude");
+        expect(skill).toContain("instructions:");
+        expect(skill).toContain("promptTemplate:");
+        expect(skill).toContain('sampling: { type: "ratio", rate: 0.1 }');
+
+        expect(skill).not.toContain("faithfulnessScorer()");
+        expect(skill).not.toContain("relevancyScorer()");
+        expect(skill).not.toContain("model:");
+        expect(skill).not.toContain("prompt:");
+        expect(skill).not.toContain("kind:");
+        expect(skill).not.toContain("ratio:");
+    });
+});

--- a/skills/eval-writer/SKILL.md
+++ b/skills/eval-writer/SKILL.md
@@ -78,8 +78,8 @@ import { llmJudge } from "smithers-orchestrator/scorers";
 <Task id="draft" output={outputs.notes} agent={writer}
   scorers={{
     schema:    { scorer: schemaAdherenceScorer() },
-    grounded:  { scorer: faithfulnessScorer() },
-    onTopic:   { scorer: relevancyScorer() },
+    grounded:  { scorer: faithfulnessScorer(claude) },
+    onTopic:   { scorer: relevancyScorer(claude) },
     quality:   { scorer: llmJudge({
                    id: "completeness",
                    name: "Completeness",
@@ -98,7 +98,8 @@ import { llmJudge } from "smithers-orchestrator/scorers";
 (shape held), and `llmJudge(...)` (rubric-as-judge) are the workhorses. `llmJudge`
 takes `{ id, name, description, judge, instructions, promptTemplate }` — a `judge`
 agent and a `promptTemplate(input)` that asks for `{ score, reason }` JSON, **not**
-a `{ model, prompt }` pair. Sample expensive judges with
+a `{ model, prompt }` pair. `faithfulnessScorer(judge)` and
+`relevancyScorer(judge)` also require a judge agent. Sample expensive judges with
 `sampling: { type: "ratio", rate: 0.1 }`. Inspect:
 
 ```bash


### PR DESCRIPTION
Relates to #304

## What was fixed

`faithfulnessScorer()` and `relevancyScorer()` both require a judge agent as their first argument, but the code examples in `skills/eval-writer/SKILL.md` called them with no arguments. This would cause runtime errors when users copy the example into their own evals.

## Root cause & approach

The SKILL.md examples omitted the required `judge` argument to `faithfulnessScorer` and `relevancyScorer`. The fix updates both call sites in the example snippet to pass the `claude` agent (consistent with how `llmJudge` already uses it), and adds a prose clarification noting that these scorers require a judge agent.

A new test file (`packages/scorers/tests/eval-writer-skill-doc.test.js`) was added by Codex via TDD to pin the correct API signature and prevent regression.

## Review

Codex implemented the fix via TDD and both Codex and Claude Opus approved it in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)