### PR TITLE
🐛 fix(gateway): guard run tree traversal cycles

### DIFF
--- a/packages/gateway-client/src/sync/flattenGatewayRunNode.ts
+++ b/packages/gateway-client/src/sync/flattenGatewayRunNode.ts
@@ -3,9 +3,12 @@ import type { GatewayRunNode } from "./GatewayRunNode.ts";
 export function flattenGatewayRunNode(root: GatewayRunNode | null | undefined): GatewayRunNode[] {
   if (!root) return [];
   const rows: GatewayRunNode[] = [];
+  const visited = new Set<string>();
   const visit = (node: GatewayRunNode, parentId?: string) => {
+    if (visited.has(node.id)) return;
+    visited.add(node.id);
     const children = node.children ?? [];
-    const childIds = children.map((child) => child.id);
+    const childIds = Array.from(new Set(children.map((child) => child.id)));
     rows.push({
       ...node,
       ...(parentId ? { parentId } : {}),

--- a/packages/gateway-client/tests/sync/flattenGatewayRunNode.test.ts
+++ b/packages/gateway-client/tests/sync/flattenGatewayRunNode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { flattenGatewayRunNode } from "../../src/sync/flattenGatewayRunNode.ts";
+import type { GatewayRunNode } from "../../src/sync/GatewayRunNode.ts";
+
+describe("flattenGatewayRunNode", () => {
+  test("terminates when child references form a cycle", () => {
+    const root: GatewayRunNode = { id: "root", name: "Root", kind: "compute", status: "running", children: [] };
+    const child: GatewayRunNode = { id: "child", name: "Child", kind: "compute", status: "queued", children: [root] };
+    root.children = [child];
+
+    expect(flattenGatewayRunNode(root).map((row) => row.id)).toEqual(["root", "child"]);
+  });
+
+  test("emits each duplicated child only once", () => {
+    const child: GatewayRunNode = { id: "child", name: "Child", kind: "compute", status: "queued", children: [] };
+    const root: GatewayRunNode = {
+      id: "root",
+      name: "Root",
+      kind: "compute",
+      status: "running",
+      children: [child, child],
+    };
+
+    expect(flattenGatewayRunNode(root).map((row) => row.id)).toEqual(["root", "child"]);
+  });
+});

--- a/packages/gateway-react/src/sync/buildGatewayRunTree.ts
+++ b/packages/gateway-react/src/sync/buildGatewayRunTree.ts
@@ -1,0 +1,25 @@
+import type { GatewayRunNode } from "@smithers-orchestrator/gateway-client";
+
+/**
+ * Rebuild the nested `children` tree from the flat, `childIds`-keyed rows the
+ * `nodes` collection stores. The collection holds the surgical diff of
+ * `snapshotToGatewayRunNode`'s output (reconciled per devtools frame), so this
+ * is a cheap pointer-chase over already-deduped rows.
+ */
+export function buildGatewayRunTree(rows: readonly GatewayRunNode[]): GatewayRunNode | null {
+  if (rows.length === 0) return null;
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const visited = new Set<string>();
+  const build = (node: GatewayRunNode): GatewayRunNode => {
+    visited.add(node.id);
+    const children: GatewayRunNode[] = [];
+    for (const id of node.childIds ?? []) {
+      const child = byId.get(id);
+      if (!child || visited.has(child.id)) continue;
+      children.push(build(child));
+    }
+    return { ...node, children };
+  };
+  const root = rows.find((row) => !row.parentId) ?? rows[0];
+  return build(root);
+}

--- a/packages/gateway-react/src/sync/useGatewayRunTree.ts
+++ b/packages/gateway-react/src/sync/useGatewayRunTree.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useLiveQuery } from "@tanstack/react-db";
 import type { GatewayRunNode } from "@smithers-orchestrator/gateway-client";
+import { buildGatewayRunTree } from "./buildGatewayRunTree.ts";
 import { useSyncClient } from "./useSyncClient.ts";
 
 /** The five tones the run UI knows; mirrors `snapshotToGatewayRunNode`'s output. */
@@ -18,26 +19,6 @@ export type UseGatewayRunTreeResult = {
 };
 
 /**
- * Rebuild the nested `children` tree from the flat, `childIds`-keyed rows the
- * `nodes` collection stores. The collection holds the surgical diff of
- * `snapshotToGatewayRunNode`'s output (reconciled per devtools frame), so this
- * is a cheap pointer-chase over already-deduped rows.
- */
-function buildRunTree(rows: readonly GatewayRunNode[]): GatewayRunNode | null {
-  if (rows.length === 0) return null;
-  const byId = new Map(rows.map((row) => [row.id, row]));
-  const build = (node: GatewayRunNode): GatewayRunNode => ({
-    ...node,
-    children: (node.childIds ?? [])
-      .map((id) => byId.get(id))
-      .filter((child): child is GatewayRunNode => child !== undefined)
-      .map(build),
-  });
-  const root = rows.find((row) => !row.parentId) ?? rows[0];
-  return build(root);
-}
-
-/**
  * Live query over the per-run `nodes` collection (initial `getDevToolsSnapshot`
  * + `streamDevTools`, reconciled into the collection). Consumers re-render only
  * for the nodes that actually changed instead of remounting the whole tree on
@@ -53,7 +34,7 @@ export function useGatewayRunTree(runId: string | undefined): UseGatewayRunTreeR
   );
 
   const nodes = (live.data ?? []) as GatewayRunNode[];
-  const root = useMemo(() => buildRunTree(nodes), [nodes]);
+  const root = useMemo(() => buildGatewayRunTree(nodes), [nodes]);
   const status = (root?.status ?? "queued") as NodeStatus;
   const isLoading = Boolean(runId) && !live.isReady && nodes.length === 0;
   return {

--- a/packages/gateway-react/tests/sync/buildGatewayRunTree.test.ts
+++ b/packages/gateway-react/tests/sync/buildGatewayRunTree.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import type { GatewayRunNode } from "@smithers-orchestrator/gateway-client";
+import { buildGatewayRunTree } from "../../src/sync/buildGatewayRunTree.ts";
+
+describe("buildGatewayRunTree", () => {
+  test("terminates when childIds form a cycle", () => {
+    const rows: GatewayRunNode[] = [
+      { id: "root", name: "Root", kind: "compute", status: "running", childIds: ["child"] },
+      { id: "child", name: "Child", kind: "compute", status: "queued", parentId: "root", childIds: ["root"] },
+    ];
+
+    expect(buildGatewayRunTree(rows)).toMatchObject({
+      id: "root",
+      children: [{ id: "child", children: [] }],
+    });
+  });
+
+  test("includes duplicated childIds only once", () => {
+    const rows: GatewayRunNode[] = [
+      { id: "root", name: "Root", kind: "compute", status: "running", childIds: ["child", "child"] },
+      { id: "child", name: "Child", kind: "compute", status: "queued", parentId: "root", childIds: [] },
+    ];
+
+    expect(buildGatewayRunTree(rows)?.children?.map((child) => child.id)).toEqual(["child"]);
+  });
+});


### PR DESCRIPTION
Relates to #303

## What

Guard the run tree flattening and build utilities against cycles and duplicate node references that could cause infinite traversal loops in the gateway run tree inspector.

## Root cause & approach

Two related issues in the run tree traversal code:

1. **`flattenGatewayRunNode`** (`packages/gateway-client/src/sync/flattenGatewayRunNode.ts`) had no cycle protection — if a node's `children` array contained a back-reference to an ancestor, the `visit` recursion would loop forever. Fixed by tracking visited node IDs with a `Set` and returning early on re-visits; also deduplicated `childIds` via `Array.from(new Set(...))` to avoid duplicate row entries.

2. **`buildGatewayRunTree`** was an inline private function inside `useGatewayRunTree.ts` with no cycle guard. It has been extracted into its own module (`packages/gateway-react/src/sync/buildGatewayRunTree.ts`) with the same visited-`Set` guard, and `useGatewayRunTree` now imports and delegates to it.

Tests for both utilities were added under their respective `tests/sync/` directories.

Codex implemented the fix via TDD; Codex + Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)