### PR TITLE
🐛 fix(cli): spawn real CLI entrypoint from cron scheduler

### DIFF
--- a/apps/cli/src/scheduler.js
+++ b/apps/cli/src/scheduler.js
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { CronExpressionParser } from "cron-parser";
 import { Effect, Schedule } from "effect";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { runPromise } from "./smithersRuntime.js";
 import { findAndOpenDb } from "./find-db.js";
+const CLI_ENTRYPOINT = fileURLToPath(new URL("./index.js", import.meta.url));
 /**
  * @param {unknown} error
  */
@@ -27,7 +29,7 @@ export function processCronEffect(adapter, job, now) {
         yield* Effect.logInfo(`[smithers-cron] Triggering due workflow: ${job.workflowPath} (Schedule: ${job.pattern})`);
         yield* Effect.try({
             try: () => {
-                const proc = spawn("bun", ["run", "src/index.js", "up", job.workflowPath, "-d"], {
+                const proc = spawn(process.execPath, [CLI_ENTRYPOINT, "up", job.workflowPath, "-d"], {
                     cwd: process.cwd(),
                     detached: true,
                     stdio: "ignore",

--- a/apps/cli/tests/cron-command-scheduler.test.js
+++ b/apps/cli/tests/cron-command-scheduler.test.js
@@ -107,7 +107,7 @@ describe("smithers cron commands", () => {
         });
         expect(afterRm.exitCode).toBe(0);
         expect(afterRm.json).toMatchObject({ crons: [] });
-    });
+    }, 30_000);
 
     test("start delegates to the scheduler entrypoint", async () => {
         const repo = createTempRepo();
@@ -119,13 +119,13 @@ describe("smithers cron commands", () => {
             cwd: repo.dir,
             env: process.env,
             encoding: "utf8",
-            timeout: 1_000,
+            timeout: 10_000,
             killSignal: "SIGTERM",
         });
 
         expect(result.status ?? 0).toBe(0);
         expect(result.stderr + result.stdout).toContain("[smithers-cron] Starting background scheduler loop...");
-    });
+    }, 30_000);
 });
 
 describe("scheduler tick effects", () => {
@@ -168,8 +168,8 @@ describe("scheduler tick effects", () => {
 
         expect(spawnCalls).toEqual([
             {
-                command: "bun",
-                args: ["run", "src/index.js", "up", "due.tsx", "-d"],
+                command: process.execPath,
+                args: [CLI_ENTRY, "up", "due.tsx", "-d"],
                 options: {
                     cwd: process.cwd(),
                     detached: true,


### PR DESCRIPTION
Relates to #303

## What was fixed

The cron scheduler in `apps/cli/src/scheduler.js` was spawning sub-processes with a hardcoded `bun run src/index.js` command. This broke in any environment where `bun` is not on `PATH` or where the working directory is not the `apps/cli` source tree (e.g. when smithers is installed as a package or run from a different `cwd`).

## How it was fixed

- **Root cause**: `spawn("bun", ["run", "src/index.js", ...])` assumed the runtime is always `bun` and the entrypoint is always at a relative `src/index.js` path.
- **Approach**: Replace with `spawn(process.execPath, [CLI_ENTRYPOINT, ...])` where `CLI_ENTRYPOINT` is the absolute path to `index.js` resolved at module load time via `fileURLToPath(new URL("./index.js", import.meta.url))`. This is correct regardless of installation method, working directory, or runtime.
- **Key files**: `apps/cli/src/scheduler.js` (fix), `apps/cli/tests/cron-command-scheduler.test.js` (tests updated to assert the new spawn arguments and use absolute `CLI_ENTRY` path).

Codex implemented this via TDD. Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)