### PR TITLE
🐛 fix(usage): clamp negative rate-limit usage

### DIFF
--- a/packages/usage/src/parseAnthropicRateLimitHeaders.js
+++ b/packages/usage/src/parseAnthropicRateLimitHeaders.js
@@ -22,7 +22,7 @@ function countWindow(get, prefix, id, label) {
     const remaining = int(get(`${prefix}-remaining`));
     if (limit === undefined && remaining === undefined) return undefined;
     const reset = get(`${prefix}-reset`);
-    const used = limit !== undefined && remaining !== undefined ? limit - remaining : undefined;
+    const used = limit !== undefined && remaining !== undefined ? Math.max(0, limit - remaining) : undefined;
     return {
         id,
         label,

--- a/packages/usage/src/parseOpenAiRateLimitHeaders.js
+++ b/packages/usage/src/parseOpenAiRateLimitHeaders.js
@@ -25,7 +25,7 @@ function countWindow(get, suffix, id, label, nowMs) {
     const remaining = int(get(`x-ratelimit-remaining-${suffix}`));
     if (limit === undefined && remaining === undefined) return undefined;
     const resetSeconds = parseDurationSeconds(get(`x-ratelimit-reset-${suffix}`));
-    const used = limit !== undefined && remaining !== undefined ? limit - remaining : undefined;
+    const used = limit !== undefined && remaining !== undefined ? Math.max(0, limit - remaining) : undefined;
     return {
         id,
         label,

--- a/packages/usage/tests/usage.test.js
+++ b/packages/usage/tests/usage.test.js
@@ -168,6 +168,19 @@ describe("rate-limit header parsers", () => {
         expect(windows[0]).toMatchObject({ id: "requests-per-min", remaining: 99, used: 1 });
         expect(windows[0].resetsAt).toBe(isoIn(360));
     });
+    test("count windows never report negative used values", () => {
+        const anthropicWindows = parseAnthropicRateLimitHeaders(getter({
+            "anthropic-ratelimit-requests-limit": "100",
+            "anthropic-ratelimit-requests-remaining": "120",
+        }));
+        expect(anthropicWindows[0]).toMatchObject({ limit: 100, remaining: 120, used: 0 });
+
+        const openAiWindows = parseOpenAiRateLimitHeaders(getter({
+            "x-ratelimit-limit-requests": "100",
+            "x-ratelimit-remaining-requests": "120",
+        }), NOW);
+        expect(openAiWindows[0]).toMatchObject({ limit: 100, remaining: 120, used: 0 });
+    });
     test("no headers -> no windows", () => {
         expect(parseAnthropicRateLimitHeaders(getter({}))).toEqual([]);
         expect(parseOpenAiRateLimitHeaders(getter({}), NOW)).toEqual([]);


### PR DESCRIPTION
Relates to #303

## What & Why

`parseAnthropicRateLimitHeaders` and `parseOpenAiRateLimitHeaders` both compute `used` as `limit - remaining`. When a burst window resets mid-flight (or the API returns `remaining > limit`), this produces a **negative** `used` count, which breaks downstream consumers that expect a non-negative usage figure.

## Fix

Both parsers now clamp `used` to zero:

```js
const used = limit !== undefined && remaining !== undefined
  ? Math.max(0, limit - remaining)
  : undefined;
```

**Files changed:**
- `packages/usage/src/parseAnthropicRateLimitHeaders.js`
- `packages/usage/src/parseOpenAiRateLimitHeaders.js`
- `packages/usage/tests/usage.test.js` — TDD test asserting `used: 0` when `remaining > limit`

Codex implemented this via TDD; Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)