### PR TITLE
✅ test(protocol): assert full error code arrays

### DIFF
--- a/packages/protocol/tests/protocol-contracts.test.js
+++ b/packages/protocol/tests/protocol-contracts.test.js
@@ -29,22 +29,49 @@ describe("protocol runtime constants", () => {
   });
 
   test("node output error codes cover malformed rows and payload limits", () => {
-    expect(NODE_OUTPUT_ERROR_CODES).toContain("MalformedOutputRow");
-    expect(NODE_OUTPUT_ERROR_CODES).toContain("PayloadTooLarge");
-    expect(NODE_OUTPUT_ERROR_CODES).toContain("SchemaConversionError");
+    expect(NODE_OUTPUT_ERROR_CODES).toEqual([
+      "InvalidRunId",
+      "InvalidNodeId",
+      "InvalidIteration",
+      "RunNotFound",
+      "NodeNotFound",
+      "IterationNotFound",
+      "NodeHasNoOutput",
+      "SchemaConversionError",
+      "MalformedOutputRow",
+      "PayloadTooLarge",
+    ]);
   });
 
   test("node diff error codes cover dirty worktrees and attempt states", () => {
-    expect(NODE_DIFF_ERROR_CODES).toContain("WorkingTreeDirty");
-    expect(NODE_DIFF_ERROR_CODES).toContain("AttemptNotFound");
-    expect(NODE_DIFF_ERROR_CODES).toContain("AttemptNotFinished");
+    expect(NODE_DIFF_ERROR_CODES).toEqual([
+      "InvalidRunId",
+      "InvalidNodeId",
+      "InvalidIteration",
+      "RunNotFound",
+      "NodeNotFound",
+      "AttemptNotFound",
+      "AttemptNotFinished",
+      "VcsError",
+      "WorkingTreeDirty",
+      "DiffTooLarge",
+    ]);
   });
 
   test("jump-to-frame error codes cover confirmation busy rate-limit and auth paths", () => {
-    expect(JUMP_TO_FRAME_ERROR_CODES).toContain("ConfirmationRequired");
-    expect(JUMP_TO_FRAME_ERROR_CODES).toContain("Busy");
-    expect(JUMP_TO_FRAME_ERROR_CODES).toContain("RateLimited");
-    expect(JUMP_TO_FRAME_ERROR_CODES).toContain("Unauthorized");
+    expect(JUMP_TO_FRAME_ERROR_CODES).toEqual([
+      "InvalidRunId",
+      "InvalidFrameNo",
+      "RunNotFound",
+      "FrameOutOfRange",
+      "ConfirmationRequired",
+      "Busy",
+      "UnsupportedSandbox",
+      "VcsError",
+      "RewindFailed",
+      "RateLimited",
+      "Unauthorized",
+    ]);
   });
 
   test("all error code lists are duplicate-free", () => {


### PR DESCRIPTION
Relates to #305

## What & Why

The protocol contract tests for `NODE_OUTPUT_ERROR_CODES`, `NODE_DIFF_ERROR_CODES`, and `JUMP_TO_FRAME_ERROR_CODES` used partial `toContain` spot-checks — meaning unknown codes could be silently added or removed without any test failing. This is a coverage gap identified in issue #305 (protocol contract test coverage audit).

## How

Replaced all three partial `toContain` assertions in `packages/protocol/tests/protocol-contracts.test.js` with exhaustive `toEqual` arrays that pin the full set of error codes. Any future addition or removal of an error code in the protocol constants now causes an immediate, explicit test failure.

**Root cause:** The original tests were written as smoke checks rather than contract tests, leaving the full array shape unverified.

**Key file:** `packages/protocol/tests/protocol-contracts.test.js`

Codex implemented this via TDD and both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)