### PR TITLE
🐛 fix(review): require OIDC kid to match JWKS key

### DIFF
--- a/apps/review/src/server/sessions/verifyOidc.ts
+++ b/apps/review/src/server/sessions/verifyOidc.ts
@@ -101,7 +101,7 @@ export async function verifyOidc(
   if (header.alg !== "RS256") return { ok: false, reason: "unsupported-alg" };
 
   const keys = await fetchJwks(jwksUrl, now, fetchImpl);
-  const match = keys.find((k) => k.kid === header.kid) ?? (keys.length === 1 ? keys[0] : undefined);
+  const match = keys.find((k) => k.kid === header.kid);
   if (!match) return { ok: false, reason: "unknown-key" };
 
   const key = await importJwk(match);

--- a/apps/review/tests/server/verifyOidc.test.ts
+++ b/apps/review/tests/server/verifyOidc.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { jwksCache } from "../../src/server/sessions/jwksCache.ts";
+import { verifyOidc } from "../../src/server/sessions/verifyOidc.ts";
+import { rsaKeypair } from "./helpers/rsaKeypair.ts";
+import { serveJwks } from "./helpers/serveJwks.ts";
+import { signTestJwt } from "./helpers/signTestJwt.ts";
+
+function baseClaims(exp: number) {
+  return {
+    iss: "https://token.actions.githubusercontent.com",
+    aud: "smithers-review",
+    exp,
+    repository: "octo/widgets",
+  };
+}
+
+beforeEach(() => {
+  jwksCache.clear();
+});
+
+describe("verifyOidc", () => {
+  test("rejects a single JWKS key when the token kid differs", async () => {
+    const keypair = await rsaKeypair("token-kid");
+    const publicJwk = { ...keypair.publicJwk, kid: "jwks-kid" };
+    const jwks = serveJwks([publicJwk]);
+    try {
+      const token = await signTestJwt(keypair, baseClaims(Math.floor(Date.now() / 1000) + 600));
+      const outcome = await verifyOidc(token, jwks.url, Date.now());
+
+      expect(outcome).toEqual({ ok: false, reason: "unknown-key" });
+    } finally {
+      jwks.stop();
+    }
+  });
+});


### PR DESCRIPTION
Relates to #307

## What was fixed

`verifyOidc` in `apps/review/src/server/sessions/verifyOidc.ts` had a single-key fallback: if the JWKS endpoint returned exactly one key and it didn't match the token's `kid` header, the code would silently use that key anyway. This allowed an attacker who could control a JWKS endpoint with a single key to bypass the `kid`-match check entirely.

## Root cause & approach

The unsafe fallback was removed from the key-selection expression:

```
// before
const match = keys.find((k) => k.kid === header.kid) ?? (keys.length === 1 ? keys[0] : undefined);

// after
const match = keys.find((k) => k.kid === header.kid);
```

Now `verifyOidc` strictly requires an exact `kid` match; any mismatch returns `{ ok: false, reason: "unknown-key" }`.

A regression test was added in `apps/review/tests/server/verifyOidc.test.ts` (TDD approach): it constructs a JWKS with a single key whose `kid` differs from the token's `kid` and asserts the outcome is rejected with `unknown-key`.

Codex implemented the fix via TDD; Codex and Claude Opus both approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)