### PR TITLE
🐛 fix(engine): stop advancing EventBus seq for DB-assigned events

### DIFF
--- a/packages/engine/src/events.js
+++ b/packages/engine/src/events.js
@@ -133,16 +133,16 @@ export class EventBus extends EventEmitter {
             type: event.type,
             payloadJson,
         };
-        const eventRow = {
-            ...nextSeqRow,
-            seq: this.seq++,
-        };
         if (typeof this.db.insertEventWithNextSeqEffect === "function") {
             return this.callDbPersistence(`insert event ${event.type}`, this.db.insertEventWithNextSeqEffect, nextSeqRow);
         }
         if (typeof this.db.insertEventWithNextSeq === "function") {
             return this.callDbPersistence(`insert event ${event.type}`, this.db.insertEventWithNextSeq, nextSeqRow);
         }
+        const eventRow = {
+            ...nextSeqRow,
+            seq: this.seq++,
+        };
         if (typeof this.db.insertEventEffect === "function") {
             return this.callDbPersistence(`insert event ${event.type}`, this.db.insertEventEffect, eventRow);
         }

--- a/packages/engine/tests/events-advanced.test.js
+++ b/packages/engine/tests/events-advanced.test.js
@@ -77,6 +77,20 @@ describe("EventBus", () => {
         expect(inserted).toHaveLength(1);
         expect(inserted[0].runId).toBe("seq-test");
     });
+    test("does not advance local seq when DB assigns event seq", async () => {
+        const inserted = [];
+        const mockDb = {
+            insertEventWithNextSeqEffect: (row) => {
+                inserted.push(row);
+                return Effect.void;
+            },
+        };
+        const bus = new EventBus({ db: mockDb, startSeq: 42 });
+        await Effect.runPromise(bus.emitEvent(makeEvent({ runId: "db-assigned-seq" })));
+        expect(inserted).toHaveLength(1);
+        expect(inserted[0].seq).toBeUndefined();
+        expect(bus.seq).toBe(42);
+    });
     test("works without DB (no persistence)", async () => {
         const bus = new EventBus({});
         const events = [];


### PR DESCRIPTION
Relates to #307

## What was fixed

`EventBus.emitEvent()` unconditionally incremented the local `this.seq` counter before checking which DB persistence path to use. When the DB-assigned-seq paths (`insertEventWithNextSeqEffect` / `insertEventWithNextSeq`) were present, the local counter was still advanced even though the DB would assign the actual sequence number. Over time this caused `seq` to drift out of sync with the DB, eventually producing a dead state where the engine stalled waiting on a sequence value that would never arrive.

## How it was fixed

Moved the `eventRow` construction (which contains `seq++`) to after the DB-path guard checks in `packages/engine/src/events.js`. The local counter is now only consumed when the legacy `insertEventEffect` / `insertEvent` fallback paths are actually used — the DB-assigned paths receive a `nextSeqRow` without a pre-assigned seq, which was already the correct intent.

A regression test was added in `packages/engine/tests/events-advanced.test.js` verifying that `bus.seq` is unchanged after emitting via `insertEventWithNextSeqEffect`.

## Review

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)