### PR TITLE
🐛 fix(scorers): pass task context to live scorers

### DIFF
--- a/packages/components/src/components/TaskProps.ts
+++ b/packages/components/src/components/TaskProps.ts
@@ -54,6 +54,10 @@ export type TaskProps<Row, Output extends OutputTarget = OutputTarget, D extends
 	cache?: CachePolicy;
 	/** Optional scorers to evaluate this task's output after completion. */
 	scorers?: ScorersMap;
+	/** Expected output supplied to scorers that compare against a reference answer. */
+	groundTruth?: unknown;
+	/** Additional source context supplied to scorers such as faithfulnessScorer. */
+	context?: unknown;
 	/** Optional cross-run memory configuration. */
 	memory?: TaskMemoryConfig;
 	/** Request an immediate hijack handoff as soon as the task starts running. */

--- a/packages/components/src/index.d.ts
+++ b/packages/components/src/index.d.ts
@@ -158,6 +158,10 @@ type TaskProps$2<Row, Output extends OutputTarget$1 = OutputTarget$1, D extends 
     cache?: CachePolicy$1;
     /** Optional scorers to evaluate this task's output after completion. */
     scorers?: ScorersMap$1;
+    /** Expected output supplied to scorers that compare against a reference answer. */
+    groundTruth?: unknown;
+    /** Additional source context supplied to scorers such as faithfulnessScorer. */
+    context?: unknown;
     /** Optional cross-run memory configuration. */
     memory?: TaskMemoryConfig;
     /** Request an immediate hijack handoff as soon as the task starts running. */

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -4206,6 +4206,8 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                 attempt: attemptNo,
                 input: desc.prompt ?? desc.staticPayload ?? null,
                 output: payload,
+                groundTruth: desc.groundTruth,
+                context: desc.context,
                 latencyMs: taskElapsedMs,
                 outputSchema: desc.outputSchema,
             }, adapter, eventBus);

--- a/packages/engine/tests/engine-workflow.test.jsx
+++ b/packages/engine/tests/engine-workflow.test.jsx
@@ -2,6 +2,7 @@
 import { describe, expect, test } from "bun:test";
 import { Workflow, Task, Sequence, Parallel, Branch, Loop, MergeQueue, runWorkflow, } from "smithers-orchestrator";
 import { createTestSmithers } from "../../smithers/tests/helpers.js";
+import { faithfulnessScorer } from "@smithers-orchestrator/scorers";
 import { z } from "zod";
 import { Effect } from "effect";
 const schemas = {
@@ -23,6 +24,37 @@ describe("runWorkflow end-to-end", () => {
         </Workflow>));
         const result = await Effect.runPromise(runWorkflow(wf, { input: {} }));
         expect(result.status).toBe("finished");
+        cleanup();
+    }, END_TO_END_TIMEOUT_MS);
+    test("passes task context to faithfulnessScorer during live execution", async () => {
+        const { smithers, outputs, cleanup } = build();
+        let receivedPrompt = "";
+        let resolveScored;
+        const scored = new Promise((resolve) => {
+            resolveScored = resolve;
+        });
+        const judge = {
+            generate: async ({ prompt }) => {
+                receivedPrompt = prompt;
+                resolveScored();
+                return { text: '{ "score": 1, "reason": "faithful" }' };
+            },
+        };
+        const sourceContext = { document: "The release codename is Juniper." };
+        const wf = smithers((_ctx) => (<Workflow name="faithfulness-context">
+          <Task
+            id="answer"
+            output={outputs.outputA}
+            scorers={{ faithfulness: { scorer: faithfulnessScorer(judge) } }}
+            context={sourceContext}
+          >
+            {{ value: 42 }}
+          </Task>
+        </Workflow>));
+        const result = await Effect.runPromise(runWorkflow(wf, { input: {} }));
+        expect(result.status).toBe("finished");
+        await scored;
+        expect(receivedPrompt).toContain(JSON.stringify(sourceContext));
         cleanup();
     }, END_TO_END_TIMEOUT_MS);
     test("sequence executes tasks in order", async () => {

--- a/packages/graph/src/extract.js
+++ b/packages/graph/src/extract.js
@@ -672,6 +672,8 @@ export function extractGraph(root, opts) {
                 scorers: raw.scorers && typeof raw.scorers === "object" && !Array.isArray(raw.scorers)
                     ? /** @type {import("./ScorersMap.ts").ScorersMap} */ (raw.scorers)
                     : undefined,
+                groundTruth: raw.groundTruth,
+                context: raw.context,
                 memoryConfig: raw.memory && typeof raw.memory === "object" && !Array.isArray(raw.memory)
                     ? raw.memory
                     : undefined,

--- a/packages/graph/src/index.d.ts
+++ b/packages/graph/src/index.d.ts
@@ -169,6 +169,8 @@ type TaskDescriptor$1 = {
     label?: string;
     meta?: Record<string, unknown>;
     scorers?: ScorersMap$1;
+    groundTruth?: unknown;
+    context?: unknown;
     memoryConfig?: TaskMemoryConfig$1;
     aspects?: TaskAspects$1;
 };

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -191,6 +191,8 @@ export type TaskDescriptor = {
   label?: string;
   meta?: Record<string, unknown>;
   scorers?: ScorersMap;
+  groundTruth?: unknown;
+  context?: unknown;
 
   memoryConfig?: TaskMemoryConfig;
   /** Resolved `<Aspects>` budget configuration enforced by the engine at dispatch. */

--- a/packages/graph/tests/extract.test.jsx
+++ b/packages/graph/tests/extract.test.jsx
@@ -273,11 +273,13 @@ describe("extractGraph", () => {
 	});
 
 	describe("approval options", () => {
-		test("extracts rich approval, hijack, memory, scorers, and agent retry metadata", () => {
+		test("extracts rich approval, hijack, memory, scorers, scorer inputs, and agent retry metadata", () => {
 			const outputSchema = z.object({ value: z.string() });
 			const agent = { generate: async () => ({}) };
 			const memory = { namespace: "task" };
 			const scorers = { quality: {} };
+			const groundTruth = { value: "expected" };
+			const context = { document: "source material" };
 			const root = hostEl("smithers:task", {
 				id: "approval",
 				output: "out",
@@ -301,6 +303,8 @@ describe("extractGraph", () => {
 				onHijackExit: "reopen",
 				memory,
 				scorers,
+				groundTruth,
+				context,
 				children: "inspect the diff",
 			});
 			const task = extractGraph(root).tasks[0];
@@ -326,6 +330,8 @@ describe("extractGraph", () => {
 			expect(task.onHijackExit).toBe("reopen");
 			expect(task.memoryConfig).toBe(memory);
 			expect(task.scorers).toBe(scorers);
+			expect(task.groundTruth).toBe(groundTruth);
+			expect(task.context).toBe(context);
 		});
 
 		test("rejects array meta and array scorers", () => {

--- a/packages/scorers/src/index.d.ts
+++ b/packages/scorers/src/index.d.ts
@@ -98,6 +98,8 @@ type ScorerContext$2 = {
     attempt: number;
     input: unknown;
     output: unknown;
+    groundTruth?: unknown;
+    context?: unknown;
     latencyMs?: number;
     outputSchema?: ZodObject;
 };

--- a/packages/scorers/src/run-scorers.js
+++ b/packages/scorers/src/run-scorers.js
@@ -66,6 +66,8 @@ function runSingleScorerEffect(key, binding, ctx, adapter, source, eventBus) {
             try: () => scorer.score({
                 input: ctx.input,
                 output: ctx.output,
+                groundTruth: ctx.groundTruth,
+                context: ctx.context,
                 latencyMs: ctx.latencyMs,
                 outputSchema: ctx.outputSchema,
             }),

--- a/packages/scorers/src/types.ts
+++ b/packages/scorers/src/types.ts
@@ -112,6 +112,8 @@ export type ScorerContext = {
   attempt: number;
   input: unknown;
   output: unknown;
+  groundTruth?: unknown;
+  context?: unknown;
   latencyMs?: number;
   outputSchema?: ZodObject;
 };

--- a/packages/scorers/tests/run-scorers.test.js
+++ b/packages/scorers/tests/run-scorers.test.js
@@ -364,4 +364,28 @@ describe("runScorersBatch", () => {
         expect(receivedInput.output).toEqual({ data: "my output" });
         expect(receivedInput.latencyMs).toBe(2500);
     });
+    it("forwards context and groundTruth to scorers", async () => {
+        let receivedInput;
+        const scorers = {
+            capture: {
+                scorer: createScorer({
+                    id: "capture-context",
+                    name: "Capture Context",
+                    description: "d",
+                    score: async (input) => {
+                        receivedInput = input;
+                        return { score: input.context === "source material" ? 1 : 0 };
+                    },
+                }),
+            },
+        };
+        const ctx = makeContext({
+            context: "source material",
+            groundTruth: { expected: "answer" },
+        });
+        const results = await runScorersBatch(scorers, ctx, null);
+        expect(results.capture?.score).toBe(1);
+        expect(receivedInput.context).toBe("source material");
+        expect(receivedInput.groundTruth).toEqual({ expected: "answer" });
+    });
 });


### PR DESCRIPTION
Relates to #303

## What was fixed

Live scorers did not receive `groundTruth` or `context` even when those fields were set on a task definition. This meant any scorer that needed ground-truth labels or per-task context metadata to compute a score would silently get `undefined` for both fields at runtime.

## Root cause & approach

`ScorerContext` (in `packages/scorers/src/types.ts`) was missing the `groundTruth` and `context` fields entirely. The call-site in `packages/scorers/src/run-scorers.js` therefore never forwarded them into `scorer.score()`. Additionally, `TaskDescriptor` in `packages/graph/src/types.ts` and the raw-node extractor in `packages/graph/src/extract.js` did not carry the fields through the graph pipeline at all.

Fix:
- Added `groundTruth?` and `context?` to `TaskDescriptor` (`packages/graph/src/types.ts`)
- Extract both fields from raw task nodes (`packages/graph/src/extract.js`)
- Added `groundTruth?` and `context?` to `ScorerContext` (`packages/scorers/src/types.ts`)
- Forward `ctx.groundTruth` and `ctx.context` in `runSingleScorerEffect` (`packages/scorers/src/run-scorers.js`)
- Updated `.d.ts` type declarations and added tests for both the graph extraction path and the scorer invocation path

Codex implemented the fix via TDD; Codex and Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)