### PR TITLE
🐛 fix(openapi): validate typed additionalProperties

### DIFF
--- a/packages/openapi/src/jsonSchemaToZod.js
+++ b/packages/openapi/src/jsonSchemaToZod.js
@@ -145,7 +145,10 @@ function buildObject(s, spec, visited) {
         props[key] = zodProp;
     }
     let obj = z.object(props);
-    if (s.additionalProperties === true || s.additionalProperties === undefined) {
+    if (typeof s.additionalProperties === "object" && s.additionalProperties !== null) {
+        obj = obj.catchall(jsonSchemaToZod(s.additionalProperties, spec, visited));
+    }
+    else if (s.additionalProperties === true || s.additionalProperties === undefined) {
         // Allow additional properties — use catchall for objects with props
         if (Object.keys(props).length > 0) {
             obj = obj.catchall(z.unknown());

--- a/packages/openapi/tests/schema-conversion.test.js
+++ b/packages/openapi/tests/schema-conversion.test.js
@@ -82,6 +82,20 @@ describe("jsonSchemaToZod", () => {
         expect(schema.parse({ name: "Bob" })).toEqual({ name: "Bob" });
         expect(() => schema.parse({ age: 30 })).toThrow();
     });
+    test("converts typed additionalProperties", () => {
+        const schema = jsonSchemaToZod({
+            type: "object",
+            properties: {
+                name: { type: "string" },
+            },
+            additionalProperties: { type: "number" },
+        }, emptySpec);
+        expect(schema.parse({ name: "Alice", score: 42 })).toEqual({
+            name: "Alice",
+            score: 42,
+        });
+        expect(() => schema.parse({ name: "Alice", score: "high" })).toThrow();
+    });
     test("converts nullable type", () => {
         const schema = jsonSchemaToZod({ type: "string", nullable: true }, emptySpec);
         expect(schema.parse("hello")).toBe("hello");


### PR DESCRIPTION
Relates to #303

## What was fixed

`jsonSchemaToZod` in `packages/openapi/src/jsonSchemaToZod.js` silently ignored `additionalProperties` when it was a schema object (e.g. `{ type: "number" }`). The condition only handled the boolean cases (`true` / `undefined` → allow unknown, `false` → strict), so a typed additional-properties constraint was treated as if no constraint existed, letting any extra property value through without type-checking.

## How it was fixed

Added an `object` branch before the boolean check in `buildObject`:

```js
if (typeof s.additionalProperties === "object" && s.additionalProperties !== null) {
    obj = obj.catchall(jsonSchemaToZod(s.additionalProperties, spec, visited));
}
```

This recursively converts the schema object and attaches it as a Zod `catchall`, so extra properties are validated against the declared type. A new test in `packages/openapi/tests/schema-conversion.test.js` covers a typed `additionalProperties: { type: "number" }` — it asserts that numeric extra values parse successfully and non-numeric ones throw.

Codex implemented this fix via TDD; Codex and Claude Opus both approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)