### PR TITLE
🐛 fix(pi-plugin): unsubscribe RunInspector store listener

### DIFF
--- a/packages/pi-plugin/src/views/RunInspector.ts
+++ b/packages/pi-plugin/src/views/RunInspector.ts
@@ -45,6 +45,7 @@ export class RunInspector {
   private readonly theme: Theme;
   private readonly onClose: () => void;
   private readonly onNotify: (message: string, level?: "info" | "warning" | "error") => void;
+  private readonly unsubscribeStore: () => void;
   private focus: FocusPane = "tree";
   private cachedLines: string[] | undefined;
   private cachedWidth = 0;
@@ -61,7 +62,7 @@ export class RunInspector {
     this.theme = options.theme ?? {};
     this.onClose = options.onClose ?? (() => undefined);
     this.onNotify = options.onNotify ?? (() => undefined);
-    store.subscribe(() => this.invalidate());
+    this.unsubscribeStore = store.subscribe(() => this.invalidate());
   }
 
   handleInput(data: string) {
@@ -162,6 +163,7 @@ export class RunInspector {
   }
 
   dispose() {
+    this.unsubscribeStore();
     this.store.disconnect();
   }
 

--- a/packages/pi-plugin/tests/DevToolsStore.test.ts
+++ b/packages/pi-plugin/tests/DevToolsStore.test.ts
@@ -119,6 +119,18 @@ describe("DevToolsStore", () => {
     expect(lines).toContain("RUNNING");
     store.disconnect();
   });
+
+  test("RunInspector dispose removes its store listener", () => {
+    const store = new DevToolsStore({ ghostNodeCap: 8 });
+    const client = new DevToolsClient({ baseUrl: "http://127.0.0.1:1" });
+    const inspector = new RunInspector(store, client);
+
+    expect((store as unknown as { listeners: Set<unknown> }).listeners.size).toBe(1);
+
+    inspector.dispose();
+
+    expect((store as unknown as { listeners: Set<unknown> }).listeners.size).toBe(0);
+  });
 });
 
 describe("DevToolsClient integration", () => {


### PR DESCRIPTION
Relates to #303

## What was fixed

`RunInspector` subscribed to the `DevToolsStore` in its constructor but never unsubscribed when `dispose()` was called, causing a listener leak every time a `RunInspector` instance was created and discarded.

## Root cause & approach

`store.subscribe()` returns an unsubscribe callback, but the return value was being discarded:

```ts
// Before
store.subscribe(() => this.invalidate());

// After
this.unsubscribeStore = store.subscribe(() => this.invalidate());
```

The fix captures the unsubscribe function into `this.unsubscribeStore` (declared as a new private field in `RunInspector.ts`) and calls it at the top of `dispose()` before `store.disconnect()`.

A regression test in `packages/pi-plugin/tests/DevToolsStore.test.ts` verifies that the listener count drops from 1 → 0 after `dispose()`, ensuring this stays fixed.

## Review

Codex implemented this via TDD, and both Codex and Claude Opus approved the change in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)