### PR TITLE
🐛 fix(openapi): substitute repeated path params

### DIFF
--- a/packages/openapi/src/tool-factory/_helpers.js
+++ b/packages/openapi/src/tool-factory/_helpers.js
@@ -55,7 +55,7 @@ export function buildUrl(baseUrl, path, pathParams, queryParams, options) {
     // Substitute path parameters
     let url = path;
     for (const [key, value] of Object.entries(pathParams)) {
-        url = url.replace(`{${key}}`, encodeURIComponent(value));
+        url = url.replaceAll(`{${key}}`, encodeURIComponent(value));
     }
     // Join the server base path with the operation path so a base URL with a
     // path component (e.g. https://api.example.com/v2) is preserved. Passing an

--- a/packages/openapi/tests/build-url-base-path.test.js
+++ b/packages/openapi/tests/build-url-base-path.test.js
@@ -81,6 +81,17 @@ describe("buildUrl preserves server base path", () => {
         expect(url).toBe("https://api.example.com/v2/orgs/acme/users/5");
     });
 
+    test("repeated path params are all substituted", () => {
+        const url = buildUrl(
+            "https://api.example.com/v2",
+            "/orgs/{id}/aliases/{id}",
+            { id: "acme/primary" },
+            {},
+            noOptions,
+        );
+        expect(url).toBe("https://api.example.com/v2/orgs/acme%2Fprimary/aliases/acme%2Fprimary");
+    });
+
     test("apiKey-in-query auth still appends to a preserved base path", () => {
         const url = buildUrl(
             "https://api.example.com/v2",


### PR DESCRIPTION
Relates to #303

## What was fixed

`buildUrl()` in `packages/openapi/src/tool-factory/_helpers.js` used `String.prototype.replace()` to substitute path parameters into URL templates. `replace()` only replaces the **first** occurrence of a string pattern, so path templates that reference the same parameter more than once (e.g. `/orgs/{id}/aliases/{id}`) would leave the second `{id}` un-substituted, producing a broken URL.

## Root cause & approach

Switched from `.replace(\`{${key}}\`, ...)` to `.replaceAll(\`{${key}}\`, ...)` — a minimal one-character change that fixes all repeated-parameter occurrences in a single pass. A new test in `packages/openapi/tests/build-url-base-path.test.js` covers this case end-to-end, following TDD: the test was written first and drove the fix.

Codex implemented the fix via TDD, and both Codex and Claude Opus reviewed and approved it before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)