### PR TITLE
fix(cli): avoid hardcoded /bin/bash for agent detection

### DIFF
--- a/apps/cli/src/agent-detection.js
+++ b/apps/cli/src/agent-detection.js
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
+import { constants, accessSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
+
 import { SmithersError } from "@smithers-orchestrator/errors";
 import { listAccounts } from "@smithers-orchestrator/accounts";
 /** @typedef {import("./AgentAvailability.ts").AgentAvailability} AgentAvailability */
@@ -255,11 +255,18 @@ function displayNameForProviderId(id) {
  * @param {NodeJS.ProcessEnv} env
  */
 function commandExists(binary, env) {
-    const result = spawnSync("/bin/bash", ["-c", `command -v ${binary}`], {
-        env,
-        encoding: "utf8",
+    const pathEntries = env.PATH?.split(":") ?? [];
+    return pathEntries.some((entry) => {
+        if (!entry)
+            return false;
+        try {
+            accessSync(join(entry, binary), constants.X_OK);
+            return true;
+        }
+        catch {
+            return false;
+        }
     });
-    return result.status === 0;
 }
 /**
  * @param {boolean} hasBinary

--- a/apps/cli/tests/cli-agent-detection.test.js
+++ b/apps/cli/tests/cli-agent-detection.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, onTestFinished, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createExecutableDir, writeFakeAntigravityBinary, writeFakeClaudeBinary, writeFakeCodexBinary, writeFakeOpenCodeBinary } from "../../../packages/smithers/tests/e2e-helpers.js";
@@ -151,6 +151,10 @@ describe("detectAvailableAgents", () => {
             const binaryCheck = result.checks.find((c) => c.startsWith("binary:"));
             expect(binaryCheck).toBeDefined();
         }
+    });
+    test("binary detection does not hardcode /bin/bash", () => {
+        const source = readFileSync(new URL("../src/agent-detection.js", import.meta.url), "utf8");
+        expect(source).not.toContain("/bin/bash");
     });
     test("checks array includes env checks for agents with api keys", () => {
         const results = detectAvailableAgents({});


### PR DESCRIPTION
## Summary
- replace shelling out through hardcoded `/bin/bash` during agent CLI detection with direct executable lookup on `PATH`
- add a regression test to ensure agent detection does not reintroduce `/bin/bash`

## Why
Hardcoding `/bin/bash` breaks on non-FHS systems like NixOS, where Bash may be available on `PATH` but not at `/bin/bash`. In that case `smithers init` can incorrectly report `binary:codex:no` even when `codex` is installed and authenticated.

## Verification
- `bun test --timeout=120000 --max-concurrency=1 apps/cli/tests/cli-agent-detection.test.js`
- `./node_modules/.bin/tsc -p apps/cli/tsconfig.json --noEmit`
- manual smoke: `bun /home/agent/projects/smithers/apps/cli/src/index.js init --no-skill --force` succeeds on NixOS with Codex installed/authenticated


Requested by @shazow.
