### PR TITLE
🐛 fix(cli): generate OpenAPI tools via public import

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -1439,7 +1439,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[73]:
+commands[74]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1982,6 +1982,11 @@ commands[73]:
     purpose: Preview tools generated from an OpenAPI spec
     args[1]{name,type,required,desc}:
       specPath,string,true,File path or URL to OpenAPI spec
+  - name: openapi.generate
+    purpose: Generate an AI SDK tools module from an OpenAPI spec
+    args[2]{name,type,required,desc}:
+      specPath,string,true,File path to OpenAPI spec
+      outputPath,string,true,Output JavaScript file for generated tools
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
     flags[6]{name,short,type,default,desc}:
@@ -7915,13 +7920,21 @@ Pass the spec itself as the first argument to `createOpenApiTools(input, options
 | `loadSpecSync(input)` | Load and parse a spec from object, local file path, or raw text. It does not fetch URLs. |
 | `jsonSchemaToZod(schema, spec, visited?)` / `buildOperationSchema(parameters, requestBody, spec)` | Lower-level schema conversion helpers. |
 
-## CLI preview
+## CLI
+
+Generate a reusable AI SDK tools module:
+
+```bash
+bunx smithers-orchestrator openapi generate ./api/openapi.yaml ./src/openapi-tools.js
+```
+
+The generated module imports `createOpenApiToolsSync`, creates the tools from the spec, and exports them as both `tools` and the default export.
 
 ```bash
 bunx smithers-orchestrator openapi list ./api/openapi.yaml
 ```
 
-Lists every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
+`openapi list` previews every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
 
 ## What gets generated
 

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -2,9 +2,9 @@
 import { setJsonMode } from "./util/logger.ts";
 import { findFirstPositionalIndex, parseMcpSurfaceArgv, rewriteBareResumeFlagArgv } from "./argv-utils.js";
 import { CLI_JSON_ARGUMENT_MAX_BYTES, parseJsonArgument, parseJsonInput } from "./json-args.js";
-import { resolve, dirname, basename } from "node:path";
+import { resolve, dirname, basename, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { readFileSync, existsSync, openSync, statSync, writeSync } from "node:fs";
+import { readFileSync, existsSync, mkdirSync, openSync, statSync, writeFileSync, writeSync } from "node:fs";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Effect, Fiber } from "effect";
 import { Cli, Mcp as IncurMcp, z } from "incur";
@@ -2484,6 +2484,19 @@ const agentsCli = Cli.create({
 const openapiListArgs = z.object({
     specPath: z.string().describe("Path or URL to an OpenAPI spec"),
 });
+const openapiGenerateArgs = z.object({
+    specPath: z.string().describe("Path to an OpenAPI spec"),
+    outputPath: z.string().describe("Output JavaScript file for generated tools"),
+});
+/**
+ * @param {string} fromDir
+ * @param {string} targetPath
+ * @returns {string}
+ */
+function relativeImportPath(fromDir, targetPath) {
+    const rel = relative(fromDir, targetPath).split("\\").join("/");
+    return rel.startsWith(".") ? rel : `./${rel}`;
+}
 const openapiCli = Cli.create({
     name: "openapi",
     description: "Generate AI SDK tools from OpenAPI specs.",
@@ -2508,6 +2521,39 @@ const openapiCli = Cli.create({
         catch (err) {
             console.error(`Error: ${err?.message ?? String(err)}`);
             return c.error({ code: "OPENAPI_LIST_FAILED", message: err?.message ?? String(err) });
+        }
+    },
+})
+    .command("generate", {
+    description: "Generate an AI SDK tools module from an OpenAPI spec.",
+    args: openapiGenerateArgs,
+    async run(c) {
+        try {
+            const { createOpenApiToolsSync } = await import("@smithers-orchestrator/openapi/tool-factory");
+            const specPath = resolve(process.cwd(), c.args.specPath);
+            const outputPath = resolve(process.cwd(), c.args.outputPath);
+            const outputDir = dirname(outputPath);
+            const importPath = relativeImportPath(outputDir, specPath);
+            const tools = createOpenApiToolsSync(specPath);
+            const toolCount = Object.keys(tools).length;
+            mkdirSync(outputDir, { recursive: true });
+            writeFileSync(outputPath, [
+                'import { fileURLToPath } from "node:url";',
+                'import { createOpenApiToolsSync } from "smithers-orchestrator/openapi";',
+                "",
+                `const specPath = fileURLToPath(new URL(${JSON.stringify(importPath)}, import.meta.url));`,
+                "",
+                "export const tools = createOpenApiToolsSync(specPath);",
+                "",
+                "export default tools;",
+                "",
+            ].join("\n"), "utf8");
+            console.log(`Generated ${toolCount} OpenAPI tool(s) at ${outputPath}`);
+            return c.ok({ outputPath, toolCount });
+        }
+        catch (err) {
+            console.error(`Error: ${err?.message ?? String(err)}`);
+            return c.error({ code: "OPENAPI_GENERATE_FAILED", message: err?.message ?? String(err) });
         }
     },
 });

--- a/apps/cli/tests/openapi-generate-command.test.js
+++ b/apps/cli/tests/openapi-generate-command.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { createTempRepo, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+const spec = {
+    openapi: "3.0.0",
+    info: { title: "Pets", version: "1.0.0" },
+    servers: [{ url: "https://api.example.test" }],
+    paths: {
+        "/pets": {
+            get: {
+                operationId: "listPets",
+                summary: "List pets",
+                responses: {
+                    200: { description: "ok" },
+                },
+            },
+        },
+    },
+};
+
+describe("smithers openapi generate", () => {
+    test("writes an AI SDK tools module using the OpenAPI tool factory", () => {
+        const repo = createTempRepo();
+        const specPath = repo.write("openapi.json", `${JSON.stringify(spec, null, 2)}\n`);
+
+        const result = runSmithers(["openapi", "generate", specPath, "src/pet-tools.js"], {
+            cwd: repo.dir,
+            format: null,
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("Generated 1 OpenAPI tool(s)");
+        expect(existsSync(repo.path("src/pet-tools.js"))).toBe(true);
+
+        const generated = readFileSync(repo.path("src/pet-tools.js"), "utf8");
+        expect(generated).toContain('new URL("../openapi.json", import.meta.url)');
+        expect(generated).toContain('from "smithers-orchestrator/openapi"');
+        expect(generated).toContain('export const tools = createOpenApiToolsSync');
+        expect(generated).toContain("export default tools;");
+
+        const imported = spawnSync(process.execPath, [
+            "--eval",
+            'const mod = await import("./src/pet-tools.js"); console.log(JSON.stringify(Object.keys(mod.tools)));',
+        ], {
+            cwd: repo.dir,
+            encoding: "utf8",
+        });
+        expect(imported.stderr).toBe("");
+        expect(imported.status).toBe(0);
+        expect(JSON.parse(imported.stdout)).toEqual(["listPets"]);
+    });
+});

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -56,7 +56,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[73]:
+commands[74]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -599,6 +599,11 @@ commands[73]:
     purpose: Preview tools generated from an OpenAPI spec
     args[1]{name,type,required,desc}:
       specPath,string,true,File path or URL to OpenAPI spec
+  - name: openapi.generate
+    purpose: Generate an AI SDK tools module from an OpenAPI spec
+    args[2]{name,type,required,desc}:
+      specPath,string,true,File path to OpenAPI spec
+      outputPath,string,true,Output JavaScript file for generated tools
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
     flags[6]{name,short,type,default,desc}:

--- a/docs/concepts/openapi-tools.mdx
+++ b/docs/concepts/openapi-tools.mdx
@@ -65,13 +65,21 @@ Pass the spec itself as the first argument to `createOpenApiTools(input, options
 | `loadSpecSync(input)` | Load and parse a spec from object, local file path, or raw text. It does not fetch URLs. |
 | `jsonSchemaToZod(schema, spec, visited?)` / `buildOperationSchema(parameters, requestBody, spec)` | Lower-level schema conversion helpers. |
 
-## CLI preview
+## CLI
+
+Generate a reusable AI SDK tools module:
+
+```bash
+bunx smithers-orchestrator openapi generate ./api/openapi.yaml ./src/openapi-tools.js
+```
+
+The generated module imports `createOpenApiToolsSync`, creates the tools from the spec, and exports them as both `tools` and the default export.
 
 ```bash
 bunx smithers-orchestrator openapi list ./api/openapi.yaml
 ```
 
-Lists every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
+`openapi list` previews every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
 
 ## What gets generated
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -1418,7 +1418,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[73]:
+commands[74]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1961,6 +1961,11 @@ commands[73]:
     purpose: Preview tools generated from an OpenAPI spec
     args[1]{name,type,required,desc}:
       specPath,string,true,File path or URL to OpenAPI spec
+  - name: openapi.generate
+    purpose: Generate an AI SDK tools module from an OpenAPI spec
+    args[2]{name,type,required,desc}:
+      specPath,string,true,File path to OpenAPI spec
+      outputPath,string,true,Output JavaScript file for generated tools
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
     flags[6]{name,short,type,default,desc}:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1439,7 +1439,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[73]:
+commands[74]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1982,6 +1982,11 @@ commands[73]:
     purpose: Preview tools generated from an OpenAPI spec
     args[1]{name,type,required,desc}:
       specPath,string,true,File path or URL to OpenAPI spec
+  - name: openapi.generate
+    purpose: Generate an AI SDK tools module from an OpenAPI spec
+    args[2]{name,type,required,desc}:
+      specPath,string,true,File path to OpenAPI spec
+      outputPath,string,true,Output JavaScript file for generated tools
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
     flags[6]{name,short,type,default,desc}:
@@ -7915,13 +7920,21 @@ Pass the spec itself as the first argument to `createOpenApiTools(input, options
 | `loadSpecSync(input)` | Load and parse a spec from object, local file path, or raw text. It does not fetch URLs. |
 | `jsonSchemaToZod(schema, spec, visited?)` / `buildOperationSchema(parameters, requestBody, spec)` | Lower-level schema conversion helpers. |
 
-## CLI preview
+## CLI
+
+Generate a reusable AI SDK tools module:
+
+```bash
+bunx smithers-orchestrator openapi generate ./api/openapi.yaml ./src/openapi-tools.js
+```
+
+The generated module imports `createOpenApiToolsSync`, creates the tools from the spec, and exports them as both `tools` and the default export.
 
 ```bash
 bunx smithers-orchestrator openapi list ./api/openapi.yaml
 ```
 
-Lists every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
+`openapi list` previews every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
 
 ## What gets generated
 

--- a/docs/llms-openapi.txt
+++ b/docs/llms-openapi.txt
@@ -70,13 +70,21 @@ Pass the spec itself as the first argument to `createOpenApiTools(input, options
 | `loadSpecSync(input)` | Load and parse a spec from object, local file path, or raw text. It does not fetch URLs. |
 | `jsonSchemaToZod(schema, spec, visited?)` / `buildOperationSchema(parameters, requestBody, spec)` | Lower-level schema conversion helpers. |
 
-## CLI preview
+## CLI
+
+Generate a reusable AI SDK tools module:
+
+```bash
+bunx smithers-orchestrator openapi generate ./api/openapi.yaml ./src/openapi-tools.js
+```
+
+The generated module imports `createOpenApiToolsSync`, creates the tools from the spec, and exports them as both `tools` and the default export.
 
 ```bash
 bunx smithers-orchestrator openapi list ./api/openapi.yaml
 ```
 
-Lists every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
+`openapi list` previews every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
 
 ## What gets generated
 

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -1439,7 +1439,7 @@ If no Gateway is reachable on the default local port, `bunx smithers-orchestrato
 Commands listed by dotted name. `human` and `alerts` use an action positional instead of nested subcommands.
 
 ```toon
-commands[73]:
+commands[74]:
   - name: init
     purpose: Install the workflow pack into .smithers/ (local) or ~/.smithers/ (--global)
     flags[6]{name,short,type,default,desc}:
@@ -1982,6 +1982,11 @@ commands[73]:
     purpose: Preview tools generated from an OpenAPI spec
     args[1]{name,type,required,desc}:
       specPath,string,true,File path or URL to OpenAPI spec
+  - name: openapi.generate
+    purpose: Generate an AI SDK tools module from an OpenAPI spec
+    args[2]{name,type,required,desc}:
+      specPath,string,true,File path to OpenAPI spec
+      outputPath,string,true,Output JavaScript file for generated tools
   - name: token.issue
     purpose: Issue a local short-lived Gateway bearer token grant
     flags[6]{name,short,type,default,desc}:
@@ -7915,13 +7920,21 @@ Pass the spec itself as the first argument to `createOpenApiTools(input, options
 | `loadSpecSync(input)` | Load and parse a spec from object, local file path, or raw text. It does not fetch URLs. |
 | `jsonSchemaToZod(schema, spec, visited?)` / `buildOperationSchema(parameters, requestBody, spec)` | Lower-level schema conversion helpers. |
 
-## CLI preview
+## CLI
+
+Generate a reusable AI SDK tools module:
+
+```bash
+bunx smithers-orchestrator openapi generate ./api/openapi.yaml ./src/openapi-tools.js
+```
+
+The generated module imports `createOpenApiToolsSync`, creates the tools from the spec, and exports them as both `tools` and the default export.
 
 ```bash
 bunx smithers-orchestrator openapi list ./api/openapi.yaml
 ```
 
-Lists every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
+`openapi list` previews every operationId, method, path, and summary. Useful for auditing what an agent will be able to call before wiring it up.
 
 ## What gets generated
 


### PR DESCRIPTION
Relates to #302

## What was fixed

The `smithers openapi generate` command was missing entirely. Issue #302 reported that the CLI had no way to generate an AI SDK tools module from an OpenAPI spec file.

## Root cause & approach

The `openapiCli` in `apps/cli/src/index.js` only had the `list` subcommand — the `generate` subcommand was never implemented. The fix adds a `generate` subcommand that:

1. Imports `createOpenApiToolsSync` from the public `@smithers-orchestrator/openapi/tool-factory` entry point (not internal paths).
2. Resolves the spec path and output path from the CWD.
3. Generates a JavaScript module that re-exports tools via the public `smithers-orchestrator/openapi` import — so the generated file is self-contained and portable.
4. Creates the output directory if needed (`mkdirSync` with `recursive: true`), then writes the file with `writeFileSync`.
5. A `relativeImportPath` helper computes the correct relative path from the output file back to the spec, using `node:path`'s `relative()`.

Key files changed:
- `apps/cli/src/index.js` — adds `generate` command with `openapiGenerateArgs` schema and implementation
- `apps/cli/tests/openapi-generate-command.test.js` — new TDD test covering happy path, generated file content, and dynamic import of the generated module
- `docs/concepts/openapi-tools.mdx`, `docs/cli/overview.mdx` — docs updated to cover the new command
- `docs/llms-*.txt`, `apps/cli/docs/llms-full.txt`, `skills/smithers/llms-full.txt` — regenerated LLM bundles

Codex implemented this via TDD. Both Codex and Claude Opus reviewed and approved the implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)