### PR TITLE
✅ test(pi-plugin): cover devtools client store and views

### DIFF
--- a/packages/pi-plugin/tests/DevToolsClient.test.ts
+++ b/packages/pi-plugin/tests/DevToolsClient.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createServer, type Server } from "node:http";
+import { WebSocketServer } from "ws";
+import { DevToolsClient } from "../src/runtime/DevToolsClient.js";
+import type { DevToolsNode, DevToolsSnapshot } from "@smithers-orchestrator/protocol";
+
+function node(id: number, nodeId: string, state = "running"): DevToolsNode {
+  return {
+    id,
+    type: "task",
+    name: nodeId,
+    props: { state },
+    task: { nodeId, kind: "compute", label: nodeId, iteration: 0 },
+    children: [],
+    depth: 1,
+  };
+}
+
+function snapshot(seq: number): DevToolsSnapshot {
+  return {
+    version: 1,
+    runId: "run-client",
+    frameNo: seq,
+    seq,
+    root: {
+      id: 1,
+      type: "workflow",
+      name: "Workflow",
+      props: { state: "running" },
+      children: [node(2, "task:a")],
+      depth: 0,
+    },
+  };
+}
+
+async function httpFixture(handler: (body: any, request: Request) => Response | Promise<Response>) {
+  const requests: Array<{ body: any; authorization: string | undefined }> = [];
+  const server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    requests.push({ body, authorization: req.headers.authorization });
+    const response = await handler(body, new Request(`http://fixture${req.url}`));
+    res.writeHead(response.status, Object.fromEntries(response.headers));
+    res.end(await response.text());
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (typeof address === "string" || address === null) {
+    throw new Error("expected TCP server address");
+  }
+  return { server, requests, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function next<T>(generator: AsyncGenerator<T>) {
+  const result = await generator.next();
+  if (result.done) {
+    throw new Error("expected generator value");
+  }
+  return result.value;
+}
+
+async function expectSmithersError(promise: Promise<unknown>, code: string, message: string) {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toHaveProperty("code", code);
+    expect(error).toBeInstanceOf(Error);
+    expect(error instanceof Error ? error.message : String(error)).toContain(message);
+    return;
+  }
+  throw new Error(`expected ${code}`);
+}
+
+describe("DevToolsClient", () => {
+  const servers: Array<Server | WebSocketServer> = [];
+
+  afterEach(() => {
+    for (const server of servers.splice(0)) {
+      server.close();
+    }
+  });
+
+  test("sends authenticated snapshot RPCs and records the latest seq", async () => {
+    const fixture = await httpFixture((body) => {
+      expect(body.method).toBe("getDevToolsSnapshot");
+      expect(body.params).toEqual({ runId: "run-client", frameNo: 7 });
+      return Response.json({ type: "res", id: body.id, ok: true, payload: snapshot(7) });
+    });
+    servers.push(fixture.server);
+    const client = new DevToolsClient({ baseUrl: fixture.baseUrl, apiKey: "srk_test" });
+
+    const result = await client.getDevToolsSnapshot("run-client", 7);
+
+    expect(result.seq).toBe(7);
+    expect(client.lastSeqSeen("run-client")).toBe(7);
+    expect(fixture.requests[0]?.authorization).toBe("Bearer srk_test");
+  });
+
+  test("falls back to workflowRuns.resume when runs.resume is unsupported", async () => {
+    const methods: string[] = [];
+    const fixture = await httpFixture((body) => {
+      methods.push(body.method);
+      if (body.method === "runs.resume") {
+        return Response.json({
+          type: "res",
+          id: body.id,
+          ok: false,
+          error: { code: "METHOD_NOT_FOUND", message: "method not found" },
+        });
+      }
+      return Response.json({
+        type: "res",
+        id: body.id,
+        ok: true,
+        payload: { result: { audit_row_id: "audit-123" } },
+      });
+    });
+    servers.push(fixture.server);
+    const client = new DevToolsClient({ baseUrl: fixture.baseUrl });
+
+    await expect(client.resume("run-client")).resolves.toEqual({ auditRowId: "audit-123" });
+    expect(methods).toEqual(["runs.resume", "workflowRuns.resume"]);
+  });
+
+  test("surfaces HTTP and RPC failures with Smithers error codes", async () => {
+    const httpFailure = await httpFixture(() => new Response("nope", { status: 503 }));
+    servers.push(httpFailure.server);
+    await expectSmithersError(
+      new DevToolsClient({ baseUrl: httpFailure.baseUrl }).cancel("run-client"),
+      "PI_GATEWAY_HTTP_ERROR",
+      "Gateway HTTP 503",
+    );
+
+    const rpcFailure = await httpFixture((body) => Response.json({
+      type: "res",
+      id: body.id,
+      ok: false,
+      error: { code: "RUN_LOCKED", message: "run is locked" },
+    }));
+    servers.push(rpcFailure.server);
+    await expectSmithersError(
+      new DevToolsClient({ baseUrl: rpcFailure.baseUrl }).cancel("run-client"),
+      "RUN_LOCKED",
+      "run is locked",
+    );
+  });
+
+  test("normalizes stream events, ignores other stream ids, and emits a gap resync for stale cursors", async () => {
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    servers.push(server);
+    server.on("connection", (ws) => {
+      ws.send(JSON.stringify({ type: "event", event: "connect.challenge", payload: {} }));
+      ws.on("message", (raw) => {
+        const frame = JSON.parse(String(raw));
+        if (frame.method === "connect") {
+          ws.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: {} }));
+          return;
+        }
+        if (frame.method === "streamDevTools" && frame.params.afterSeq === 10) {
+          ws.send(JSON.stringify({
+            type: "res",
+            id: frame.id,
+            ok: false,
+            error: { code: "SeqOutOfRange", message: "stale" },
+          }));
+          return;
+        }
+        if (frame.method === "streamDevTools") {
+          ws.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { streamId: "wanted" } }));
+          ws.send(JSON.stringify({
+            type: "event",
+            event: "devtools.event",
+            payload: { streamId: "other", event: { type: "snapshot", ...snapshot(1) } },
+          }));
+          ws.send(JSON.stringify({
+            type: "event",
+            event: "devtools.event",
+            payload: { streamId: "wanted", event: { type: "snapshot", ...snapshot(2) } },
+          }));
+        }
+      });
+    });
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected TCP server address");
+    }
+    const abort = new AbortController();
+    const client = new DevToolsClient({ baseUrl: `http://127.0.0.1:${address.port}` });
+    const stream = client.streamDevTools("run-client", 10, abort.signal);
+
+    expect(await next(stream)).toEqual({ version: 1, kind: "gapResync", gapResync: { fromSeq: 10, toSeq: 10 } });
+    const event = await next(stream);
+    expect(event.kind).toBe("snapshot");
+    expect(event.kind === "snapshot" ? event.snapshot.seq : undefined).toBe(2);
+    expect(client.lastSeqSeen("run-client")).toBe(2);
+    abort.abort();
+  });
+
+  test("throws devtools stream errors for the active stream", async () => {
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    servers.push(server);
+    server.on("connection", (ws) => {
+      ws.send(JSON.stringify({ type: "event", event: "connect.challenge", payload: {} }));
+      ws.on("message", (raw) => {
+        const frame = JSON.parse(String(raw));
+        if (frame.method === "connect") {
+          ws.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: {} }));
+        }
+        if (frame.method === "streamDevTools") {
+          ws.send(JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { streamId: "stream-1" } }));
+          ws.send(JSON.stringify({
+            type: "event",
+            event: "devtools.error",
+            payload: { streamId: "stream-1", error: { code: "BROKEN", message: "broken stream" } },
+          }));
+        }
+      });
+    });
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected TCP server address");
+    }
+    const stream = new DevToolsClient({ baseUrl: `http://127.0.0.1:${address.port}` })
+      .streamDevTools("run-client");
+
+    await expectSmithersError(stream.next(), "BROKEN", "broken stream");
+  });
+});

--- a/packages/pi-plugin/tests/DevToolsStore.behavior.test.ts
+++ b/packages/pi-plugin/tests/DevToolsStore.behavior.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { diffSnapshots } from "@smithers-orchestrator/devtools";
+import { DevToolsStore } from "../src/runtime/DevToolsStore.js";
+import type { DevToolsClient } from "../src/runtime/DevToolsClient.js";
+import type { DevToolsNode, DevToolsSnapshot } from "@smithers-orchestrator/protocol";
+
+function task(id: number, nodeId: string, state: string, props: Record<string, unknown> = {}): DevToolsNode {
+  return {
+    id,
+    type: "task",
+    name: nodeId,
+    props: { state, ...props },
+    task: { nodeId, kind: "compute", label: nodeId, iteration: 0 },
+    children: [],
+    depth: 1,
+  };
+}
+
+function snapshot(seq: number, children: DevToolsNode[], runId = "run-store"): DevToolsSnapshot {
+  return {
+    version: 1,
+    runId,
+    frameNo: seq,
+    seq,
+    root: {
+      id: 1,
+      type: "workflow",
+      name: "Workflow",
+      props: { state: children.some((child) => child.props.state === "running") ? "running" : "finished" },
+      children,
+      depth: 0,
+    },
+  };
+}
+
+function fakeClient(overrides: Partial<DevToolsClient>): DevToolsClient {
+  return overrides as DevToolsClient;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("timed out waiting for predicate");
+}
+
+describe("DevToolsStore historical controls", () => {
+  test("scrubTo loads a historical frame, buffers live updates, and returnToLive restores the live tree", async () => {
+    const live = snapshot(5, [task(2, "task:live", "running")]);
+    const historical = snapshot(2, [task(3, "task:past", "finished")]);
+    const resyncs: Array<number | undefined> = [];
+    const store = new DevToolsStore({
+      client: fakeClient({
+        getDevToolsSnapshot: async (_runId, frameNo) => (frameNo === 2 ? historical : live),
+        streamDevTools: async function* (_runId, afterSeq) {
+          resyncs.push(afterSeq);
+        },
+      }),
+    });
+
+    store.connect("run-store");
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: live });
+    await store.scrubTo(2);
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot(6, [task(4, "task:new-live", "running")]) });
+
+    expect(store.mode).toEqual({ kind: "historical", frameNo: 2 });
+    expect(store.tree?.children[0]?.task?.nodeId).toBe("task:past");
+    expect(store.bufferedLiveEvents).toBe(1);
+
+    store.returnToLive();
+
+    expect(store.mode).toEqual({ kind: "live" });
+    expect(store.tree?.children[0]?.task?.nodeId).toBe("task:new-live");
+    expect(store.bufferedLiveEvents).toBe(0);
+    expect(resyncs).toContain(undefined);
+    store.disconnect();
+  });
+
+  test("scrubTo returns to live at or beyond the latest frame and records missing-run errors", async () => {
+    const store = new DevToolsStore({
+      client: fakeClient({ getDevToolsSnapshot: async () => snapshot(0, []) }),
+    });
+
+    await store.scrubTo(1);
+    expect(store.scrubError).toMatchObject({ code: "PI_RUN_NOT_FOUND" });
+
+    store.connect("run-store");
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot(3, [task(2, "task:a", "running")]) });
+    await store.scrubTo(1);
+    expect(store.mode).toEqual({ kind: "historical", frameNo: 0 });
+    await store.scrubTo(3);
+    expect(store.mode).toEqual({ kind: "live" });
+    store.disconnect();
+  });
+
+  test("rewind requires confirmation and a historical live run, then records audit toast and returns live", async () => {
+    const toasts: string[] = [];
+    const calls: string[] = [];
+    const afterRewind = snapshot(9, [task(2, "task:rewound", "running")]);
+    const store = new DevToolsStore({
+      toastSink: (message) => toasts.push(message),
+      client: fakeClient({
+        rewind: async (_runId, frameNo, confirm) => {
+          calls.push(`${frameNo}:${confirm}`);
+          return { auditRowId: "audit-rewind" };
+        },
+        getDevToolsSnapshot: async (_runId, frameNo) => frameNo === 1
+          ? snapshot(1, [task(3, "task:past", "finished")])
+          : afterRewind,
+        streamDevTools: async function* () {},
+      }),
+    });
+
+    await store.rewind(1, true);
+    expect(store.rewindError).toMatchObject({ code: "PI_RUN_NOT_FOUND" });
+
+    store.connect("run-store");
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot(4, [task(2, "task:live", "running")]) });
+    await store.rewind(1, false);
+    expect(calls).toEqual([]);
+    await store.rewind(1, true);
+    expect(store.rewindError).toMatchObject({ code: "PI_CONFIRMATION_REQUIRED" });
+
+    await store.scrubTo(1);
+    await store.rewind(1, true);
+
+    expect(calls).toEqual(["1:true"]);
+    expect(store.mode).toEqual({ kind: "live" });
+    expect(store.tree?.children[0]?.task?.nodeId).toBe("task:rewound");
+    expect(store.lastAuditRowId).toBe("audit-rewind");
+    expect(toasts).toEqual(["Rewound to frame 1. Audit: audit-rewind"]);
+    store.disconnect();
+  });
+
+  test("ghost node budget evicts oldest removed records and clears an evicted ghost selection", () => {
+    const store = new DevToolsStore({ ghostNodeCap: 1 });
+    const first = snapshot(0, [
+      task(2, "task:first", "finished", { output: "first" }),
+      task(3, "task:second", "finished", { output: "second" }),
+    ]);
+    const second = snapshot(1, [task(3, "task:second", "finished", { output: "second" })]);
+    const third = snapshot(2, []);
+
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: first });
+    store.selectNode(2);
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: second });
+    expect(store.isGhost).toBe(true);
+    expect(store.ghostNodes.has("task:first")).toBe(true);
+
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: third });
+
+    expect([...store.ghostNodes.keys()]).toEqual(["task:second"]);
+    expect(store.isGhost).toBe(false);
+    expect(store.selectedNodeId).toBeUndefined();
+  });
+});
+
+describe("DevToolsStore reconnect state", () => {
+  test("failed streams mark stale state, reveal the stale banner, and reconnect with last seen seq", async () => {
+    const attempts: Array<number | undefined> = [];
+    const store = new DevToolsStore({
+      staleBannerDelayMs: 5,
+      client: fakeClient({
+        streamDevTools: async function* (_runId, afterSeq) {
+          attempts.push(afterSeq);
+          if (attempts.length === 1) {
+            yield { version: 1, kind: "snapshot", snapshot: snapshot(3, [task(2, "task:a", "running")]) };
+          }
+          throw new Error("stream dropped");
+        },
+      }),
+    });
+
+    store.connect("run-store");
+    await waitFor(() => attempts.length >= 2 && store.reconnectCount >= 1 && store.isStaleBannerVisible);
+
+    expect(store.connectionState.kind).toBe("error");
+    expect(store.staleSince).toBeInstanceOf(Date);
+    expect(store.reconnectCount).toBeGreaterThanOrEqual(1);
+    expect(attempts[0]).toBeUndefined();
+    expect(attempts[1]).toBe(3);
+    store.disconnect();
+  });
+
+  test("decode errors increment the counter and force the next reconnect to request a fresh stream", async () => {
+    const attempts: Array<number | undefined> = [];
+    const store = new DevToolsStore({
+      staleBannerDelayMs: 5,
+      client: fakeClient({
+        streamDevTools: async function* (_runId, afterSeq) {
+          attempts.push(afterSeq);
+          if (attempts.length === 1) {
+            throw new Error("DevTools event must be an object.");
+          }
+        },
+      }),
+    });
+
+    store.connect("run-store");
+    await waitFor(() => attempts.length >= 2);
+
+    expect(store.decodeErrorCount).toBe(1);
+    expect(attempts).toEqual([undefined, undefined]);
+    store.disconnect();
+  });
+});

--- a/packages/pi-plugin/tests/views.test.ts
+++ b/packages/pi-plugin/tests/views.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { DevToolsStore } from "../src/runtime/DevToolsStore.js";
+import { FrameScrubber } from "../src/views/FrameScrubber.js";
+import { Header } from "../src/views/Header.js";
+import { NodeInspector } from "../src/views/NodeInspector.js";
+import { RunTree } from "../src/views/RunTree.js";
+import type { DevToolsNode, DevToolsSnapshot } from "@smithers-orchestrator/protocol";
+
+const theme = {
+  fg: (color: string, value: string) => `<${color}>${value}</${color}>`,
+  bold: (value: string) => `**${value}**`,
+};
+const plainTheme = {
+  fg: (_color: string, value: string) => value,
+  bold: (value: string) => value,
+};
+
+function task(
+  id: number,
+  nodeId: string,
+  state: string,
+  props: Record<string, unknown> = {},
+  children: DevToolsNode[] = [],
+): DevToolsNode {
+  return {
+    id,
+    type: "task",
+    name: nodeId,
+    props: { state, ...props },
+    task: { nodeId, kind: "compute", label: nodeId, agent: "agent-a", iteration: 1 },
+    children,
+    depth: 1,
+  };
+}
+
+function snapshot(children: DevToolsNode[], extra: Partial<DevToolsSnapshot> = {}): DevToolsSnapshot {
+  return {
+    version: 1,
+    runId: "run-views",
+    frameNo: 12,
+    seq: 12,
+    root: {
+      id: 1,
+      type: "workflow",
+      name: "Workflow",
+      props: { state: "running" },
+      children,
+      depth: 0,
+    },
+    ...extra,
+  };
+}
+
+function storeWithTree(children: DevToolsNode[]) {
+  const store = new DevToolsStore();
+  store.runId = "run-views";
+  store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot(children) });
+  return store;
+}
+
+describe("RunTree", () => {
+  test("renders auto-expanded running and failed paths, supports search, and moves selection", () => {
+    const store = storeWithTree([
+      task(2, "task:running", "running", { id: "alpha" }),
+      task(3, "task:failed", "failed", { name: "bravo" }),
+    ]);
+    const tree = new RunTree(store);
+
+    const initial = tree.render(100, 6, theme).join("\n");
+    expect(initial).toContain("tree 3 rows");
+    expect(initial).toContain("task:running");
+    expect(initial).toContain("task:failed");
+    expect(store.selectedNodeId).toBe(1);
+
+    expect(tree.handleInput("j")).toBe("handled");
+    expect(store.selectedNodeId).toBe(2);
+    expect(tree.handleInput("/")).toBe("handled");
+    expect(tree.handleInput("f")).toBe("handled");
+    expect(tree.handleInput("a")).toBe("handled");
+    expect(tree.handleInput("i")).toBe("handled");
+    expect(tree.handleInput("l")).toBe("handled");
+    const filtered = tree.render(100, 6, theme).join("\n");
+    expect(filtered).toContain("/fail");
+    expect(filtered).toContain("task:failed");
+    expect(filtered).not.toContain("task:running");
+    expect(tree.handleInput("\x1b")).toBe("handled");
+    expect(tree.handleInput("\r")).toBe("focusInspector");
+  });
+});
+
+describe("NodeInspector", () => {
+  test("renders empty, output, diff, logs, error, tool calls, and ghost metadata states", () => {
+    const store = storeWithTree([
+      task(2, "task:inspect", "failed", {
+        output: { value: 42 },
+        diff: "- old\n+ new",
+        logs: ["line one"],
+        error: "boom",
+        toolCalls: [{ name: "write_file", status: "done", sideEffect: "filesystem" }],
+      }),
+    ]);
+    const inspector = new NodeInspector(store);
+
+    expect(inspector.render(80, 4, theme).join("\n")).toContain("select a node");
+
+    store.selectNode(2);
+    const output = inspector.render(180, 16, theme).join("\n");
+    expect(output).toContain("task:inspect");
+    expect(output).toContain("boom");
+    expect(output).toContain("write_file done filesystem");
+    expect(output).toContain('"value": 42');
+
+    expect(inspector.handleInput("2")).toBe("handled");
+    expect(inspector.render(120, 10, theme).join("\n")).toContain("- old");
+    expect(inspector.handleInput("3")).toBe("handled");
+    expect(inspector.render(120, 12, plainTheme).join("\n")).toContain("line one");
+
+    store.applyEvent({ version: 1, kind: "snapshot", snapshot: snapshot([], { frameNo: 13, seq: 13 }) });
+    const ghost = inspector.render(160, 10, plainTheme).join("\n");
+    expect(ghost).toContain("ghost: node no longer mounted at frame 13");
+  });
+});
+
+describe("Header", () => {
+  test("renders status, workflow, run id, seq, heartbeat ages, and non-streaming connection state", () => {
+    const store = storeWithTree([task(2, "task:a", "running")]);
+    store.connectionState = { kind: "connecting" };
+    store.runStatus = "waiting-approval";
+    store.runStateView = {
+      state: "blocked",
+      engineHeartbeatMs: 1_000,
+      engineHeartbeatAtMs: Date.now() - 1_500,
+      uiHeartbeatMs: 1_000,
+      uiHeartbeatAtMs: Date.now() - 6_000,
+    };
+    const header = new Header(store, "fixture-workflow");
+
+    const line = header.render(220, theme)[0] ?? "";
+
+    expect(line).toContain("WAITING-APPROVAL");
+    expect(line).toContain("fixture-workflow");
+    expect(line).toContain("run-views");
+    expect(line).toContain("blocked");
+    expect(line).toContain("eng");
+    expect(line).toContain("box");
+    expect(line).toContain("seq 12");
+    expect(line).toContain("connecting");
+  });
+});
+
+describe("FrameScrubber", () => {
+  test("renders live, historical, and error states and delegates keyboard input to the store", async () => {
+    const calls: number[] = [];
+    const store = storeWithTree([task(2, "task:a", "running")]);
+    const originalScrubTo = store.scrubTo.bind(store);
+    store.scrubTo = async (frameNo: number) => {
+      calls.push(frameNo);
+      await originalScrubTo(frameNo);
+    };
+    const scrubber = new FrameScrubber(store);
+
+    expect(scrubber.render(140, plainTheme).join("\n")).toContain("live");
+    expect(scrubber.handleInput("\x1b[D")).toBe(true);
+    expect(calls).toEqual([11]);
+    expect(scrubber.handleInput("\x1b[C")).toBe(true);
+    expect(calls).toEqual([11, 12]);
+    expect(scrubber.handleInput("x")).toBe(false);
+
+    store.mode = { kind: "historical", frameNo: 4 };
+    store.runningNodeCount = 2;
+    store.scrubError = new Error("snapshot unavailable");
+    const historical = scrubber.render(140, plainTheme).join("\n");
+    expect(historical).toContain("viewing stale frame 4; live has 12. 2 running at this frame.");
+    expect(historical).toContain("snapshot unavailable");
+
+    expect(scrubber.handleInput("\x1b[H")).toBe(true);
+    expect(calls.at(-1)).toBe(0);
+    expect(scrubber.handleInput("\x1b[F")).toBe(true);
+    expect(store.mode).toEqual({ kind: "live" });
+  });
+});


### PR DESCRIPTION
Relates to #306

## What

Added missing test coverage for the `pi-plugin` package's runtime DevTools surface. Three new test files were introduced:

- `packages/pi-plugin/tests/DevToolsClient.test.ts` — unit tests for the DevTools client, covering connection lifecycle, event dispatch, and error handling.
- `packages/pi-plugin/tests/DevToolsStore.behavior.test.ts` — behavioral tests for the DevTools store, verifying state transitions, subscriptions, and derived views.
- `packages/pi-plugin/tests/views.test.ts` — tests for the views layer, ensuring correct rendering behavior and view-model derivation from store state.

## Root cause & approach

Issue #306 identified that `packages/pi-plugin` lacked runtime test coverage for its DevTools client, store, and views — leaving regressions undetectable. Codex implemented the tests via TDD, writing tests against the existing public API without mocks of the modules under test. Both Codex and Claude Opus reviewed the implementation and approved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)