### PR TITLE
✅ test(openapi): cover parameter merge and tool filtering

### DIFF
--- a/packages/openapi/tests/spec-parser.test.js
+++ b/packages/openapi/tests/spec-parser.test.js
@@ -122,6 +122,60 @@ describe("extractOperations", () => {
         expect(getPet.parameters[0].in).toBe("path");
         expect(getPet.parameters[0].required).toBe(true);
     });
+    test("merges path-level parameters and lets operation-level parameters override matching keys", () => {
+        const ops = extractOperations({
+            openapi: "3.0.0",
+            info: { title: "Path Params", version: "1.0.0" },
+            paths: {
+                "/orgs/{orgId}/pets": {
+                    parameters: [
+                        {
+                            name: "orgId",
+                            in: "path",
+                            required: true,
+                            description: "Path-level org id",
+                            schema: { type: "string", pattern: "org_[0-9]+" },
+                        },
+                        {
+                            name: "includeArchived",
+                            in: "query",
+                            description: "Shared archive filter",
+                            schema: { type: "boolean", default: false },
+                        },
+                    ],
+                    get: {
+                        operationId: "listOrgPets",
+                        parameters: [
+                            {
+                                name: "orgId",
+                                in: "path",
+                                required: true,
+                                description: "Operation-level org id",
+                                schema: { type: "string", minLength: 3 },
+                            },
+                            {
+                                name: "limit",
+                                in: "query",
+                                schema: { type: "integer" },
+                            },
+                        ],
+                        responses: { "200": { description: "ok" } },
+                    },
+                },
+            },
+        });
+
+        const listOrgPets = ops.find((o) => o.operationId === "listOrgPets");
+        expect(listOrgPets.parameters.map((p) => `${p.in}:${p.name}`)).toEqual([
+            "query:includeArchived",
+            "path:orgId",
+            "query:limit",
+        ]);
+        expect(listOrgPets.parameters.find((p) => p.name === "orgId")).toMatchObject({
+            description: "Operation-level org id",
+            schema: { type: "string", minLength: 3 },
+        });
+    });
     test("handles empty paths", () => {
         const ops = extractOperations({
             openapi: "3.0.0",

--- a/packages/openapi/tests/tool-factory.test.js
+++ b/packages/openapi/tests/tool-factory.test.js
@@ -1,9 +1,16 @@
 // ---------------------------------------------------------------------------
 // Tool factory tests — creation of AI SDK tools from specs
 // ---------------------------------------------------------------------------
-import { describe, test, expect } from "bun:test";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import { createOpenApiToolsSync, createOpenApiToolSync, listOperations, } from "../src/tool-factory.js";
 import { petStoreSpec, complexSchemaSpec } from "./fixtures.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
 describe("createOpenApiToolsSync", () => {
     test("creates tools for all operations", () => {
         const tools = createOpenApiToolsSync(petStoreSpec);
@@ -30,6 +37,13 @@ describe("createOpenApiToolsSync", () => {
         });
         expect(Object.keys(tools)).not.toContain("deletePet");
         expect(Object.keys(tools).length).toBe(3);
+    });
+    test("applies exclude after include when both filters are provided", () => {
+        const tools = createOpenApiToolsSync(petStoreSpec, {
+            include: ["listPets", "getPet", "deletePet"],
+            exclude: ["getPet"],
+        });
+        expect(Object.keys(tools).sort()).toEqual(["deletePet", "listPets"]);
     });
     test("applies name prefix", () => {
         const tools = createOpenApiToolsSync(petStoreSpec, {
@@ -83,6 +97,30 @@ describe("createOpenApiToolsSync", () => {
             baseUrl: "https://custom.api.example.com",
         });
         expect(Object.keys(tools).length).toBeGreaterThan(0);
+    });
+    test("falls back to localhost when no base URL option or server is present", async () => {
+        const specWithoutServers = {
+            openapi: "3.0.0",
+            info: { title: "Local", version: "1.0.0" },
+            paths: {
+                "/health": {
+                    get: {
+                        operationId: "getHealth",
+                        responses: { "200": { description: "ok" } },
+                    },
+                },
+            },
+        };
+        const mockFetch = mock(() => Promise.resolve(new Response("ok")));
+        globalThis.fetch = mockFetch;
+
+        const tools = createOpenApiToolsSync(specWithoutServers);
+        await tools.getHealth.execute({});
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, init] = mockFetch.mock.calls[0];
+        expect(url).toBe("http://localhost/health");
+        expect(init.method).toBe("GET");
     });
     test("creates tools from complex schema spec", () => {
         const tools = createOpenApiToolsSync(complexSchemaSpec);


### PR DESCRIPTION
Relates to #306

## What & Why

Two behaviours in the `openapi` package lacked test coverage, discovered during the audit behind issue #306:

1. **Path-level parameter merging** (`packages/openapi/tests/spec-parser.test.js`): `extractOperations` is supposed to merge path-level `parameters` into each operation and let operation-level entries with the same `(in, name)` key override the shared definition. No test exercised this merge/override logic; the new test covers the full round-trip: shared path param, shared query param, operation-level override of the path param, and an operation-only query param.

2. **Include + exclude filter precedence** (`packages/openapi/tests/tool-factory.test.js`): `createOpenApiToolsSync` accepts both `include` and `exclude` filter arrays; the contract is that `exclude` is applied _after_ `include`. No test verified both filters could be supplied simultaneously or that the ordering was correct. The new test passes overlapping lists and asserts only the expected operations survive.

Both tests were implemented via TDD by Codex and passed dual review (Codex + Claude Opus) before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)