### PR TITLE
🐛 fix(react-reconciler): preserve ordered container roots

### DIFF
--- a/packages/react-reconciler/src/HostContainer.ts
+++ b/packages/react-reconciler/src/HostContainer.ts
@@ -2,4 +2,5 @@ import type { HostNode } from "@smithers-orchestrator/graph/types";
 
 export type HostContainer = {
 	root: HostNode | null;
+	roots?: HostNode[];
 };

--- a/packages/react-reconciler/src/index.d.ts
+++ b/packages/react-reconciler/src/index.d.ts
@@ -12,6 +12,7 @@ type SmithersRendererOptions$1 = {
 
 type HostContainer$1 = {
     root: HostNode$1 | null;
+    roots?: HostNode$1[];
 };
 
 declare class SmithersRenderer {

--- a/packages/react-reconciler/src/reconciler.js
+++ b/packages/react-reconciler/src/reconciler.js
@@ -62,6 +62,40 @@ function createElement(type, props) {
     };
 }
 let currentUpdatePriority = 1;
+/**
+ * @param {readonly HostNode[]} roots
+ * @returns {HostNode | null}
+ */
+function materializeRoot(roots) {
+    if (roots.length === 0)
+        return null;
+    if (roots.length === 1)
+        return roots[0];
+    return {
+        kind: "element",
+        tag: "smithers:fragment",
+        props: {},
+        rawProps: {},
+        children: roots,
+    };
+}
+/**
+ * @param {HostContainer} container
+ * @returns {HostNode[]}
+ */
+function ensureContainerRoots(container) {
+    if (Array.isArray(container.roots))
+        return container.roots;
+    container.roots = container.root ? [container.root] : [];
+    return container.roots;
+}
+/**
+ * @param {HostContainer} container
+ * @returns {void}
+ */
+function refreshContainerRoot(container) {
+    container.root = materializeRoot(ensureContainerRoots(container));
+}
 const hostConfig = {
     supportsMutation: true,
     supportsPersistence: false,
@@ -127,7 +161,12 @@ const hostConfig = {
    * @returns {void}
    */
     appendChildToContainer(container, child) {
-        container.root = child;
+        const roots = ensureContainerRoots(container);
+        const existing = roots.indexOf(child);
+        if (existing >= 0)
+            roots.splice(existing, 1);
+        roots.push(child);
+        refreshContainerRoot(container);
     },
     /**
    * @param {MutableHostElement} parent
@@ -141,10 +180,20 @@ const hostConfig = {
     },
     /**
    * @param {HostContainer} container
+   * @param {HostNode} [child]
    * @returns {void}
    */
-    removeChildFromContainer(container) {
-        container.root = null;
+    removeChildFromContainer(container, child) {
+        const roots = ensureContainerRoots(container);
+        if (child) {
+            const idx = roots.indexOf(child);
+            if (idx >= 0)
+                roots.splice(idx, 1);
+        }
+        else {
+            roots.length = 0;
+        }
+        refreshContainerRoot(container);
     },
     /**
    * @param {MutableHostElement} parent
@@ -165,11 +214,20 @@ const hostConfig = {
     /**
    * @param {HostContainer} container
    * @param {HostNode} child
-   * @param {HostNode} _beforeChild
+   * @param {HostNode} beforeChild
    * @returns {void}
    */
-    insertInContainerBefore(container, child, _beforeChild) {
-        container.root = child;
+    insertInContainerBefore(container, child, beforeChild) {
+        const roots = ensureContainerRoots(container);
+        const existing = roots.indexOf(child);
+        if (existing >= 0)
+            roots.splice(existing, 1);
+        const idx = roots.indexOf(beforeChild);
+        if (idx >= 0)
+            roots.splice(idx, 0, child);
+        else
+            roots.push(child);
+        refreshContainerRoot(container);
     },
     /**
    * @param {MutableHostElement} _instance
@@ -246,7 +304,8 @@ const hostConfig = {
    * @returns {void}
    */
     clearContainer(container) {
-        container.root = null;
+        ensureContainerRoots(container).length = 0;
+        refreshContainerRoot(container);
     },
     /**
    * @returns {number}
@@ -421,7 +480,7 @@ export class SmithersRenderer {
    */
     constructor(options = {}) {
         this.extractGraph = options.extractGraph;
-        this.container = { root: null };
+        this.container = { root: null, roots: [] };
         this.root = reconciler.createContainer(this.container, 0, null, false, null, "", reconciler.defaultOnUncaughtError, reconciler.defaultOnCaughtError, reconciler.defaultOnRecoverableError, null);
     }
     /**

--- a/packages/react-reconciler/tests/reconciler-coverage.test.jsx
+++ b/packages/react-reconciler/tests/reconciler-coverage.test.jsx
@@ -86,19 +86,24 @@ describe("host config defensive branches", () => {
         expect(() => __testingHostConfig.requestPostPaintCallback()).not.toThrow();
     });
 
-    test("container mutation stubs update the headless root", () => {
-        const container = { root: null };
+    test("container mutation stubs preserve ordered root children", () => {
+        const container = { root: null, roots: [] };
         const first = __testingHostConfig.createInstance("smithers:task", { id: "first" });
         const second = __testingHostConfig.createInstance("smithers:task", { id: "second" });
+        const third = __testingHostConfig.createInstance("smithers:task", { id: "third" });
 
         __testingHostConfig.appendChildToContainer(container, first);
         expect(container.root).toBe(first);
 
         __testingHostConfig.insertInContainerBefore(container, second, first);
-        expect(container.root).toBe(second);
+        expect(container.root.children.map((child) => child.props.id)).toEqual(["second", "first"]);
+
+        __testingHostConfig.appendChildToContainer(container, third);
+        expect(container.root.children.map((child) => child.props.id)).toEqual(["second", "first", "third"]);
 
         __testingHostConfig.removeChildFromContainer(container);
         expect(container.root).toBeNull();
+        expect(container.roots).toEqual([]);
     });
 
     test("bindToConsole dispatches to the selected console method with log fallback", () => {

--- a/packages/react-reconciler/tests/reconciler.test.js
+++ b/packages/react-reconciler/tests/reconciler.test.js
@@ -69,4 +69,13 @@ describe("SmithersRenderer", () => {
         expect(root.tag).toBe("smithers:task");
         expect(root.props.id).toBe("second");
     });
+    it("preserves all ordered top-level Fragment children", async () => {
+        const renderer = new SmithersRenderer({ extractGraph: graphFrom });
+        await renderer.render(React.createElement(React.Fragment, null, React.createElement("smithers:task", { id: "first", output: "out" }), React.createElement("smithers:task", { id: "second", output: "out" }), React.createElement("smithers:task", { id: "third", output: "out" })));
+
+        const root = renderer.getRoot();
+        expect(root.kind).toBe("element");
+        expect(root.tag).toBe("smithers:fragment");
+        expect(root.children.map((child) => child.props.id)).toEqual(["first", "second", "third"]);
+    });
 });


### PR DESCRIPTION
Relates to #303

## What was fixed

The React reconciler's container host config maintained only a single `root` node, so rendering a React Fragment with multiple top-level children silently dropped all but the last child. `appendChildToContainer`, `insertInContainerBefore`, and `removeChildFromContainer` each overwrote `container.root` with the incoming child rather than maintaining an ordered list.

## Root cause

The three container-mutation host config methods treated the container as a single-slot holder instead of an ordered sequence, so only the last mounted top-level node survived reconciliation.

## Approach

**Key files:** `packages/react-reconciler/src/HostContainer.ts`, `packages/react-reconciler/src/index.d.ts`, `packages/react-reconciler/src/reconciler.js`, `packages/react-reconciler/tests/reconciler.test.js`, `packages/react-reconciler/tests/reconciler-coverage.test.jsx`

- Added a `roots: HostNode[]` array to `HostContainer` to track all top-level children in insertion order.
- Added `materializeRoot`, `ensureContainerRoots`, and `refreshContainerRoot` helpers in `reconciler.js`.
- `appendChildToContainer`, `insertInContainerBefore`, `removeChildFromContainer`, and `clearContainer` now operate on the `roots` array and derive `container.root` from it: `null` when empty, the single node when length === 1, or a synthetic `smithers:fragment` wrapper for multiple roots.
- `SmithersRenderer` initialises the container with `roots: []` so the lazy migration path is never exercised.
- Tests updated to assert correct ordering and multi-child Fragment rendering.

## Review

Codex implemented the fix via TDD, and both Codex and Claude Opus approved it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)