### PR TITLE
✅ test(tool-context): cover idempotency and seq boundaries

### DIFF
--- a/packages/tool-context/tests/tool-context.test.js
+++ b/packages/tool-context/tests/tool-context.test.js
@@ -23,9 +23,49 @@ describe("tool-context", () => {
         expect(getToolIdempotencyKey({ runId: "r" })).toBeNull();
     });
 
+    test("idempotency key derives from the ambient context when no ctx is passed", () => {
+        const ctx = { runId: "r", nodeId: "n", iteration: 7 };
+
+        runWithToolContext(ctx, () => {
+            expect(getToolIdempotencyKey()).toBe("smithers:r:n:7");
+        });
+    });
+
+    test("idempotency key treats missing or falsey run/node ids as absent", () => {
+        expect(getToolIdempotencyKey({ runId: "", nodeId: "n", iteration: 1 })).toBeNull();
+        expect(getToolIdempotencyKey({ runId: "r", nodeId: "", iteration: 1 })).toBeNull();
+        expect(getToolIdempotencyKey({ runId: 0, nodeId: "n", iteration: 1 })).toBeNull();
+        expect(getToolIdempotencyKey({ runId: "r", nodeId: 0, iteration: 1 })).toBeNull();
+    });
+
+    test("idempotency key ignores empty or non-string explicit keys", () => {
+        expect(getToolIdempotencyKey({ idempotencyKey: "", runId: "r", nodeId: "n", iteration: 2 })).toBe(
+            "smithers:r:n:2",
+        );
+        expect(getToolIdempotencyKey({ idempotencyKey: 123, runId: "r", nodeId: "n", iteration: 2 })).toBe(
+            "smithers:r:n:2",
+        );
+    });
+
+    test("idempotency key defaults nullish iteration to zero without overriding falsey numbers", () => {
+        expect(getToolIdempotencyKey({ runId: "r", nodeId: "n" })).toBe("smithers:r:n:0");
+        expect(getToolIdempotencyKey({ runId: "r", nodeId: "n", iteration: null })).toBe("smithers:r:n:0");
+        expect(getToolIdempotencyKey({ runId: "r", nodeId: "n", iteration: false })).toBe("smithers:r:n:false");
+    });
+
     test("nextToolSeq increments the context's seq", () => {
         const ctx = {};
         expect(nextToolSeq(ctx)).toBe(1);
         expect(nextToolSeq(ctx)).toBe(2);
+    });
+
+    test("nextToolSeq increments from existing values and defaults nullish seq to zero", () => {
+        const withExistingSeq = { seq: 41 };
+        const withNullSeq = { seq: null };
+        const withFalseSeq = { seq: false };
+
+        expect(nextToolSeq(withExistingSeq)).toBe(42);
+        expect(nextToolSeq(withNullSeq)).toBe(1);
+        expect(nextToolSeq(withFalseSeq)).toBe(1);
     });
 });


### PR DESCRIPTION
Relates to #305

## What & Why

`packages/tool-context` lacked tests for key edge cases in `getToolIdempotencyKey` and `nextToolSeq`, leaving silent regressions possible in:

- **Ambient context fallback** — `getToolIdempotencyKey()` called with no argument inside a `runWithToolContext` scope
- **Falsy runId/nodeId** — empty strings and `0` should produce `null` (no key), not a bogus key
- **Non-string `idempotencyKey`** — a numeric or empty explicit key should fall through to the derived `smithers:runId:nodeId:iter` form
- **Nullish iteration** — `null` iteration should default to `0`; other falsy values (e.g. `false`) are preserved
- **`nextToolSeq` with existing seq** — increments correctly from an existing value
- **`nextToolSeq` with null/false seq** — treats them as `0` before incrementing

## Approach

Added five new `test()` cases to `packages/tool-context/tests/tool-context.test.js`, exercising the above branches directly with the real implementation (no mocks). Codex implemented the tests via TDD; both Codex and Claude Opus approved the implementation in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)