### PR TITLE
♻️ refactor(db): remove run status hot path shim

### DIFF
--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -325,23 +325,6 @@ function isAlertActiveStatus(status) {
     return status !== undefined && status !== null && ACTIVE_ALERT_STATUSES.has(status);
 }
 /**
- * Returns the row unchanged. Historically this helper relabeled
- * stale-heartbeat "running" rows as "continued", which is wrong: "continued"
- * is reserved for runs that successfully forked into a new run, and
- * `deriveRunState` then maps "continued" → "succeeded" — so a dead workflow
- * was being reported as a success. Heartbeat-based classification now lives
- * exclusively in `deriveRunState`, which correctly returns "stale" or
- * "orphaned". This shim is kept so the `listRuns` / `getRun` call sites
- * continue to compile; remove it once they call `deriveRunState` directly.
- *
- * @template T
- * @param {T} row
- * @returns {T}
- */
-function classifyRunRowStatus(row) {
-    return row;
-}
-/**
  * @template A, E
  * @param {Effect.Effect<A, E>} effect
  * @returns {RunnableEffect<A, E>}
@@ -899,11 +882,10 @@ export class SmithersDb {
    */
     getRun(runId) {
         return this.read(`get run ${runId}`, async () => {
-            const row = await this.internalStorage.queryOne(`SELECT *
+            return this.internalStorage.queryOne(`SELECT *
          FROM _smithers_runs
          WHERE run_id = ?
          LIMIT 1`, [runId]);
-            return row ? classifyRunRowStatus(row) : undefined;
         });
     }
     /**
@@ -962,7 +944,7 @@ export class SmithersDb {
          ${whereSql}
          ORDER BY created_at_ms DESC
          LIMIT ?`, [...params, limit]);
-            return rows.map((row) => classifyRunRowStatus(row));
+            return rows;
         });
     }
     /**

--- a/packages/db/tests/db-adapter-run-status-hot-path.test.js
+++ b/packages/db/tests/db-adapter-run-status-hot-path.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const adapterSourcePath = fileURLToPath(new URL("../src/adapter.js", import.meta.url));
+
+describe("SmithersDb run row status hot path", () => {
+    test("does not route run rows through classifyRunRowStatus", () => {
+        const adapterSource = readFileSync(adapterSourcePath, "utf8");
+
+        expect(adapterSource).not.toContain("classifyRunRowStatus");
+    });
+});


### PR DESCRIPTION
Relates to #307

## What & Why

Removed the no-op `classifyRunRowStatus` shim from `packages/db/src/adapter.js`.

**Root cause:** The function was a historical placeholder — it originally relabeled stale-heartbeat "running" rows as "continued", which incorrectly caused dead workflows to be reported as succeeded. That classification was moved to `deriveRunState`, but the shim was left in place to avoid breaking call sites. Since it became a pure pass-through (`return row`), its presence was dead weight and a source of confusion.

**Approach:** Deleted `classifyRunRowStatus` entirely and updated the two call sites — `getRun` and `listRuns` in `SmithersDb` — to return rows directly. Added a regression test (`packages/db/tests/db-adapter-run-status-hot-path.test.js`) that reads the adapter source and asserts the symbol no longer exists there.

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)