### PR TITLE
♻️ refactor(engine): remove dead JSON extraction quote guard

### DIFF
--- a/packages/engine/src/json-extraction.js
+++ b/packages/engine/src/json-extraction.js
@@ -21,7 +21,7 @@ export function extractBalancedJson(str) {
             escape = true;
             continue;
         }
-        if (c === '"' && !escape) {
+        if (c === '"') {
             inString = !inString;
             continue;
         }

--- a/packages/engine/tests/json-extraction.test.js
+++ b/packages/engine/tests/json-extraction.test.js
@@ -1,7 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { extractLastBalancedJson } from "../src/json-extraction.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { extractBalancedJson, extractLastBalancedJson } from "../src/json-extraction.js";
 
 describe("JSON extraction", () => {
+    test("extractBalancedJson keeps escaped quotes inside strings without a dead quote guard", () => {
+        const sourcePath = fileURLToPath(new URL("../src/json-extraction.js", import.meta.url));
+        const source = readFileSync(sourcePath, "utf8");
+        expect(source).not.toContain('c === \'"\' && !escape');
+
+        const extracted = extractBalancedJson('prefix {"message":"say \\"hello\\" {still string}","ok":true} suffix');
+        expect(JSON.parse(extracted)).toEqual({
+            message: 'say "hello" {still string}',
+            ok: true,
+        });
+    });
+
     test("extracts the outer final JSON object after prose when it contains nested objects", () => {
         const text = `I've reviewed the implementation and found a couple of issues.
 


### PR DESCRIPTION
Relates to #307

## What

Removes a dead condition in `packages/engine/src/json-extraction.js` inside `extractBalancedJson`. The original guard was:

```js
if (c === '"' && !escape) {
```

The `escape` flag is reset to `false` at the top of each loop iteration before this check is ever reached, so `!escape` is always `true`. The guard is unreachable dead code that adds confusion without providing any protection.

## Root cause

The `escape` variable was reset unconditionally at the start of every iteration (`escape = false`), meaning by the time the quote character check ran, `escape` could never be `true`. The `&& !escape` branch condition was therefore always satisfied and served no purpose.

## Approach

- Removed `&& !escape` from the quote check in `extractBalancedJson` (the sole change to production code).
- Added a regression test in `packages/engine/tests/json-extraction.test.js` that:
  1. Asserts the source file no longer contains the dead pattern `c === '"' && !escape`.
  2. Verifies end-to-end that escaped quotes inside JSON string values are parsed correctly.

Codex implemented the fix via TDD. Both Codex and Claude Opus reviewed and approved the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)