### PR TITLE
✅ test(sandbox): cover egress and execute error branches

### DIFF
--- a/packages/sandbox/tests/egress.test.js
+++ b/packages/sandbox/tests/egress.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import {
+    normalizeSandboxEgressConfig,
+    redactSandboxEgressConfig,
+    sandboxEgressEnv,
+} from "../src/egress.js";
+
+describe("sandbox egress config", () => {
+    test("normalizes absent and empty configs to undefined", () => {
+        expect(normalizeSandboxEgressConfig(undefined)).toBeUndefined();
+        expect(normalizeSandboxEgressConfig(null)).toBeUndefined();
+        expect(normalizeSandboxEgressConfig(false)).toBeUndefined();
+        expect(normalizeSandboxEgressConfig({ env: {}, secretBindings: {} })).toBeUndefined();
+    });
+
+    test("normalizes string records, no_proxy arrays, and CA env", () => {
+        const caCertPem = "-----BEGIN CERTIFICATE-----\nproxy-ca\n-----END CERTIFICATE-----\n";
+        expect(
+            normalizeSandboxEgressConfig({
+                env: { SAFE_TOKEN: "token" },
+                httpProxy: "http://127.0.0.1:8080",
+                httpsProxy: "http://127.0.0.1:8443",
+                noProxy: ["127.0.0.1", "localhost"],
+                caCertPem,
+                secretBindings: { "secret-id": "ANTHROPIC_API_KEY" },
+            }),
+        ).toEqual({
+            env: { SAFE_TOKEN: "token" },
+            httpProxy: "http://127.0.0.1:8080",
+            httpsProxy: "http://127.0.0.1:8443",
+            noProxy: "127.0.0.1,localhost",
+            caCertPem,
+            secretBindings: { "secret-id": "ANTHROPIC_API_KEY" },
+        });
+        expect(
+            sandboxEgressEnv({
+                env: { SAFE_TOKEN: "token" },
+                httpsProxy: "http://127.0.0.1:8443",
+                noProxy: "localhost",
+                caCertPem,
+            }),
+        ).toEqual({
+            SAFE_TOKEN: "token",
+            HTTPS_PROXY: "http://127.0.0.1:8443",
+            NO_PROXY: "localhost",
+            NODE_EXTRA_CA_CERTS: "/workspace/.smithers/egress/ca.crt",
+        });
+    });
+
+    test("rejects malformed fields with useful validation errors", () => {
+        expect(() => normalizeSandboxEgressConfig("proxy")).toThrow("Sandbox egress must be an object");
+        expect(() => normalizeSandboxEgressConfig({ env: [] })).toThrow("egress.env must be a flat object");
+        expect(() => normalizeSandboxEgressConfig({ env: { "bad-key": "value" } })).toThrow(
+            "egress.env keys must be valid environment variable names",
+        );
+        expect(() => normalizeSandboxEgressConfig({ env: { SAFE: 1 } })).toThrow(
+            "egress.env values must be strings",
+        );
+        expect(() => normalizeSandboxEgressConfig({ env: { [("A".repeat(513))]: "value" } })).toThrow(
+            "egress.env keys must be strings within supported bounds",
+        );
+        expect(() => normalizeSandboxEgressConfig({ noProxy: 5 })).toThrow(
+            "egress.noProxy must be a string or string array",
+        );
+        expect(() => normalizeSandboxEgressConfig({ noProxy: [".example.test", ""] })).toThrow(
+            "egress.noProxy[1] must be a non-empty string",
+        );
+        expect(() =>
+            normalizeSandboxEgressConfig({
+                caCertPem: "pem",
+                caCertPath: "/tmp/ca.crt",
+            }),
+        ).toThrow("either caCertPem or caCertPath");
+    });
+
+    test("redacts sorted egress values and hides secret binding names", () => {
+        expect(
+            redactSandboxEgressConfig({
+                env: { Z_TOKEN: "z", A_TOKEN: "a" },
+                httpProxy: "http://proxy",
+                caCertPath: "/tmp/ca.crt",
+                secretBindings: { "secret-two": "two", "secret-one": "one" },
+            }),
+        ).toEqual({
+            env: { A_TOKEN: "[redacted]", Z_TOKEN: "[redacted]" },
+            httpProxy: "[redacted]",
+            caCertPath: "[redacted]",
+            secretBindings: { binding_1: "[redacted]", binding_2: "[redacted]" },
+        });
+        expect(redactSandboxEgressConfig(false)).toBe(false);
+    });
+});

--- a/packages/sandbox/tests/execute.test.js
+++ b/packages/sandbox/tests/execute.test.js
@@ -261,6 +261,17 @@ describe("executeSandbox", () => {
         }
     });
 
+    test("rejects sandbox execution when no runtime database is available", async () => {
+        const runtime = createRuntime(undefined);
+
+        await expect(
+            runInRuntime(runtime, {
+                sandboxId: "sandbox-no-db",
+                parentWorkflow: { build: () => null },
+            }),
+        ).rejects.toThrow("Sandbox execution requires a task runtime database");
+    });
+
     test("runs a registered provider, materializes its bundle, and applies accepted diff bundles", async () => {
         const { adapter, db, sqlite } = createDb();
         const rootDir = tempDir("smithers-sandbox-provider-");
@@ -482,6 +493,127 @@ describe("executeSandbox", () => {
             ).rejects.toThrow("must include either bundlePath or status");
 
             expect(cleanupCalls).toEqual(["sandbox-provider-cleanup"]);
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("materializes provider bundle paths and rejects invalid provider results", async () => {
+        const resultPath = tempDir("smithers-provider-materialized-");
+        const materialized = await __executeSandboxInternals.materializeProviderResult(
+            {
+                bundlePath: resultPath,
+                remoteRunId: "remote-run",
+                workspaceId: "workspace-1",
+                containerId: "container-1",
+            },
+            tempDir("smithers-provider-default-"),
+        );
+
+        expect(materialized).toEqual({
+            bundlePath: resultPath,
+            remoteRunId: "remote-run",
+            workspaceId: "workspace-1",
+            containerId: "container-1",
+        });
+        await expect(
+            __executeSandboxInternals.materializeProviderResult(null, tempDir("smithers-provider-null-")),
+        ).rejects.toThrow("invalid result");
+        await expect(
+            __executeSandboxInternals.materializeProviderResult(
+                { status: "running" },
+                tempDir("smithers-provider-status-"),
+            ),
+        ).rejects.toThrow("must include either bundlePath or status");
+    });
+
+    test("rejects accepted provider diff bundles without an applier", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const runtime = createRuntime(db, { runId: "run-provider-no-applier" });
+        try {
+            await expect(
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-provider-no-applier",
+                    provider: {
+                        id: "no-applier-provider",
+                        run: async () => ({
+                            status: "finished",
+                            output: { changed: true },
+                            diffBundle: onePatchDiffBundle(),
+                        }),
+                    },
+                    runtime: undefined,
+                    reviewDiffs: false,
+                }),
+            ).rejects.toThrow("no diff applier was provided");
+
+            expect(await adapter.getSandbox("run-provider-no-applier", "sandbox-provider-no-applier")).toMatchObject({
+                status: "failed",
+            });
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("rejects malformed accepted provider diff bundles before applying", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const runtime = createRuntime(db, { runId: "run-provider-bad-diff" });
+        let applied = false;
+        try {
+            await expect(
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-provider-bad-diff",
+                    provider: {
+                        id: "bad-diff-provider",
+                        run: async () => ({
+                            status: "finished",
+                            output: { changed: true },
+                            diffBundle: { patches: [] },
+                        }),
+                    },
+                    runtime: undefined,
+                    reviewDiffs: false,
+                    applyDiffBundle: async () => {
+                        applied = true;
+                    },
+                }),
+            ).rejects.toThrow("diffBundle is malformed");
+
+            expect(applied).toBe(false);
+            expect(await adapter.getSandbox("run-provider-bad-diff", "sandbox-provider-bad-diff")).toMatchObject({
+                status: "failed",
+            });
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("runs configured transport commands through the selected executor", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const runtime = createRuntime(db, { runId: "run-transport-command" });
+        let childCalled = false;
+        try {
+            await expect(
+                withCodeplaneEnv(() =>
+                    runInRuntime(runtime, {
+                        sandboxId: "sandbox-transport-command",
+                        config: { command: "echo should-run-in-sandbox" },
+                        executeChildWorkflow: async () => {
+                            childCalled = true;
+                            return { runId: "child-never", status: "finished", output: {} };
+                        },
+                    }),
+                ),
+            ).rejects.toThrow("Codeplane sandbox command execution requires");
+
+            expect(childCalled).toBe(false);
+            expect(await adapter.getSandbox("run-transport-command", "sandbox-transport-command")).toMatchObject({
+                status: "failed",
+                workspaceId: "run-transport-command:sandbox-transport-command",
+            });
         }
         finally {
             sqlite.close();

--- a/packages/sandbox/tests/transport-runners.test.js
+++ b/packages/sandbox/tests/transport-runners.test.js
@@ -479,6 +479,40 @@ describe("sandbox transport runners", () => {
         });
     });
 
+    test("codeplane executor reports unsupported direct command execution", async () => {
+        await withEnv({ CODEPLANE_API_URL: "http://codeplane.test", CODEPLANE_API_KEY: "test-key" }, async () => {
+            const handle = await runExecutor(CodeplaneSandboxExecutorLive, (executor) =>
+                executor.create(configFor(tempDir("smithers-codeplane-"), "run-codeplane", "sandbox", "codeplane")),
+            );
+
+            await expect(
+                runExecutor(CodeplaneSandboxExecutorLive, (executor) => executor.execute("npm test", handle)),
+            ).rejects.toThrow("remote Codeplane worker integration");
+        });
+    });
+
+    test("macOS fallback execute reports the missing sandbox-exec binary", async () => {
+        await withPlatform("darwin", () =>
+            withBunWhich(() => null, async () => {
+                const rootDir = tempDir("smithers-sandbox-exec-missing-");
+                const sandboxRoot = join(rootDir, ".smithers", "sandboxes", "run-no-exec", "sandbox");
+                const handle = {
+                    runtime: "bubblewrap",
+                    runId: "run-no-exec",
+                    sandboxId: "sandbox",
+                    sandboxRoot,
+                    requestPath: join(sandboxRoot, "request"),
+                    resultPath: join(sandboxRoot, "result"),
+                    allowNetwork: false,
+                };
+
+                await expect(
+                    runExecutor(BubblewrapSandboxExecutorLive, (executor) => executor.execute("npm test", handle)),
+                ).rejects.toThrow("sandbox-exec");
+            }),
+        );
+    });
+
     test("runtime selection covers all transport layer branches", async () => {
         expect(layerForSandboxRuntime("docker")).toBeDefined();
         expect(layerForSandboxRuntime("codeplane")).toBeDefined();


### PR DESCRIPTION
Relates to #305

## What

Adds missing test coverage to `packages/sandbox` across three areas:

- **`egress.test.js`** (new): covers `normalizeSandboxEgressConfig`, `redactSandboxEgressConfig`, and `sandboxEgressEnv` — the egress helpers had zero test coverage; all normalization paths, secret redaction, and proxy env-var injection are now exercised.
- **`execute.test.js`** (extended): adds error-branch coverage for execution failures and edge cases that were previously untested.
- **`transport-runners.test.js`** (extended): adds coverage for runner error branches and boundary conditions.

## Root cause & approach

Issue #305 identified that sandbox egress and execute error paths lacked unit tests, leaving regressions undetectable. Tests were implemented via TDD: specs were written first against the public API, then verified against the existing implementation.

## Review

Codex implemented the tests via TDD and both Codex and Claude Opus approved the implementation in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)