### PR TITLE
✅ test(time-travel): cover rewind audit and VCS success paths

### DIFF
--- a/packages/time-travel/tests/recoverInProgressRewindAudits.test.ts
+++ b/packages/time-travel/tests/recoverInProgressRewindAudits.test.ts
@@ -63,4 +63,96 @@ describe("recoverInProgressRewindAudits", () => {
       sqlite.close();
     }
   });
+
+  test("falls back to failed status when needs_attention is rejected", async () => {
+    const { adapter, sqlite } = setupDb();
+    try {
+      const runId = "run-recover-fallback";
+      await adapter.insertRun({
+        runId,
+        workflowName: "wf",
+        status: "running",
+        createdAtMs: 1,
+      });
+      await writeRewindAuditRow(adapter, {
+        runId,
+        fromFrameNo: 5,
+        toFrameNo: 2,
+        caller: "user:test",
+        timestampMs: 1_000,
+        result: "in_progress",
+        durationMs: null,
+      });
+
+      const updateStatuses: string[] = [];
+      const fallbackAdapter = {
+        ...adapter,
+        updateRun(id: string, patch: Record<string, unknown>) {
+          updateStatuses.push(String(patch.status));
+          if (patch.status === "needs_attention") {
+            throw new Error("status rejected");
+          }
+          return adapter.updateRun(id, patch);
+        },
+      } as typeof adapter;
+
+      const { recovered } = await recoverInProgressRewindAudits(fallbackAdapter, {
+        nowMs: () => 2_500,
+      });
+
+      expect(recovered).toEqual([{ id: 1, runId }]);
+      expect(updateStatuses).toEqual(["needs_attention", "failed"]);
+      const run = await adapter.getRun(runId);
+      expect(run?.status).toBe("failed");
+      expect(run?.errorJson).toContain("Rewind was in_progress at startup");
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("still recovers the audit row when both run-status updates fail", async () => {
+    const { adapter, sqlite } = setupDb();
+    try {
+      const runId = "run-recover-deleted";
+      await adapter.insertRun({
+        runId,
+        workflowName: "wf",
+        status: "running",
+        createdAtMs: 1,
+      });
+      await writeRewindAuditRow(adapter, {
+        runId,
+        fromFrameNo: 5,
+        toFrameNo: 2,
+        caller: "user:test",
+        timestampMs: 1_000,
+        result: "in_progress",
+        durationMs: null,
+      });
+
+      const updateStatuses: string[] = [];
+      const fallbackAdapter = {
+        ...adapter,
+        updateRun(_id: string, patch: Record<string, unknown>) {
+          updateStatuses.push(String(patch.status));
+          throw new Error("run row unavailable");
+        },
+      } as typeof adapter;
+
+      const { recovered } = await recoverInProgressRewindAudits(fallbackAdapter, {
+        nowMs: () => 2_500,
+      });
+
+      expect(recovered).toEqual([{ id: 1, runId }]);
+      expect(updateStatuses).toEqual(["needs_attention", "failed"]);
+      const audits = await listRewindAuditRows(adapter, { runId });
+      expect(audits[0]).toMatchObject({
+        id: 1,
+        result: "partial",
+        durationMs: 1_500,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
 });

--- a/packages/time-travel/tests/rewindAuditHelpers.test.ts
+++ b/packages/time-travel/tests/rewindAuditHelpers.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { countRecentRewindAuditRows } from "../src/countRecentRewindAuditRows.js";
+import { evaluateRewindRateLimit } from "../src/evaluateRewindRateLimit.js";
+import { listRewindAuditRows } from "../src/listRewindAuditRows.js";
+import { updateRewindAuditRow } from "../src/updateRewindAuditRow.js";
+import { writeRewindAuditRow } from "../src/writeRewindAuditRow.js";
+import { expandResetSet } from "../src/fork/_helpers.js";
+
+function setupDb() {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  ensureSmithersTables(db);
+  return { sqlite, adapter: new SmithersDb(db) };
+}
+
+async function seedRun(adapter: SmithersDb, runId = "run-1") {
+  await adapter.insertRun({
+    runId,
+    workflowName: "wf",
+    status: "running",
+    createdAtMs: 1,
+  });
+}
+
+async function writeAudit(adapter: SmithersDb, overrides: Partial<Parameters<typeof writeRewindAuditRow>[1]> = {}) {
+  return writeRewindAuditRow(adapter, {
+    runId: "run-1",
+    fromFrameNo: 5,
+    toFrameNo: 2,
+    caller: "user:owner",
+    timestampMs: 1_000,
+    result: "success",
+    durationMs: 10,
+    ...overrides,
+  });
+}
+
+describe("rewind audit helpers", () => {
+  test("counts only terminal rows for the caller and window", async () => {
+    const { adapter, sqlite } = setupDb();
+    try {
+      await seedRun(adapter);
+      await writeAudit(adapter, { timestampMs: 900, result: "success" });
+      await writeAudit(adapter, { timestampMs: 950, result: "failed" });
+      await writeAudit(adapter, { timestampMs: 980, result: "in_progress" });
+      await writeAudit(adapter, { timestampMs: 990, caller: "user:other" });
+      await writeAudit(adapter, { timestampMs: 100, result: "partial" });
+
+      await expect(
+        countRecentRewindAuditRows(adapter, {
+          runId: "run-1",
+          caller: "user:owner",
+          sinceMs: 800,
+        }),
+      ).resolves.toBe(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("evaluates quota with normalized max/window values", async () => {
+    const { adapter, sqlite } = setupDb();
+    try {
+      await seedRun(adapter);
+      await writeAudit(adapter, { timestampMs: 900 });
+      await writeAudit(adapter, { timestampMs: 950 });
+
+      const result = await evaluateRewindRateLimit({
+        adapter,
+        runId: "run-1",
+        caller: "user:owner",
+        nowMs: () => 1_000,
+        maxPerWindow: 2,
+        windowMs: 200,
+      });
+
+      expect(result).toEqual({
+        limited: true,
+        used: 2,
+        remaining: 0,
+        max: 2,
+        windowMs: 200,
+        windowStartedAtMs: 800,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("updates result, duration, and optional from frame", async () => {
+    const { adapter, sqlite } = setupDb();
+    try {
+      await seedRun(adapter);
+      const inserted = await writeAudit(adapter, {
+        fromFrameNo: 8,
+        result: "in_progress",
+        durationMs: null,
+      });
+
+      await updateRewindAuditRow(adapter, {
+        id: inserted ?? -1,
+        result: "partial",
+        durationMs: 250,
+        fromFrameNo: 6,
+      });
+
+      const rows = await listRewindAuditRows(adapter, { runId: "run-1" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        id: inserted,
+        result: "partial",
+        durationMs: 250,
+        fromFrameNo: 6,
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+describe("expandResetSet", () => {
+  test("falls back to exact keys when reset IDs are not base node IDs", () => {
+    const nodes = {
+      "task-a::0": {},
+      "task-b::1": {},
+    };
+
+    expect(expandResetSet(nodes, ["task-b::1"])).toEqual(["task-b::1"]);
+  });
+});

--- a/packages/time-travel/tests/vcs-version.test.js
+++ b/packages/time-travel/tests/vcs-version.test.js
@@ -1,9 +1,56 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect } from "effect";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
-import { loadVcsTag } from "../src/vcs-version/index.js";
+import { smithersVcsTags } from "../src/schema.js";
+
+const jjCalls = [];
+
+mock.module("@smithers-orchestrator/vcs/jj", () => ({
+    getJjPointer: (cwd) => {
+        jjCalls.push({ fn: "getJjPointer", cwd });
+        return Effect.succeed("change-live");
+    },
+    captureWorkspaceSnapshot: (cwd) => {
+        jjCalls.push({ fn: "captureWorkspaceSnapshot", cwd });
+        return Effect.succeed({
+            commitId: "commit-live",
+            changeId: "change-live",
+            operationId: "op-live",
+        });
+    },
+    isJjRepo: (cwd) => {
+        jjCalls.push({ fn: "isJjRepo", cwd });
+        return Effect.succeed(true);
+    },
+    revertToJjPointer: (pointer, cwd) => {
+        jjCalls.push({ fn: "revertToJjPointer", pointer, cwd });
+        return Effect.succeed({ success: true });
+    },
+    runJj: (args, opts = {}) => {
+        jjCalls.push({ fn: "runJj", args, cwd: opts.cwd });
+        return Effect.succeed({
+            code: 0,
+            stdout: "op-live\n",
+            stderr: "",
+        });
+    },
+    workspaceAdd: (workspaceName, workspacePath, opts = {}) => {
+        jjCalls.push({ fn: "workspaceAdd", workspaceName, workspacePath, opts });
+        return Effect.succeed({ success: true, workspacePath });
+    },
+    workspaceClose: (workspaceName, opts = {}) => {
+        jjCalls.push({ fn: "workspaceClose", workspaceName, opts });
+        return Effect.succeed({ success: true });
+    },
+    workspaceList: (cwd) => {
+        jjCalls.push({ fn: "workspaceList", cwd });
+        return Effect.succeed([]);
+    },
+}));
+
 function createTestDb() {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);
@@ -13,24 +60,60 @@ function createTestDb() {
 describe("loadVcsTag", () => {
     test("returns undefined when no tag exists", async () => {
         const { adapter } = createTestDb();
+        const { loadVcsTag } = await import("../src/vcs-version/index.js");
         const tag = await loadVcsTag(adapter, "run-1", 0);
         expect(tag).toBeUndefined();
     });
+    test("loads a stored VCS tag", async () => {
+        const { adapter, db } = createTestDb();
+        await db.insert(smithersVcsTags).values({
+            runId: "run-1",
+            frameNo: 3,
+            vcsType: "jj",
+            vcsPointer: "change-abc",
+            vcsRoot: "/repo",
+            jjOperationId: "op-123",
+            createdAtMs: 1234,
+        });
+        const { loadVcsTag } = await import("../src/vcs-version/index.js");
+        const tag = await loadVcsTag(adapter, "run-1", 3);
+        expect(tag).toEqual({
+            runId: "run-1",
+            frameNo: 3,
+            vcsType: "jj",
+            vcsPointer: "change-abc",
+            vcsRoot: "/repo",
+            jjOperationId: "op-123",
+            createdAtMs: 1234,
+        });
+    });
 });
 describe("tagSnapshotVcs", () => {
-    // tagSnapshotVcs requires a live jj repository — it will return null
-    // when jj is not available. We test the DB layer via loadVcsTag and
-    // verify the no-jj path returns null gracefully.
-    test("returns null when jj is not available (no crash)", async () => {
+    test("records the current jj pointer and operation id", async () => {
+        jjCalls.length = 0;
         const { adapter } = createTestDb();
-        // Import dynamically so we don't fail at module level if jj helpers change
-        const { tagSnapshotVcs } = await import("../src/vcs-version/index.js");
-        // tagSnapshotVcs calls getJjPointer which returns null when jj is not installed
-        // or the cwd is not a jj repo. This should return null without throwing.
-        const result = await tagSnapshotVcs(adapter, "run-1", 0, {
-            cwd: "/tmp/definitely-not-a-jj-repo",
+        const { loadVcsTag, tagSnapshotVcs } = await import("../src/vcs-version/index.js");
+
+        const result = await tagSnapshotVcs(adapter, "run-1", 0, { cwd: "/repo" });
+
+        expect(result).toMatchObject({
+            runId: "run-1",
+            frameNo: 0,
+            vcsType: "jj",
+            vcsPointer: "change-live",
+            vcsRoot: "/repo",
+            jjOperationId: "op-live",
         });
-        expect(result).toBeNull();
+        expect(result?.createdAtMs).toBeNumber();
+        await expect(loadVcsTag(adapter, "run-1", 0)).resolves.toEqual(result);
+        expect(jjCalls).toEqual([
+            { fn: "getJjPointer", cwd: "/repo" },
+            {
+                fn: "runJj",
+                args: ["operation", "log", "--no-graph", "--limit", "1", "-T", "self.id()"],
+                cwd: "/repo",
+            },
+        ]);
     });
 });
 describe("rerunAtRevision", () => {
@@ -41,6 +124,25 @@ describe("rerunAtRevision", () => {
         expect(result.restored).toBe(false);
         expect(result.vcsPointer).toBeNull();
     });
+    test("restores the stored VCS pointer for a tag", async () => {
+        jjCalls.length = 0;
+        const { adapter, db } = createTestDb();
+        await db.insert(smithersVcsTags).values({
+            runId: "run-1",
+            frameNo: 4,
+            vcsType: "jj",
+            vcsPointer: "change-stored",
+            vcsRoot: "/repo",
+            jjOperationId: null,
+            createdAtMs: 1234,
+        });
+        const { rerunAtRevision } = await import("../src/vcs-version/index.js");
+        const result = await rerunAtRevision(adapter, "run-1", 4);
+        expect(result).toEqual({ restored: true, vcsPointer: "change-stored" });
+        expect(jjCalls).toEqual([
+            { fn: "revertToJjPointer", pointer: "change-stored", cwd: "/repo" },
+        ]);
+    });
 });
 describe("resolveWorkflowAtRevision", () => {
     test("returns null when no VCS tag exists", async () => {
@@ -48,5 +150,35 @@ describe("resolveWorkflowAtRevision", () => {
         const { resolveWorkflowAtRevision } = await import("../src/vcs-version/index.js");
         const result = await resolveWorkflowAtRevision(adapter, "run-1", 0, "/tmp/workspace");
         expect(result).toBeNull();
+    });
+
+    test("creates a workspace at the stored VCS pointer", async () => {
+        jjCalls.length = 0;
+        const { adapter, db } = createTestDb();
+        await db.insert(smithersVcsTags).values({
+            runId: "run-abcdef123456",
+            frameNo: 7,
+            vcsType: "jj",
+            vcsPointer: "change-workflow",
+            vcsRoot: "/repo",
+            jjOperationId: "op-123",
+            createdAtMs: 1234,
+        });
+        const { resolveWorkflowAtRevision } = await import("../src/vcs-version/index.js");
+
+        const result = await resolveWorkflowAtRevision(adapter, "run-abcdef123456", 7, "/tmp/workspace");
+
+        expect(result).toEqual({
+            workspacePath: "/tmp/workspace",
+            vcsPointer: "change-workflow",
+        });
+        expect(jjCalls).toEqual([
+            {
+                fn: "workspaceAdd",
+                workspaceName: "smithers-replay-run-abcd-f7",
+                workspacePath: "/tmp/workspace",
+                opts: { cwd: "/repo", atRev: "change-workflow" },
+            },
+        ]);
     });
 });

--- a/packages/time-travel/tests/vcsRestoreSuccess.test.js
+++ b/packages/time-travel/tests/vcsRestoreSuccess.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, mock, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect } from "effect";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+
+const restoreCalls = [];
+
+mock.module("@smithers-orchestrator/vcs/jj", () => ({
+    captureWorkspaceSnapshot: (cwd) => {
+        restoreCalls.push({ fn: "captureWorkspaceSnapshot", cwd });
+        return Effect.succeed({
+            commitId: "commit-live",
+            changeId: "change-live",
+            operationId: "op-live",
+        });
+    },
+    getJjPointer: (cwd) => {
+        restoreCalls.push({ fn: "getJjPointer", cwd });
+        return Effect.succeed("change-live");
+    },
+    isJjRepo: (cwd) => {
+        restoreCalls.push({ fn: "isJjRepo", cwd });
+        return Effect.succeed(true);
+    },
+    revertToJjPointer: (pointer, cwd) => {
+        restoreCalls.push({ pointer, cwd });
+        return Effect.succeed({ success: true });
+    },
+    runJj: (args, opts = {}) => {
+        restoreCalls.push({ fn: "runJj", args, cwd: opts.cwd });
+        return Effect.succeed({ code: 0, stdout: "op-live\n", stderr: "" });
+    },
+    workspaceAdd: (workspaceName, workspacePath, opts = {}) => {
+        restoreCalls.push({ fn: "workspaceAdd", workspaceName, workspacePath, opts });
+        return Effect.succeed({ success: true, workspacePath });
+    },
+    workspaceClose: (workspaceName, opts = {}) => {
+        restoreCalls.push({ fn: "workspaceClose", workspaceName, opts });
+        return Effect.succeed({ success: true });
+    },
+    workspaceList: (cwd) => {
+        restoreCalls.push({ fn: "workspaceList", cwd });
+        return Effect.succeed([]);
+    },
+}));
+
+function buildDb() {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    ensureSmithersTables(db);
+    sqlite.exec(`
+        CREATE TABLE IF NOT EXISTS out_unused (
+            run_id TEXT NOT NULL,
+            node_id TEXT NOT NULL,
+            iteration INTEGER NOT NULL,
+            value INTEGER,
+            PRIMARY KEY (run_id, node_id, iteration)
+        );
+    `);
+    return { sqlite, adapter: new SmithersDb(db) };
+}
+
+async function seedRun(adapter, runId) {
+    await adapter.insertRun({
+        runId,
+        workflowName: "wf",
+        status: "finished",
+        createdAtMs: 1,
+        startedAtMs: 1,
+        finishedAtMs: 999,
+    });
+    await adapter.insertNode({
+        runId,
+        nodeId: "target",
+        iteration: 0,
+        state: "finished",
+        lastAttempt: 1,
+        updatedAtMs: 300,
+        outputTable: "out_unused",
+        label: "target",
+    });
+    await adapter.insertNode({
+        runId,
+        nodeId: "later",
+        iteration: 0,
+        state: "finished",
+        lastAttempt: 1,
+        updatedAtMs: 400,
+        outputTable: "out_unused",
+        label: "later",
+    });
+    await adapter.insertAttempt({
+        runId,
+        nodeId: "target",
+        iteration: 0,
+        attempt: 1,
+        state: "finished",
+        startedAtMs: 200,
+        finishedAtMs: 220,
+        jjPointer: "change-target",
+        jjCwd: "/repo",
+    });
+    await adapter.insertAttempt({
+        runId,
+        nodeId: "later",
+        iteration: 0,
+        attempt: 1,
+        state: "finished",
+        startedAtMs: 300,
+        finishedAtMs: 320,
+        jjPointer: "change-later",
+        jjCwd: "/repo",
+    });
+    await adapter.insertFrame({
+        runId,
+        frameNo: 0,
+        createdAtMs: 100,
+        xmlJson: JSON.stringify({ frame: 0 }),
+        xmlHash: "h0",
+    });
+    await adapter.insertFrame({
+        runId,
+        frameNo: 1,
+        createdAtMs: 200,
+        xmlJson: JSON.stringify({ frame: 1 }),
+        xmlHash: "h1",
+    });
+    await adapter.insertFrame({
+        runId,
+        frameNo: 2,
+        createdAtMs: 300,
+        xmlJson: JSON.stringify({ frame: 2 }),
+        xmlHash: "h2",
+    });
+}
+
+describe("VCS restore success paths", () => {
+    test("revertToAttempt restores the pointer and deletes frames after the attempt start", async () => {
+        restoreCalls.length = 0;
+        const { adapter, sqlite } = buildDb();
+        try {
+            await seedRun(adapter, "run-revert-success");
+            const { revertToAttempt } = await import("../src/revert.js");
+            const events = [];
+
+            const result = await revertToAttempt(adapter, {
+                runId: "run-revert-success",
+                nodeId: "target",
+                iteration: 0,
+                attempt: 1,
+                onProgress: (event) => events.push(event),
+            });
+
+            expect(result).toEqual({ success: true, jjPointer: "change-target" });
+            expect(restoreCalls).toEqual([{ pointer: "change-target", cwd: "/repo" }]);
+            expect(events.map((event) => event.type)).toEqual(["RevertStarted", "RevertFinished"]);
+            expect(events.at(-1)).toMatchObject({ success: true, error: undefined });
+            const frames = await adapter.listFrames("run-revert-success", 10);
+            expect(frames.map((frame) => frame.frameNo).sort()).toEqual([0, 1]);
+        } finally {
+            sqlite.close();
+        }
+    });
+
+    test("timeTravel reports vcsRestored true after a successful restore", async () => {
+        restoreCalls.length = 0;
+        const { adapter, sqlite } = buildDb();
+        try {
+            await seedRun(adapter, "run-time-travel-vcs-success");
+            const { timeTravel } = await import("../src/timetravel.js");
+            const events = [];
+
+            const result = await timeTravel(adapter, {
+                runId: "run-time-travel-vcs-success",
+                nodeId: "target",
+                restoreVcs: true,
+                onProgress: (event) => events.push(event),
+            });
+
+            expect(result).toMatchObject({
+                success: true,
+                jjPointer: "change-target",
+                vcsRestored: true,
+            });
+            expect(result.resetNodes.toSorted()).toEqual(["later", "target"]);
+            expect(restoreCalls).toEqual([{ pointer: "change-target", cwd: "/repo" }]);
+            expect(events.at(-1)).toMatchObject({
+                type: "TimeTravelFinished",
+                success: true,
+                vcsRestored: true,
+            });
+            expect(events.at(-1)?.resetNodes.toSorted()).toEqual(["later", "target"]);
+            const frames = await adapter.listFrames("run-time-travel-vcs-success", 10);
+            expect(frames.map((frame) => frame.frameNo).sort()).toEqual([0, 1]);
+            const laterAttempt = (await adapter.listAttempts("run-time-travel-vcs-success", "later", 0))[0];
+            expect(laterAttempt?.state).toBe("cancelled");
+        } finally {
+            sqlite.close();
+        }
+    });
+});


### PR DESCRIPTION
Relates to #305

## What was fixed and how

The time-travel package had significant gaps in test coverage for its rewind audit and VCS restore paths (identified in issue #305 — whole-codebase coverage audit).

**Root cause:** The rewind audit helper utilities and VCS restore success flow lacked unit tests entirely, leaving critical recovery logic unverified.

**Approach (TDD via Codex):**
- `packages/time-travel/tests/rewindAuditHelpers.test.ts` — new test file covering rewind audit helper utilities
- `packages/time-travel/tests/recoverInProgressRewindAudits.test.ts` — expanded to cover in-progress audit recovery scenarios
- `packages/time-travel/tests/vcsRestoreSuccess.test.js` — new test file covering the VCS restore success path
- `packages/time-travel/tests/vcs-version.test.js` — expanded VCS version test coverage

Codex implemented the tests via TDD. Both Codex and Claude Opus reviewed and approved the changes before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)