### PR TITLE
🐛 fix(gateway-react): include params in refetch dependencies

### DIFF
--- a/packages/gateway-react/src/useGatewayApprovals.ts
+++ b/packages/gateway-react/src/useGatewayApprovals.ts
@@ -17,7 +17,7 @@ export function useGatewayApprovals(params: ListApprovalsRequest = {}): GatewayA
   const live = useLiveQuery((q) => q.from({ row: collection }), [collection]);
   const refetch = useCallback(async () => {
     await registry.invalidate(gatewayKeys.approvals(params));
-  }, [registry, collection]);
+  }, [registry, collection, params]);
 
   const data = (live.data ?? []) as GatewayApprovalRow[] as ListApprovalsResponse;
   return {

--- a/packages/gateway-react/src/useGatewayRuns.ts
+++ b/packages/gateway-react/src/useGatewayRuns.ts
@@ -15,7 +15,7 @@ export function useGatewayRuns(params: ListRunsRequest = {}): GatewayAsyncState<
   const live = useLiveQuery((q) => q.from({ row: collection }), [collection]);
   const refetch = useCallback(async () => {
     await registry.invalidate(gatewayKeys.runs(params));
-  }, [registry, collection]);
+  }, [registry, collection, params]);
 
   const data = (live.data ?? []) as GatewayRunSummaryRow[] as GatewayRpcPayload<"listRuns">;
   return {

--- a/packages/gateway-react/src/useGatewayWorkflows.ts
+++ b/packages/gateway-react/src/useGatewayWorkflows.ts
@@ -16,7 +16,7 @@ export function useGatewayWorkflows(params: ListWorkflowsRequest = {}): GatewayA
   const live = useLiveQuery((q) => q.from({ row: collection }), [collection]);
   const refetch = useCallback(async () => {
     await registry.invalidate(gatewayKeys.workflows(params.filter));
-  }, [registry, collection]);
+  }, [registry, collection, params]);
 
   const data = (live.data ?? []) as GatewayWorkflowRow[] as ListWorkflowsResponse;
   return {

--- a/packages/gateway-react/tests/sync/sync.test.ts
+++ b/packages/gateway-react/tests/sync/sync.test.ts
@@ -4,6 +4,8 @@
 // the only seam is a fake `SyncTransport` whose rpc/stream handlers return real
 // promises and real async iterables (no hook logic is faked).
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // happy-dom errors if registered twice across test files in the same bun run.
 if (typeof globalThis.document === "undefined") {
@@ -487,6 +489,23 @@ describe("useGatewayRunStream", () => {
 });
 
 describe("legacy synced hooks over collections", () => {
+  test("list hook refetch callbacks depend on params", () => {
+    const hooks = [
+      "useGatewayApprovals.ts",
+      "useGatewayRuns.ts",
+      "useGatewayWorkflows.ts",
+    ];
+
+    for (const hook of hooks) {
+      const source = readFileSync(
+        fileURLToPath(new URL(`../../src/${hook}`, import.meta.url)),
+        "utf8",
+      );
+      expect(source).toContain("const refetch = useCallback(async () => {");
+      expect(source).toMatch(/\}, \[[^\]]*\bparams\b[^\]]*\]\);/);
+    }
+  });
+
   test("useGatewayRuns lists rows from listRuns", async () => {
     const registry = createGatewayCollections({
       client: makeTransport((method) => {


### PR DESCRIPTION
Relates to #307

## What was fixed

The `refetch` callbacks in `useGatewayRuns`, `useGatewayWorkflows`, and `useGatewayApprovals` were missing `params` from their `useCallback` dependency arrays. This meant that when the `params` argument changed (e.g. a filter was updated by the caller), the captured `params` inside the callback would be stale — the invalidation call would target the old cache key rather than the new one, silently failing to trigger a fresh fetch.

## Root cause & approach

Each hook calls `registry.invalidate(gatewayKeys.<resource>(params))` inside a `useCallback`, but only listed `[registry, collection]` as dependencies. Adding `params` to the dep array ensures the callback is recreated whenever params change, so the correct cache key is always invalidated.

Files changed:
- `packages/gateway-react/src/useGatewayApprovals.ts`
- `packages/gateway-react/src/useGatewayRuns.ts`
- `packages/gateway-react/src/useGatewayWorkflows.ts`
- `packages/gateway-react/tests/sync/sync.test.ts` (TDD regression test)

Codex implemented this via TDD (test first, then fix). Both Codex and Claude Opus approved the change in dual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)