### PR TITLE
🐛 fix(usage): reject malformed duration strings

### DIFF
--- a/packages/usage/src/parseDurationSeconds.js
+++ b/packages/usage/src/parseDurationSeconds.js
@@ -20,8 +20,11 @@ export function parseDurationSeconds(value) {
     const re = /(\d+(?:\.\d+)?)(ms|us|µs|ns|s|m|h)/g;
     let total = 0;
     let matched = false;
+    let position = 0;
     let match;
     while ((match = re.exec(trimmed)) !== null) {
+        if (match.index !== position) return undefined;
+        position = re.lastIndex;
         matched = true;
         const amount = Number(match[1]);
         switch (match[2]) {
@@ -34,5 +37,5 @@ export function parseDurationSeconds(value) {
             case "ns": total += amount / 1_000_000_000; break;
         }
     }
-    return matched ? total : undefined;
+    return matched && position === trimmed.length ? total : undefined;
 }

--- a/packages/usage/tests/usage.test.js
+++ b/packages/usage/tests/usage.test.js
@@ -56,6 +56,8 @@ describe("parseDurationSeconds", () => {
         expect(parseDurationSeconds(null)).toBeUndefined();
         expect(parseDurationSeconds("")).toBeUndefined();
         expect(parseDurationSeconds("nope")).toBeUndefined();
+        expect(parseDurationSeconds("nope1s")).toBeUndefined();
+        expect(parseDurationSeconds("1sx")).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
Relates to #307

## What was fixed

`parseDurationSeconds` in `packages/usage/src/parseDurationSeconds.js` accepted strings with leading garbage or trailing characters — e.g. `"nope1s"` and `"1sx"` both returned a numeric value instead of `undefined`. The regex `/(\d+(?:\.\d+)?)(ms|us|µs|ns|s|m|h)/g` would silently skip non-matching characters and only match the embedded unit tokens.

## How it was fixed

Added position tracking inside the match loop. After each `re.exec` hit, the code checks that `match.index === position` (no gap since the last match end) and advances `position` to `re.lastIndex`. After the loop, the final return also guards that `position === trimmed.length` (nothing left unconsumed). Together these two checks ensure the full input consists of back-to-back valid unit tokens with no stray text anywhere.

Tests in `packages/usage/tests/usage.test.js` were extended with `"nope1s"` and `"1sx"` cases that previously passed but should have returned `undefined`.

Codex implemented the fix via TDD; Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)