### PR TITLE
🐛 fix(scorers): persist scorer context and ground truth

### DIFF
--- a/packages/db/migrations/0017_add_scorer_context_columns.sql
+++ b/packages/db/migrations/0017_add_scorer_context_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE _smithers_scorers ADD COLUMN ground_truth_json TEXT;
+ALTER TABLE _smithers_scorers ADD COLUMN context_json TEXT;

--- a/packages/db/src/internal-schema/smithersScorers.js
+++ b/packages/db/src/internal-schema/smithersScorers.js
@@ -14,6 +14,8 @@ export const smithersScorers = sqliteTable("_smithers_scorers", {
     metaJson: text("meta_json"),
     inputJson: text("input_json"),
     outputJson: text("output_json"),
+    groundTruthJson: text("ground_truth_json"),
+    contextJson: text("context_json"),
     latencyMs: real("latency_ms"),
     scoredAtMs: integer("scored_at_ms").notNull(),
     durationMs: real("duration_ms"),

--- a/packages/db/src/schema-migrations.js
+++ b/packages/db/src/schema-migrations.js
@@ -473,6 +473,25 @@ function buildMigrations(context) {
                 return { table: "_smithers_workspace_checkpoints" };
             },
         },
+        {
+            id: "0017_add_scorer_context_columns",
+            name: "Add scorer context correlation columns",
+            checksum: "packages/db/migrations/0017_add_scorer_context_columns.sql",
+            isApplied: (sqlite) => {
+                const columns = tableColumnNames(sqlite, "_smithers_scorers");
+                return columns.has("ground_truth_json") && columns.has("context_json");
+            },
+            up: (sqlite) => {
+                const addedColumns = [];
+                if (addColumnIfMissing(sqlite, "_smithers_scorers", "ground_truth_json", "ground_truth_json TEXT")) {
+                    addedColumns.push("ground_truth_json");
+                }
+                if (addColumnIfMissing(sqlite, "_smithers_scorers", "context_json", "context_json TEXT")) {
+                    addedColumns.push("context_json");
+                }
+                return { table: "_smithers_scorers", addedColumns };
+            },
+        },
     ];
 }
 

--- a/packages/db/src/sql-message-storage.js
+++ b/packages/db/src/sql-message-storage.js
@@ -321,6 +321,8 @@ const CREATE_TABLE_STATEMENTS = [
     meta_json TEXT,
     input_json TEXT,
     output_json TEXT,
+    ground_truth_json TEXT,
+    context_json TEXT,
     latency_ms REAL,
     scored_at_ms INTEGER NOT NULL,
     duration_ms REAL

--- a/packages/db/src/storage/StorageServiceTypes.ts
+++ b/packages/db/src/storage/StorageServiceTypes.ts
@@ -117,10 +117,24 @@ export type CronRow = {
 };
 
 export type ScorerResultRow = {
+  readonly id?: string;
   readonly runId: string;
   readonly nodeId?: string;
+  readonly iteration?: number;
+  readonly attempt?: number;
   readonly scorerId?: string;
+  readonly scorerName?: string;
+  readonly source?: string;
+  readonly score?: number;
+  readonly reason?: string | null;
+  readonly metaJson?: string | null;
+  readonly inputJson?: string | null;
+  readonly outputJson?: string | null;
+  readonly groundTruthJson?: string | null;
+  readonly contextJson?: string | null;
+  readonly latencyMs?: number | null;
   readonly scoredAtMs?: number;
+  readonly durationMs?: number | null;
   readonly [key: string]: unknown;
 };
 

--- a/packages/db/tests/in-memory-storage-scorers.test.js
+++ b/packages/db/tests/in-memory-storage-scorers.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { makeInMemoryStorageService } from "../src/storage/InMemoryStorage.js";
+
+describe("InMemoryStorage scorer results", () => {
+    test("round-trips scorer context and groundTruth JSON", async () => {
+        const storage = makeInMemoryStorageService();
+        await Effect.runPromise(storage.insertScorerResult({
+            id: "score-1",
+            runId: "run-1",
+            nodeId: "node-1",
+            scorerId: "accuracy",
+            groundTruthJson: JSON.stringify({ expected: "answer" }),
+            contextJson: JSON.stringify({ docs: ["source"] }),
+            scoredAtMs: 1000,
+        }));
+
+        const rows = await Effect.runPromise(storage.listScorerResults("run-1", "node-1"));
+        expect(rows).toHaveLength(1);
+        expect(JSON.parse(rows[0].groundTruthJson)).toEqual({ expected: "answer" });
+        expect(JSON.parse(rows[0].contextJson)).toEqual({ docs: ["source"] });
+    });
+});

--- a/packages/db/tests/migrations.test.js
+++ b/packages/db/tests/migrations.test.js
@@ -194,6 +194,53 @@ describe("DB migration edges", () => {
     sqlite.close();
   });
 
+  test("forward migration adds scorer context columns to legacy scorer tables", () => {
+    const sqlite = new Database(":memory:");
+    sqlite.exec(`
+      CREATE TABLE _smithers_scorers (
+        id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        iteration INTEGER NOT NULL DEFAULT 0,
+        attempt INTEGER NOT NULL DEFAULT 0,
+        scorer_id TEXT NOT NULL,
+        scorer_name TEXT NOT NULL,
+        source TEXT NOT NULL,
+        score REAL NOT NULL,
+        reason TEXT,
+        meta_json TEXT,
+        input_json TEXT,
+        output_json TEXT,
+        latency_ms REAL,
+        scored_at_ms INTEGER NOT NULL,
+        duration_ms REAL
+      );
+      INSERT INTO _smithers_scorers (id, run_id, node_id, scorer_id, scorer_name, source, score, scored_at_ms)
+        VALUES ('score-legacy', 'run-1', 'node-1', 'accuracy', 'Accuracy', 'batch', 0.8, 1000);
+    `);
+    const db = drizzle(sqlite);
+    ensureSmithersTables(db);
+
+    const cols = sqlite.query('PRAGMA table_info("_smithers_scorers")').all().map((c) => c.name);
+    expect(cols).toContain("ground_truth_json");
+    expect(cols).toContain("context_json");
+
+    sqlite.run(
+      `UPDATE _smithers_scorers SET ground_truth_json = ?, context_json = ? WHERE id = ?`,
+      [
+        JSON.stringify({ expected: "answer" }),
+        JSON.stringify({ docs: ["source"] }),
+        "score-legacy",
+      ],
+    );
+    const row = sqlite
+      .query("SELECT ground_truth_json, context_json FROM _smithers_scorers WHERE id = ?")
+      .get("score-legacy");
+    expect(JSON.parse(row.ground_truth_json)).toEqual({ expected: "answer" });
+    expect(JSON.parse(row.context_json)).toEqual({ docs: ["source"] });
+    sqlite.close();
+  });
+
   test("malformed JSON in valueJson / xmlJson / configJson is caught at deserialize layer with a useful error", () => {
     // The DB stores TEXT — so writing arbitrary bytes succeeds. The contract
     // is that the deserialize layer (JSON.parse on read) surfaces the

--- a/packages/scorers/src/__type-tests__/smithersScorers.test-d.ts
+++ b/packages/scorers/src/__type-tests__/smithersScorers.test-d.ts
@@ -28,6 +28,8 @@ const selectRow: SelectScorer = {
     metaJson: null,
     inputJson: null,
     outputJson: null,
+    groundTruthJson: null,
+    contextJson: null,
     latencyMs: null,
     scoredAtMs: 1_700_000_000_000,
     durationMs: null,

--- a/packages/scorers/src/index.d.ts
+++ b/packages/scorers/src/index.d.ts
@@ -75,6 +75,8 @@ type ScoreRow$1 = {
     metaJson: string | null;
     inputJson: string | null;
     outputJson: string | null;
+    groundTruthJson: string | null;
+    contextJson: string | null;
     latencyMs: number | null;
     scoredAtMs: number;
     durationMs: number | null;
@@ -193,6 +195,8 @@ declare const smithersScorers: drizzle_orm_sqlite_core.SQLiteTableWithColumns<{
         metaJson: SmithersScorerColumn<"meta_json", string, false, false, false, "SQLiteText", "string">;
         inputJson: SmithersScorerColumn<"input_json", string, false, false, false, "SQLiteText", "string">;
         outputJson: SmithersScorerColumn<"output_json", string, false, false, false, "SQLiteText", "string">;
+        groundTruthJson: SmithersScorerColumn<"ground_truth_json", string, false, false, false, "SQLiteText", "string">;
+        contextJson: SmithersScorerColumn<"context_json", string, false, false, false, "SQLiteText", "string">;
         latencyMs: SmithersScorerColumn<"latency_ms", number, false, false, false, "SQLiteReal", "number">;
         scoredAtMs: SmithersScorerColumn<"scored_at_ms", number, true, false, false, "SQLiteInteger", "number">;
         durationMs: SmithersScorerColumn<"duration_ms", number, false, false, false, "SQLiteReal", "number">;

--- a/packages/scorers/src/run-scorers.js
+++ b/packages/scorers/src/run-scorers.js
@@ -125,6 +125,8 @@ function runSingleScorerEffect(key, binding, ctx, adapter, source, eventBus) {
                 metaJson: result.meta ? JSON.stringify(result.meta) : null,
                 inputJson: safeJsonStringify(ctx.input),
                 outputJson: safeJsonStringify(ctx.output),
+                groundTruthJson: safeJsonStringify(ctx.groundTruth),
+                contextJson: safeJsonStringify(ctx.context),
                 latencyMs: ctx.latencyMs ?? null,
                 scoredAtMs: nowMs(),
                 durationMs,

--- a/packages/scorers/src/types.ts
+++ b/packages/scorers/src/types.ts
@@ -83,6 +83,8 @@ export type ScoreRow = {
   metaJson: string | null;
   inputJson: string | null;
   outputJson: string | null;
+  groundTruthJson: string | null;
+  contextJson: string | null;
   latencyMs: number | null;
   scoredAtMs: number;
   durationMs: number | null;

--- a/packages/scorers/tests/run-scorers.test.js
+++ b/packages/scorers/tests/run-scorers.test.js
@@ -388,4 +388,30 @@ describe("runScorersBatch", () => {
         expect(receivedInput.context).toBe("source material");
         expect(receivedInput.groundTruth).toEqual({ expected: "answer" });
     });
+    it("persists context and groundTruth JSON with scorer results", async () => {
+        const adapter = createMockAdapter();
+        const scorers = {
+            persisted: {
+                scorer: createScorer({
+                    id: "persisted-context",
+                    name: "Persisted Context",
+                    description: "d",
+                    score: async () => ({ score: 0.91 }),
+                }),
+            },
+        };
+        await runScorersBatch(scorers, makeContext({
+            context: { docs: ["source-a"], traceId: "trace-1" },
+            groundTruth: { expected: "answer" },
+        }), adapter);
+        expect(adapter.insertScorerResult).toHaveBeenCalledTimes(1);
+        const insertedRow = adapter.rows[0];
+        expect(JSON.parse(insertedRow.contextJson)).toEqual({
+            docs: ["source-a"],
+            traceId: "trace-1",
+        });
+        expect(JSON.parse(insertedRow.groundTruthJson)).toEqual({
+            expected: "answer",
+        });
+    });
 });

--- a/packages/scorers/tests/scorers-schema.test.js
+++ b/packages/scorers/tests/scorers-schema.test.js
@@ -20,6 +20,8 @@ describe("smithersScorers schema", () => {
         "meta_json" TEXT,
         "input_json" TEXT,
         "output_json" TEXT,
+        "ground_truth_json" TEXT,
+        "context_json" TEXT,
         "latency_ms" REAL,
         "scored_at_ms" INTEGER NOT NULL,
         "duration_ms" REAL
@@ -42,6 +44,8 @@ describe("smithersScorers schema", () => {
             metaJson: JSON.stringify({ model: "claude" }),
             inputJson: JSON.stringify({ prompt: "test" }),
             outputJson: JSON.stringify({ result: "ok" }),
+            groundTruthJson: JSON.stringify({ expected: "ok" }),
+            contextJson: JSON.stringify({ docs: ["source"] }),
             latencyMs: 123.45,
             scoredAtMs: Date.now(),
             durationMs: 50.2,
@@ -57,6 +61,8 @@ describe("smithersScorers schema", () => {
         expect(rows[0].scorerName).toBe("Accuracy Scorer");
         expect(rows[0].source).toBe("live");
         expect(rows[0].reason).toBe("High quality output");
+        expect(JSON.parse(rows[0].groundTruthJson)).toEqual({ expected: "ok" });
+        expect(JSON.parse(rows[0].contextJson)).toEqual({ docs: ["source"] });
         expect(rows[0].latencyMs).toBe(123.45);
         sqlite.close();
     });
@@ -77,6 +83,8 @@ describe("smithersScorers schema", () => {
         "meta_json" TEXT,
         "input_json" TEXT,
         "output_json" TEXT,
+        "ground_truth_json" TEXT,
+        "context_json" TEXT,
         "latency_ms" REAL,
         "scored_at_ms" INTEGER NOT NULL,
         "duration_ms" REAL
@@ -105,6 +113,8 @@ describe("smithersScorers schema", () => {
         "meta_json" TEXT,
         "input_json" TEXT,
         "output_json" TEXT,
+        "ground_truth_json" TEXT,
+        "context_json" TEXT,
         "latency_ms" REAL,
         "scored_at_ms" INTEGER NOT NULL,
         "duration_ms" REAL
@@ -154,6 +164,8 @@ describe("smithersScorers schema", () => {
         "meta_json" TEXT,
         "input_json" TEXT,
         "output_json" TEXT,
+        "ground_truth_json" TEXT,
+        "context_json" TEXT,
         "latency_ms" REAL,
         "scored_at_ms" INTEGER NOT NULL,
         "duration_ms" REAL


### PR DESCRIPTION
Relates to #302

## What was fixed

Scorer runs were not persisting `context` and `groundTruth` fields — the data was passed into the scorer pipeline but never written to or read from the database. This meant downstream analysis, evals, and re-scoring could not access the context or ground truth that was present during the original run.

## Root cause & approach

The `smithersScorers` schema and SQL message storage layer lacked columns for `context` and `groundTruth`. The fix:

- **`packages/db/migrations/0017_add_scorer_context_columns.sql`** — adds `context` and `ground_truth` columns to the scorers table.
- **`packages/db/src/internal-schema/smithersScorers.js`** — extends the internal schema to include the new fields.
- **`packages/db/src/schema-migrations.js`** — registers migration 0017.
- **`packages/db/src/sql-message-storage.js`** — reads/writes the new columns on insert and select.
- **`packages/db/src/storage/StorageServiceTypes.ts`** — adds `context` and `groundTruth` to the storage type definitions.
- **`packages/scorers/src/run-scorers.js`** — passes context/groundTruth through to the storage layer.
- **`packages/scorers/src/types.ts`** and **`packages/scorers/src/index.d.ts`** — type definitions updated to expose the new fields.
- Tests added in `packages/db/tests/in-memory-storage-scorers.test.js` and updated in `packages/scorers/tests/` to cover round-trip persistence.

Codex implemented this via TDD; both Codex and Claude Opus reviewed and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)