### PR TITLE
🐛 fix(openapi): enforce numeric and typeless schema enums

### DIFF
--- a/packages/openapi/src/jsonSchemaToZod.js
+++ b/packages/openapi/src/jsonSchemaToZod.js
@@ -76,6 +76,9 @@ export function jsonSchemaToZod(schema, spec, visited = new Set()) {
         return maybeDescribe(z.null(), s);
     }
     // Fallback
+    if (s.enum && s.enum.length > 0) {
+        return maybeDescribe(buildLiteralUnion(s.enum), s);
+    }
     const desc = s.description ? `${s.description} (untyped)` : "untyped schema";
     return z.any().describe(desc);
 }
@@ -120,6 +123,9 @@ function buildNumber(s) {
         num = num.min(s.minimum);
     if (s.maximum !== undefined)
         num = num.max(s.maximum);
+    if (s.enum && s.enum.length > 0) {
+        num = z.intersection(num, buildLiteralUnion(s.enum));
+    }
     return maybeDescribe(maybeNullable(maybeDefault(num, s), s), s);
 }
 /**
@@ -165,6 +171,16 @@ function buildUnion(variants, spec, visited, parent) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+/**
+ * @param {unknown[]} values
+ * @returns {z.ZodType}
+ */
+function buildLiteralUnion(values) {
+    const literals = values.map((value) => z.literal(value));
+    if (literals.length === 1)
+        return literals[0];
+    return z.union(literals);
+}
 /**
  * @param {z.ZodType} schema
  * @param {SchemaObject} s

--- a/packages/openapi/tests/schema-conversion.test.js
+++ b/packages/openapi/tests/schema-conversion.test.js
@@ -45,6 +45,16 @@ describe("jsonSchemaToZod", () => {
         expect(() => schema.parse(-1)).toThrow();
         expect(() => schema.parse(101)).toThrow();
     });
+    test("converts number and integer enums", () => {
+        const numeric = jsonSchemaToZod({ type: "number", enum: [1.5, 2.5] }, emptySpec);
+        expect(numeric.parse(1.5)).toBe(1.5);
+        expect(() => numeric.parse(3.5)).toThrow();
+
+        const integer = jsonSchemaToZod({ type: "integer", enum: [1, 2] }, emptySpec);
+        expect(integer.parse(2)).toBe(2);
+        expect(() => integer.parse(3)).toThrow();
+        expect(() => integer.parse(1.5)).toThrow();
+    });
     test("converts boolean type", () => {
         const schema = jsonSchemaToZod({ type: "boolean" }, emptySpec);
         expect(schema.parse(true)).toBe(true);
@@ -111,6 +121,13 @@ describe("jsonSchemaToZod", () => {
     test("handles unknown type as z.any()", () => {
         const schema = jsonSchemaToZod({ description: "mysterious" }, emptySpec);
         expect(schema.parse("anything")).toBe("anything");
+    });
+    test("converts typeless enum", () => {
+        const schema = jsonSchemaToZod({ enum: ["draft", "published", 1, null] }, emptySpec);
+        expect(schema.parse("draft")).toBe("draft");
+        expect(schema.parse(1)).toBe(1);
+        expect(schema.parse(null)).toBe(null);
+        expect(() => schema.parse("archived")).toThrow();
     });
     test("converts composed schemas and unions", () => {
         const allOf = jsonSchemaToZod({


### PR DESCRIPTION
Relates to #303

Re-landing of #329, which GitHub auto-closed when its stacked base branch was deleted during the landing train (the fix itself was never merged). Branch is rebased onto main; content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)