### PR TITLE
🐛 fix(gateway-client): close socket on open failure

### DIFF
--- a/packages/gateway-client/src/SmithersGatewayClient.ts
+++ b/packages/gateway-client/src/SmithersGatewayClient.ts
@@ -271,6 +271,7 @@ export class SmithersGatewayClient {
       };
       const onError = () => {
         cleanup();
+        ws.close();
         reject(new Error("Gateway WebSocket failed to open."));
       };
       const onAbort = () => {

--- a/packages/gateway-client/tests/gateway-client.test.ts
+++ b/packages/gateway-client/tests/gateway-client.test.ts
@@ -375,6 +375,7 @@ describe("SmithersGatewayClient WebSocket helpers", () => {
     ws.dispatchEvent(new Event("error"));
 
     await expect(pending).rejects.toThrow("Gateway WebSocket failed to open");
+    expect(ws.closeCalls).toBe(1);
   });
 
   test("aborts a pending WebSocket open and closes the socket", async () => {


### PR DESCRIPTION
Relates to #307

## What

When a WebSocket connection attempt failed during the open phase (i.e. the `error` event fired before `open`), the socket was left in an open/pending state. The `onError` handler rejected the connect promise but never called `ws.close()`, leaving the socket dangling.

## How

Added `ws.close()` inside the `onError` handler in `SmithersGatewayClient.ts` (the `connectWebSocket` helper, ~line 273) before the `reject` call, so failed sockets are always cleaned up.

A regression test was added to `gateway-client.test.ts` that asserts `ws.closeCalls === 1` after an error event fires — verified via TDD (Codex implemented the fix with the test failing first).

## Review

Codex implemented this via TDD and both Codex and Claude Opus reviewed and approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)