### PR TITLE
🐛 fix(protocol): add runtime root export

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -6,7 +6,9 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./src/index.d.ts"
+      "types": "./src/index.d.ts",
+      "import": "./src/index.js",
+      "default": "./src/index.js"
     },
     "./errors": {
       "types": "./src/index.d.ts",

--- a/packages/protocol/src/index.js
+++ b/packages/protocol/src/index.js
@@ -1,0 +1,7 @@
+export { DEVTOOLS_PROTOCOL_VERSION } from "./devtools.js";
+export {
+  DEVTOOLS_ERROR_CODES,
+  JUMP_TO_FRAME_ERROR_CODES,
+  NODE_DIFF_ERROR_CODES,
+  NODE_OUTPUT_ERROR_CODES,
+} from "./errors/index.js";

--- a/packages/protocol/tests/protocol-contracts.test.js
+++ b/packages/protocol/tests/protocol-contracts.test.js
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { DEVTOOLS_PROTOCOL_VERSION } from "../src/devtools.js";
 import {
   DEVTOOLS_ERROR_CODES,
@@ -7,11 +10,51 @@ import {
   NODE_OUTPUT_ERROR_CODES,
 } from "../src/errors/index.js";
 
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
 function expectNoDuplicates(values) {
   expect(new Set(values).size).toBe(values.length);
 }
 
 describe("protocol runtime constants", () => {
+  test("package root exposes runtime constants", () => {
+    const result = spawnSync(
+      "node",
+      [
+        "--input-type=module",
+        "--eval",
+        `
+          import {
+            DEVTOOLS_ERROR_CODES,
+            DEVTOOLS_PROTOCOL_VERSION,
+            JUMP_TO_FRAME_ERROR_CODES,
+            NODE_DIFF_ERROR_CODES,
+            NODE_OUTPUT_ERROR_CODES,
+          } from "@smithers-orchestrator/protocol";
+
+          console.log(JSON.stringify({
+            DEVTOOLS_ERROR_CODES,
+            DEVTOOLS_PROTOCOL_VERSION,
+            JUMP_TO_FRAME_ERROR_CODES,
+            NODE_DIFF_ERROR_CODES,
+            NODE_OUTPUT_ERROR_CODES,
+          }));
+        `,
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      DEVTOOLS_ERROR_CODES,
+      DEVTOOLS_PROTOCOL_VERSION,
+      JUMP_TO_FRAME_ERROR_CODES,
+      NODE_DIFF_ERROR_CODES,
+      NODE_OUTPUT_ERROR_CODES,
+    });
+  });
+
   test("devtools protocol version is the v1 wire contract", () => {
     expect(DEVTOOLS_PROTOCOL_VERSION).toBe(1);
   });


### PR DESCRIPTION
Relates to #307

## What was fixed

`@smithers-orchestrator/protocol` had no runtime root export — the package's root entry in `exports` only contained a `types` field with no `import`/`default` counterpart, and `src/index.js` did not exist. Any consumer importing from the package root at runtime received `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Root cause & approach

**Root cause:** `packages/protocol/package.json` declared `"exports": { ".": { "types": "./src/index.d.ts" } }` with no runtime fields, making the root path unreachable at runtime.

**Fix (three files):**
1. `packages/protocol/src/index.js` — new file re-exporting all runtime constants (`DEVTOOLS_PROTOCOL_VERSION`, `DEVTOOLS_ERROR_CODES`, `JUMP_TO_FRAME_ERROR_CODES`, `NODE_DIFF_ERROR_CODES`, `NODE_OUTPUT_ERROR_CODES`) from their respective sub-modules.
2. `packages/protocol/package.json` — added `"import"` and `"default"` fields to the root export condition pointing at `src/index.js`.
3. `packages/protocol/tests/protocol-contracts.test.js` — added a TDD contract test that spawns a real `node` process importing from `@smithers-orchestrator/protocol` and asserts the returned values match the known constants end-to-end.

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the change before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)