### PR TITLE
🐛 fix(driver): suppress spurious scheduler wait telemetry

### DIFF
--- a/packages/driver/src/WorkflowDriver.js
+++ b/packages/driver/src/WorkflowDriver.js
@@ -276,6 +276,8 @@ export class WorkflowDriver {
     baseOutputs = {};
     /** @type {Map<string, Promise<{ key: string; task: TaskDescriptor; kind: "completed" | "failed" | "cancelled"; output?: unknown; error?: unknown }>>} */
     inflightTasks = new Map();
+    /** @type {Map<string, TaskDescriptor>} */
+    inflightTaskDescriptors = new Map();
     /** @type {Array<{ key: string; task: TaskDescriptor; kind: "completed" | "failed" | "cancelled"; output?: unknown; error?: unknown }>} */
     settledTasks = [];
     /**
@@ -490,10 +492,12 @@ export class WorkflowDriver {
             }
         })().then((settled) => {
             this.inflightTasks.delete(key);
+            this.inflightTaskDescriptors.delete(key);
             this.settledTasks.push(settled);
             return settled;
         });
         this.inflightTasks.set(key, promise);
+        this.inflightTaskDescriptors.set(key, task);
     }
     /**
    * Wait for the next settled task (or an optional deadline) and report it to
@@ -506,9 +510,12 @@ export class WorkflowDriver {
         if (!this.session) {
             throw new Error("WorkflowSession is not initialized.");
         }
-        const waitStart = performance.now();
+        let waitedTasks = [];
+        let waitStart = 0;
         try {
             if (this.settledTasks.length === 0 && this.inflightTasks.size > 0) {
+                waitedTasks = [...this.inflightTaskDescriptors.values()];
+                waitStart = performance.now();
                 const racers = [...this.inflightTasks.values()];
                 if (deadlineMs != null) {
                     racers.push(sleepWithAbort(deadlineMs, this.activeOptions?.signal).then(() => null));
@@ -517,10 +524,12 @@ export class WorkflowDriver {
             }
         }
         finally {
-            await this.onSchedulerWait?.(performance.now() - waitStart, {
-                runId: this.activeRunId,
-                tasks: [],
-            });
+            if (waitedTasks.length > 0) {
+                await this.onSchedulerWait?.(performance.now() - waitStart, {
+                    runId: this.activeRunId,
+                    tasks: waitedTasks,
+                });
+            }
         }
         if (this.activeOptions?.signal?.aborted) {
             return this.cancelRun();

--- a/packages/driver/tests/ctx-utils.test.js
+++ b/packages/driver/tests/ctx-utils.test.js
@@ -786,4 +786,48 @@ describe("WorkflowDriver", () => {
     await expect(abortedDriver.executeTasks([{ nodeId: "never", iteration: 0 }]))
       .resolves.toEqual({ runId: "run-aborted", status: "cancelled" });
   });
+
+  test("reports scheduler wait only when waiting on pending tasks", async () => {
+    const waits = [];
+    const task = { nodeId: "task-1", iteration: 0 };
+    const driver = makeDriver({
+      onSchedulerWait: (durationMs, context) => waits.push({ durationMs, context }),
+      session: makeSession({
+        taskCompleted: () => ({ _tag: "Finished", result: { runId: "run-1", status: "finished" } }),
+      }),
+    });
+    driver.activeRunId = "run-1";
+    driver.activeOptions = { input: {} };
+    driver.settledTasks.push({
+      key: "task-1::0",
+      task,
+      kind: "completed",
+      output: "ready",
+    });
+
+    await driver.nextCompletionDecision();
+
+    expect(waits).toEqual([]);
+
+    let finishTask;
+    const pendingTask = { nodeId: "task-2", iteration: 0 };
+    driver.executeTask = () => new Promise((resolve) => {
+      finishTask = resolve;
+    });
+    driver.startInflightTask(pendingTask, {
+      runId: "run-1",
+      options: { input: {} },
+    });
+    const decisionPromise = driver.nextCompletionDecision();
+    await Promise.resolve();
+    finishTask("done");
+    await decisionPromise;
+
+    expect(waits).toHaveLength(1);
+    expect(waits[0].durationMs).toBeGreaterThan(0);
+    expect(waits[0].context).toEqual({
+      runId: "run-1",
+      tasks: [pendingTask],
+    });
+  });
 });


### PR DESCRIPTION
Relates to #307

## What was fixed

`WorkflowDriver.nextCompletionDecision()` unconditionally invoked `onSchedulerWait` in its `finally` block, even when there was nothing to wait on — i.e., when settled tasks were already available and the driver never blocked. This produced spurious telemetry events with a near-zero duration and an empty `tasks` array, polluting scheduler wait metrics with noise.

## Root cause & approach

**Root cause:** `waitStart` was initialised before the conditional wait branch, and `tasks` was hard-coded to `[]` in the `finally` call. Both were always emitted regardless of whether actual blocking occurred.

**Fix (`packages/driver/src/WorkflowDriver.js`):**
- Moved `waitStart` and `waitedTasks` initialisation inside the branch that actually races on `inflightTasks`, so they remain at their zero/empty defaults when the fast path is taken.
- Added an `inflightTaskDescriptors` mirror map so the real `TaskDescriptor` objects (not an empty array) are passed to the hook when a wait does occur.
- Wrapped the `onSchedulerWait` call in `if (waitedTasks.length > 0)` so it is skipped entirely on the fast path.

**Tests (`packages/driver/tests/ctx-utils.test.js`):**
- Added a TDD test that asserts no wait event is emitted when settled tasks are already present, and that exactly one event with correct duration and task list is emitted when the driver genuinely blocks.

Codex implemented the fix via TDD; both Codex and Claude Opus reviewed and approved the change before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)