### PR TITLE
🐛 fix(graph): publish TaskDescriptor forkSource type

### DIFF
--- a/packages/graph/src/index.d.ts
+++ b/packages/graph/src/index.d.ts
@@ -128,6 +128,8 @@ type TaskDescriptor$1 = {
     ralphId?: string;
     dependsOn?: string[];
     needs?: Record<string, string>;
+    /** Logical id of the task whose final agent session this task forks. Gates execution and seeds the session. */
+    forkSource?: string;
     worktreeId?: string;
     worktreePath?: string;
     worktreeBranch?: string;

--- a/packages/graph/tests/task-descriptor-declarations.test.js
+++ b/packages/graph/tests/task-descriptor-declarations.test.js
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const root = resolve(import.meta.dir, "../../..");
+const sourceTypes = readFileSync(resolve(root, "packages/graph/src/types.ts"), "utf8");
+const publishedTypes = readFileSync(resolve(root, "packages/graph/src/index.d.ts"), "utf8");
+
+function extractTypeBody(source, typeName) {
+	const match = source.match(new RegExp(`type ${typeName} = \\{([\\s\\S]*?)\\n\\};`));
+	if (!match) throw new Error(`Could not find ${typeName}`);
+	return match[1];
+}
+
+describe("published TaskDescriptor declarations", () => {
+	test("include the forkSource field from the source TaskDescriptor type", () => {
+		const sourceTaskDescriptor = extractTypeBody(sourceTypes, "TaskDescriptor");
+		const publishedTaskDescriptor = extractTypeBody(publishedTypes, "TaskDescriptor\\$1");
+
+		expect(sourceTaskDescriptor).toContain("forkSource?: string;");
+		expect(publishedTaskDescriptor).toContain("forkSource?: string;");
+		expect(publishedTaskDescriptor.indexOf("needs?: Record<string, string>;")).toBeLessThan(
+			publishedTaskDescriptor.indexOf("forkSource?: string;"),
+		);
+		expect(publishedTaskDescriptor.indexOf("forkSource?: string;")).toBeLessThan(
+			publishedTaskDescriptor.indexOf("worktreeId?: string;"),
+		);
+	});
+});


### PR DESCRIPTION
Relates to #303

## What was fixed

The `forkSource` field on `TaskDescriptor` was present in the source type (`packages/graph/src/types.ts`) but missing from the hand-maintained published declaration file (`packages/graph/src/index.d.ts`). This meant downstream consumers of the published `@smithers/graph` types could not type-check or author `forkSource` on task descriptors, even though the runtime accepted the field.

## Root cause & approach

`packages/graph/src/index.d.ts` is a manually maintained ambient declaration bundle that mirrors the TypeScript source. The `forkSource?: string` field (with its JSDoc noting that it gates execution and seeds the agent session from a prior task's final session) was never added when the field was introduced in the source.

The fix adds the missing field at the correct position in the `TaskDescriptor$1` declaration (between `needs` and `worktreeId`), matching the source order. A new regression test (`packages/graph/tests/task-descriptor-declarations.test.js`) parses both files and asserts the field exists in both and appears in the correct position — preventing future drift.

Codex implemented this fix via TDD. Both Codex and Claude Opus reviewed and approved the implementation before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)