### PR TITLE
🐛 fix(scorers): bind aggregate score query filters

### DIFF
--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -573,10 +573,11 @@ export class SmithersDb {
         }
     }
     /**
-   * @param {string} queryString
+     * @param {string} queryString
+     * @param {unknown[]} [params]
    * @returns {RunnableEffect<unknown[], SmithersError>}
    */
-    rawQuery(queryString) {
+    rawQuery(queryString, params = []) {
         const self = this;
         return runnableEffect(Effect.gen(function* () {
             const validatedQuery = yield* Effect.try({
@@ -588,11 +589,11 @@ export class SmithersDb {
             });
             return yield* self.read(`raw query ${validatedQuery.slice(0, 20)}`, () => {
                 if (self.internalStorage.dialect === POSTGRES) {
-                    return self.internalStorage.queryAllRaw(validatedQuery);
+                    return self.internalStorage.queryAllRaw(validatedQuery, params);
                 }
                 const client = self.db.session.client;
                 const stmt = client.query(validatedQuery);
-                return Promise.resolve(stmt.all());
+                return Promise.resolve(stmt.all(...params));
             });
         }));
     }

--- a/packages/db/src/index.d.ts
+++ b/packages/db/src/index.d.ts
@@ -432,10 +432,11 @@ declare class SmithersDb {
    */
     clearFrameCacheForRun(runId: string): void;
     /**
-   * @param {string} queryString
+     * @param {string} queryString
+     * @param {unknown[]} [params]
    * @returns {RunnableEffect<unknown[], SmithersError>}
    */
-    rawQuery(queryString: string): RunnableEffect<unknown[], SmithersError$1>;
+    rawQuery(queryString: string, params?: unknown[]): RunnableEffect<unknown[], SmithersError$1>;
     /**
    * @param {string} currentFiberThread
    * @returns {boolean}

--- a/packages/scorers/src/aggregate.js
+++ b/packages/scorers/src/aggregate.js
@@ -18,12 +18,13 @@
  */
 export async function aggregateScores(adapter, opts) {
     const conditions = [];
+    const params = [];
     if (opts?.runId)
-        conditions.push(`run_id = '${escapeSql(opts.runId)}'`);
+        addFilter(conditions, params, "run_id", opts.runId);
     if (opts?.nodeId)
-        conditions.push(`node_id = '${escapeSql(opts.nodeId)}'`);
+        addFilter(conditions, params, "node_id", opts.nodeId);
     if (opts?.scorerId)
-        conditions.push(`scorer_id = '${escapeSql(opts.scorerId)}'`);
+        addFilter(conditions, params, "scorer_id", opts.scorerId);
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
     // Step 1: Get aggregate stats via SQL
     const aggQuery = `
@@ -39,7 +40,7 @@ export async function aggregateScores(adapter, opts) {
     GROUP BY scorer_id, scorer_name
     ORDER BY scorer_name
   `;
-    const aggRows = (await adapter.rawQuery(aggQuery));
+    const aggRows = (await adapter.rawQuery(aggQuery, params));
     if (aggRows.length === 0)
         return [];
     // Step 2: Get all scores to compute p50 and stddev per scorer in memory
@@ -49,7 +50,7 @@ export async function aggregateScores(adapter, opts) {
     ${where}
     ORDER BY scorer_id, score
   `;
-    const allScores = (await adapter.rawQuery(scoresQuery));
+    const allScores = (await adapter.rawQuery(scoresQuery, params));
     // Group scores by scorer_id
     const scoresByScorer = new Map();
     for (const row of allScores) {
@@ -100,9 +101,12 @@ function computeStddev(values, mean) {
     return Math.sqrt(variance);
 }
 /**
+ * @param {string[]} conditions
+ * @param {string[]} params
+ * @param {string} column
  * @param {string} value
- * @returns {string}
  */
-function escapeSql(value) {
-    return value.replace(/'/g, "''");
+function addFilter(conditions, params, column, value) {
+    conditions.push(`${column} = ?`);
+    params.push(value);
 }

--- a/packages/scorers/tests/aggregate.test.js
+++ b/packages/scorers/tests/aggregate.test.js
@@ -89,11 +89,23 @@ describe("aggregateScores", () => {
         expect(result).toHaveLength(1);
         expect(result[0].scorerName).toBe("Latency");
     });
-    it("combines filters and escapes single quotes in SQL predicates", async () => {
-        const queries = [];
+    it("combines filters with bound SQL parameters", async () => {
+        const calls = [];
         const mockAdapter = {
-            rawQuery: async (sql) => {
-                queries.push(sql);
+            rawQuery: async (sql, params) => {
+                calls.push({ sql, params });
+                if (calls.length === 1) {
+                    return [
+                        {
+                            scorer_id: "score-'id'",
+                            scorer_name: "Quoted",
+                            cnt: 1,
+                            mean: 0.5,
+                            min_score: 0.5,
+                            max_score: 0.5,
+                        },
+                    ];
+                }
                 return [];
             },
         };
@@ -102,11 +114,19 @@ describe("aggregateScores", () => {
             nodeId: "node-1",
             scorerId: "score-'id'",
         });
-        expect(queries).toHaveLength(1);
-        expect(queries[0]).toContain("run_id = 'run-''quoted'''");
-        expect(queries[0]).toContain("node_id = 'node-1'");
-        expect(queries[0]).toContain("scorer_id = 'score-''id'''");
-        expect(queries[0]).toContain(" AND ");
+        expect(calls).toHaveLength(2);
+        for (const call of calls) {
+            expect(call.sql).toContain("run_id = ?");
+            expect(call.sql).toContain("node_id = ?");
+            expect(call.sql).toContain("scorer_id = ?");
+            expect(call.sql).not.toContain("run-'quoted'");
+            expect(call.sql).not.toContain("score-'id'");
+            expect(call.params).toEqual([
+                "run-'quoted'",
+                "node-1",
+                "score-'id'",
+            ]);
+        }
     });
     it("computes p50 (median) correctly", async () => {
         // Insert 5 scores: 0.1, 0.3, 0.5, 0.7, 0.9


### PR DESCRIPTION
Relates to #303

## What was fixed

`aggregateScores()` in `packages/scorers/src/aggregate.js` was building SQL filter clauses by interpolating user-supplied values (runId, nodeId, scorerId) directly into the query string via an `escapeSql()` helper. Quote-escaping is an incomplete defense against SQL injection.

## How it was fixed

Replaced the string-interpolation approach with parameterized bindings:

- **`packages/scorers/src/aggregate.js`**: Removed `escapeSql()`. Added `addFilter()` which pushes `column = ?` placeholders and collects bound values into a `params` array. Both `rawQuery()` calls now pass this array.
- **`packages/db/src/adapter.js`**: Extended `rawQuery(queryString, params = [])` to accept an optional params array, forwarded to `queryAllRaw(sql, params)` for Postgres and `stmt.all(...params)` for SQLite.
- **`packages/db/src/index.d.ts`**: Updated the type signature to match.
- **`packages/scorers/tests/aggregate.test.js`**: Tests updated to verify that SQL contains `?` placeholders (not literal values) and that the correct bound params array is passed through.

Codex implemented this via TDD; Codex and Claude Opus both approved in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)