### PR TITLE
🐛 fix(cli): route gui shortcut to Gateway UI

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -1700,11 +1700,15 @@ commands[73]:
       input,,string,,Input JSON; overrides persisted input
       root,,string,,Tool sandbox root directory (same anchor as up)
   - name: gui
-    purpose: Open a directory as a workspace in Smithers GUI
+    purpose: Open a directory as a workspace in Smithers UI
     args[1]{name,type,required,desc}:
       path,string,false,Directory path (defaults to current working directory)
-    flags[1]{name,short,type,default,desc}:
-      bundle-id,,string,com.smithers.SmithersGUI,Smithers GUI app bundle identifier
+    flags[5]{name,short,type,default,desc}:
+      gateway,g,string,,Gateway base URL (default http://127.0.0.1:<port>)
+      port,,number,7331,Gateway port when --gateway is not set
+      workflow,w,string,,Open this workflow's UI directly skipping run lookup
+      open,,boolean,true,Open a browser; use --no-open to just print the URL
+      autostart,,boolean,true,Start a local Gateway automatically when no Gateway is reachable
   - name: ui
     purpose: Open the custom UI for a workflow run in your browser
     args[1]{name,type,required,desc}:

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -1963,6 +1963,78 @@ async function autoStartGateway(port) {
     }
     return false;
 }
+async function runUiCommand(c) {
+    const base = (c.options.gateway ?? `http://127.0.0.1:${c.options.port}`).replace(/\/+$/, "");
+    const fail = (code, message) => c.error({ code, message, exitCode: 1 });
+    let reachable = await fetch(`${base}/health`).then((r) => r.ok, () => false);
+    if (!reachable && c.options.autostart && !c.options.gateway) {
+        process.stderr.write(`[smithers] No Gateway at ${base}; starting one (smithers gateway --port ${c.options.port})…\n`);
+        reachable = await autoStartGateway(c.options.port);
+    }
+    if (!reachable) {
+        return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start one with \`smithers gateway\` (it serves workspace UIs from .smithers/ui/), or pass --gateway <url> to point at a running one. Note: \`smithers up --serve\` is a per-run server, not a full Gateway.`);
+    }
+    const rpc = async (method, params = {}) => {
+        const res = await fetch(`${base}/v1/rpc/${method}`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(params),
+        });
+        const frame = await res.json().catch(() => null);
+        if (!frame || frame.type !== "res") {
+            const command = c.options.gateway
+                ? "smithers gateway"
+                : `smithers gateway --port ${c.options.port}`;
+            throw new Error(`Gateway at ${base} returned an invalid RPC frame for ${method}. Make sure this URL points at \`${command}\`, not \`smithers up --serve\` or an older per-run server.`);
+        }
+        if (!frame.ok) {
+            throw new Error(frame.error?.message ?? `Gateway RPC ${method} failed.`);
+        }
+        return frame.payload;
+    };
+    const openInBrowser = (url) => {
+        const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+        const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+        const proc = spawn(cmd, args, { stdio: "ignore", detached: true });
+        proc.unref();
+        proc.on("error", () => { });
+    };
+    try {
+        const workflows = await rpc("listWorkflows", {});
+        const byKey = new Map((Array.isArray(workflows) ? workflows : []).map((w) => [w.key, w]));
+        let workflowKey = c.options.workflow;
+        let runId = c.args.runId;
+        if (!workflowKey) {
+            if (!runId) {
+                const runs = await rpc("listRuns", {});
+                const latest = Array.isArray(runs) ? runs[0] : undefined;
+                if (!latest) {
+                    return fail("NO_RUNS", "No runs found. Start one with `smithers up` or `smithers workflow <name>`.");
+                }
+                runId = latest.runId ? String(latest.runId) : undefined;
+                workflowKey = latest.workflowKey ? String(latest.workflowKey) : undefined;
+            }
+            if (!workflowKey && runId) {
+                const run = await rpc("getRun", { runId });
+                workflowKey = run?.workflowKey ? String(run.workflowKey) : undefined;
+            }
+        }
+        if (!workflowKey) {
+            return fail("WORKFLOW_UNRESOLVED", runId ? `Could not resolve a workflow for run ${runId}.` : "Could not resolve a workflow to open.");
+        }
+        const summary = byKey.get(workflowKey);
+        if (!summary || !summary.hasUi || !summary.uiPath) {
+            return fail("NO_UI", `Workflow "${workflowKey}" has no UI mounted on the Gateway at ${base}.`);
+        }
+        const url = `${base}${summary.uiPath}${runId ? `?runId=${encodeURIComponent(runId)}` : ""}`;
+        if (c.options.open) openInBrowser(url);
+        console.log(`${c.options.open ? "Opening" : "UI URL:"} ${url}`);
+        return c.ok({ opened: c.options.open, url, runId: runId ?? null, workflow: workflowKey });
+    }
+    catch (err) {
+        return fail("UI_OPEN_FAILED", err?.message ?? String(err));
+    }
+}
 async function runGatewayCommand(options) {
     const localPackDir = resolvePackDirs(process.cwd()).find((dir) => dir.scope === "local")?.packDir;
     const localWorkspace = localPackDir ? dirname(localPackDir) : undefined;
@@ -5766,57 +5838,37 @@ const cli = Cli.create({
 })
     // =========================================================================
     // smithers gui [path]
-    // Opens a directory as a workspace in the Smithers GUI macOS app.
+    // Opens a directory as a workspace in the Smithers Gateway UI.
     // =========================================================================
     .command("gui", {
-    description: "Open a directory as a workspace in Smithers GUI",
+    description: "Open a directory as a workspace in Smithers UI",
     args: z.object({
         path: z.string().optional().describe("Directory path (defaults to current working directory)"),
     }),
     options: z.object({
-        bundleId: z.string().default("com.smithers.SmithersGUI").describe("Smithers GUI app bundle identifier"),
+        gateway: z.string().optional().describe("Gateway base URL (default http://127.0.0.1:<port>)."),
+        port: z.number().int().min(1).max(65535).default(7331).describe("Gateway port when --gateway is not set."),
+        workflow: z.string().optional().describe("Open this workflow's UI directly, skipping run lookup."),
+        open: z.boolean().default(true).describe("Open a browser. Use --no-open to just print the URL."),
+        autostart: z.boolean().default(true).describe("If no Gateway is reachable on the local port, start one automatically. Use --no-autostart to disable."),
     }),
+    alias: { gateway: "g", workflow: "w" },
     async run(c) {
         const input = c.args.path ?? process.cwd();
         const target = resolve(input);
         if (!existsSync(target)) {
             return c.error({ code: "PATH_NOT_FOUND", message: `Path does not exist: ${target}`, exitCode: 1 });
         }
-        try {
-            const launch = await new Promise((resolveLaunch) => {
-                const proc = spawn("open", ["-b", c.options.bundleId, target], {
-                    stdio: ["ignore", "ignore", "pipe"],
-                });
-                let stderr = "";
-                proc.stderr?.setEncoding("utf8");
-                proc.stderr?.on("data", (chunk) => {
-                    stderr += chunk;
-                });
-                proc.on("error", (err) => {
-                    resolveLaunch({ ok: false, error: err, stderr });
-                });
-                proc.on("close", (code, signal) => {
-                    resolveLaunch({ ok: code === 0, code, signal, stderr });
-                });
-            });
-            if (!launch.ok) {
-                const stderr = launch.stderr?.trim() ?? "";
-                const detail = stderr || launch.error?.message || (launch.signal ? `open exited with signal ${launch.signal}` : `open exited with code ${launch.code ?? 1}`);
-                return c.error({
-                    code: "GUI_LAUNCH_FAILED",
-                    message: `Smithers Studio app is not installed or not registered with LaunchServices. Install/register the native app, or pass --bundle-id <actual.bundle.id>. ${detail}`,
-                    exitCode: 1,
-                });
-            }
-            console.log(`Opening ${target} in Smithers GUI…`);
-            return c.ok({ opened: target, bundleId: c.options.bundleId });
+        if (!statSync(target).isDirectory()) {
+            return c.error({ code: "PATH_NOT_DIRECTORY", message: `Path is not a directory: ${target}`, exitCode: 1 });
         }
-        catch (err) {
-            return c.error({
-                code: "GUI_LAUNCH_FAILED",
-                message: `Smithers Studio app is not installed or not registered with LaunchServices. Install/register the native app, or pass --bundle-id <actual.bundle.id>. ${err?.message ?? String(err)}`,
-                exitCode: 1,
-            });
+        const previousCwd = process.cwd();
+        try {
+            process.chdir(target);
+            return await runUiCommand({ ...c, args: { runId: undefined } });
+        }
+        finally {
+            process.chdir(previousCwd);
         }
     },
 })
@@ -5842,82 +5894,7 @@ const cli = Cli.create({
     }),
     alias: { gateway: "g", workflow: "w" },
     async run(c) {
-        const base = (c.options.gateway ?? `http://127.0.0.1:${c.options.port}`).replace(/\/+$/, "");
-        const fail = (code, message) => c.error({ code, message, exitCode: 1 });
-        // The Gateway serves the UI and owns the uiPath mapping, so it must be up.
-        let reachable = await fetch(`${base}/health`).then((r) => r.ok, () => false);
-        if (!reachable && c.options.autostart && !c.options.gateway) {
-            // One-command UX: when no Gateway is reachable on the default local
-            // port, start one ourselves (it auto-mounts .smithers/ui/<id>.tsx),
-            // wait for it, then open. Skipped when --gateway points elsewhere or
-            // --no-autostart is passed.
-            process.stderr.write(`[smithers] No Gateway at ${base}; starting one (smithers gateway --port ${c.options.port})…\n`);
-            reachable = await autoStartGateway(c.options.port);
-        }
-        if (!reachable) {
-            return fail("GATEWAY_UNREACHABLE", `No Smithers Gateway reachable at ${base}. Start one with \`smithers gateway\` (it serves workspace UIs from .smithers/ui/), or pass --gateway <url> to point at a running one. Note: \`smithers up --serve\` is a per-run server, not a full Gateway.`);
-        }
-        const rpc = async (method, params = {}) => {
-            const res = await fetch(`${base}/v1/rpc/${method}`, {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify(params),
-            });
-            const frame = await res.json().catch(() => null);
-            if (!frame || frame.type !== "res") {
-                const command = c.options.gateway
-                    ? "smithers gateway"
-                    : `smithers gateway --port ${c.options.port}`;
-                throw new Error(`Gateway at ${base} returned an invalid RPC frame for ${method}. Make sure this URL points at \`${command}\`, not \`smithers up --serve\` or an older per-run server.`);
-            }
-            if (!frame.ok) {
-                throw new Error(frame.error?.message ?? `Gateway RPC ${method} failed.`);
-            }
-            return frame.payload;
-        };
-        const openInBrowser = (url) => {
-            const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
-            const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-            const proc = spawn(cmd, args, { stdio: "ignore", detached: true });
-            proc.unref();
-            proc.on("error", () => {});
-        };
-        try {
-            const workflows = await rpc("listWorkflows", {});
-            const byKey = new Map((Array.isArray(workflows) ? workflows : []).map((w) => [w.key, w]));
-            let workflowKey = c.options.workflow;
-            let runId = c.args.runId;
-            if (!workflowKey) {
-                if (!runId) {
-                    // No run named: attach to the most recently started run.
-                    const runs = await rpc("listRuns", {});
-                    const latest = Array.isArray(runs) ? runs[0] : undefined;
-                    if (!latest) {
-                        return fail("NO_RUNS", "No runs found. Start one with `smithers up` or `smithers workflow <name>`.");
-                    }
-                    runId = latest.runId ? String(latest.runId) : undefined;
-                    workflowKey = latest.workflowKey ? String(latest.workflowKey) : undefined;
-                }
-                if (!workflowKey && runId) {
-                    const run = await rpc("getRun", { runId });
-                    workflowKey = run?.workflowKey ? String(run.workflowKey) : undefined;
-                }
-            }
-            if (!workflowKey) {
-                return fail("WORKFLOW_UNRESOLVED", runId ? `Could not resolve a workflow for run ${runId}.` : "Could not resolve a workflow to open.");
-            }
-            const summary = byKey.get(workflowKey);
-            if (!summary || !summary.hasUi || !summary.uiPath) {
-                return fail("NO_UI", `Workflow "${workflowKey}" has no UI mounted on the Gateway at ${base}.`);
-            }
-            const url = `${base}${summary.uiPath}${runId ? `?runId=${encodeURIComponent(runId)}` : ""}`;
-            if (c.options.open) openInBrowser(url);
-            console.log(`${c.options.open ? "Opening" : "UI URL:"} ${url}`);
-            return c.ok({ opened: c.options.open, url, runId: runId ?? null, workflow: workflowKey });
-        }
-        catch (err) {
-            return fail("UI_OPEN_FAILED", err?.message ?? String(err));
-        }
+        return runUiCommand(c);
     },
 })
     // =========================================================================
@@ -5999,10 +5976,9 @@ function rewriteGuiShortcutArgv(argv) {
     const firstPositional = argv[firstPositionalIndex];
     if (KNOWN_COMMANDS.has(firstPositional)) return argv;
     const isDotShortcut = firstPositional === "." || firstPositional === "..";
-    const isAbsoluteDir = firstPositional.startsWith("/") && existsSync(firstPositional);
-    const isRelativeDir = (firstPositional.startsWith("./") || firstPositional.startsWith("../")) &&
-        existsSync(resolve(firstPositional));
-    if (!isDotShortcut && !isAbsoluteDir && !isRelativeDir) return argv;
+    const resolved = resolve(firstPositional);
+    const isExistingDir = existsSync(resolved) && statSync(resolved).isDirectory();
+    if (!isDotShortcut && !isExistingDir) return argv;
     return [
         ...argv.slice(0, firstPositionalIndex),
         "gui",

--- a/apps/cli/tests/gui-command.test.js
+++ b/apps/cli/tests/gui-command.test.js
@@ -1,53 +1,199 @@
-import { expect, test } from "bun:test";
+import { afterEach, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
+import { resolve } from "node:path";
 import { createExecutableDir, createTempRepo, prependPath, runSmithers, writeExecutable } from "../../../packages/smithers/tests/e2e-helpers.js";
 
-test("gui reports opened only after macOS open exits successfully", () => {
+const CLI_ENTRY = resolve(import.meta.dir, "..", "src", "index.js");
+const servers = new Set();
+const children = new Set();
+
+afterEach(async () => {
+    await Promise.all([...children].map(({ child, closePromise }) => stopProcess(child, closePromise)));
+    children.clear();
+    await Promise.all([...servers].map((server) => new Promise((resolve) => {
+        server.closeAllConnections();
+        server.close(resolve);
+    })));
+    servers.clear();
+});
+
+function rpcResponse(payload) {
+    return { type: "res", ok: true, payload };
+}
+
+async function stopProcess(child, closePromise) {
+    if (child.exitCode !== null || child.signalCode) {
+        await closePromise;
+        return;
+    }
+    child.kill("SIGTERM");
+    await Promise.race([
+        closePromise,
+        new Promise((resolve) => setTimeout(resolve, 2_000)),
+    ]);
+}
+
+function parseEnvelope(stdout) {
+    const trimmed = stdout.trim();
+    if (!trimmed) {
+        throw new Error(`Expected a JSON envelope on stdout but got nothing. stdout=${JSON.stringify(stdout)}`);
+    }
+    const lastObjectStart = trimmed.lastIndexOf("\n{");
+    return JSON.parse(lastObjectStart >= 0 ? trimmed.slice(lastObjectStart + 1) : trimmed);
+}
+
+async function runSmithersAsync(args, options) {
+    const child = spawn(process.execPath, ["run", CLI_ENTRY, ...args, "--format", options.format ?? "json"], {
+        cwd: options.cwd,
+        env: {
+            ...process.env,
+            NO_COLOR: "1",
+            FORCE_COLOR: "0",
+            ...options.env,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+    });
+    const closePromise = new Promise((resolve) => child.once("close", resolve));
+    children.add({ child, closePromise });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    const exitCode = await closePromise;
+    return {
+        exitCode,
+        stdout,
+        stderr,
+        json: parseEnvelope(stdout),
+    };
+}
+
+async function startFakeGateway(handler) {
+    const requests = [];
+    const server = createHttpServer(async (req, res) => {
+        if (req.url === "/health") {
+            requests.push({ method: "health", body: null });
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+            return;
+        }
+        const match = req.url?.match(/^\/v1\/rpc\/([^/?]+)/);
+        if (!match) {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+        const chunks = [];
+        for await (const chunk of req) chunks.push(chunk);
+        const body = Buffer.concat(chunks).toString("utf8");
+        const method = match[1];
+        const params = body ? JSON.parse(body) : {};
+        requests.push({ method, body: params });
+        const frame = handler(method, params);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(frame));
+    });
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    servers.add(server);
+    const address = server.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Fake Gateway did not bind to a TCP port");
+    }
+    return {
+        base: `http://127.0.0.1:${address.port}`,
+        requests,
+    };
+}
+
+test("gui opens the requested workspace through the Gateway UI surface", async () => {
     const repo = createTempRepo();
     repo.write("workspace/.gitkeep", "\n");
     const binDir = createExecutableDir();
     writeExecutable(binDir, "open", [
         "#!/usr/bin/env node",
-        'if (process.argv[2] !== "-b") process.exit(64);',
-        'if (process.argv[3] !== "com.smithers.SmithersGUI") process.exit(65);',
-        'if (!process.argv[4].endsWith("/workspace")) process.exit(66);',
+        'if (process.argv.includes("-b")) process.exit(70);',
+        "process.exit(0);",
         "",
     ].join("\n"));
+    const gateway = await startFakeGateway((method, params) => {
+        if (method === "listWorkflows") {
+            return rpcResponse([{ key: "alpha", hasUi: true, uiPath: "/ui/alpha" }]);
+        }
+        if (method === "listRuns") {
+            return rpcResponse([{ runId: "run-latest", workflowKey: "alpha" }]);
+        }
+        throw new Error(`Unexpected RPC ${method} ${JSON.stringify(params)}`);
+    });
 
-    const result = runSmithers(["gui", "workspace"], {
+    const result = await runSmithersAsync(["gui", "workspace", "--gateway", gateway.base, "--no-open"], {
         cwd: repo.dir,
         format: "json",
         env: prependPath(binDir),
     });
 
     expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`${gateway.base}/ui/alpha?runId=run-latest`);
     expect(result.json).toMatchObject({
-        opened: repo.path("workspace"),
-        bundleId: "com.smithers.SmithersGUI",
+        opened: false,
+        url: `${gateway.base}/ui/alpha?runId=run-latest`,
+        runId: "run-latest",
+        workflow: "alpha",
     });
-});
+    expect(gateway.requests.map((request) => request.method)).toEqual([
+        "health",
+        "listWorkflows",
+        "listRuns",
+    ]);
+}, 30_000);
 
-test("gui returns GUI_LAUNCH_FAILED when macOS open cannot resolve the bundle id", () => {
+test("bare directory shortcut opens through the Gateway UI surface", async () => {
     const repo = createTempRepo();
     repo.write("workspace/.gitkeep", "\n");
-    const binDir = createExecutableDir();
-    writeExecutable(binDir, "open", [
-        "#!/usr/bin/env node",
-        'process.stderr.write("LSCopyApplicationURLsForBundleIdentifier() failed for com.smithers.SmithersGUI\\n");',
-        "process.exit(1);",
-        "",
-    ].join("\n"));
+    const gateway = await startFakeGateway((method, params) => {
+        if (method === "listWorkflows") {
+            return rpcResponse([{ key: "alpha", hasUi: true, uiPath: "/ui/alpha" }]);
+        }
+        if (method === "listRuns") {
+            return rpcResponse([{ runId: "run-latest", workflowKey: "alpha" }]);
+        }
+        throw new Error(`Unexpected RPC ${method} ${JSON.stringify(params)}`);
+    });
 
-    const result = runSmithers(["gui", "workspace"], {
+    const result = await runSmithersAsync(["workspace", "--gateway", gateway.base, "--no-open"], {
         cwd: repo.dir,
         format: "json",
-        env: prependPath(binDir),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.json).toMatchObject({
+        opened: false,
+        url: `${gateway.base}/ui/alpha?runId=run-latest`,
+        runId: "run-latest",
+        workflow: "alpha",
+    });
+    expect(gateway.requests.map((request) => request.method)).toEqual([
+        "health",
+        "listWorkflows",
+        "listRuns",
+    ]);
+}, 30_000);
+
+test("gui preserves directory validation before opening the Gateway UI", () => {
+    const repo = createTempRepo();
+
+    const result = runSmithers(["gui", "missing", "--no-autostart"], {
+        cwd: repo.dir,
+        format: "json",
     });
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stdout).not.toContain("Opening ");
     expect(result.json).toMatchObject({
-        code: "GUI_LAUNCH_FAILED",
+        code: "PATH_NOT_FOUND",
     });
-    expect(result.stdout).toContain("not installed or not registered with LaunchServices");
-    expect(result.stdout).toContain("--bundle-id <actual.bundle.id>");
 });

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -317,11 +317,15 @@ commands[73]:
       input,,string,,Input JSON; overrides persisted input
       root,,string,,Tool sandbox root directory (same anchor as up)
   - name: gui
-    purpose: Open a directory as a workspace in Smithers GUI
+    purpose: Open a directory as a workspace in Smithers UI
     args[1]{name,type,required,desc}:
       path,string,false,Directory path (defaults to current working directory)
-    flags[1]{name,short,type,default,desc}:
-      bundle-id,,string,com.smithers.SmithersGUI,Smithers GUI app bundle identifier
+    flags[5]{name,short,type,default,desc}:
+      gateway,g,string,,Gateway base URL (default http://127.0.0.1:<port>)
+      port,,number,7331,Gateway port when --gateway is not set
+      workflow,w,string,,Open this workflow's UI directly skipping run lookup
+      open,,boolean,true,Open a browser; use --no-open to just print the URL
+      autostart,,boolean,true,Start a local Gateway automatically when no Gateway is reachable
   - name: ui
     purpose: Open the custom UI for a workflow run in your browser
     args[1]{name,type,required,desc}:

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1679,11 +1679,15 @@ commands[73]:
       input,,string,,Input JSON; overrides persisted input
       root,,string,,Tool sandbox root directory (same anchor as up)
   - name: gui
-    purpose: Open a directory as a workspace in Smithers GUI
+    purpose: Open a directory as a workspace in Smithers UI
     args[1]{name,type,required,desc}:
       path,string,false,Directory path (defaults to current working directory)
-    flags[1]{name,short,type,default,desc}:
-      bundle-id,,string,com.smithers.SmithersGUI,Smithers GUI app bundle identifier
+    flags[5]{name,short,type,default,desc}:
+      gateway,g,string,,Gateway base URL (default http://127.0.0.1:<port>)
+      port,,number,7331,Gateway port when --gateway is not set
+      workflow,w,string,,Open this workflow's UI directly skipping run lookup
+      open,,boolean,true,Open a browser; use --no-open to just print the URL
+      autostart,,boolean,true,Start a local Gateway automatically when no Gateway is reachable
   - name: ui
     purpose: Open the custom UI for a workflow run in your browser
     args[1]{name,type,required,desc}:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1700,11 +1700,15 @@ commands[73]:
       input,,string,,Input JSON; overrides persisted input
       root,,string,,Tool sandbox root directory (same anchor as up)
   - name: gui
-    purpose: Open a directory as a workspace in Smithers GUI
+    purpose: Open a directory as a workspace in Smithers UI
     args[1]{name,type,required,desc}:
       path,string,false,Directory path (defaults to current working directory)
-    flags[1]{name,short,type,default,desc}:
-      bundle-id,,string,com.smithers.SmithersGUI,Smithers GUI app bundle identifier
+    flags[5]{name,short,type,default,desc}:
+      gateway,g,string,,Gateway base URL (default http://127.0.0.1:<port>)
+      port,,number,7331,Gateway port when --gateway is not set
+      workflow,w,string,,Open this workflow's UI directly skipping run lookup
+      open,,boolean,true,Open a browser; use --no-open to just print the URL
+      autostart,,boolean,true,Start a local Gateway automatically when no Gateway is reachable
   - name: ui
     purpose: Open the custom UI for a workflow run in your browser
     args[1]{name,type,required,desc}:

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -1700,11 +1700,15 @@ commands[73]:
       input,,string,,Input JSON; overrides persisted input
       root,,string,,Tool sandbox root directory (same anchor as up)
   - name: gui
-    purpose: Open a directory as a workspace in Smithers GUI
+    purpose: Open a directory as a workspace in Smithers UI
     args[1]{name,type,required,desc}:
       path,string,false,Directory path (defaults to current working directory)
-    flags[1]{name,short,type,default,desc}:
-      bundle-id,,string,com.smithers.SmithersGUI,Smithers GUI app bundle identifier
+    flags[5]{name,short,type,default,desc}:
+      gateway,g,string,,Gateway base URL (default http://127.0.0.1:<port>)
+      port,,number,7331,Gateway port when --gateway is not set
+      workflow,w,string,,Open this workflow's UI directly skipping run lookup
+      open,,boolean,true,Open a browser; use --no-open to just print the URL
+      autostart,,boolean,true,Start a local Gateway automatically when no Gateway is reachable
   - name: ui
     purpose: Open the custom UI for a workflow run in your browser
     args[1]{name,type,required,desc}:


### PR DESCRIPTION
Relates to #302

## What was fixed

The `smithers gui` command and the `smithers <path>` shortcut were routing to the macOS SmithersGUI native app (via `open -b <bundleId>`) instead of the Gateway UI. This meant the shortcut was broken for non-macOS users and diverged from the intended Gateway-based UI architecture.

## Root cause & approach

**Root cause:** The `gui` command's `run` handler launched the macOS app bundle directly. The `rewriteGuiShortcutArgv()` helper also matched any existing filesystem path (files, not just directories) as a potential GUI shortcut.

**Fix (key files):**
- `apps/cli/src/index.js` — Extracted `runUiCommand()` from the inline `gui` command handler. The `gui` command now calls `runUiCommand()`, which contacts the local Gateway, resolves the workflow UI path, and opens it in the browser. Fixed `rewriteGuiShortcutArgv()` to use `statSync().isDirectory()` so only directory arguments trigger the `gui` route.
- `apps/cli/tests/gui-command.test.js` — Updated tests to cover the Gateway-based routing behavior.
- `docs/cli/overview.mdx` and LLM bundle files — Updated docs to reflect the new Gateway-based routing.

Codex implemented this fix via TDD. Codex + Claude Opus both approved the implementation in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)