### PR TITLE
🐛 fix(control-plane): map duplicate slugs to SmithersError

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -13282,6 +13282,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -7945,6 +7945,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/apps/cli/tests/docs-public-surface-coverage.test.js
+++ b/apps/cli/tests/docs-public-surface-coverage.test.js
@@ -619,6 +619,47 @@ test("community connector spec documents the long-tail package contract", () => 
     for (const term of loaderTerms) expect(doc).toContain(term);
 });
 
+test("community connector spec documents the long-tail package contract", () => {
+    const docsConfig = readRepoFile("docs/docs.json");
+    expect(docsConfig).toContain("integrations/community-connectors");
+
+    const doc = readRepoFile("docs/integrations/community-connectors.mdx");
+    const requiredSections = [
+        "## Package Layout",
+        "## Manifest Format",
+        "## Loader Contract",
+        "## Tool Declarations",
+        "## Trigger Declarations",
+        "## Auth Requirements",
+        "## Tier 0 Integration Points",
+        "## Anti-Patterns",
+    ];
+    const manifestKeys = [
+        "smithers.connector.v1",
+        "tools",
+        "triggers",
+        "auth",
+        "surfaces",
+        "oauth",
+        "tokenBroker",
+        "mcp",
+        "openapi",
+        "webhooks",
+    ];
+    const loaderTerms = [
+        "validate the manifest",
+        "project tools",
+        "register triggers",
+        "resolve auth",
+        "enforce scopes",
+        "idempotency",
+    ];
+
+    for (const section of requiredSections) expect(doc).toContain(section);
+    for (const key of manifestKeys) expect(doc).toContain(key);
+    for (const term of loaderTerms) expect(doc).toContain(term);
+});
+
 test("memory docs cover current MemoryStore method names", () => {
     const memoryStoreSource = readRepoFile("packages/memory/src/store/MemoryStore.ts");
     const docs = `${readRepoFile("docs/concepts/memory.mdx")}\n${readRepoFile("docs/reference/types.mdx")}`;

--- a/docs/concepts/openapi-tools.mdx
+++ b/docs/concepts/openapi-tools.mdx
@@ -108,6 +108,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13282,6 +13282,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7945,6 +7945,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -3509,6 +3509,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/docs/llms-openapi.txt
+++ b/docs/llms-openapi.txt
@@ -113,6 +113,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.

--- a/packages/control-plane/src/index.js
+++ b/packages/control-plane/src/index.js
@@ -335,6 +335,33 @@ function projectKey(projectId) {
 }
 
 /**
+ * @param {unknown} error
+ * @param {string} constraint
+ */
+function isUniqueConstraintError(error, constraint) {
+    return error instanceof Error && error.message.includes(`UNIQUE constraint failed: ${constraint}`);
+}
+
+/**
+ * @param {unknown} error
+ * @param {{ entity: "org" | "team" | "project"; slug: string; orgId?: string }} input
+ */
+function throwDuplicateSlugError(error, input) {
+    const details = {
+        kind: `control-plane.${input.entity}`,
+        id: input.slug,
+        slug: input.slug,
+        ...(input.orgId ? { orgId: input.orgId } : {}),
+    };
+    throw new SmithersError(
+        "DUPLICATE_ID",
+        `Duplicate control-plane ${input.entity} slug: ${input.slug}`,
+        details,
+        { cause: error },
+    );
+}
+
+/**
  * @param {Record<string, unknown>} row
  * @returns {ControlPlaneOrg}
  */
@@ -513,11 +540,20 @@ export class ControlPlaneStore {
      */
     createOrg(input) {
         const orgId = optionalId("orgId", input.orgId);
+        const orgSlug = slug("slug", input.slug);
         const createdAtMs = timestamp(input.createdAtMs);
-        this.sqlite.query(`
+        try {
+            this.sqlite.query(`
 INSERT INTO _smithers_cp_orgs (org_id, slug, name, created_at_ms)
 VALUES (?, ?, ?, ?)
-`).run(orgId, slug("slug", input.slug), nonEmptyString("name", input.name), createdAtMs);
+`).run(orgId, orgSlug, nonEmptyString("name", input.name), createdAtMs);
+        }
+        catch (error) {
+            if (isUniqueConstraintError(error, "_smithers_cp_orgs.slug")) {
+                throwDuplicateSlugError(error, { entity: "org", slug: orgSlug });
+            }
+            throw error;
+        }
         this.recordAuditEvent({
             orgId,
             actorId: "system",
@@ -550,11 +586,20 @@ LIMIT 1
     createTeam(input) {
         const orgId = requiredId("orgId", input.orgId);
         const teamId = optionalId("teamId", input.teamId);
+        const teamSlug = slug("slug", input.slug);
         const createdAtMs = timestamp(input.createdAtMs);
-        this.sqlite.query(`
+        try {
+            this.sqlite.query(`
 INSERT INTO _smithers_cp_teams (org_id, team_id, slug, name, created_at_ms)
 VALUES (?, ?, ?, ?, ?)
-`).run(orgId, teamId, slug("slug", input.slug), nonEmptyString("name", input.name), createdAtMs);
+`).run(orgId, teamId, teamSlug, nonEmptyString("name", input.name), createdAtMs);
+        }
+        catch (error) {
+            if (isUniqueConstraintError(error, "_smithers_cp_teams.org_id, _smithers_cp_teams.slug")) {
+                throwDuplicateSlugError(error, { entity: "team", slug: teamSlug, orgId });
+            }
+            throw error;
+        }
         this.recordAuditEvent({
             orgId,
             action: "team.create",
@@ -603,12 +648,21 @@ ON CONFLICT(org_id, team_id, user_id) DO UPDATE SET role = excluded.role
     createProject(input) {
         const orgId = requiredId("orgId", input.orgId);
         const projectId = optionalId("projectId", input.projectId);
+        const projectSlug = slug("slug", input.slug);
         const metadata = jsonObject(input.metadata);
         const createdAtMs = timestamp(input.createdAtMs);
-        this.sqlite.query(`
+        try {
+            this.sqlite.query(`
 INSERT INTO _smithers_cp_projects (org_id, project_id, slug, name, metadata_json, created_at_ms)
 VALUES (?, ?, ?, ?, ?, ?)
-`).run(orgId, projectId, slug("slug", input.slug), nonEmptyString("name", input.name), JSON.stringify(metadata), createdAtMs);
+`).run(orgId, projectId, projectSlug, nonEmptyString("name", input.name), JSON.stringify(metadata), createdAtMs);
+        }
+        catch (error) {
+            if (isUniqueConstraintError(error, "_smithers_cp_projects.org_id, _smithers_cp_projects.slug")) {
+                throwDuplicateSlugError(error, { entity: "project", slug: projectSlug, orgId });
+            }
+            throw error;
+        }
         this.recordAuditEvent({
             orgId,
             projectId,

--- a/packages/control-plane/tests/control-plane.test.js
+++ b/packages/control-plane/tests/control-plane.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 import { ControlPlaneStore, ensureControlPlaneTables } from "../src/index.js";
 
 function makeStore() {
@@ -17,6 +18,45 @@ describe("ControlPlaneStore", () => {
       const project = store.createProject({ orgId: org.orgId, projectId: "project_b", slug: "b", name: "B", createdAtMs: 3 });
       expect(team.slug).toBe("a");
       expect(project.slug).toBe("b");
+    }
+    finally {
+      sqlite.close();
+    }
+  });
+
+  test("maps duplicate slugs to typed Smithers errors", () => {
+    const { sqlite, store } = makeStore();
+    try {
+      store.createOrg({ orgId: "org_acme", slug: "acme", name: "Acme", createdAtMs: 1 });
+
+      expect(() =>
+        store.createOrg({ orgId: "org_other", slug: "acme", name: "Other", createdAtMs: 2 }),
+      ).toThrow(SmithersError);
+      expect(() =>
+        store.createOrg({ orgId: "org_other", slug: "acme", name: "Other", createdAtMs: 2 }),
+      ).toThrow(expect.objectContaining({
+        code: "DUPLICATE_ID",
+        summary: "Duplicate control-plane org slug: acme",
+        details: { kind: "control-plane.org", id: "acme", slug: "acme" },
+      }));
+
+      store.createTeam({ orgId: "org_acme", teamId: "team_ops", slug: "ops", name: "Ops", createdAtMs: 3 });
+      expect(() =>
+        store.createTeam({ orgId: "org_acme", teamId: "team_support", slug: "ops", name: "Support", createdAtMs: 4 }),
+      ).toThrow(expect.objectContaining({
+        code: "DUPLICATE_ID",
+        summary: "Duplicate control-plane team slug: ops",
+        details: { kind: "control-plane.team", id: "ops", slug: "ops", orgId: "org_acme" },
+      }));
+
+      store.createProject({ orgId: "org_acme", projectId: "project_api", slug: "api", name: "API", createdAtMs: 5 });
+      expect(() =>
+        store.createProject({ orgId: "org_acme", projectId: "project_web", slug: "api", name: "Web", createdAtMs: 6 }),
+      ).toThrow(expect.objectContaining({
+        code: "DUPLICATE_ID",
+        summary: "Duplicate control-plane project slug: api",
+        details: { kind: "control-plane.project", id: "api", slug: "api", orgId: "org_acme" },
+      }));
     }
     finally {
       sqlite.close();

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -13282,6 +13282,252 @@ Before accepting a community connector, verify:
 
 ---
 
+## Community Connectors
+
+> Package long-tail integrations as manifest-declared tools, triggers, and auth requirements.
+
+Community connectors are package-level integration descriptors. They let a maintainer publish one connector package that projects agent-callable tools and triggers onto Smithers' existing Tier 0 substrate instead of adding one workflow node per app.
+
+A connector package is declarative at the boundary: the manifest says what tool and trigger surfaces exist, which auth grants they require, and which runtime adapter should load them. Runtime code may still live in the package, but Smithers only discovers it through the loader contract below.
+
+## Package Layout
+
+```text
+smithers-connector-acme/
+  package.json
+  smithers.connector.json
+  openapi/acme.yaml
+  mcp/server.json
+  src/index.ts
+  README.md
+```
+
+`smithers.connector.json` is the contract. `package.json` should expose the loader module with a normal ESM export and include a `smithers.connector` field that points at the manifest:
+
+```json
+{
+  "name": "smithers-connector-acme",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "smithers": {
+    "connector": "./smithers.connector.json"
+  }
+}
+```
+
+## Manifest Format
+
+The manifest format id is `smithers.connector.v1`. Unknown top-level keys are ignored, but unknown keys inside `tools`, `triggers`, `auth`, and `surfaces` must fail validation so package authors notice typos before an agent receives the tool catalog.
+
+```json
+{
+  "schema": "smithers.connector.v1",
+  "id": "acme",
+  "name": "Acme",
+  "version": "0.1.0",
+  "description": "Curated Acme tools for Smithers agents.",
+  "loader": "./src/index.ts",
+  "auth": {
+    "oauth": {
+      "provider": "acme",
+      "grant": "authorization_code_pkce",
+      "scopes": ["tickets:read", "tickets:write"],
+      "tenantKey": "workspace_id"
+    }
+  },
+  "surfaces": {
+    "openapi": {
+      "spec": "./openapi/acme.yaml",
+      "baseUrl": "https://api.acme.example"
+    },
+    "mcp": {
+      "command": "node",
+      "args": ["./dist/mcp-server.js"]
+    },
+    "webhooks": {
+      "provider": "acme",
+      "signature": "hmac-sha256",
+      "idempotencyKey": "$.event_id"
+    }
+  },
+  "tools": [
+    {
+      "name": "acme_create_ticket",
+      "surface": "openapi",
+      "operationId": "createTicket",
+      "description": "Create one Acme ticket after checking for an existing ticket with the same external id.",
+      "auth": "oauth",
+      "scopes": ["tickets:write"],
+      "sideEffect": true,
+      "idempotency": {
+        "key": "externalId",
+        "required": true
+      }
+    },
+    {
+      "name": "acme_search_tickets",
+      "surface": "mcp",
+      "tool": "search_tickets",
+      "description": "Search Acme tickets by text, status, assignee, or customer.",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "sideEffect": false
+    }
+  ],
+  "triggers": [
+    {
+      "name": "acme_ticket_updated",
+      "surface": "webhook",
+      "event": "ticket.updated",
+      "auth": "oauth",
+      "scopes": ["tickets:read"],
+      "dedupe": {
+        "key": "$.event_id"
+      },
+      "payloadSchema": {
+        "type": "object",
+        "required": ["ticketId"],
+        "properties": {
+          "ticketId": { "type": "string" }
+        }
+      }
+    }
+  ],
+  "tokenBroker": {
+    "audience": "acme",
+    "defaultTtlSeconds": 300,
+    "allowedActions": ["acme_create_ticket", "acme_search_tickets"]
+  }
+}
+```
+
+## Loader Contract
+
+A Smithers connector loader must:
+
+1. validate the manifest before loading package code.
+2. resolve auth through the OAuth plane and token broker, never by handing durable credentials to an LLM-visible tool call.
+3. project tools from `surfaces.openapi`, `surfaces.mcp`, or the package loader into AI SDK-compatible tools.
+4. register triggers from `surfaces.webhooks` with signature verification and dedupe before workflow dispatch.
+5. enforce scopes for every tool and trigger invocation against the connected user and tenant.
+6. Preserve idempotency metadata so retries and resumes can avoid duplicate write-side effects.
+
+Loader modules export one named `loadConnector` function:
+
+```ts
+export type SmithersConnectorContext = {
+  manifest: unknown;
+  connection: {
+    userId: string;
+    tenantId?: string;
+    scopes: string[];
+  };
+  tokenBroker: {
+    issue(input: {
+      audience: string;
+      scopes: string[];
+      action: string;
+      ttlSeconds?: number;
+    }): Promise<{ token: string; expiresAt: string }>;
+  };
+};
+
+export async function loadConnector(ctx: SmithersConnectorContext) {
+  return {
+    tools: {},
+    triggers: [],
+  };
+}
+```
+
+The loader may add custom tools that cannot be represented by OpenAPI or MCP, but those tools still need manifest entries. The manifest remains the auditable catalog Smithers can show to agents and humans.
+
+## Tool Declarations
+
+Each tool declaration describes one agent-callable capability, not one raw endpoint. Prefer a small curated surface with clear names and task-shaped descriptions.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable tool name exposed to the agent. Prefix with the connector id. |
+| `surface` | `openapi`, `mcp`, or `custom`. |
+| `description` | Agent-facing behavior, limits, and recovery guidance. |
+| `auth` | Auth profile key, or `none` for public tools. |
+| `scopes` | Minimum delegated scopes required for this action. |
+| `sideEffect` | `true` for writes, sends, charges, deletes, or external state changes. |
+
+OpenAPI tools bind with `operationId`. MCP tools bind with the upstream MCP `tool` name. Custom tools bind to code returned by `loadConnector`.
+
+Side-effecting tools must declare `idempotency.required: true` unless the upstream provider supplies an equivalent idempotency key, request id, or natural unique key.
+
+## Trigger Declarations
+
+Triggers describe external events that can start or resume workflows. They are not workflow nodes and should not grow into a provider-specific palette.
+
+Required fields:
+
+| Field | Purpose |
+|---|---|
+| `name` | Stable trigger id exposed to workflow authors. |
+| `surface` | `webhook`, `poll`, or `mcp`. |
+| `event` | Provider event name or polling resource. |
+| `auth` | Auth profile key required to subscribe or poll. |
+| `dedupe.key` | JSONPath or provider event id used for idempotent dispatch. |
+
+Webhook triggers must declare the provider signature scheme and payload mapper through `surfaces.webhooks`. Poll triggers must declare interval bounds and cursor storage requirements in the manifest before registration.
+
+## Auth Requirements
+
+Connector auth declarations are requirements, not secrets. The OAuth plane owns authorization-code + PKCE flows, encrypted refresh-token storage, single-flight refresh, and per-user/per-tenant scoping.
+
+Supported auth profiles:
+
+| Profile | Use |
+|---|---|
+| `oauth` | Delegated per-user OAuth through the Smithers OAuth plane. |
+| `apiKey` | User-supplied key stored in the credential vault, exposed only through the token broker. |
+| `none` | Public or local-only tools. |
+
+Do not put tokens, client secrets, refresh tokens, service-account credentials, or shared bot tokens in a connector package. Runtime calls receive scoped action tokens from the `tokenBroker`, and the broker exchanges or unwraps provider credentials outside the agent transcript.
+
+## Tier 0 Integration Points
+
+Community connectors plug into existing universal surfaces:
+
+| Tier 0 surface | Connector field | Loader behavior |
+|---|---|---|
+| OAuth plane | `auth.oauth` | Resolve delegated user consent, tenant key, scopes, and refresh lifecycle. |
+| Scoped token broker | `tokenBroker` and per-tool `scopes` | Issue short-lived, revocable, auditable action tokens the LLM never sees. |
+| OpenAPI tools | `surfaces.openapi` + `tools[].operationId` | Build curated tools with `createOpenApiTools`; never dump every endpoint by default. |
+| MCP client | `surfaces.mcp` + `tools[].tool` | Pass selected MCP tools through with names and descriptions from the manifest. |
+| Webhook ingress | `surfaces.webhooks` + `triggers[]` | Verify signatures, map payloads, dedupe events, and dispatch workflows. |
+| Generic HTTP / sandbox | `surface: "custom"` | Run package code for cases that cannot be expressed as OpenAPI or MCP. |
+
+## Anti-Patterns
+
+- Do not add a node per app. Connectors contribute agent tools and triggers, not a giant fixed-schema workflow palette.
+- Do not publish every OpenAPI operation as a tool. Collapse noisy endpoint sets into task-shaped actions.
+- Do not bypass delegated OAuth with service-account or shared-bot tokens.
+- Do not refresh tokens independently in each tool call; refresh must go through the single-flight OAuth/token broker path.
+- Do not omit idempotency from write tools or webhook triggers.
+- Do not hide tool behavior in package code when it can be declared in the manifest.
+
+## Review Checklist
+
+Before accepting a community connector, verify:
+
+- The manifest validates as `smithers.connector.v1`.
+- Every tool has a clear description, auth profile, scope list, and side-effect marker.
+- Every write tool has idempotency metadata.
+- Every trigger has signature verification or polling cursor rules plus dedupe.
+- OAuth scopes are the minimum needed for the declared tools and triggers.
+- The package uses OpenAPI, MCP, webhook ingress, or the token broker instead of inventing a parallel integration plane.
+
+---
+
 ## Ecosystem
 
 > Community projects built on Smithers.

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -7945,6 +7945,8 @@ Use `operations` for per-operation curation keyed by the original `operationId`.
 
 Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
 
+Use `operations` for per-operation curation keyed by the original `operationId`. Set an entry to `false` or `{ include: false }` to skip that endpoint, set `name` to rename the generated tool, set `description` to replace the spec summary/description with agent-facing instructions, and add `responseExamples` to append concrete response shapes to the tool description. This lets a connector expose a small curated set instead of dumping every endpoint as an agent-callable tool. `include` / `exclude` still use the original `operationId`, not the curated name.
+
 ## Observability
 
 OpenAPI tool calls update the exported Effect metrics (`openApiToolCallsTotal`, `openApiToolCallErrorsTotal`, `openApiToolDuration`) and carry Effect log annotations/spans with the operation id, method, and path. The current tool factory does not emit `OpenApiToolCalled` onto the Smithers run event bus; that event variant is typed/categorized for future event-bus integration.


### PR DESCRIPTION
Relates to #307

## What was fixed

`ControlPlaneStore.createOrg`, `createTeam`, and `createProject` previously leaked raw SQLite `UNIQUE constraint failed` errors to callers when a duplicate slug was inserted. Callers had no typed way to detect or handle the conflict.

## Root cause & approach

SQLite throws a plain `Error` with a message containing `UNIQUE constraint failed: <table>.<column>` on duplicate inserts. The fix wraps each of the three INSERT statements in a `try/catch` that:

1. Detects the constraint violation via `isUniqueConstraintError(error, constraint)`.
2. Re-throws as `new SmithersError("DUPLICATE_ID", …, details, { cause: error })` with structured `details` (`kind`, `id`, `slug`, and `orgId` where applicable).

All other errors are re-thrown unchanged.

## Key files

- `packages/control-plane/src/index.js` — added `isUniqueConstraintError` and `throwDuplicateSlugError` helpers; wrapped `createOrg`, `createTeam`, `createProject` INSERT calls.
- `packages/control-plane/tests/control-plane.test.js` — new test asserting that duplicate-slug attempts on all three entity types throw `SmithersError` with `code: "DUPLICATE_ID"` and the correct `summary` and `details`.

Codex implemented this via TDD; both Codex and Claude Opus reviewed and approved the change before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)