### PR TITLE
🐛 fix(ci): run smithers orchestrator unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "generate:init-pack": "bun scripts/generate-workflow-pack.ts",
     "demo:smithers": "pnpm --filter @smithers-orchestrator/smithers-demo dev",
     "demo:smithers:tui": "pnpm --filter @smithers-orchestrator/smithers-tui-demo tui",
-    "test": "node scripts/check-single-effect-version.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-docs.mjs && node scripts/check-llms.mjs && pnpm -r test",
+    "test": "node scripts/check-single-effect-version.mjs && node scripts/check-dependency-boundaries.mjs && node scripts/check-docs.mjs && node scripts/check-llms.mjs && node scripts/check-smithers-test-script.mjs && pnpm -r test",
     "check:effect": "node scripts/check-single-effect-version.mjs",
     "check:deps": "node scripts/check-dependency-boundaries.mjs",
     "check:docs": "node scripts/check-docs.mjs",

--- a/packages/smithers/package.json
+++ b/packages/smithers/package.json
@@ -58,6 +58,7 @@
     "smithers": "./src/bin/smithers.js"
   },
   "scripts": {
+    "test": "bun test tests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsup --dts-only"
   },

--- a/scripts/check-smithers-test-script.mjs
+++ b/scripts/check-smithers-test-script.mjs
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const packageDir = join(root, "packages", "smithers");
+const manifestPath = join(packageDir, "package.json");
+const testFilePattern = /\.(?:test|spec)(?:-[^.]+)?\.[cm]?[jt]sx?$/;
+
+function containsRuntimeTestFile(dir) {
+  if (!existsSync(dir)) {
+    return false;
+  }
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (containsRuntimeTestFile(path)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (entry.isFile() && testFilePattern.test(entry.name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+
+if (
+  containsRuntimeTestFile(join(packageDir, "tests")) &&
+  typeof manifest.scripts?.test !== "string"
+) {
+  console.error(
+    `${relative(root, manifestPath)} has runtime tests but no scripts.test for pnpm -r test`,
+  );
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Relates to #299

## What was fixed

`packages/smithers` had no `scripts.test` entry in its `package.json`, so `pnpm -r test` silently skipped its unit tests entirely. CI appeared green while the smithers package's own tests never ran.

## How it was fixed

**Root cause:** `packages/smithers/package.json` was missing a `test` script, so the recursive `pnpm -r test` invocation in root CI did not execute tests for the smithers package.

**Approach (two parts):**
1. **`packages/smithers/package.json`** — added `"test": "bun test tests"` so `pnpm -r test` now picks up smithers unit tests.
2. **`scripts/check-smithers-test-script.mjs`** — new gate script that verifies `packages/smithers` has a `scripts.test` entry whenever runtime test files exist under `tests/`. Added to the root `test` script in `package.json` so CI enforces the invariant going forward.

Codex implemented this fix via TDD. Codex and Claude Opus both reviewed and approved the implementation before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)