### PR TITLE
🐛 fix(vcs): record jj duration on all exits

### DIFF
--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -45,19 +45,20 @@ export function runJj(args, opts = {}) {
     }
     return Effect.scoped(Effect.gen(function* () {
         const start = performance.now();
-        yield* Effect.logDebug(`jj ${args.join(" ")}`);
-        const process = yield* Command.start(command);
-        const stdoutFiber = yield* Effect.fork(collectUtf8(process.stdout));
-        const stderrFiber = yield* Effect.fork(collectUtf8(process.stderr));
-        const exitCode = yield* process.exitCode;
-        const stdout = yield* Fiber.join(stdoutFiber);
-        const stderr = yield* Fiber.join(stderrFiber);
-        yield* Metric.update(vcsDuration, performance.now() - start);
-        return {
-            code: Number(exitCode),
-            stdout,
-            stderr,
-        };
+        return yield* Effect.gen(function* () {
+            yield* Effect.logDebug(`jj ${args.join(" ")}`);
+            const process = yield* Command.start(command);
+            const stdoutFiber = yield* Effect.fork(collectUtf8(process.stdout));
+            const stderrFiber = yield* Effect.fork(collectUtf8(process.stderr));
+            const exitCode = yield* process.exitCode;
+            const stdout = yield* Fiber.join(stdoutFiber);
+            const stderr = yield* Fiber.join(stderrFiber);
+            return {
+                code: Number(exitCode),
+                stdout,
+                stderr,
+            };
+        }).pipe(Effect.ensuring(Effect.suspend(() => Metric.update(vcsDuration, performance.now() - start))));
     })).pipe(Effect.annotateLogs({
         vcs: "jj",
         cwd: opts.cwd ?? "",

--- a/packages/vcs/tests/jj-workspace.test.js
+++ b/packages/vcs/tests/jj-workspace.test.js
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import { Effect } from "effect";
 import * as BunContext from "@effect/platform-bun/BunContext";
+import { renderPrometheusMetrics } from "@smithers-orchestrator/observability";
 import * as vcsEffects from "../src/jj.js";
 
 const JJ_ENV = "SMITHERS_JJ_PATH";
@@ -24,6 +25,14 @@ const vcs = {
     getJjPointer: (cwd) => runVcs(vcsEffects.getJjPointer(cwd)),
     revertToJjPointer: (pointer, cwd) => runVcs(vcsEffects.revertToJjPointer(pointer, cwd)),
 };
+function vcsDurationCount() {
+    const match = renderPrometheusMetrics().match(/^smithers_vcs_duration_ms_count (\d+(?:\.\d+)?)$/m);
+    return match ? Number(match[1]) : 0;
+}
+function vcsDurationSum() {
+    const match = renderPrometheusMetrics().match(/^smithers_vcs_duration_ms_sum (\d+(?:\.\d+)?)$/m);
+    return match ? Number(match[1]) : 0;
+}
 /**
  * @param {string} script
  * @param {() => Promise<void>} fn
@@ -106,6 +115,38 @@ describe("runJj", () => {
             }
             await fs.rm(tmp, { recursive: true, force: true });
         }
+    });
+    test("records vcs duration when spawning jj fails", async () => {
+        const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "jj-missing-metric-"));
+        const badJj = path.join(tmp, "not-a-command");
+        await fs.mkdir(badJj);
+        const prevJj = process.env[JJ_ENV];
+        const before = vcsDurationCount();
+        try {
+            process.env[JJ_ENV] = badJj;
+            const res = await vcs.runJj(["--version"]);
+            expect(res.code).toBe(127);
+            expect(vcsDurationCount()).toBe(before + 1);
+        }
+        finally {
+            if (prevJj === undefined) {
+                delete process.env[JJ_ENV];
+            }
+            else {
+                process.env[JJ_ENV] = prevJj;
+            }
+            await fs.rm(tmp, { recursive: true, force: true });
+        }
+    });
+    test("records vcs duration when jj pointer lookup times out", async () => {
+        await withFakeJj(`sleep 5; exit 0`, async () => {
+            const before = vcsDurationCount();
+            const beforeSum = vcsDurationSum();
+            const pointer = await vcs.getJjPointer();
+            expect(pointer).toBe(null);
+            expect(vcsDurationCount()).toBe(before + 1);
+            expect(vcsDurationSum() - beforeSum).toBeGreaterThanOrEqual(1_000);
+        });
     });
 });
 describe("isJjRepo", () => {


### PR DESCRIPTION
Relates to #307

## What was fixed

`runJj` in `packages/vcs/src/jj.js` only recorded the `vcsDuration` metric on the success path — a `Metric.update` call placed after the exit-code/stdout/stderr collection. If the effect failed (e.g. the jj binary was not found, or a timeout interrupted the fiber chain), the metric was never emitted.

## How it was fixed

Wrapped the inner process-execution block in `Effect.ensuring(...)` so `Metric.update(vcsDuration, elapsed)` fires unconditionally on every exit — success, failure, or interruption. The `start` timestamp is captured before the inner effect and `performance.now() - start` is evaluated lazily inside `Effect.suspend` so it reflects the true elapsed time regardless of exit path.

**Key files changed:**
- `packages/vcs/src/jj.js` — restructured the inner effect with `.pipe(Effect.ensuring(...))` to guarantee metric emission
- `packages/vcs/tests/jj-workspace.test.js` — added two new TDD tests: one for spawn failure (bad jj path) and one for timeout, both asserting that `vcsDurationCount` increments on the error path

Codex implemented this via TDD; both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)