### PR TITLE
✅ test(gateway-client): cover sync transport and collection mappers

### DIFF
--- a/packages/gateway-client/src/sync/gatewayCollectionDefs.ts
+++ b/packages/gateway-client/src/sync/gatewayCollectionDefs.ts
@@ -42,7 +42,7 @@ function snapshotRows(payload: unknown): GatewayRunNode[] {
   );
 }
 
-function eventRows(frame: { key: readonly unknown[]; seq?: number; event: string; payload: unknown }): GatewayRunEventRow[] {
+export function eventRows(frame: { key: readonly unknown[]; seq?: number; event: string; payload: unknown }): GatewayRunEventRow[] {
   if (typeof frame.seq !== "number") return [];
   return [{
     key: frame.key as GatewayRunEventRow["key"],
@@ -52,7 +52,7 @@ function eventRows(frame: { key: readonly unknown[]; seq?: number; event: string
   }];
 }
 
-function runStatusFromFrame(frame: { payload: unknown }): string | undefined {
+export function runStatusFromFrame(frame: { payload: unknown }): string | undefined {
   const payload = asRecord(frame.payload);
   const innerEvent = asString(payload.event);
   if (!innerEvent) return undefined;
@@ -77,7 +77,7 @@ function withoutVirtualFields<TRow extends Record<string, unknown>>(row: TRow): 
   return out as TRow;
 }
 
-function runRowsFromFrame(runId: string) {
+export function runRowsFromFrame(runId: string) {
   return (frame: { payload: unknown }, { collection }: { collection: Collection<GatewayRunRow, string> }) => {
     const status = runStatusFromFrame(frame);
     const current = collection.get(runId);

--- a/packages/gateway-client/tests/sync/createSmithersGatewayTransport.test.ts
+++ b/packages/gateway-client/tests/sync/createSmithersGatewayTransport.test.ts
@@ -3,6 +3,63 @@ import type { SmithersGatewayClient } from "../../src/SmithersGatewayClient.ts";
 import { createSmithersGatewayTransport } from "../../src/sync/createSmithersGatewayTransport.ts";
 
 describe("createSmithersGatewayTransport", () => {
+  test("passes afterSeq and healthyAfterMs through streamRunEvents subscriptions", async () => {
+    const calls: Array<{ params: unknown; signal: AbortSignal | undefined; healthyAfterMs: number | undefined }> = [];
+    const client = {
+      rpcRaw() {
+        throw new Error("not used");
+      },
+      async *streamRunEventsResilient(
+        params: unknown,
+        options: { signal?: AbortSignal; healthyAfterMs?: number },
+      ) {
+        calls.push({ params, signal: options.signal, healthyAfterMs: options.healthyAfterMs });
+        yield {
+          event: "gateway.event",
+          payload: { seq: 8, event: "run.started", payload: { runId: "run-1" } },
+        };
+        yield {
+          event: "gateway.event",
+          seq: 9,
+          payload: { event: "run.completed", payload: { state: "ok" } },
+        };
+      },
+    } as unknown as SmithersGatewayClient;
+    const transport = createSmithersGatewayTransport(client, { streamHealthyAfterMs: 123 });
+    const controller = new AbortController();
+    const frames = [];
+
+    for await (const frame of transport.stream?.(
+      "streamRunEvents",
+      { runId: "run-1" },
+      { afterSeq: 7, signal: controller.signal },
+    ) ?? []) {
+      frames.push(frame);
+    }
+
+    expect(calls).toEqual([
+      {
+        params: { runId: "run-1", afterSeq: 7 },
+        signal: controller.signal,
+        healthyAfterMs: 123,
+      },
+    ]);
+    expect(frames).toEqual([
+      {
+        key: ["gateway:streamRunEvents", { runId: "run-1" }],
+        event: "gateway.event",
+        seq: 8,
+        payload: { seq: 8, event: "run.started", payload: { runId: "run-1" } },
+      },
+      {
+        key: ["gateway:streamRunEvents", { runId: "run-1" }],
+        event: "gateway.event",
+        seq: 9,
+        payload: { event: "run.completed", payload: { state: "ok" } },
+      },
+    ]);
+  });
+
   test("passes afterSeq through streamDevTools subscriptions", async () => {
     const calls: Array<{ params: unknown; signal: AbortSignal | undefined }> = [];
     const client = {

--- a/packages/gateway-client/tests/sync/gatewayCollectionDefs.test.ts
+++ b/packages/gateway-client/tests/sync/gatewayCollectionDefs.test.ts
@@ -1,8 +1,14 @@
 import { createCollection } from "@tanstack/db";
 import { describe, expect, test } from "bun:test";
 import { createGatewayCollection } from "../../src/sync/createGatewayCollection.ts";
-import { gatewayCollectionDefs } from "../../src/sync/gatewayCollectionDefs.ts";
+import {
+  eventRows,
+  gatewayCollectionDefs,
+  runRowsFromFrame,
+  runStatusFromFrame,
+} from "../../src/sync/gatewayCollectionDefs.ts";
 import type { GatewayRunNode } from "../../src/sync/GatewayRunNode.ts";
+import type { GatewayRunRow } from "../../src/sync/GatewayRunRow.ts";
 import type { SyncStreamFrame, SyncTransport } from "../../src/sync/SyncTransport.ts";
 
 /** A real `getDevToolsSnapshot` payload: a `{ root }` tree, not an array. */
@@ -88,5 +94,120 @@ describe("gatewayCollectionDefs.nodes", () => {
 
     expect(collection.size).toBe(0);
     expect(collection.status).toBe("ready");
+  });
+});
+
+describe("gatewayCollectionDefs", () => {
+  test("defines workflow, run list, run, approvals, and run event collections", () => {
+    const workflows = gatewayCollectionDefs.workflows({ filter: { hasUi: true } });
+    expect(workflows).toMatchObject({
+      key: ["gateway:listWorkflows", { hasUi: true }],
+      method: "listWorkflows",
+      params: { filter: { hasUi: true } },
+    });
+    expect(workflows.getKey({ key: "wf", name: "Workflow" } as never)).toBe("wf");
+    expect(workflows.rows([{ key: "wf" }])).toEqual([{ key: "wf" }]);
+    expect(workflows.rows({ key: "wf" })).toEqual([]);
+
+    const runs = gatewayCollectionDefs.runs({ workflowKey: "wf" });
+    expect(runs).toMatchObject({
+      key: ["gateway:listRuns", { workflowKey: "wf" }],
+      method: "listRuns",
+      params: { workflowKey: "wf" },
+    });
+    expect(runs.getKey({ runId: "run-1" })).toBe("run-1");
+    expect(runs.rows([{ runId: "run-1" }])).toEqual([{ runId: "run-1" }]);
+
+    const run = gatewayCollectionDefs.run("run-1");
+    expect(run).toMatchObject({
+      key: ["gateway:getRun", { runId: "run-1" }],
+      method: "getRun",
+      params: { runId: "run-1" },
+      stream: { scope: "streamRunEvents", params: { runId: "run-1" } },
+    });
+    expect(run.getKey({ runId: "run-1" })).toBe("run-1");
+    expect(run.rows({ runId: "run-1", status: "running" })).toEqual([{ runId: "run-1", status: "running" }]);
+    expect(run.rows([{ runId: "run-1" }])).toEqual([]);
+
+    const approvals = gatewayCollectionDefs.approvals({ runId: "run-1" });
+    expect(approvals).toMatchObject({
+      key: ["gateway:listApprovals", { runId: "run-1" }],
+      method: "listApprovals",
+      params: { runId: "run-1" },
+    });
+    expect(approvals.getKey({ runId: "run-1", nodeId: "approve", iteration: 2 } as never)).toBe("run-1:approve:2");
+    expect(approvals.rows([{ runId: "run-1", nodeId: "approve", iteration: 2 }])).toEqual([
+      { runId: "run-1", nodeId: "approve", iteration: 2 },
+    ]);
+
+    const runEvents = gatewayCollectionDefs.runEvents("run-1", 2);
+    expect(runEvents).toMatchObject({
+      key: ["gateway:streamRunEvents", { runId: "run-1" }],
+      stream: { scope: "streamRunEvents", params: { runId: "run-1" }, maxRows: 2 },
+    });
+    expect(runEvents.getKey({ key: ["gateway:streamRunEvents", { runId: "run-1" }], seq: 12, event: "event", payload: {} })).toBe(12);
+  });
+});
+
+describe("gateway run stream frame mappers", () => {
+  test("maps run event frames only when a sequence is present", () => {
+    const keyedFrame = {
+      key: ["gateway:streamRunEvents", { runId: "run-1" }],
+      seq: 11,
+      event: "gateway.event",
+      payload: { event: "run.started", payload: { runId: "run-1" } },
+    } as const;
+
+    expect(eventRows(keyedFrame)).toEqual([
+      {
+        key: ["gateway:streamRunEvents", { runId: "run-1" }],
+        seq: 11,
+        event: "gateway.event",
+        payload: { event: "run.started", payload: { runId: "run-1" } },
+      },
+    ]);
+    expect(eventRows({ ...keyedFrame, seq: undefined })).toEqual([]);
+  });
+
+  test("maps gateway run lifecycle events to run statuses", () => {
+    expect(runStatusFromFrame({ payload: { event: "run.started", payload: {} } })).toBe("running");
+    expect(runStatusFromFrame({ payload: { event: "run.resumed", payload: {} } })).toBe("running");
+    expect(runStatusFromFrame({ payload: { event: "run.paused", payload: {} } })).toBe("waiting");
+    expect(runStatusFromFrame({ payload: { event: "run.completed", payload: { state: "ok" } } })).toBe("ok");
+    expect(runStatusFromFrame({ payload: { event: "run.completed", payload: { status: "succeeded" } } })).toBe("succeeded");
+    expect(runStatusFromFrame({ payload: { event: "run.completed", payload: { state: "failed" } } })).toBe("failed");
+    expect(runStatusFromFrame({ payload: { event: "run.completed", payload: { state: "cancelled" } } })).toBe("failed");
+    expect(runStatusFromFrame({ payload: { event: "run.completed", payload: {} } })).toBe("ok");
+    expect(runStatusFromFrame({ payload: { event: "node.started", payload: {} } })).toBeUndefined();
+    expect(runStatusFromFrame({ payload: null })).toBeUndefined();
+  });
+
+  test("updates the current run row and omits virtual fields", () => {
+    const current: GatewayRunRow = {
+      runId: "run-1",
+      status: "waiting",
+      workflowKey: "wf",
+      $optimistic: true,
+      summary: undefined,
+    };
+    const mapper = runRowsFromFrame("run-1");
+    const collection = {
+      get(key: string) {
+        return key === "run-1" ? current : undefined;
+      },
+    };
+
+    expect(mapper(
+      { payload: { event: "run.started", payload: {} } },
+      { collection: collection as never },
+    )).toEqual([{ runId: "run-1", status: "running", workflowKey: "wf" }]);
+    expect(mapper(
+      { payload: { event: "node.started", payload: {} } },
+      { collection: collection as never },
+    )).toEqual([]);
+    expect(runRowsFromFrame("missing")(
+      { payload: { event: "run.started", payload: {} } },
+      { collection: collection as never },
+    )).toEqual([]);
   });
 });


### PR DESCRIPTION
Relates to #306

## What was fixed and how

Three internal helpers in `packages/gateway-client/src/sync/gatewayCollectionDefs.ts` — `eventRows`, `runStatusFromFrame`, and `runRowsFromFrame` — were unexported, making them untestable without reaching into module internals. This PR exports them so unit tests can exercise them directly.

**Root cause:** The helpers were intentionally private but had non-trivial logic (status derivation from run lifecycle events, virtual-field stripping, keyed-frame mapping) that lacked coverage.

**Approach:**
- Export `eventRows`, `runStatusFromFrame`, and `runRowsFromFrame` from `gatewayCollectionDefs.ts`
- Add comprehensive unit tests in `tests/sync/gatewayCollectionDefs.test.ts` covering all five collection-def factories (`workflows`, `runs`, `run`, `approvals`, `runEvents`) and the three mappers
- Add a new test in `tests/sync/createSmithersGatewayTransport.test.ts` covering `afterSeq` + `healthyAfterMs` propagation through `streamRunEvents` subscriptions

Codex implemented the changes via TDD; both Codex and Claude Opus reviewed and approved in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)