### PR TITLE
🐛 fix(gateway-react): initialize extension stream state as not streaming

### DIFF
--- a/packages/gateway-react/src/useGatewayExtensionStream.ts
+++ b/packages/gateway-react/src/useGatewayExtensionStream.ts
@@ -50,7 +50,7 @@ export function useGatewayExtensionStream<T = unknown>(
   const [frames, setFrames] = useState<T[]>([]);
   const [latest, setLatest] = useState<T>();
   const [error, setError] = useState<Error>();
-  const [streaming, setStreaming] = useState(enabled);
+  const [streaming, setStreaming] = useState(false);
 
   useEffect(() => {
     if (!enabled || !namespace || !key) {

--- a/packages/gateway-react/tests/extension-hooks.test.ts
+++ b/packages/gateway-react/tests/extension-hooks.test.ts
@@ -158,6 +158,29 @@ describe("useGatewayExtensionAction", () => {
 });
 
 describe("useGatewayExtensionStream", () => {
+  test("does not report streaming before the subscription effect starts", async () => {
+    const streamingSnapshots: boolean[] = [];
+    const client = {
+      streamExtension: async function* () {
+        await new Promise(() => {});
+      },
+    } as unknown as SmithersGatewayClient;
+
+    function Probe() {
+      const snapshot = useGatewayExtensionStream("logs", "tail");
+      streamingSnapshots.push(snapshot.streaming);
+      return null;
+    }
+
+    const harness = await mountHarness();
+    await harness.render(
+      createElement(SmithersGatewayProvider, { client }, createElement(Probe)),
+    );
+
+    expect(streamingSnapshots[0]).toBe(false);
+    await harness.unmount();
+  });
+
   test("re-renders with a fresh backoff literal do NOT re-subscribe", async () => {
     // The hook used to depend on `options.backoff` as an unstable object
     // reference, so every parent re-render would tear down + resubscribe.


### PR DESCRIPTION
Relates to #307

## What was fixed

The `useGatewayExtensionStream` hook initialized its internal streaming state incorrectly, causing consumers to briefly see a "streaming" state on mount before any stream had started. This led to premature UI updates and incorrect initial render behavior.

## Root cause & approach

The root cause was that the initial state value for the streaming flag in `useGatewayExtensionStream.ts` was set to `true` (or left uninitialized in a way that evaluated as truthy) rather than `false`. The fix sets the initial streaming state explicitly to `false`, ensuring the hook starts in a non-streaming state and only transitions to streaming when a stream actually begins.

Key files changed:
- `packages/gateway-react/src/useGatewayExtensionStream.ts` — corrected initial state
- `packages/gateway-react/tests/extension-hooks.test.ts` — added/updated tests covering the initial-state behavior (TDD approach: tests written first, then the fix)

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the implementation before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)