### PR TITLE
🐛 fix(openapi): support non-json request bodies

### DIFF
--- a/packages/openapi/src/ParsedOperation.ts
+++ b/packages/openapi/src/ParsedOperation.ts
@@ -10,5 +10,6 @@ export type ParsedOperation = {
 	description: string;
 	parameters: ParameterObject[];
 	requestBody?: RequestBodyObject;
+	requestBodyMediaType?: string;
 	deprecated: boolean;
 };

--- a/packages/openapi/src/buildOperationSchema.js
+++ b/packages/openapi/src/buildOperationSchema.js
@@ -10,6 +10,24 @@ import { jsonSchemaToZod } from "./jsonSchemaToZod.js";
 /** @typedef {import("./RequestBodyObject.ts").RequestBodyObject} RequestBodyObject */
 
 /**
+ * @param {RequestBodyObject | undefined} requestBody
+ * @returns {{ mediaType: string; content: NonNullable<RequestBodyObject["content"]>[string] } | undefined}
+ */
+export function selectRequestBodyContent(requestBody) {
+    const content = requestBody?.content;
+    if (!content)
+        return undefined;
+    if (content["application/json"]) {
+        return { mediaType: "application/json", content: content["application/json"] };
+    }
+    const firstEntry = Object.entries(content)[0];
+    if (!firstEntry)
+        return undefined;
+    const [mediaType, mediaContent] = firstEntry;
+    return { mediaType, content: mediaContent };
+}
+
+/**
  * Build a single Zod object schema for an operation's input, combining:
  * - path parameters
  * - query parameters
@@ -42,9 +60,11 @@ export function buildOperationSchema(parameters, requestBody, spec) {
     }
     // Request body
     if (requestBody) {
-        const jsonContent = requestBody.content?.["application/json"];
-        if (jsonContent?.schema) {
-            const bodySchema = jsonSchemaToZod(jsonContent.schema, spec);
+        const selectedContent = selectRequestBodyContent(requestBody);
+        if (selectedContent) {
+            const bodySchema = selectedContent.content.schema
+                ? jsonSchemaToZod(selectedContent.content.schema, spec)
+                : z.any();
             // If the body schema is an object, merge its properties
             // into the top-level props under a "body" key
             if (requestBody.required) {

--- a/packages/openapi/src/extractOperations.js
+++ b/packages/openapi/src/extractOperations.js
@@ -4,6 +4,7 @@
 import { deref } from "./ref-resolver.js";
 import { HTTP_METHODS, } from "./types.js";
 import { mergeParameters, generateOperationId } from "./_specHelpers.js";
+import { selectRequestBodyContent } from "./buildOperationSchema.js";
 
 /** @typedef {import("./OpenApiSpec.ts").OpenApiSpec} OpenApiSpec */
 /** @typedef {import("./ParsedOperation.ts").ParsedOperation} ParsedOperation */
@@ -33,6 +34,7 @@ export function extractOperations(spec) {
             const requestBody = operation.requestBody
                 ? deref(spec, operation.requestBody)
                 : undefined;
+            const requestBodyMediaType = selectRequestBodyContent(requestBody)?.mediaType;
             const operationId = operation.operationId ?? generateOperationId(method, path);
             operations.push({
                 operationId,
@@ -42,6 +44,7 @@ export function extractOperations(spec) {
                 description: operation.description ?? operation.summary ?? "",
                 parameters: mergedParams,
                 requestBody,
+                requestBodyMediaType,
                 deprecated: operation.deprecated ?? false,
             });
         }

--- a/packages/openapi/src/index.d.ts
+++ b/packages/openapi/src/index.d.ts
@@ -60,6 +60,7 @@ type ParsedOperation$2 = {
     description: string;
     parameters: ParameterObject$1[];
     requestBody?: RequestBodyObject$1;
+    requestBodyMediaType?: string;
     deprecated: boolean;
 };
 

--- a/packages/openapi/src/tool-factory/_helpers.js
+++ b/packages/openapi/src/tool-factory/_helpers.js
@@ -75,6 +75,97 @@ export function buildUrl(baseUrl, path, pathParams, queryParams, options) {
     return fullUrl.toString();
 }
 /**
+ * @param {unknown} value
+ * @returns {string | Blob}
+ */
+function toFormValue(value) {
+    if (value instanceof Blob)
+        return value;
+    if (typeof value === "string")
+        return value;
+    return String(value);
+}
+/**
+ * @param {unknown} body
+ * @returns {FormData}
+ */
+function buildFormData(body) {
+    const formData = new FormData();
+    if (body && typeof body === "object" && !(body instanceof Blob) && !(body instanceof ArrayBuffer)) {
+        for (const [key, value] of Object.entries(body)) {
+            if (value === undefined)
+                continue;
+            if (Array.isArray(value)) {
+                for (const item of value) {
+                    formData.append(key, toFormValue(item));
+                }
+            }
+            else {
+                formData.append(key, toFormValue(value));
+            }
+        }
+        return formData;
+    }
+    formData.append("body", toFormValue(body));
+    return formData;
+}
+/**
+ * @param {unknown} body
+ * @returns {URLSearchParams}
+ */
+function buildUrlEncodedBody(body) {
+    const params = new URLSearchParams();
+    if (body && typeof body === "object" && !(body instanceof Blob) && !(body instanceof ArrayBuffer)) {
+        for (const [key, value] of Object.entries(body)) {
+            if (value === undefined)
+                continue;
+            if (Array.isArray(value)) {
+                for (const item of value) {
+                    params.append(key, String(item));
+                }
+            }
+            else {
+                params.append(key, String(value));
+            }
+        }
+        return params;
+    }
+    params.set("body", String(body));
+    return params;
+}
+/**
+ * @param {unknown} body
+ * @returns {BodyInit}
+ */
+function buildRawBody(body) {
+    if (body instanceof Blob || body instanceof ArrayBuffer || typeof body === "string") {
+        return body;
+    }
+    return JSON.stringify(body);
+}
+/**
+ * @param {unknown} body
+ * @param {string | undefined} mediaType
+ * @param {Record<string, string>} headers
+ * @returns {BodyInit}
+ */
+function serializeRequestBody(body, mediaType, headers) {
+    const requestMediaType = mediaType ?? "application/json";
+    if (requestMediaType.includes("multipart/form-data")) {
+        delete headers["Content-Type"];
+        return buildFormData(body);
+    }
+    if (requestMediaType.includes("application/x-www-form-urlencoded")) {
+        headers["Content-Type"] = requestMediaType;
+        return buildUrlEncodedBody(body);
+    }
+    headers["Content-Type"] = requestMediaType;
+    if (requestMediaType.includes("application/json") || requestMediaType.includes("+json")) {
+        return JSON.stringify(body);
+    }
+    return buildRawBody(body);
+}
+/**
  * @param {ParsedOperation} operation
  * @param {Record<string, unknown>} args
  * @param {string} baseUrl
@@ -119,9 +210,8 @@ export async function executeRequest(operation, args, baseUrl, options) {
     };
     // Request body
     if (args.body !== undefined) {
-        headers["Content-Type"] = "application/json";
+        fetchInit.body = serializeRequestBody(args.body, operation.requestBodyMediaType, headers);
         fetchInit.headers = headers;
-        fetchInit.body = JSON.stringify(args.body);
     }
     const response = await fetch(url, fetchInit);
     const contentType = response.headers.get("content-type") ?? "";

--- a/packages/openapi/tests/execution.test.js
+++ b/packages/openapi/tests/execution.test.js
@@ -48,6 +48,77 @@ describe("OpenAPI tool execution", () => {
         expect(init.body).toBe(JSON.stringify({ name: "Fido", tag: "dog" }));
         expect(init.headers["Content-Type"]).toBe("application/json");
     });
+    test("POST request with multipart form body", async () => {
+        const tools = createOpenApiToolsSync({
+            openapi: "3.0.0",
+            info: { title: "Uploads", version: "1.0.0" },
+            servers: [{ url: "https://api.example.com" }],
+            paths: {
+                "/uploads": {
+                    post: {
+                        operationId: "uploadFile",
+                        requestBody: {
+                            required: true,
+                            content: {
+                                "multipart/form-data": {
+                                    schema: {
+                                        type: "object",
+                                        required: ["file"],
+                                        properties: {
+                                            file: { type: "string", format: "binary" },
+                                            purpose: { type: "string" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        responses: { "200": { description: "ok" } },
+                    },
+                },
+            },
+        });
+        await tools.uploadFile.execute({ body: { file: "contents", purpose: "avatar" } });
+        const [, init] = mockFetch.mock.calls[0];
+        expect(init.body).toBeInstanceOf(FormData);
+        expect(init.body.get("file")).toBe("contents");
+        expect(init.body.get("purpose")).toBe("avatar");
+        expect(init.headers["Content-Type"]).toBeUndefined();
+    });
+    test("POST request with urlencoded form body", async () => {
+        const tools = createOpenApiToolsSync({
+            openapi: "3.0.0",
+            info: { title: "Forms", version: "1.0.0" },
+            servers: [{ url: "https://api.example.com" }],
+            paths: {
+                "/subscriptions": {
+                    post: {
+                        operationId: "subscribe",
+                        requestBody: {
+                            required: true,
+                            content: {
+                                "application/x-www-form-urlencoded": {
+                                    schema: {
+                                        type: "object",
+                                        required: ["email"],
+                                        properties: {
+                                            email: { type: "string" },
+                                            optIn: { type: "boolean" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        responses: { "200": { description: "ok" } },
+                    },
+                },
+            },
+        });
+        await tools.subscribe.execute({ body: { email: "a@example.com", optIn: true } });
+        const [, init] = mockFetch.mock.calls[0];
+        expect(init.body).toBeInstanceOf(URLSearchParams);
+        expect(init.body.toString()).toBe("email=a%40example.com&optIn=true");
+        expect(init.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    });
     test("DELETE request", async () => {
         const tools = createOpenApiToolsSync(petStoreSpec);
         const deletePet = tools.deletePet;

--- a/packages/openapi/tests/schema-conversion.test.js
+++ b/packages/openapi/tests/schema-conversion.test.js
@@ -286,6 +286,28 @@ describe("buildOperationSchema", () => {
             body: { name: "Fido" },
         });
     });
+    test("builds schema from the first non-JSON request body when JSON is absent", () => {
+        const requestBody = {
+            required: true,
+            content: {
+                "application/x-www-form-urlencoded": {
+                    schema: {
+                        type: "object",
+                        required: ["email"],
+                        properties: {
+                            email: { type: "string" },
+                            subscribe: { type: "boolean" },
+                        },
+                    },
+                },
+            },
+        };
+        const schema = buildOperationSchema([], requestBody, emptySpec);
+        expect(schema.parse({ body: { email: "a@example.com", subscribe: true } })).toEqual({
+            body: { email: "a@example.com", subscribe: true },
+        });
+        expect(() => schema.parse({})).toThrow();
+    });
     test("builds schema with both params and body", () => {
         const params = [
             { name: "ownerId", in: "path", required: true, schema: { type: "string" } },

--- a/packages/openapi/tests/spec-parser.test.js
+++ b/packages/openapi/tests/spec-parser.test.js
@@ -103,6 +103,36 @@ describe("extractOperations", () => {
         expect(createPet.requestBody).toBeDefined();
         const jsonSchema = createPet.requestBody?.content["application/json"]?.schema;
         expect(jsonSchema).toBeDefined();
+        expect(createPet.requestBodyMediaType).toBe("application/json");
+    });
+    test("records fallback request body media type when JSON is absent", () => {
+        const ops = extractOperations({
+            openapi: "3.0.0",
+            info: { title: "Forms", version: "1.0.0" },
+            paths: {
+                "/uploads": {
+                    post: {
+                        operationId: "uploadFile",
+                        requestBody: {
+                            required: true,
+                            content: {
+                                "multipart/form-data": {
+                                    schema: {
+                                        type: "object",
+                                        required: ["file"],
+                                        properties: {
+                                            file: { type: "string", format: "binary" },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        responses: { "200": { description: "ok" } },
+                    },
+                },
+            },
+        });
+        expect(ops[0].requestBodyMediaType).toBe("multipart/form-data");
     });
     test("resolves $ref in request body", () => {
         const ops = extractOperations(refSpec);


### PR DESCRIPTION
Relates to #302

## What was fixed

The OpenAPI package's `executeRequest` helper always serialized request bodies as JSON and hard-coded `Content-Type: application/json`, breaking any API operation whose spec declares a non-JSON body (e.g. `multipart/form-data` for file uploads, `application/x-www-form-urlencoded` for form submissions, or raw binary/text bodies).

## Root cause & approach

**Root cause:** `_helpers.js:executeRequest` unconditionally called `JSON.stringify(body)` and set `Content-Type: application/json`, ignoring the operation's declared `requestBody.content` media type.

**Fix (key files):**

- `buildOperationSchema.js` — added `selectRequestBodyContent()` to pick the best content entry (preferring `application/json`, falling back to the first declared media type). Schema building now works for any media type, defaulting to `z.any()` when no schema is given.
- `extractOperations.js` — surfaces the selected `requestBodyMediaType` on every `ParsedOperation` so downstream helpers know what the spec declared.
- `ParsedOperation.ts` / `index.d.ts` — added `requestBodyMediaType?: string` to the type.
- `tool-factory/_helpers.js` — added `serializeRequestBody()` which dispatches on `requestBodyMediaType`: `multipart/form-data` → `FormData` (browser lets fetch set the boundary), `application/x-www-form-urlencoded` → `URLSearchParams`, `application/json` / `+json` → `JSON.stringify`, anything else → raw pass-through. Also added helpers `buildFormData()` and `buildUrlEncodedBody()`.

Codex implemented this via TDD. Both Codex and Claude Opus reviewed and approved before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)