### PR TITLE
🐛 fix(usage): reject expired Claude OAuth tokens

### DIFF
--- a/packages/usage/src/claudeOauthUsage.js
+++ b/packages/usage/src/claudeOauthUsage.js
@@ -25,6 +25,9 @@ export async function claudeOauthUsage(account) {
     if (!creds) {
         return { source: "none", error: "No Claude OAuth credentials in configDir or Keychain" };
     }
+    if (typeof creds.expiresAt === "number" && creds.expiresAt <= Date.now()) {
+        return { source: "none", error: "Claude OAuth token expired; run `claude` to refresh" };
+    }
     try {
         const res = await fetch(USAGE_URL, {
             headers: {

--- a/packages/usage/tests/usage.test.js
+++ b/packages/usage/tests/usage.test.js
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
     buildUsageReport,
+    claudeOauthUsage,
     decodeJwtClaims,
     formatRelativeReset,
     formatUsageReports,
@@ -91,6 +92,35 @@ describe("parseClaudeOauthUsage", () => {
     test("tolerates junk", () => {
         expect(parseClaudeOauthUsage(null)).toEqual([]);
         expect(parseClaudeOauthUsage({ five_hour: { utilization: "x" } })).toEqual([]);
+    });
+});
+
+describe("claudeOauthUsage", () => {
+    test("does not send expired Claude OAuth tokens", async () => {
+        const configDir = mkdtempSync(join(tmpdir(), "smithers-claude-"));
+        tempDirs.push(configDir);
+        writeFileSync(join(configDir, ".credentials.json"), JSON.stringify({
+            claudeAiOauth: {
+                accessToken: "expired-token",
+                expiresAt: Date.now() - 1,
+            },
+        }));
+        const originalFetch = globalThis.fetch;
+        let fetchCalls = 0;
+        globalThis.fetch = /** @type {typeof fetch} */ (async () => {
+            fetchCalls += 1;
+            return new Response("{}");
+        });
+        try {
+            const result = await claudeOauthUsage({ configDir });
+            expect(fetchCalls).toBe(0);
+            expect(result).toMatchObject({
+                source: "none",
+                error: "Claude OAuth token expired; run `claude` to refresh",
+            });
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
     });
 });
 


### PR DESCRIPTION
Relates to #307

## What & Why

`claudeOauthUsage` read the Claude OAuth token from credentials but never inspected the `expiresAt` field. Expired tokens were forwarded to the Claude usage API, resulting in silent failures or confusing 401 errors.

## How

Added an expiry guard in `packages/usage/src/claudeOauthUsage.js` before the `fetch` call: if `creds.expiresAt` is set and is in the past, return early with a descriptive error (`"Claude OAuth token expired; run \`claude\` to refresh"`) instead of sending the request.

A new TDD test in `packages/usage/tests/usage.test.js` stubs `globalThis.fetch` and asserts it is **never called** when the token is expired.

**Key files:**
- `packages/usage/src/claudeOauthUsage.js` — expiry guard added before fetch
- `packages/usage/tests/usage.test.js` — test verifies fetch is skipped on expired token

Codex implemented this via TDD; Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)