### PR TITLE
🐛 fix(skills): correct report slideshow input docs

### DIFF
--- a/skills/report-maker/SKILL.md
+++ b/skills/report-maker/SKILL.md
@@ -61,15 +61,18 @@ bunx smithers-orchestrator diff <run-id> <node-id>    # a node's DiffBundle for 
 
 You don't have to hand-build the deck. The seeded **`report-slideshow`** workflow
 takes a run, reads its persisted state, and emits the self-contained HTML
-slideshow for you (it reuses the `capture:slideshow` renderer):
+slideshow for you:
 
 ```bash
-bunx smithers-orchestrator workflow run report-slideshow --input '{"runId":"<run-id>"}'
+bunx smithers-orchestrator workflow run report-slideshow --input '{"targetRunId":"<run-id>"}'
 ```
 
 Reach for it to bootstrap the report, then hand-tighten the decisions and
-next-run slides. The `context-engineer` flagship calls the same component as its
-`report` step, and `monitor-smithers` can attach one to its periodic digest.
+next-run slides. The workflow has its own deterministic `gather` step and
+agent-backed `render` step; `targetRunId` is the input name because `runId` is
+reserved for the report workflow's own run. For ongoing monitoring with an HTML
+report, use the separate `monitor` workflow. `monitor-smithers` is a fleet
+watchdog that emits a triage digest rather than attaching a slideshow.
 
 ## Progress is events, not "working on it"
 

--- a/skills/report-maker/SKILL.test.js
+++ b/skills/report-maker/SKILL.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../..");
+
+function read(path) {
+  return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("report-maker skill", () => {
+  test("documents the report-slideshow workflow input and reporting boundaries", () => {
+    const skill = read("skills/report-maker/SKILL.md");
+    const workflow = read(".smithers/workflows/report-slideshow.tsx");
+    const monitorSmithers = read(".smithers/workflows/monitor-smithers.tsx");
+    const monitor = read(".smithers/workflows/monitor.tsx");
+
+    expect(workflow).toContain("targetRunId:");
+    expect(workflow).toContain("const runId = ctx.input.targetRunId;");
+    expect(skill).toContain(`--input '{"targetRunId":"<run-id>"}'`);
+    expect(skill).not.toContain(`--input '{"runId":"<run-id>"}'`);
+
+    expect(workflow).not.toContain("capture:slideshow");
+    expect(skill).not.toContain("capture:slideshow");
+    expect(skill).not.toContain("same component");
+    expect(skill).not.toContain("monitor-smithers` can attach");
+
+    expect(monitorSmithers).toContain("digest: z.string()");
+    expect(monitor).toContain("const reportSchema");
+    expect(skill).toMatch(/For ongoing monitoring with an HTML\s+report, use the separate `monitor` workflow/);
+  });
+});


### PR DESCRIPTION
Relates to #304

## What was fixed

The `report-maker` skill documentation (`skills/report-maker/SKILL.md`) incorrectly named the input key for the `report-slideshow` workflow as `runId` when the actual parameter is `targetRunId`.

## Root cause & approach

`runId` is a reserved field for the report workflow's own run identifier. The target run to render must be passed as `targetRunId`. The docs used the wrong key, which would cause silent failures or confusing errors for anyone following the example command.

The fix updates the `--input` example in SKILL.md from `{"runId":"<run-id>"}` to `{"targetRunId":"<run-id>"}` and corrects downstream copy that:
- Described `monitor-smithers` as "attach[ing] a slideshow" (it emits a triage digest, not a slideshow)
- Omitted the workflow's deterministic `gather`/`render` step names

A `SKILL.test.js` test was added (TDD approach) to verify the correct input key is documented. Codex implemented the fix via TDD, and both Codex and Claude Opus approved the change in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)