### PR TITLE
🐛 fix(cli): expose time-travel tools on semantic MCP

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -8899,7 +8899,8 @@ The response is also echoed as a `text` content block, so clients that do not pa
 |---|---|---|
 | `readOnlyHint: true` | Most query tools | Tool does not modify state |
 | `readOnlyHint: false, openWorldHint: true` | `run_workflow` | Launches external processes |
-| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt`, `rewind_run`, `restore_checkpoint`, `time_travel` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, idempotentHint: false` | `fork_run`, `replay_run` | Creates new run/branch state |
 
 ---
 
@@ -9296,6 +9297,117 @@ Revert the workspace and frame history back to the state captured at a specific 
   run: RunSummary | null;
 }
 ```
+
+---
+
+### fork_run
+
+Create a branched run from a time-travel snapshot checkpoint without starting it.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `parentRunId` | `string` | Source run ID |
+| `frameNo` | `number` | Snapshot frame number |
+| `resetNodes` | `string[]` | Node IDs to reset to pending in the fork |
+| `inputOverrides` | `Record<string, unknown>` | Input fields to overlay on the snapshot input |
+| `branchLabel` | `string` | Optional branch label |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, run }`
+
+---
+
+### replay_run
+
+Fork a run from a checkpoint for replay, optionally restoring VCS state. Resume the returned `runId` with `run_workflow` when needed.
+
+**Input:** same as `fork_run`, plus:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `restoreVcs` | `boolean` | `false` | Restore the working copy to the source frame revision |
+| `cwd` | `string` | - | Working directory used for VCS restore |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, vcsRestored, vcsPointer, vcsError?, run }`
+
+---
+
+### rewind_run
+
+Rewind a run to a previous frame, deleting later frames and invalidating derived state. This is destructive and requires `confirm: true`.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run to rewind |
+| `frameNo` | `number` | Target frame number |
+| `confirm` | `boolean` | Must be `true` |
+
+**Output:** `{ result, run }`
+
+---
+
+### restore_checkpoint
+
+Restore the worktree to a durability checkpoint for a node. If `seq` is omitted, the latest matching checkpoint is used.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run containing the checkpoint |
+| `nodeId` | `string` | Node whose checkpoint should be restored |
+| `iteration` | `number` | Optional loop iteration |
+| `seq` | `number` | Optional checkpoint sequence |
+
+**Output:** `{ runId, nodeId, iteration, seq, commitId, cwd, success, error? }`
+
+---
+
+### list_snapshots
+
+List durability workspace checkpoints for a run with matching VCS operation IDs when available.
+
+**Input:** `{ runId: string }`
+
+**Output:** `{ snapshots: Array<{ seq, nodeId, iteration, attempt, tier, source, label, commitId, operationId, cwd, createdAtMs }> }`
+
+---
+
+### get_timeline
+
+Return the time-travel timeline for a run, optionally including all child forks recursively.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `tree` | `boolean` | `false` | Include child forks recursively |
+
+**Output:** `{ timeline: unknown }`
+
+---
+
+### time_travel
+
+Reset a run back to a prior node attempt and optionally restore VCS state. If the run is still marked running, pass `force: true`.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `nodeId` | `string` | required | Node to travel back to |
+| `iteration` | `number` | `0` | Loop iteration |
+| `attempt` | `number` | latest | Attempt number |
+| `restoreVcs` | `boolean` | `true` | Restore filesystem state |
+| `resetDependents` | `boolean` | `true` | Reset dependent nodes too |
+| `force` | `boolean` | `false` | Allow time travel when the run is still running |
+
+**Output:** `{ result, run }`
 
 ---
 

--- a/apps/cli/src/mcp/SemanticToolName.ts
+++ b/apps/cli/src/mcp/SemanticToolName.ts
@@ -10,6 +10,13 @@ export type SemanticToolName =
     | "ask_human"
     | "get_node_detail"
     | "revert_attempt"
+    | "fork_run"
+    | "replay_run"
+    | "rewind_run"
+    | "restore_checkpoint"
+    | "list_snapshots"
+    | "get_timeline"
+    | "time_travel"
     | "list_artifacts"
     | "get_chat_transcript"
     | "get_run_events";

--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -16,7 +16,13 @@ import { buildAgentAskRequestRow, waitForHumanAnswer, } from "@smithers-orchestr
 import { buildAskKindFields, buildAskPromptText, buildAskUniqueToken, resolveAskHumanContext, } from "../ask-human.js";
 import { runWorkflow } from "@smithers-orchestrator/engine";
 import { revertToAttempt } from "@smithers-orchestrator/time-travel/revert";
+import { forkRun } from "@smithers-orchestrator/time-travel/fork";
+import { replayFromCheckpoint } from "@smithers-orchestrator/time-travel/replay";
+import { timeTravel } from "@smithers-orchestrator/time-travel/timetravel";
+import { buildTimeline, buildTimelineTree } from "@smithers-orchestrator/time-travel/timeline";
+import { jumpToFrameRoute } from "@smithers-orchestrator/server/gatewayRoutes/jumpToFrame";
 import { runPromise } from "../smithersRuntime.js";
+import { pickTargetCheckpoint, runRestoreOnce } from "../restore.js";
 import { SmithersError } from "@smithers-orchestrator/errors";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 /**
@@ -43,6 +49,13 @@ export const SEMANTIC_TOOL_NAMES = [
     "ask_human",
     "get_node_detail",
     "revert_attempt",
+    "fork_run",
+    "replay_run",
+    "rewind_run",
+    "restore_checkpoint",
+    "list_snapshots",
+    "get_timeline",
+    "time_travel",
     "list_artifacts",
     "get_chat_transcript",
     "get_run_events",
@@ -385,6 +398,93 @@ const revertAttemptDataSchema = z.object({
     success: z.boolean(),
     error: z.string().optional(),
     jjPointer: z.string().optional(),
+    run: runSummarySchema.nullable(),
+});
+const forkRunInputSchema = z.object({
+    parentRunId: z.string(),
+    frameNo: z.number().int().min(0),
+    resetNodes: z.array(z.string()).optional(),
+    inputOverrides: z.record(z.string(), z.unknown()).optional(),
+    branchLabel: z.string().optional(),
+});
+const forkRunDataSchema = z.object({
+    runId: z.string(),
+    parentRunId: z.string(),
+    parentFrameNo: z.number().int(),
+    branch: z.unknown(),
+    snapshot: z.unknown(),
+    run: runSummarySchema.nullable(),
+});
+const replayRunInputSchema = forkRunInputSchema.extend({
+    restoreVcs: z.boolean().default(false),
+    cwd: z.string().optional(),
+});
+const replayRunDataSchema = forkRunDataSchema.extend({
+    vcsRestored: z.boolean(),
+    vcsPointer: z.string().nullable(),
+    vcsError: z.string().optional(),
+});
+const rewindRunInputSchema = z.object({
+    runId: z.string(),
+    frameNo: z.number().int().min(0),
+    confirm: z.boolean().default(false),
+});
+const rewindRunDataSchema = z.object({
+    result: z.unknown(),
+    run: runSummarySchema.nullable(),
+});
+const restoreCheckpointInputSchema = z.object({
+    runId: z.string(),
+    nodeId: z.string(),
+    iteration: z.number().int().min(0).optional(),
+    seq: z.number().int().min(0).optional(),
+});
+const restoreCheckpointDataSchema = z.object({
+    runId: z.string(),
+    nodeId: z.string(),
+    iteration: z.number().int().nullable(),
+    seq: z.number().int(),
+    commitId: z.string(),
+    cwd: z.string(),
+    success: z.boolean(),
+    error: z.string().optional(),
+});
+const listSnapshotsInputSchema = z.object({
+    runId: z.string(),
+});
+const listSnapshotsDataSchema = z.object({
+    snapshots: z.array(z.object({
+        seq: z.number().int(),
+        nodeId: z.string(),
+        iteration: z.number().int(),
+        attempt: z.number().int(),
+        tier: z.number().int(),
+        source: z.string(),
+        label: z.string().nullable(),
+        commitId: z.string(),
+        operationId: z.string().nullable(),
+        cwd: z.string(),
+        createdAtMs: z.number(),
+    })),
+});
+const getTimelineInputSchema = z.object({
+    runId: z.string(),
+    tree: z.boolean().default(false),
+});
+const getTimelineDataSchema = z.object({
+    timeline: z.unknown(),
+});
+const timeTravelInputSchema = z.object({
+    runId: z.string(),
+    nodeId: z.string(),
+    iteration: z.number().int().min(0).default(0),
+    attempt: z.number().int().min(1).optional(),
+    restoreVcs: z.boolean().default(true),
+    resetDependents: z.boolean().default(true),
+    force: z.boolean().default(false),
+});
+const timeTravelDataSchema = z.object({
+    result: z.unknown(),
     run: runSummarySchema.nullable(),
 });
 const listArtifactsInputSchema = z.object({
@@ -1207,6 +1307,232 @@ export function createSemanticToolDefinitions(options = {}) {
                     ...(result.jjPointer ? { jjPointer: result.jjPointer } : {}),
                     run: run != null
                         ? await buildRunSummary(adapter, run)
+                        : null,
+                };
+            })),
+        },
+        {
+            name: "fork_run",
+            description: "Create a branched run from a time-travel snapshot checkpoint without starting it.",
+            inputSchema: forkRunInputSchema,
+            outputSchema: resultSchema(forkRunDataSchema),
+            annotations: {
+                readOnlyHint: false,
+                idempotentHint: false,
+            },
+            handler: (input) => executeSemanticTool("fork_run", async () => withDb(context, async (adapter) => {
+                const result = await forkRun(adapter, {
+                    parentRunId: input.parentRunId,
+                    frameNo: input.frameNo,
+                    inputOverrides: input.inputOverrides,
+                    resetNodes: input.resetNodes,
+                    branchLabel: input.branchLabel,
+                });
+                const run = await adapter.getRun(result.runId);
+                return {
+                    runId: result.runId,
+                    parentRunId: input.parentRunId,
+                    parentFrameNo: input.frameNo,
+                    branch: result.branch,
+                    snapshot: result.snapshot,
+                    run: run != null
+                        ? await buildRunSummary(adapter, run)
+                        : null,
+                };
+            })),
+        },
+        {
+            name: "replay_run",
+            description: "Fork a run from a checkpoint for replay, optionally restoring VCS state; callers can resume the returned runId.",
+            inputSchema: replayRunInputSchema,
+            outputSchema: resultSchema(replayRunDataSchema),
+            annotations: {
+                readOnlyHint: false,
+                idempotentHint: false,
+            },
+            handler: (input) => executeSemanticTool("replay_run", async () => withDb(context, async (adapter) => {
+                const result = await replayFromCheckpoint(adapter, {
+                    parentRunId: input.parentRunId,
+                    frameNo: input.frameNo,
+                    inputOverrides: input.inputOverrides,
+                    resetNodes: input.resetNodes,
+                    branchLabel: input.branchLabel,
+                    restoreVcs: input.restoreVcs,
+                    cwd: input.cwd,
+                });
+                const run = await adapter.getRun(result.runId);
+                return {
+                    runId: result.runId,
+                    parentRunId: input.parentRunId,
+                    parentFrameNo: input.frameNo,
+                    branch: result.branch,
+                    snapshot: result.snapshot,
+                    vcsRestored: result.vcsRestored,
+                    vcsPointer: result.vcsPointer ?? null,
+                    ...(result.vcsError ? { vcsError: result.vcsError } : {}),
+                    run: run != null
+                        ? await buildRunSummary(adapter, run)
+                        : null,
+                };
+            })),
+        },
+        {
+            name: "rewind_run",
+            description: "Destructive: rewind a run to a previous frame, deleting later frames and invalidating derived state. Requires confirm=true.",
+            inputSchema: rewindRunInputSchema,
+            outputSchema: resultSchema(rewindRunDataSchema),
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+            },
+            handler: (input) => executeSemanticTool("rewind_run", async () => withDb(context, async (adapter) => {
+                if (!input.confirm) {
+                    throw new SmithersError("INVALID_INPUT", "rewind_run requires confirm=true because it is destructive.", {
+                        runId: input.runId,
+                        frameNo: input.frameNo,
+                    });
+                }
+                const result = await jumpToFrameRoute({
+                    adapter,
+                    runId: input.runId,
+                    frameNo: input.frameNo,
+                    confirm: true,
+                    caller: "mcp:semantic",
+                });
+                const run = await adapter.getRun(input.runId);
+                return {
+                    result,
+                    run: run != null
+                        ? await buildRunSummary(adapter, run)
+                        : null,
+                };
+            })),
+        },
+        {
+            name: "restore_checkpoint",
+            description: "Destructive: restore the worktree to a durability checkpoint for a node, selecting the latest matching checkpoint unless seq is provided.",
+            inputSchema: restoreCheckpointInputSchema,
+            outputSchema: resultSchema(restoreCheckpointDataSchema),
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+            },
+            handler: (input) => executeSemanticTool("restore_checkpoint", async () => withDb(context, async (adapter) => {
+                const checkpoints = await adapter.listWorkspaceCheckpoints(input.runId);
+                const target = pickTargetCheckpoint(checkpoints, {
+                    nodeId: input.nodeId,
+                    iteration: input.iteration,
+                    seq: input.seq,
+                });
+                if (!target) {
+                    throw new SmithersError("CHECKPOINT_NOT_FOUND", `No matching durability checkpoint for run ${input.runId} node ${input.nodeId}${input.seq !== undefined ? ` seq ${input.seq}` : ""}`, {
+                        runId: input.runId,
+                        nodeId: input.nodeId,
+                        iteration: input.iteration,
+                        seq: input.seq,
+                    });
+                }
+                let stdoutText = "";
+                let stderrText = "";
+                const result = await runRestoreOnce({
+                    adapter,
+                    runId: input.runId,
+                    nodeId: input.nodeId,
+                    iteration: input.iteration,
+                    seq: input.seq,
+                    stdout: { write: (chunk) => { stdoutText += chunk; } },
+                    stderr: { write: (chunk) => { stderrText += chunk; } },
+                });
+                return {
+                    runId: input.runId,
+                    nodeId: input.nodeId,
+                    iteration: target.iteration ?? null,
+                    seq: target.seq,
+                    commitId: target.jjCommitId,
+                    cwd: target.jjCwd,
+                    success: result.exitCode === 0,
+                    ...(result.exitCode === 0
+                        ? {}
+                        : { error: stderrText.trim() || stdoutText.trim() || "restore failed" }),
+                };
+            })),
+        },
+        {
+            name: "list_snapshots",
+            description: "List durability workspace checkpoints for a run with matching VCS operation ids when available.",
+            inputSchema: listSnapshotsInputSchema,
+            outputSchema: resultSchema(listSnapshotsDataSchema),
+            annotations: { readOnlyHint: true },
+            handler: (input) => executeSemanticTool("list_snapshots", async () => withDb(context, async (adapter) => {
+                const [checkpoints, states] = await Promise.all([
+                    adapter.listWorkspaceCheckpoints(input.runId),
+                    adapter.listWorkspaceStates(input.runId),
+                ]);
+                const opByCommit = new Map();
+                for (const state of states) {
+                    opByCommit.set(`${state.jjCwd}\0${state.jjCommitId}`, state.jjOperationId);
+                }
+                return {
+                    snapshots: checkpoints.map((checkpoint) => ({
+                        seq: checkpoint.seq,
+                        nodeId: checkpoint.nodeId,
+                        iteration: checkpoint.iteration,
+                        attempt: checkpoint.attempt,
+                        tier: checkpoint.tier,
+                        source: checkpoint.source,
+                        label: checkpoint.label ?? null,
+                        commitId: checkpoint.jjCommitId,
+                        operationId: opByCommit.get(`${checkpoint.jjCwd}\0${checkpoint.jjCommitId}`) ?? null,
+                        cwd: checkpoint.jjCwd,
+                        createdAtMs: checkpoint.createdAtMs,
+                    })),
+                };
+            })),
+        },
+        {
+            name: "get_timeline",
+            description: "Return the time-travel timeline for a run, optionally including all child forks recursively.",
+            inputSchema: getTimelineInputSchema,
+            outputSchema: resultSchema(getTimelineDataSchema),
+            annotations: { readOnlyHint: true },
+            handler: (input) => executeSemanticTool("get_timeline", async () => withDb(context, async (adapter) => ({
+                timeline: input.tree
+                    ? await buildTimelineTree(adapter, input.runId)
+                    : await buildTimeline(adapter, input.runId),
+            }))),
+        },
+        {
+            name: "time_travel",
+            description: "Destructive: reset a run back to a prior node attempt and optionally restore VCS state. Requires force=true when the run is still running.",
+            inputSchema: timeTravelInputSchema,
+            outputSchema: resultSchema(timeTravelDataSchema),
+            annotations: {
+                readOnlyHint: false,
+                destructiveHint: true,
+                idempotentHint: false,
+            },
+            handler: (input) => executeSemanticTool("time_travel", async () => withDb(context, async (adapter) => {
+                const run = await adapter.getRun(input.runId);
+                if (run?.status === "running" && !input.force) {
+                    throw new SmithersError("RUN_STILL_RUNNING", `Run ${input.runId} is still marked running. Pass force=true to time-travel it anyway.`, {
+                        runId: input.runId,
+                    });
+                }
+                const result = await timeTravel(adapter, {
+                    runId: input.runId,
+                    nodeId: input.nodeId,
+                    iteration: input.iteration,
+                    attempt: input.attempt,
+                    resetDependents: input.resetDependents,
+                    restoreVcs: input.restoreVcs,
+                });
+                const updatedRun = await adapter.getRun(input.runId);
+                return {
+                    result,
+                    run: updatedRun != null
+                        ? await buildRunSummary(adapter, updatedRun)
                         : null,
                 };
             })),

--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -281,6 +281,27 @@ function makeSemanticAdapter(overrides = {}) {
         listAttemptsForRun: async (runId) => state.attempts.filter((attempt) => attempt.runId === runId),
         listEvents: async (_runId, afterSeq) => afterSeq < 0 ? state.events : [],
         listEventHistory: async () => state.historyEvents,
+        listWorkspaceCheckpoints: async () => [
+            {
+                seq: 0,
+                nodeId: "artifact-node",
+                iteration: 0,
+                attempt: 1,
+                tier: 1,
+                source: "hook",
+                label: "Edit output",
+                jjCwd: "/tmp/work",
+                jjCommitId: "commit-1",
+                createdAtMs: NOW - 1_000,
+            },
+        ],
+        listWorkspaceStates: async () => [
+            {
+                jjCwd: "/tmp/work",
+                jjCommitId: "commit-1",
+                jjOperationId: "op-1",
+            },
+        ],
     };
     return { adapter, state };
 }
@@ -322,6 +343,13 @@ describe("semantic tool definitions", () => {
     test("exposes the expected tools and validates run workflow resume input", async () => {
         const harness = makeHarness();
         expect([...harness.tools.keys()].sort()).toEqual([...SEMANTIC_TOOL_NAMES].sort());
+        expect(SEMANTIC_TOOL_NAMES).toContain("fork_run");
+        expect(SEMANTIC_TOOL_NAMES).toContain("replay_run");
+        expect(SEMANTIC_TOOL_NAMES).toContain("rewind_run");
+        expect(SEMANTIC_TOOL_NAMES).toContain("restore_checkpoint");
+        expect(SEMANTIC_TOOL_NAMES).toContain("list_snapshots");
+        expect(SEMANTIC_TOOL_NAMES).toContain("get_timeline");
+        expect(SEMANTIC_TOOL_NAMES).toContain("time_travel");
 
         const list = await harness.call("list_workflows");
         expect(list.structuredContent.ok).toBe(true);
@@ -589,6 +617,41 @@ describe("semantic tool definitions", () => {
         ]);
 
         expect(harness.state.cleanupCalls).toBeGreaterThanOrEqual(8);
+    });
+
+    test("serves semantic durability snapshot and restore tools", async () => {
+        const harness = makeHarness();
+
+        const snapshots = await harness.call("list_snapshots", { runId: "run-1" });
+        expect(snapshots.structuredContent.ok).toBe(true);
+        expect(snapshots.structuredContent.data.snapshots).toEqual([
+            {
+                seq: 0,
+                nodeId: "artifact-node",
+                iteration: 0,
+                attempt: 1,
+                tier: 1,
+                source: "hook",
+                label: "Edit output",
+                commitId: "commit-1",
+                operationId: "op-1",
+                cwd: "/tmp/work",
+                createdAtMs: NOW - 1_000,
+            },
+        ]);
+
+        const restore = await harness.call("restore_checkpoint", {
+            runId: "run-1",
+            nodeId: "artifact-node",
+        });
+        expect(restore.structuredContent.ok).toBe(true);
+        expect(restore.structuredContent.data).toMatchObject({
+            runId: "run-1",
+            nodeId: "artifact-node",
+            seq: 0,
+            success: false,
+        });
+        expect(restore.structuredContent.data.error).toBeString();
     });
 
     test("returns structured errors for missing and ambiguous operations", async () => {

--- a/docs/integrations/mcp-server.mdx
+++ b/docs/integrations/mcp-server.mdx
@@ -128,7 +128,8 @@ The response is also echoed as a `text` content block, so clients that do not pa
 |---|---|---|
 | `readOnlyHint: true` | Most query tools | Tool does not modify state |
 | `readOnlyHint: false, openWorldHint: true` | `run_workflow` | Launches external processes |
-| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt`, `rewind_run`, `restore_checkpoint`, `time_travel` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, idempotentHint: false` | `fork_run`, `replay_run` | Creates new run/branch state |
 
 ---
 
@@ -525,6 +526,117 @@ Revert the workspace and frame history back to the state captured at a specific 
   run: RunSummary | null;
 }
 ```
+
+---
+
+### fork_run
+
+Create a branched run from a time-travel snapshot checkpoint without starting it.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `parentRunId` | `string` | Source run ID |
+| `frameNo` | `number` | Snapshot frame number |
+| `resetNodes` | `string[]` | Node IDs to reset to pending in the fork |
+| `inputOverrides` | `Record<string, unknown>` | Input fields to overlay on the snapshot input |
+| `branchLabel` | `string` | Optional branch label |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, run }`
+
+---
+
+### replay_run
+
+Fork a run from a checkpoint for replay, optionally restoring VCS state. Resume the returned `runId` with `run_workflow` when needed.
+
+**Input:** same as `fork_run`, plus:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `restoreVcs` | `boolean` | `false` | Restore the working copy to the source frame revision |
+| `cwd` | `string` | - | Working directory used for VCS restore |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, vcsRestored, vcsPointer, vcsError?, run }`
+
+---
+
+### rewind_run
+
+Rewind a run to a previous frame, deleting later frames and invalidating derived state. This is destructive and requires `confirm: true`.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run to rewind |
+| `frameNo` | `number` | Target frame number |
+| `confirm` | `boolean` | Must be `true` |
+
+**Output:** `{ result, run }`
+
+---
+
+### restore_checkpoint
+
+Restore the worktree to a durability checkpoint for a node. If `seq` is omitted, the latest matching checkpoint is used.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run containing the checkpoint |
+| `nodeId` | `string` | Node whose checkpoint should be restored |
+| `iteration` | `number` | Optional loop iteration |
+| `seq` | `number` | Optional checkpoint sequence |
+
+**Output:** `{ runId, nodeId, iteration, seq, commitId, cwd, success, error? }`
+
+---
+
+### list_snapshots
+
+List durability workspace checkpoints for a run with matching VCS operation IDs when available.
+
+**Input:** `{ runId: string }`
+
+**Output:** `{ snapshots: Array<{ seq, nodeId, iteration, attempt, tier, source, label, commitId, operationId, cwd, createdAtMs }> }`
+
+---
+
+### get_timeline
+
+Return the time-travel timeline for a run, optionally including all child forks recursively.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `tree` | `boolean` | `false` | Include child forks recursively |
+
+**Output:** `{ timeline: unknown }`
+
+---
+
+### time_travel
+
+Reset a run back to a prior node attempt and optionally restore VCS state. If the run is still marked running, pass `force: true`.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `nodeId` | `string` | required | Node to travel back to |
+| `iteration` | `number` | `0` | Loop iteration |
+| `attempt` | `number` | latest | Attempt number |
+| `restoreVcs` | `boolean` | `true` | Restore filesystem state |
+| `resetDependents` | `boolean` | `true` | Reset dependent nodes too |
+| `force` | `boolean` | `false` | Allow time travel when the run is still running |
+
+**Output:** `{ result, run }`
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8899,7 +8899,8 @@ The response is also echoed as a `text` content block, so clients that do not pa
 |---|---|---|
 | `readOnlyHint: true` | Most query tools | Tool does not modify state |
 | `readOnlyHint: false, openWorldHint: true` | `run_workflow` | Launches external processes |
-| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt`, `rewind_run`, `restore_checkpoint`, `time_travel` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, idempotentHint: false` | `fork_run`, `replay_run` | Creates new run/branch state |
 
 ---
 
@@ -9296,6 +9297,117 @@ Revert the workspace and frame history back to the state captured at a specific 
   run: RunSummary | null;
 }
 ```
+
+---
+
+### fork_run
+
+Create a branched run from a time-travel snapshot checkpoint without starting it.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `parentRunId` | `string` | Source run ID |
+| `frameNo` | `number` | Snapshot frame number |
+| `resetNodes` | `string[]` | Node IDs to reset to pending in the fork |
+| `inputOverrides` | `Record<string, unknown>` | Input fields to overlay on the snapshot input |
+| `branchLabel` | `string` | Optional branch label |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, run }`
+
+---
+
+### replay_run
+
+Fork a run from a checkpoint for replay, optionally restoring VCS state. Resume the returned `runId` with `run_workflow` when needed.
+
+**Input:** same as `fork_run`, plus:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `restoreVcs` | `boolean` | `false` | Restore the working copy to the source frame revision |
+| `cwd` | `string` | - | Working directory used for VCS restore |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, vcsRestored, vcsPointer, vcsError?, run }`
+
+---
+
+### rewind_run
+
+Rewind a run to a previous frame, deleting later frames and invalidating derived state. This is destructive and requires `confirm: true`.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run to rewind |
+| `frameNo` | `number` | Target frame number |
+| `confirm` | `boolean` | Must be `true` |
+
+**Output:** `{ result, run }`
+
+---
+
+### restore_checkpoint
+
+Restore the worktree to a durability checkpoint for a node. If `seq` is omitted, the latest matching checkpoint is used.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run containing the checkpoint |
+| `nodeId` | `string` | Node whose checkpoint should be restored |
+| `iteration` | `number` | Optional loop iteration |
+| `seq` | `number` | Optional checkpoint sequence |
+
+**Output:** `{ runId, nodeId, iteration, seq, commitId, cwd, success, error? }`
+
+---
+
+### list_snapshots
+
+List durability workspace checkpoints for a run with matching VCS operation IDs when available.
+
+**Input:** `{ runId: string }`
+
+**Output:** `{ snapshots: Array<{ seq, nodeId, iteration, attempt, tier, source, label, commitId, operationId, cwd, createdAtMs }> }`
+
+---
+
+### get_timeline
+
+Return the time-travel timeline for a run, optionally including all child forks recursively.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `tree` | `boolean` | `false` | Include child forks recursively |
+
+**Output:** `{ timeline: unknown }`
+
+---
+
+### time_travel
+
+Reset a run back to a prior node attempt and optionally restore VCS state. If the run is still marked running, pass `force: true`.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `nodeId` | `string` | required | Node to travel back to |
+| `iteration` | `number` | `0` | Loop iteration |
+| `attempt` | `number` | latest | Attempt number |
+| `restoreVcs` | `boolean` | `true` | Restore filesystem state |
+| `resetDependents` | `boolean` | `true` | Reset dependent nodes too |
+| `force` | `boolean` | `false` | Allow time travel when the run is still running |
+
+**Output:** `{ result, run }`
 
 ---
 

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -903,7 +903,8 @@ The response is also echoed as a `text` content block, so clients that do not pa
 |---|---|---|
 | `readOnlyHint: true` | Most query tools | Tool does not modify state |
 | `readOnlyHint: false, openWorldHint: true` | `run_workflow` | Launches external processes |
-| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt`, `rewind_run`, `restore_checkpoint`, `time_travel` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, idempotentHint: false` | `fork_run`, `replay_run` | Creates new run/branch state |
 
 ---
 
@@ -1300,6 +1301,117 @@ Revert the workspace and frame history back to the state captured at a specific 
   run: RunSummary | null;
 }
 ```
+
+---
+
+### fork_run
+
+Create a branched run from a time-travel snapshot checkpoint without starting it.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `parentRunId` | `string` | Source run ID |
+| `frameNo` | `number` | Snapshot frame number |
+| `resetNodes` | `string[]` | Node IDs to reset to pending in the fork |
+| `inputOverrides` | `Record<string, unknown>` | Input fields to overlay on the snapshot input |
+| `branchLabel` | `string` | Optional branch label |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, run }`
+
+---
+
+### replay_run
+
+Fork a run from a checkpoint for replay, optionally restoring VCS state. Resume the returned `runId` with `run_workflow` when needed.
+
+**Input:** same as `fork_run`, plus:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `restoreVcs` | `boolean` | `false` | Restore the working copy to the source frame revision |
+| `cwd` | `string` | - | Working directory used for VCS restore |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, vcsRestored, vcsPointer, vcsError?, run }`
+
+---
+
+### rewind_run
+
+Rewind a run to a previous frame, deleting later frames and invalidating derived state. This is destructive and requires `confirm: true`.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run to rewind |
+| `frameNo` | `number` | Target frame number |
+| `confirm` | `boolean` | Must be `true` |
+
+**Output:** `{ result, run }`
+
+---
+
+### restore_checkpoint
+
+Restore the worktree to a durability checkpoint for a node. If `seq` is omitted, the latest matching checkpoint is used.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run containing the checkpoint |
+| `nodeId` | `string` | Node whose checkpoint should be restored |
+| `iteration` | `number` | Optional loop iteration |
+| `seq` | `number` | Optional checkpoint sequence |
+
+**Output:** `{ runId, nodeId, iteration, seq, commitId, cwd, success, error? }`
+
+---
+
+### list_snapshots
+
+List durability workspace checkpoints for a run with matching VCS operation IDs when available.
+
+**Input:** `{ runId: string }`
+
+**Output:** `{ snapshots: Array<{ seq, nodeId, iteration, attempt, tier, source, label, commitId, operationId, cwd, createdAtMs }> }`
+
+---
+
+### get_timeline
+
+Return the time-travel timeline for a run, optionally including all child forks recursively.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `tree` | `boolean` | `false` | Include child forks recursively |
+
+**Output:** `{ timeline: unknown }`
+
+---
+
+### time_travel
+
+Reset a run back to a prior node attempt and optionally restore VCS state. If the run is still marked running, pass `force: true`.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `nodeId` | `string` | required | Node to travel back to |
+| `iteration` | `number` | `0` | Loop iteration |
+| `attempt` | `number` | latest | Attempt number |
+| `restoreVcs` | `boolean` | `true` | Restore filesystem state |
+| `resetDependents` | `boolean` | `true` | Reset dependent nodes too |
+| `force` | `boolean` | `false` | Allow time travel when the run is still running |
+
+**Output:** `{ result, run }`
 
 ---
 

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -8899,7 +8899,8 @@ The response is also echoed as a `text` content block, so clients that do not pa
 |---|---|---|
 | `readOnlyHint: true` | Most query tools | Tool does not modify state |
 | `readOnlyHint: false, openWorldHint: true` | `run_workflow` | Launches external processes |
-| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, destructiveHint: true, idempotentHint: false` | `resolve_approval`, `revert_attempt`, `rewind_run`, `restore_checkpoint`, `time_travel` | Mutates persisted state irreversibly |
+| `readOnlyHint: false, idempotentHint: false` | `fork_run`, `replay_run` | Creates new run/branch state |
 
 ---
 
@@ -9296,6 +9297,117 @@ Revert the workspace and frame history back to the state captured at a specific 
   run: RunSummary | null;
 }
 ```
+
+---
+
+### fork_run
+
+Create a branched run from a time-travel snapshot checkpoint without starting it.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `parentRunId` | `string` | Source run ID |
+| `frameNo` | `number` | Snapshot frame number |
+| `resetNodes` | `string[]` | Node IDs to reset to pending in the fork |
+| `inputOverrides` | `Record<string, unknown>` | Input fields to overlay on the snapshot input |
+| `branchLabel` | `string` | Optional branch label |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, run }`
+
+---
+
+### replay_run
+
+Fork a run from a checkpoint for replay, optionally restoring VCS state. Resume the returned `runId` with `run_workflow` when needed.
+
+**Input:** same as `fork_run`, plus:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `restoreVcs` | `boolean` | `false` | Restore the working copy to the source frame revision |
+| `cwd` | `string` | - | Working directory used for VCS restore |
+
+**Output:** `{ runId, parentRunId, parentFrameNo, branch, snapshot, vcsRestored, vcsPointer, vcsError?, run }`
+
+---
+
+### rewind_run
+
+Rewind a run to a previous frame, deleting later frames and invalidating derived state. This is destructive and requires `confirm: true`.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run to rewind |
+| `frameNo` | `number` | Target frame number |
+| `confirm` | `boolean` | Must be `true` |
+
+**Output:** `{ result, run }`
+
+---
+
+### restore_checkpoint
+
+Restore the worktree to a durability checkpoint for a node. If `seq` is omitted, the latest matching checkpoint is used.
+
+**Input:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `runId` | `string` | Run containing the checkpoint |
+| `nodeId` | `string` | Node whose checkpoint should be restored |
+| `iteration` | `number` | Optional loop iteration |
+| `seq` | `number` | Optional checkpoint sequence |
+
+**Output:** `{ runId, nodeId, iteration, seq, commitId, cwd, success, error? }`
+
+---
+
+### list_snapshots
+
+List durability workspace checkpoints for a run with matching VCS operation IDs when available.
+
+**Input:** `{ runId: string }`
+
+**Output:** `{ snapshots: Array<{ seq, nodeId, iteration, attempt, tier, source, label, commitId, operationId, cwd, createdAtMs }> }`
+
+---
+
+### get_timeline
+
+Return the time-travel timeline for a run, optionally including all child forks recursively.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `tree` | `boolean` | `false` | Include child forks recursively |
+
+**Output:** `{ timeline: unknown }`
+
+---
+
+### time_travel
+
+Reset a run back to a prior node attempt and optionally restore VCS state. If the run is still marked running, pass `force: true`.
+
+**Input:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `runId` | `string` | required | Run ID |
+| `nodeId` | `string` | required | Node to travel back to |
+| `iteration` | `number` | `0` | Loop iteration |
+| `attempt` | `number` | latest | Attempt number |
+| `restoreVcs` | `boolean` | `true` | Restore filesystem state |
+| `resetDependents` | `boolean` | `true` | Reset dependent nodes too |
+| `force` | `boolean` | `false` | Allow time travel when the run is still running |
+
+**Output:** `{ result, run }`
 
 ---
 


### PR DESCRIPTION
Relates to #302

## What was fixed

The semantic MCP server exposed only `revert_attempt` from the time-travel surface. The remaining seven time-travel tools — `fork_run`, `replay_run`, `rewind_run`, `restore_checkpoint`, `list_snapshots`, `get_timeline`, and `time_travel` — were implemented in `@smithers-orchestrator/time-travel` but never registered in the semantic MCP layer.

## Root cause & approach

`apps/cli/src/mcp/SemanticToolName.ts` and `apps/cli/src/mcp/semantic-tools.js` were missing the type literals, tool name constants, input/output Zod schemas, and handler implementations for the full time-travel API. This fix adds all seven missing tools following the same pattern as the existing `revert_attempt` handler: typed names in `SemanticToolName.ts`, entries in `SEMANTIC_TOOL_NAMES`, Zod schemas for input validation and response shaping, and delegating handlers that call the existing time-travel package functions (`forkRun`, `replayFromCheckpoint`, `timeTravel`, `buildTimeline`, `jumpToFrameRoute`, `pickTargetCheckpoint`/`runRestoreOnce`). Tests in `apps/cli/tests/semantic-tools-unit.test.js` verify the new tool definitions are present and correctly shaped.

Codex implemented this via TDD; both Codex and Claude Opus reviewed and approved the change before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)