### PR TITLE
🐛 fix(skills): correct context-engineer grill node id

### DIFF
--- a/apps/cli/tests/context-engineer-skill.test.js
+++ b/apps/cli/tests/context-engineer-skill.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { GENERATED_SEEDED_FILES } from "../src/seeded-workflow-pack.generated.js";
+
+const repoRoot = join(import.meta.dir, "..", "..", "..");
+
+function extractGrillMeIds(workflowSource, componentSource) {
+  const ids = new Set();
+  if (!componentSource.includes("id={`${idPrefix}:grill`}")) {
+    return ids;
+  }
+
+  for (const match of workflowSource.matchAll(/<GrillMe\b[^>]*\bidPrefix="([^"]+)"/g)) {
+    ids.add(`${match[1]}:grill`);
+  }
+  return ids;
+}
+
+function extractOperatingLoopIds(skillMarkdown) {
+  const operatingLoop = skillMarkdown.match(/## The operating loop\n\n([\s\S]*?)\n## /);
+  expect(operatingLoop).not.toBeNull();
+
+  return Array.from(operatingLoop[1].matchAll(/^\s*-\s+\*\*[^*]+\*\*\s+\(`([^`]+)`/gm), (match) => match[1]);
+}
+
+describe("context-engineer skill", () => {
+  test("cites the real GrillMe node id from the context-engineer workflow", () => {
+    const skill = readFileSync(join(repoRoot, "skills/context-engineer/SKILL.md"), "utf8");
+    const workflow = GENERATED_SEEDED_FILES.find(
+      (file) => file.path === ".smithers/workflows/context-engineer.tsx",
+    );
+    const workflowPackSource = readFileSync(join(repoRoot, "apps/cli/src/workflow-pack.js"), "utf8");
+    expect(workflow).toBeDefined();
+
+    const workflowGrillIds = extractGrillMeIds(workflow.contents, workflowPackSource);
+    const skillNodeIds = extractOperatingLoopIds(skill);
+
+    expect(skillNodeIds).toContain("context-engineer:grill");
+    expect(skillNodeIds).not.toContain("grill-until-clear");
+    expect(workflowGrillIds).toContain("context-engineer:grill");
+  });
+});

--- a/skills/context-engineer/SKILL.md
+++ b/skills/context-engineer/SKILL.md
@@ -52,7 +52,7 @@ backpressure → approve → execute → report.
 - **Build a context inventory** (`inventory-context`): scan the repo, available
   tools/commands, `.smithers/skills`, and memory to draft the contract. Fill gaps
   with explicit `assumptions`; list what's truly `missingInputs`.
-- **Grill — only to reduce risk** (`grill-until-clear`, the `<GrillMe>`
+- **Grill — only to reduce risk** (`context-engineer:grill`, the `<GrillMe>`
   component): ask **one question at a time**, each with a **recommended answer +
   the reason**, and stop the moment the remaining ambiguity no longer changes the
   plan. **Never ask what's discoverable** from repo/docs/tools/memory — auto-answer


### PR DESCRIPTION
Relates to #304

## What was fixed

The `context-engineer` SKILL.md operating-loop entry for the grill step cited the stale node id `grill-until-clear` instead of the actual id emitted by the `<GrillMe>` component in the workflow: `context-engineer:grill` (formed from `idPrefix="context-engineer"` + `:grill` suffix).

## Root cause & approach

The `<GrillMe>` component constructs its node id as `${idPrefix}:grill`. The SKILL.md docs were written before the naming convention was established and retained the old placeholder name. The fix updates the single backtick-quoted id in the operating-loop bullet from `grill-until-clear` → `context-engineer:grill` to match the real workflow node.

A regression test was added at `apps/cli/tests/context-engineer-skill.test.js` that:
- Reads the generated seeded workflow pack to find the `context-engineer.tsx` workflow source
- Extracts `GrillMe` idPrefix values and confirms the node id used in the component
- Parses the SKILL.md operating-loop section and asserts it cites `context-engineer:grill` (not the old `grill-until-clear`)

## Review

Codex implemented the fix via TDD; Codex and Claude Opus both approved in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)