### PR TITLE
🐛 fix(accounts): enforce configDir apiKey XOR invariant

### DIFF
--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -664,7 +664,7 @@ function renderAccountProviderLine(account, homeDir) {
     const opts = [];
     if (model) opts.push(`model: ${JSON.stringify(model)}`);
     if (account.configDir) opts.push(`configDir: ${pathLiteral(account.configDir, homeDir)}`);
-    if (account.apiKey) opts.push(`apiKey: ${JSON.stringify(account.apiKey)}`);
+    else if (account.apiKey) opts.push(`apiKey: ${JSON.stringify(account.apiKey)}`);
     if (account.provider === "codex" || account.provider === "openai-api") {
         opts.push("skipGitRepoCheck: true");
     }

--- a/apps/cli/tests/agents-ts-codegen.test.js
+++ b/apps/cli/tests/agents-ts-codegen.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { addAccount } from "@smithers-orchestrator/accounts";
@@ -76,6 +76,18 @@ describe("generateAgentsTs (account-driven)", () => {
         expect(generated).toContain("claude: [providers.anthropicProd]");
         // user-specified model wins over the default
         expect(generated).toContain('model: "gpt-5"');
+    });
+
+    test("does not serialize both configDir and apiKey for malformed account entries", () => {
+        const env = newSmithersHome();
+        writeFileSync(join(env.SMITHERS_HOME, "accounts.json"), JSON.stringify({
+            version: 1,
+            accounts: [
+                { label: "claude-mixed", provider: "claude-code", configDir: "/tmp/claude", apiKey: "sk-leak" },
+            ],
+        }));
+
+        expect(() => generateAgentsTs(env)).toThrow(/configDir.*apiKey|apiKey.*configDir/);
     });
 
     test("falls back to detection-based output when no accounts are registered", () => {

--- a/packages/accounts/src/addAccount.js
+++ b/packages/accounts/src/addAccount.js
@@ -22,6 +22,9 @@ export function addAccount(account, options = {}) {
     if (!VALID_PROVIDERS.has(account.provider)) {
         throw new SmithersError("ACCOUNT_INVALID", `account.provider must be one of ${[...VALID_PROVIDERS].join(", ")}, got ${JSON.stringify(account.provider)}`);
     }
+    if (typeof account.configDir === "string" && typeof account.apiKey === "string") {
+        throw new SmithersError("ACCOUNT_INVALID", `${account.provider} account "${account.label}" must set configDir or apiKey, never both`);
+    }
     if (SUBSCRIPTION_PROVIDERS.has(account.provider) && (!account.configDir || !account.configDir.trim())) {
         throw new SmithersError("ACCOUNT_INVALID", `${account.provider} accounts require a non-empty configDir`);
     }

--- a/packages/accounts/src/parseAccountsFile.js
+++ b/packages/accounts/src/parseAccountsFile.js
@@ -76,6 +76,9 @@ export function parseAccountsFile(raw) {
         seenLabels.add(e.label);
         const isSubscription = SUBSCRIPTION_PROVIDERS.has(e.provider);
         const isApiKey = API_KEY_PROVIDERS.has(e.provider);
+        if (typeof e.configDir === "string" && typeof e.apiKey === "string") {
+            throw new SmithersError("ACCOUNTS_FILE_INVALID", `accounts.json: ${e.label} (${e.provider}) must set configDir or apiKey, never both`);
+        }
         if (isSubscription && (typeof e.configDir !== "string" || !e.configDir.trim())) {
             throw new SmithersError("ACCOUNTS_FILE_INVALID", `accounts.json: ${e.label} (${e.provider}) requires a non-empty configDir`);
         }

--- a/packages/accounts/tests/accounts.test.js
+++ b/packages/accounts/tests/accounts.test.js
@@ -97,6 +97,12 @@ describe("parseAccountsFile", () => {
             accounts: [{ label: "x", provider: "openai-api" }],
         }))).toThrow(/apiKey/);
     });
+    test("rejects entries with both configDir and apiKey", () => {
+        expect(() => parseAccountsFile(JSON.stringify({
+            version: 1,
+            accounts: [{ label: "mixed", provider: "claude-code", configDir: "/p1", apiKey: "sk-leak" }],
+        }))).toThrow(/configDir.*apiKey|apiKey.*configDir/);
+    });
     test("rejects duplicate labels", () => {
         expect(() => parseAccountsFile(JSON.stringify({
             version: 1,
@@ -208,6 +214,8 @@ describe("readAccounts / writeAccounts / addAccount / removeAccount", () => {
             .toThrow(/configDir/);
         expect(() => addAccount({ label: "y", provider: "openai-api" }, { env }))
             .toThrow(/apiKey/);
+        expect(() => addAccount({ label: "mixed", provider: "claude-code", configDir: "/x", apiKey: "sk-leak" }, { env }))
+            .toThrow(/configDir.*apiKey|apiKey.*configDir/);
     });
     test("removeAccount deletes by label; throws or no-ops for missing", () => {
         const env = newSmithersHome();


### PR DESCRIPTION
Relates to #303

## What was fixed

Account entries could be created or persisted with both `configDir` and `apiKey` set simultaneously, violating the mutual-exclusion constraint that these fields represent. This could silently leak an API key into generated agent config alongside a `configDir`-based subscription account.

## Root cause & approach

Neither `addAccount()` nor `parseAccountsFile()` validated the XOR invariant — both fields could coexist without error. The code-generation path in `renderAccountProviderLine()` also emitted both fields unconditionally when present.

**Key files changed:**

- `packages/accounts/src/addAccount.js` — throws `ACCOUNT_INVALID` when both `configDir` and `apiKey` are present on the account being added
- `packages/accounts/src/parseAccountsFile.js` — throws `ACCOUNTS_FILE_INVALID` when a persisted entry carries both fields
- `apps/cli/src/agent-detection.js` — changed `if (account.apiKey)` to `else if (account.apiKey)` so the API key is only rendered when `configDir` is absent
- `packages/accounts/tests/accounts.test.js` — two new tests cover the XOR guard in `parseAccountsFile` and `addAccount`
- `apps/cli/tests/agents-ts-codegen.test.js` — new test verifies `generateAgentsTs` throws on a malformed mixed-field account entry

Codex implemented this fix via TDD; both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)