### PR TITLE
🐛 fix(scorers): type smithersScorers declaration

### DIFF
--- a/packages/scorers/src/__type-tests__/smithersScorers.test-d.ts
+++ b/packages/scorers/src/__type-tests__/smithersScorers.test-d.ts
@@ -1,0 +1,47 @@
+import { smithersScorers } from "../index.js";
+
+type InsertScorer = typeof smithersScorers.$inferInsert;
+type SelectScorer = typeof smithersScorers.$inferSelect;
+
+const insertRow: InsertScorer = {
+    id: "score-1",
+    runId: "run-1",
+    nodeId: "node-1",
+    scorerId: "accuracy",
+    scorerName: "Accuracy",
+    source: "batch",
+    score: 0.95,
+    scoredAtMs: 1_700_000_000_000,
+};
+
+const selectRow: SelectScorer = {
+    id: "score-1",
+    runId: "run-1",
+    nodeId: "node-1",
+    iteration: 0,
+    attempt: 0,
+    scorerId: "accuracy",
+    scorerName: "Accuracy",
+    source: "batch",
+    score: 0.95,
+    reason: null,
+    metaJson: null,
+    inputJson: null,
+    outputJson: null,
+    latencyMs: null,
+    scoredAtMs: 1_700_000_000_000,
+    durationMs: null,
+};
+
+selectRow.score satisfies number;
+selectRow.runId satisfies string;
+selectRow.reason satisfies string | null;
+
+// @ts-expect-error score must remain typed as a number, not erased to any.
+insertRow.score = "0.95";
+
+// @ts-expect-error runId must remain typed as a string, not erased to any.
+insertRow.runId = 123;
+
+// @ts-expect-error unknown columns must not be accepted.
+insertRow.unknownColumn = "nope";

--- a/packages/scorers/src/index.d.ts
+++ b/packages/scorers/src/index.d.ts
@@ -2,6 +2,7 @@ import * as _smithers_agents_AgentLike from '@smithers-orchestrator/agents/Agent
 import { AgentLike as AgentLike$3 } from '@smithers-orchestrator/agents/AgentLike';
 import { ZodObject } from 'zod';
 import * as _smithers_db_adapter from '@smithers-orchestrator/db/adapter';
+import * as drizzle_orm_sqlite_core from 'drizzle-orm/sqlite-core';
 import * as effect_MetricState from 'effect/MetricState';
 import * as effect_MetricKeyType from 'effect/MetricKeyType';
 import { Metric } from 'effect';
@@ -156,7 +157,46 @@ type SmithersDb$1 = _smithers_db_adapter.SmithersDb;
  * Drizzle table definition for the `_smithers_scorers` table.
  * Stores individual scorer results for each task execution.
  */
-declare const smithersScorers: any;
+type SmithersScorerColumn<Name extends string, Data, NotNull extends boolean, HasDefault extends boolean, PrimaryKey extends boolean, ColumnType extends string, DataType extends "string" | "number"> = drizzle_orm_sqlite_core.SQLiteColumn<{
+    name: Name;
+    tableName: "_smithers_scorers";
+    dataType: DataType;
+    columnType: ColumnType;
+    data: Data;
+    driverParam: Data;
+    notNull: NotNull;
+    hasDefault: HasDefault;
+    isPrimaryKey: PrimaryKey;
+    isAutoincrement: false;
+    hasRuntimeDefault: false;
+    enumValues: DataType extends "string" ? [string, ...string[]] : undefined;
+    baseColumn: never;
+    identity: undefined;
+    generated: undefined;
+}, {}, {}>;
+declare const smithersScorers: drizzle_orm_sqlite_core.SQLiteTableWithColumns<{
+    name: "_smithers_scorers";
+    schema: undefined;
+    columns: {
+        id: SmithersScorerColumn<"id", string, true, false, true, "SQLiteText", "string">;
+        runId: SmithersScorerColumn<"run_id", string, true, false, false, "SQLiteText", "string">;
+        nodeId: SmithersScorerColumn<"node_id", string, true, false, false, "SQLiteText", "string">;
+        iteration: SmithersScorerColumn<"iteration", number, true, true, false, "SQLiteInteger", "number">;
+        attempt: SmithersScorerColumn<"attempt", number, true, true, false, "SQLiteInteger", "number">;
+        scorerId: SmithersScorerColumn<"scorer_id", string, true, false, false, "SQLiteText", "string">;
+        scorerName: SmithersScorerColumn<"scorer_name", string, true, false, false, "SQLiteText", "string">;
+        source: SmithersScorerColumn<"source", string, true, false, false, "SQLiteText", "string">;
+        score: SmithersScorerColumn<"score", number, true, false, false, "SQLiteReal", "number">;
+        reason: SmithersScorerColumn<"reason", string, false, false, false, "SQLiteText", "string">;
+        metaJson: SmithersScorerColumn<"meta_json", string, false, false, false, "SQLiteText", "string">;
+        inputJson: SmithersScorerColumn<"input_json", string, false, false, false, "SQLiteText", "string">;
+        outputJson: SmithersScorerColumn<"output_json", string, false, false, false, "SQLiteText", "string">;
+        latencyMs: SmithersScorerColumn<"latency_ms", number, false, false, false, "SQLiteReal", "number">;
+        scoredAtMs: SmithersScorerColumn<"scored_at_ms", number, true, false, false, "SQLiteInteger", "number">;
+        durationMs: SmithersScorerColumn<"duration_ms", number, false, false, false, "SQLiteReal", "number">;
+    };
+    dialect: "sqlite";
+}>;
 
 /** @typedef {import("./CreateScorerConfig.js").CreateScorerConfig} CreateScorerConfig */
 /** @typedef {import("./types.js").Scorer} Scorer */


### PR DESCRIPTION
Relates to #304

## What was fixed

The exported `smithersScorers` Drizzle table constant in `packages/scorers/src/index.d.ts` was typed as `any`, providing no type safety for consumers querying the scorers table.

## Root cause & approach

The declaration file (hand-maintained or generated without full type inference) used a bare `any` as a placeholder instead of the precise `SQLiteTableWithColumns` shape. The fix introduces a helper generic `SmithersScorerColumn` and expands `smithersScorers` to its exact Drizzle column-map type, matching the real schema columns (`id`, `runId`, `nodeId`, `iteration`, `attempt`, `scorerId`, `scorerName`, `source`, `score`, `reason`, `metaJson`, `inputJson`, `outputJson`, `latencyMs`, `scoredAtMs`, `durationMs`).

A type-test file (`packages/scorers/src/__type-tests__/smithersScorers.test-d.ts`) was added to guard against future regressions.

## Review

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)