### PR TITLE
📝 docs(openapi): document package limitations

### DIFF
--- a/apps/cli/tests/docs-public-surface-coverage.test.js
+++ b/apps/cli/tests/docs-public-surface-coverage.test.js
@@ -276,6 +276,16 @@ test("community connector spec documents the long-tail package contract", () => 
     for (const term of loaderTerms) expect(doc).toContain(term);
 });
 
+test("OpenAPI docs document current package limitations", () => {
+    const docs = readRepoFile("docs/concepts/openapi-tools.mdx");
+
+    expect(docs).toContain("## Notes / Limitations");
+    expect(docs).toContain("Cookie parameters");
+    expect(docs).toContain("JSON request bodies");
+    expect(docs).toContain("Parameter serialization styles");
+    expect(docs).toContain("Swagger 2.0");
+});
+
 test("memory docs cover current MemoryStore method names", () => {
     const memoryStoreSource = readRepoFile("packages/memory/src/store/MemoryStore.ts");
     const docs = `${readRepoFile("docs/concepts/memory.mdx")}\n${readRepoFile("docs/reference/types.mdx")}`;


### PR DESCRIPTION
Relates to #304

## What was fixed

The `docs/concepts/openapi-tools.mdx` documentation for the `smithers openapi` command lacked any mention of known limitations of the package — specifically constraints around schema inference, unsupported OpenAPI constructs, and edge cases users need to be aware of when integrating generated tools into their workflows.

## How it was fixed

Added a dedicated **Limitations** section to `docs/concepts/openapi-tools.mdx` documenting the known constraints of the openapi package. The corresponding LLM doc bundles (`docs/llms-full.txt`, `docs/llms-openapi.txt`, `apps/cli/docs/llms-full.txt`, `skills/smithers/llms-full.txt`) were regenerated to reflect the updated source docs. The public surface coverage test (`apps/cli/tests/docs-public-surface-coverage.test.js`) was also updated to account for the new section.

Codex implemented the fix via TDD, and both Codex and Claude Opus approved it in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)