### PR TITLE
🐛 fix(driver): expose initial run options in public type

### DIFF
--- a/packages/driver/src/RunOptions.ts
+++ b/packages/driver/src/RunOptions.ts
@@ -1,4 +1,5 @@
 import type { RunAuthContext } from "./RunAuthContext.ts";
+import type { OutputSnapshot } from "./OutputSnapshot.ts";
 import type { SmithersEvent } from "@smithers-orchestrator/observability/SmithersEvent";
 
 export type HotReloadOptions = {
@@ -34,6 +35,9 @@ export type RunOptions = {
   auth?: RunAuthContext | null;
   config?: Record<string, unknown>;
   cliAgentToolsDefault?: "all" | "explicit-only";
+  initialOutputs?: OutputSnapshot;
+  initialIteration?: number;
+  initialIterations?: Record<string, number> | ReadonlyMap<string, number>;
   resumeClaim?: {
     claimOwnerId: string;
     claimHeartbeatAtMs: number;

--- a/packages/driver/src/index.d.ts
+++ b/packages/driver/src/index.d.ts
@@ -72,6 +72,9 @@ type RunOptions$2 = {
     auth?: RunAuthContext$2 | null;
     config?: Record<string, unknown>;
     cliAgentToolsDefault?: "all" | "explicit-only";
+    initialOutputs?: OutputSnapshot$2;
+    initialIteration?: number;
+    initialIterations?: Record<string, number> | ReadonlyMap<string, number>;
     resumeClaim?: {
         claimOwnerId: string;
         claimHeartbeatAtMs: number;

--- a/packages/driver/tests/runOptions-typecheck.test.ts
+++ b/packages/driver/tests/runOptions-typecheck.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, test } from "bun:test";
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const TSC = resolve(REPO_ROOT, "node_modules", "typescript", "bin", "tsc");
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("RunOptions public type", () => {
+  test("accepts initial output and iteration options read by WorkflowDriver.run", () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-driver-run-options-"));
+    tempDirs.push(dir);
+
+    writeFileSync(
+      join(dir, "run-options.ts"),
+      `
+        import type { RunOptions } from "@smithers-orchestrator/driver";
+
+        const options: RunOptions = {
+          input: {},
+          initialOutputs: {
+            rows: [{ value: 1 }],
+          },
+          initialIteration: 3,
+          initialIterations: {
+            task: 2,
+          },
+        };
+
+        void options;
+      `,
+    );
+
+    writeFileSync(
+      join(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: "ESNext",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          baseUrl: ".",
+          paths: {
+            "@smithers-orchestrator/driver": [
+              resolve(REPO_ROOT, "packages/driver/src/index.d.ts"),
+            ],
+          },
+          allowImportingTsExtensions: true,
+          skipLibCheck: true,
+          lib: ["ESNext", "DOM", "DOM.Iterable"],
+        },
+        include: ["run-options.ts"],
+      }),
+    );
+
+    const result = spawnSync(process.execPath, [TSC, "-p", join(dir, "tsconfig.json")], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+
+    expect(`${result.stdout}${result.stderr}`).toBe("");
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Relates to #304

## What was fixed

`RunOptions` in `packages/driver/src/RunOptions.ts` was missing three fields that the engine passes at run start but were never declared in the public type: `initialOutputs`, `initialIteration`, and `initialIterations`. Callers that forwarded these options to `smithers.run()` got TypeScript errors at the boundary.

## Root cause & approach

The driver's public `RunOptions` type (and its corresponding hand-maintained `index.d.ts` declaration) did not include the `initialOutputs`, `initialIteration`, or `initialIterations` fields. These fields are used by the engine for resuming runs with pre-existing state (outputs, loop iteration counters) but were only present in internal types.

Fix adds all three fields to `RunOptions.ts` (importing `OutputSnapshot` for the outputs type) and mirrors them in `index.d.ts`. A new type-check test in `packages/driver/tests/runOptions-typecheck.test.ts` was added via TDD to confirm the fields compile correctly.

Codex implemented the fix via TDD; both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)