### PR TITLE
🐛 fix(components): preserve SuperSmithers task outputs

### DIFF
--- a/packages/components/src/components/SuperSmithers.js
+++ b/packages/components/src/components/SuperSmithers.js
@@ -36,7 +36,7 @@ export function SuperSmithers(props) {
     const prefix = idPrefix ?? "super-smithers";
     // Task 1: Read strategy and target files
     const readTaskId = `${prefix}-read`;
-    const readOutput = reportOutput ?? "super-smithers-read";
+    const readOutput = "super-smithers-read";
     const strategyText = typeof strategy === "string" ? strategy : undefined;
     const strategyElement = typeof strategy !== "string" ? strategy : undefined;
     const readPrompt = strategyText
@@ -53,7 +53,7 @@ export function SuperSmithers(props) {
     }, readChildren);
     // Task 2: Propose modifications
     const proposeTaskId = `${prefix}-propose`;
-    const proposeOutput = reportOutput ?? "super-smithers-propose";
+    const proposeOutput = "super-smithers-propose";
     const proposeTask = React.createElement("smithers:task", {
         id: proposeTaskId,
         output: proposeOutput,
@@ -66,7 +66,7 @@ export function SuperSmithers(props) {
         (dryRun ? "This is a DRY RUN — do not apply changes, only report them." : ""));
     // Task 3: Apply modifications (only if not dryRun)
     const applyTaskId = `${prefix}-apply`;
-    const applyOutput = reportOutput ?? "super-smithers-apply";
+    const applyOutput = "super-smithers-apply";
     const applyTask = !dryRun
         ? React.createElement("smithers:task", {
             id: applyTaskId,

--- a/packages/components/tests/composite-coverage.test.jsx
+++ b/packages/components/tests/composite-coverage.test.jsx
@@ -563,6 +563,11 @@ describe("composite component expansion coverage", () => {
             "ss-propose",
             "ss-report",
         ]);
+        expect(dryRunChildren.map((child) => child.props.output)).toEqual([
+            "super-smithers-read",
+            "super-smithers-propose",
+            "report_out",
+        ]);
 
         const applyRun = SuperSmithers({
             id: "apply",
@@ -576,6 +581,12 @@ describe("composite component expansion coverage", () => {
             "apply-propose",
             "apply-apply",
             "apply-report",
+        ]);
+        expect(applyChildren.map((child) => child.props.output)).toEqual([
+            "super-smithers-read",
+            "super-smithers-propose",
+            "super-smithers-apply",
+            "report_out",
         ]);
         await expect(applyChildren[2].props.__smithersComputeFn()).resolves.toEqual({ applied: true });
 


### PR DESCRIPTION
Relates to #303

## What was fixed

`SuperSmithers` was incorrectly using the `reportOutput` prop as the output key for its three internal tasks (read, propose, apply). When `reportOutput` was supplied, all three tasks shared the same output channel, causing output key collisions and data loss — later task outputs silently overwrote earlier ones.

## Root cause & approach

In `packages/components/src/components/SuperSmithers.js`, each internal task's `output` was set to `reportOutput ?? "super-smithers-<task>"`. Passing any `reportOutput` value caused the fallback to be bypassed, making all three tasks write to the same output key.

The fix unconditionally uses the stable, task-specific keys (`super-smithers-read`, `super-smithers-propose`, `super-smithers-apply`) for the internal tasks. The `reportOutput` prop still controls only the final report task's output, which is its intended purpose.

Tests in `packages/components/tests/composite-coverage.test.jsx` were extended to assert the exact output values for both dry-run and apply modes, covering the regression.

## Process

Codex implemented the fix via TDD; Codex and Claude Opus both approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)