### PR TITLE
🐛 fix(errors): guard declaration drift for error codes

### DIFF
--- a/packages/errors/src/index.d.ts
+++ b/packages/errors/src/index.d.ts
@@ -232,6 +232,31 @@ declare namespace smithersErrorDefinitions {
         let details_4: string;
         export { details_4 as details };
     }
+    namespace TASK_HIJACK_UNSUPPORTED {
+        let category: string;
+        let when: string;
+        let details: string;
+    }
+    namespace TASK_FORK_SOURCE_NOT_FOUND {
+        let category: string;
+        let when: string;
+        let details: string;
+    }
+    namespace TASK_FORK_SOURCE_NOT_COMPLETE {
+        let category: string;
+        let when: string;
+        let details: string;
+    }
+    namespace TASK_FORK_SESSION_UNAVAILABLE {
+        let category: string;
+        let when: string;
+        let details: string;
+    }
+    namespace TASK_FORK_CYCLE {
+        let category: string;
+        let when: string;
+        let details: string;
+    }
     namespace RUN_NOT_FOUND {
         let category_11: string;
         export { category_11 as category };
@@ -569,6 +594,10 @@ declare namespace smithersErrorDefinitions {
         export { category_58 as category };
         let when_58: string;
         export { when_58 as when };
+    }
+    namespace AGENT_CONFIG_INVALID {
+        let category: string;
+        let when: string;
     }
     namespace AGENT_RPC_FILE_ARGS {
         let category_59: string;

--- a/packages/errors/tests/error-declarations.test.js
+++ b/packages/errors/tests/error-declarations.test.js
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+import { smithersErrorDefinitions } from "../src/smithersErrorDefinitions.js";
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function readDeclaredErrorCodes() {
+  const declarations = readFileSync(join(packageRoot, "src/index.d.ts"), "utf8");
+  const match = declarations.match(/declare namespace smithersErrorDefinitions \{([\s\S]*?)\n\}/);
+  expect(match).not.toBeNull();
+  return [...match[1].matchAll(/^\s{4}namespace\s+([A-Z0-9_]+)\s+\{/gm)].map((codeMatch) => codeMatch[1]);
+}
+
+describe("error declarations", () => {
+  test("KnownSmithersErrorCode declaration matches the runtime catalog", () => {
+    expect(readDeclaredErrorCodes().sort()).toEqual(Object.keys(smithersErrorDefinitions).sort());
+  });
+});

--- a/packages/errors/tsup.config.ts
+++ b/packages/errors/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: { index: "src/index.js" },
-  dts: { only: true, resolve: false },
+  dts: { only: true, resolve: true },
   outDir: "src",
   clean: false,
   format: ["esm"],

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -25,6 +25,7 @@ const README = join(root, "README.md");
 const TIMER_COMPONENT_DOC = join(DOCS, "components/timer.mdx");
 const SANDBOX_COMPONENT_DOC = join(DOCS, "components/sandbox.mdx");
 const ERROR_DEFINITIONS = join(root, "packages/errors/src/smithersErrorDefinitions.js");
+const ERROR_DECLARATIONS = join(root, "packages/errors/src/index.d.ts");
 const SMITHERS_PACKAGE_JSON = join(root, "packages/smithers/package.json");
 const SMITHERS_FACADE_SOURCE = join(root, "packages/smithers/src/index.js");
 const SMITHERS_FACADE_DECLARATIONS = join(root, "packages/smithers/src/index.d.ts");
@@ -248,6 +249,27 @@ function checkKnownErrorCodeUnion(codes) {
     if (extra.length) console.error(`    extra: ${extra.join(", ")}`);
   } else {
     console.log("✓ KnownSmithersErrorCode docs match built-in codes");
+  }
+}
+
+function checkErrorDeclarationCodes(codes) {
+  const declarations = readFileSync(ERROR_DECLARATIONS, "utf8");
+  const match = declarations.match(/declare namespace smithersErrorDefinitions \{([\s\S]*?)\n\}/);
+  const declared = match
+    ? [...match[1].matchAll(/^\s{4}namespace\s+([A-Z0-9_]+)\s+\{/gm)].map((codeMatch) => codeMatch[1])
+    : [];
+  const missing = codes.filter((code) => !declared.includes(code));
+  const extra = declared.filter((code) => !codes.includes(code));
+  const duplicates = [...new Set(declared.filter((code, index) => declared.indexOf(code) !== index))];
+  if (!match || missing.length || extra.length || duplicates.length) {
+    failed = true;
+    console.error("\n✗ packages/errors/src/index.d.ts does not match smithersErrorDefinitions:");
+    if (!match) console.error("    declare namespace smithersErrorDefinitions block not found");
+    if (missing.length) console.error(`    missing: ${missing.join(", ")}`);
+    if (extra.length) console.error(`    extra: ${extra.join(", ")}`);
+    if (duplicates.length) console.error(`    duplicate: ${duplicates.join(", ")}`);
+  } else {
+    console.log("✓ error declarations match built-in codes");
   }
 }
 
@@ -3859,6 +3881,7 @@ function checkGatewaySdkDocsMatchExports() {
 const errorCodes = readErrorDefinitionCodes();
 checkErrorReferenceCodes(errorCodes);
 checkKnownErrorCodeUnion(errorCodes);
+checkErrorDeclarationCodes(errorCodes);
 checkGatewayTypeDocs();
 checkFacadeDeclarations();
 checkDocumentedSmithersImportsMatchFacade();


### PR DESCRIPTION
Relates to #303

## What was fixed

`packages/errors/src/index.d.ts` was drifting out of sync with `smithersErrorDefinitions.js` — new error codes added to the runtime definitions were not reflected in the TypeScript declaration file, causing consumers to miss type coverage for recently-added codes (`TASK_HIJACK_UNSUPPORTED`, `TASK_FORK_*`, `AGENT_CONFIG_INVALID`, and others).

## Root cause

The tsup build config had `resolve: false`, so imported namespaces from the error definitions were not inlined into the generated `.d.ts`. This meant the declaration file had to be maintained manually and would silently fall behind as new codes were added.

## Approach

- **`packages/errors/tsup.config.ts`**: flipped `resolve` to `true` so tsup inlines referenced types into `index.d.ts`, eliminating the manual-sync requirement.
- **`packages/errors/src/index.d.ts`**: added the six missing error-code namespaces (`TASK_HIJACK_UNSUPPORTED`, `TASK_FORK_SOURCE_NOT_FOUND`, `TASK_FORK_SOURCE_NOT_COMPLETE`, `TASK_FORK_SESSION_UNAVAILABLE`, `TASK_FORK_CYCLE`, `AGENT_CONFIG_INVALID`) to bring the declarations up to date.
- **`scripts/check-docs.mjs`**: added `checkErrorDeclarationCodes()` — a new gate that reads both the runtime definitions and the `.d.ts`, then fails CI if they diverge (missing, extra, or duplicate namespaces). This makes future drift immediately visible.
- **`packages/errors/tests/error-declarations.test.js`**: TDD test suite that validates declaration completeness, implemented by Codex first.

Codex implemented this via TDD; Codex and Claude Opus both approved the implementation in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)