### PR TITLE
✨ feat(scheduler): surface masked child failures as failedChildren on finished runs

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -8648,6 +8648,24 @@ bunx smithers-orchestrator events --run RUN_ID  # the full event history, includ
 bunx smithers-orchestrator scores RUN_ID     # scorer results when you gate on judged output
 ```
 
+You don't have to re-derive the count by eye. When a `finished` run tolerated at
+least one failed child, the masking is surfaced as a first-class **`failedChildren`**
+signal in three places:
+
+- **`inspect`** adds `failedChildren` (a count) and `failedChildKeys` (the failed
+  task state keys, `nodeId::iteration`) to its JSON next to `runState`, plus a
+  `node …` call-to-action. They are absent when nothing failed, so
+  `failedChildren > 0` is the degraded-run gate.
+- The **`RunResult`** returned by a programmatic run carries the same
+  `failedChildren` / `failedChildKeys` fields (omitted when zero).
+- The **`RunFinished`** event row records `failedChildren` / `failedChildKeys`, so the
+  CLI, Gateway, and DevTools can flag the degraded outcome from the event stream
+  without re-reading every node row.
+
+The run-row `status` stays `finished` (and `RunState` stays `succeeded`) so existing
+`finished === success` callers and `continueOnFail` semantics are unchanged. The
+count is the signal, not a new terminal status.
+
 To avoid the rate-limit failures in the first place, bound fan-out concurrency with `<Parallel maxConcurrency={N}>` so you don't burst past the provider's limit.
 </Warning>
 

--- a/apps/cli/src/format.js
+++ b/apps/cli/src/format.js
@@ -176,7 +176,9 @@ export function formatEventLine(event, baseMs, options) {
         case "RunStatusChanged":
             return `${prefix}↺ Run status: ${payload?.status ?? "unknown"}`;
         case "RunFinished":
-            return `${prefix}✓ Run finished`;
+            return payload?.failedChildren > 0
+                ? `${prefix}✓ Run finished (${payload.failedChildren} failed ${payload.failedChildren === 1 ? "child" : "children"})`
+                : `${prefix}✓ Run finished`;
         case "RunFailed":
             return `${prefix}✗ Run failed: ${truncateText(formatErrorPayload(payload?.error ?? "unknown"), truncatePayloadAt)}`;
         case "RunCancelled":

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -16,6 +16,8 @@ import { loadInput, loadOutputs } from "@smithers-orchestrator/db/snapshot";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
 import { computeRunStateFromRow } from "@smithers-orchestrator/db/runState";
+import { buildStateKey } from "@smithers-orchestrator/scheduler/buildStateKey";
+import { parseStateKey } from "@smithers-orchestrator/scheduler/parseStateKey";
 import { SmithersCtx } from "@smithers-orchestrator/driver";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { runFork, runPromise } from "./smithersRuntime.js";
@@ -1206,6 +1208,17 @@ async function buildInspectSnapshot(adapter, runId) {
         attempt: n.lastAttempt ?? 0,
         label: n.label ?? n.nodeId,
     }));
+    // On a finished/continued (succeeded) run, any task still in `failed` state is
+    // a "masked" child — a continueOnFail task or transient agent failure that was
+    // tolerated, so the binary run status reads as a clean success. Surface the
+    // count so callers don't have to eyeball every node row. A genuinely `failed`
+    // run already reports its error, so don't double-count there. Keys are the
+    // canonical state keys (`nodeId::iteration`) so a node failing across loop
+    // iterations stays distinct. (#295)
+    const isSuccessTerminal = r.status === "finished" || r.status === "continued";
+    const failedChildKeys = isSuccessTerminal
+        ? nodes.filter((n) => n.state === "failed").map((n) => buildStateKey(n.nodeId, n.iteration))
+        : [];
     const pendingApprovals = approvals.map((a) => ({
         nodeId: a.nodeId,
         status: a.status,
@@ -1246,6 +1259,9 @@ async function buildInspectSnapshot(adapter, runId) {
             ...(error ? { error } : {}),
         },
         ...(runState ? { runState } : {}),
+        ...(failedChildKeys.length > 0
+            ? { failedChildren: failedChildKeys.length, failedChildKeys }
+            : {}),
         steps,
     };
     if (continuedFromVisible.length > 0) {
@@ -1289,6 +1305,13 @@ async function buildInspectSnapshot(adapter, runId) {
     }
     if (waitingTimers.length > 0) {
         ctaCommands.push({ command: `why ${runId}`, description: "Explain timer wait" });
+    }
+    if (failedChildKeys.length > 0) {
+        const first = parseStateKey(failedChildKeys[0]);
+        ctaCommands.push({
+            command: `node ${first.nodeId} -r ${runId}${first.iteration > 0 ? ` -i ${first.iteration}` : ""}`,
+            description: `Run finished with ${failedChildKeys.length} failed ${failedChildKeys.length === 1 ? "child" : "children"}; inspect`,
+        });
     }
     return {
         result,

--- a/apps/observability/src/SmithersEvent.ts
+++ b/apps/observability/src/SmithersEvent.ts
@@ -121,7 +121,19 @@ export type SmithersEvent =
       after: RunState;
       timestampMs: number;
     }
-  | { type: "RunFinished"; runId: string; timestampMs: number }
+  | {
+      type: "RunFinished";
+      runId: string;
+      timestampMs: number;
+      /**
+       * Tasks that ended `failed` but were tolerated (continueOnFail / transient
+       * agent failures) so the run still finished. Present only when `> 0` — the
+       * run "succeeded" while these children failed. See `docs/runtime/run-state.mdx`.
+       */
+      failedChildren?: number;
+      /** Task state keys (`nodeId::iteration`) counted by `failedChildren`. */
+      failedChildKeys?: readonly string[];
+    }
   | { type: "RunFailed"; runId: string; error: unknown; timestampMs: number }
   | { type: "RunCancelled"; runId: string; timestampMs: number }
   | {

--- a/apps/observability/src/index.d.ts
+++ b/apps/observability/src/index.d.ts
@@ -213,6 +213,14 @@ type SmithersEvent$2 = {
     type: "RunFinished";
     runId: string;
     timestampMs: number;
+    /**
+     * Tasks that ended `failed` but were tolerated (continueOnFail / transient
+     * agent failures) so the run still finished. Present only when `> 0` — the
+     * run "succeeded" while these children failed. See `docs/runtime/run-state.mdx`.
+     */
+    failedChildren?: number;
+    /** Task state keys (`nodeId::iteration`) counted by `failedChildren`. */
+    failedChildKeys?: readonly string[];
 } | {
     type: "RunFailed";
     runId: string;

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -8636,6 +8636,24 @@ bunx smithers-orchestrator events --run RUN_ID  # the full event history, includ
 bunx smithers-orchestrator scores RUN_ID     # scorer results when you gate on judged output
 ```
 
+You don't have to re-derive the count by eye. When a `finished` run tolerated at
+least one failed child, the masking is surfaced as a first-class **`failedChildren`**
+signal in three places:
+
+- **`inspect`** adds `failedChildren` (a count) and `failedChildKeys` (the failed
+  task state keys, `nodeId::iteration`) to its JSON next to `runState`, plus a
+  `node …` call-to-action. They are absent when nothing failed, so
+  `failedChildren > 0` is the degraded-run gate.
+- The **`RunResult`** returned by a programmatic run carries the same
+  `failedChildren` / `failedChildKeys` fields (omitted when zero).
+- The **`RunFinished`** event row records `failedChildren` / `failedChildKeys`, so the
+  CLI, Gateway, and DevTools can flag the degraded outcome from the event stream
+  without re-reading every node row.
+
+The run-row `status` stays `finished` (and `RunState` stays `succeeded`) so existing
+`finished === success` callers and `continueOnFail` semantics are unchanged. The
+count is the signal, not a new terminal status.
+
 To avoid the rate-limit failures in the first place, bound fan-out concurrency with [`<Parallel maxConcurrency={N}>`](/components/parallel) so you don't burst past the provider's limit.
 </Warning>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8648,6 +8648,24 @@ bunx smithers-orchestrator events --run RUN_ID  # the full event history, includ
 bunx smithers-orchestrator scores RUN_ID     # scorer results when you gate on judged output
 ```
 
+You don't have to re-derive the count by eye. When a `finished` run tolerated at
+least one failed child, the masking is surfaced as a first-class **`failedChildren`**
+signal in three places:
+
+- **`inspect`** adds `failedChildren` (a count) and `failedChildKeys` (the failed
+  task state keys, `nodeId::iteration`) to its JSON next to `runState`, plus a
+  `node …` call-to-action. They are absent when nothing failed, so
+  `failedChildren > 0` is the degraded-run gate.
+- The **`RunResult`** returned by a programmatic run carries the same
+  `failedChildren` / `failedChildKeys` fields (omitted when zero).
+- The **`RunFinished`** event row records `failedChildren` / `failedChildKeys`, so the
+  CLI, Gateway, and DevTools can flag the degraded outcome from the event stream
+  without re-reading every node row.
+
+The run-row `status` stays `finished` (and `RunState` stays `succeeded`) so existing
+`finished === success` callers and `continueOnFail` semantics are unchanged. The
+count is the signal, not a new terminal status.
+
 To avoid the rate-limit failures in the first place, bound fan-out concurrency with `<Parallel maxConcurrency={N}>` so you don't burst past the provider's limit.
 </Warning>
 

--- a/docs/runtime/run-state.mdx
+++ b/docs/runtime/run-state.mdx
@@ -78,6 +78,24 @@ bunx smithers-orchestrator events --run RUN_ID  # the full event history, includ
 bunx smithers-orchestrator scores RUN_ID     # scorer results when you gate on judged output
 ```
 
+You don't have to re-derive the count by eye. When a `finished` run tolerated at
+least one failed child, the masking is surfaced as a first-class **`failedChildren`**
+signal in three places:
+
+- **`inspect`** adds `failedChildren` (a count) and `failedChildKeys` (the failed
+  task state keys, `nodeId::iteration`) to its JSON next to `runState`, plus a
+  `node …` call-to-action. They are absent when nothing failed, so
+  `failedChildren > 0` is the degraded-run gate.
+- The **`RunResult`** returned by a programmatic run carries the same
+  `failedChildren` / `failedChildKeys` fields (omitted when zero).
+- The **`RunFinished`** event row records `failedChildren` / `failedChildKeys`, so the
+  CLI, Gateway, and DevTools can flag the degraded outcome from the event stream
+  without re-reading every node row.
+
+The run-row `status` stays `finished` (and `RunState` stays `succeeded`) so existing
+`finished === success` callers and `continueOnFail` semantics are unchanged. The
+count is the signal, not a new terminal status.
+
 To avoid the rate-limit failures in the first place, bound fan-out concurrency with [`<Parallel maxConcurrency={N}>`](/components/parallel) so you don't burst past the provider's limit.
 </Warning>
 

--- a/packages/driver/src/RunResult.ts
+++ b/packages/driver/src/RunResult.ts
@@ -6,4 +6,17 @@ export type RunResult = {
   readonly output?: unknown;
   readonly error?: unknown;
   readonly nextRunId?: string;
+  /**
+   * Number of tasks that ended `failed` yet did not fail the run — "masked"
+   * child failures (a `continueOnFail` task, or an agent task that failed
+   * transiently: rate limit, timeout, abort) the binary `finished` status cannot
+   * express. Present (and `> 0`) only on a `finished` result. See
+   * `docs/runtime/run-state.mdx`.
+   */
+  readonly failedChildren?: number;
+  /**
+   * Task state keys (`nodeId::iteration`) of the tasks counted by
+   * {@link failedChildren}.
+   */
+  readonly failedChildKeys?: readonly string[];
 };

--- a/packages/driver/src/index.d.ts
+++ b/packages/driver/src/index.d.ts
@@ -96,6 +96,19 @@ type RunResult$2 = {
     readonly output?: unknown;
     readonly error?: unknown;
     readonly nextRunId?: string;
+    /**
+     * Number of tasks that ended `failed` yet did not fail the run — "masked"
+     * child failures (a `continueOnFail` task, or an agent task that failed
+     * transiently: rate limit, timeout, abort) the binary `finished` status cannot
+     * express. Present (and `> 0`) only on a `finished` result. See
+     * `docs/runtime/run-state.mdx`.
+     */
+    readonly failedChildren?: number;
+    /**
+     * Task state keys (`nodeId::iteration`) of the tasks counted by
+     * {@link failedChildren}.
+     */
+    readonly failedChildKeys?: readonly string[];
 };
 
 type ContinueAsNewHandler$1 = (transition: unknown, context: {

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -5475,22 +5475,35 @@ async function runWorkflowBodyDriver(workflow, opts) {
             hijackRequestedAtMs: null,
             hijackTarget: null,
         }));
+        // A `finished` run can still have tolerated child failures (continueOnFail
+        // tasks, transient agent failures) that the binary status cannot express.
+        // Carry the count onto the result and the RunFinished event row so callers
+        // and surfaces can flag the degraded outcome without re-deriving it. (#295)
+        const failedChildren = typeof result.failedChildren === "number" ? result.failedChildren : 0;
+        const failedChildKeys = Array.isArray(result.failedChildKeys) ? result.failedChildKeys : [];
         await Effect.runPromise(eventBus.emitEventWithPersist({
             type: "RunFinished",
             runId,
             timestampMs: nowMs(),
+            ...(failedChildren > 0 ? { failedChildren, failedChildKeys } : {}),
         }));
         void Effect.runPromise(Metric.update(runDuration, performance.now() - runStartPerformanceMs));
         logInfo("workflow run finished", {
             runId,
+            ...(failedChildren > 0 ? { failedChildren } : {}),
         }, "engine:run");
-        await annotateRunSpan({ status: "finished" });
+        await annotateRunSpan({ status: "finished", ...(failedChildren > 0 ? { failedChildren } : {}) });
         const outputTable = schema.output;
         let output = undefined;
         if (outputTable) {
             output = await Effect.runPromise(loadRunOutputRowsEffect(db, outputTable, runId));
         }
-        return { runId, status: "finished", output };
+        return {
+            runId,
+            status: "finished",
+            output,
+            ...(failedChildren > 0 ? { failedChildren, failedChildKeys } : {}),
+        };
     };
     try {
         const existingRun = await Effect.runPromise(adapter.getRun(runId));

--- a/packages/scheduler/src/RunResult.ts
+++ b/packages/scheduler/src/RunResult.ts
@@ -13,4 +13,20 @@ export type RunResult = {
   readonly output?: unknown;
   readonly error?: unknown;
   readonly nextRunId?: string;
+  /**
+   * Number of tasks that ended in a `failed` state yet did not fail the run —
+   * "masked" child failures the run-level status cannot express. Present (and
+   * `> 0`) only on a `finished` result that tolerated at least one failure
+   * (a {@link https://smithers.sh/components/task `continueOnFail`} task, or an
+   * agent task that failed transiently: rate limit, timeout, abort). A binary
+   * `finished` status would otherwise read as a clean success. See
+   * `docs/runtime/run-state.mdx`.
+   */
+  readonly failedChildren?: number;
+  /**
+   * Task state keys (`nodeId::iteration`) of the tasks counted by
+   * {@link failedChildren}. The iteration disambiguates the same `nodeId` failing
+   * across loop/Ralph iterations.
+   */
+  readonly failedChildKeys?: readonly string[];
 };

--- a/packages/scheduler/src/index.d.ts
+++ b/packages/scheduler/src/index.d.ts
@@ -138,6 +138,22 @@ type RunResult$1 = {
     readonly output?: unknown;
     readonly error?: unknown;
     readonly nextRunId?: string;
+    /**
+     * Number of tasks that ended in a `failed` state yet did not fail the run —
+     * "masked" child failures the run-level status cannot express. Present (and
+     * `> 0`) only on a `finished` result that tolerated at least one failure
+     * (a {@link https://smithers.sh/components/task `continueOnFail`} task, or an
+     * agent task that failed transiently: rate limit, timeout, abort). A binary
+     * `finished` status would otherwise read as a clean success. See
+     * `docs/runtime/run-state.mdx`.
+     */
+    readonly failedChildren?: number;
+    /**
+     * Task state keys (`nodeId::iteration`) of the tasks counted by
+     * {@link failedChildren}. The iteration disambiguates the same `nodeId` failing
+     * across loop/Ralph iterations.
+     */
+    readonly failedChildKeys?: readonly string[];
 };
 
 type WaitReason$1 = {

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -353,14 +353,37 @@ export function makeWorkflowSession(options = {}) {
    * @returns {EngineDecision}
    */
     function finishedResult(status = "finished") {
-        return {
-            _tag: "Finished",
-            result: {
-                runId: state.runId,
-                status,
-                output: [...state.outputs.values()].at(-1)?.output,
-            },
+        /** @type {RunResult} */
+        const result = {
+            runId: state.runId,
+            status,
+            output: [...state.outputs.values()].at(-1)?.output,
         };
+        if (status === "finished") {
+            // At a `finished` terminal, any task still in `failed` state is a
+            // *tolerated* failure — an unhandled one would have produced a `Failed`
+            // decision via unhandledFailureDecision() and never reached here. Those
+            // are exactly the masked children (continueOnFail tasks, transient agent
+            // failures) the binary run status cannot express. Surface them so callers
+            // can detect a run that "succeeded" while children failed. See issue #295
+            // and docs/runtime/run-state.mdx.
+            //
+            // Keys are the canonical task state keys (`nodeId::iteration`), not bare
+            // node ids: a looped/Ralph workflow can fail the same nodeId across
+            // iterations, and the iteration is what disambiguates which child to
+            // inspect.
+            const failedChildKeys = [];
+            for (const [key, taskState] of state.states) {
+                if (taskState === "failed") {
+                    failedChildKeys.push(key);
+                }
+            }
+            if (failedChildKeys.length > 0) {
+                result.failedChildren = failedChildKeys.length;
+                result.failedChildKeys = failedChildKeys;
+            }
+        }
+        return { _tag: "Finished", result };
     }
     /**
    * @returns {ScheduleResult}

--- a/packages/scheduler/tests/workflowSession-degraded.test.js
+++ b/packages/scheduler/tests/workflowSession-degraded.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import { makeWorkflowSession } from "../src/makeWorkflowSession.js";
+
+// #295: a run can reach a `finished` terminal while child tasks failed —
+// `continueOnFail` tasks and transient agent failures are deliberately not
+// treated as run-level failures. The binary status hides that. The session now
+// surfaces those masked failures as `failedChildren` / `failedChildKeys` on the
+// finished RunResult so callers can detect a run that "succeeded" while children
+// failed.
+
+function el(tag, props = {}, children = []) {
+  return { kind: "element", tag, props, children };
+}
+
+function makeDescriptor(nodeId, overrides = {}) {
+  return {
+    nodeId,
+    iteration: 0,
+    ordinal: 0,
+    outputTable: null,
+    outputTableName: "",
+    continueOnFail: false,
+    retries: 0,
+    retryPolicy: undefined,
+    meta: {},
+    ...overrides,
+  };
+}
+
+function makeGraph(descriptors) {
+  return {
+    xml: el(
+      "smithers:workflow",
+      {},
+      descriptors.map((d) => el("smithers:task", { id: d.nodeId })),
+    ),
+    tasks: descriptors,
+    mountedTaskIds: new Set(descriptors.map((d) => `${d.nodeId}::${d.iteration}`)),
+  };
+}
+
+describe("makeWorkflowSession surfaces masked child failures on a finished run", () => {
+  test("continueOnFail failure: finished result carries failedChildren + keys", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const good = makeDescriptor("good-task");
+    const bad = makeDescriptor("bad-task", { continueOnFail: true });
+    Effect.runSync(session.submitGraph(makeGraph([good, bad])));
+
+    // A continueOnFail task fails — the run must not fail, but the failure must
+    // not vanish either.
+    const afterFailure = Effect.runSync(
+      session.taskFailed({
+        nodeId: "bad-task",
+        iteration: 0,
+        error: { code: "INVALID_OUTPUT", message: "bad output" },
+      }),
+    );
+    expect(afterFailure._tag).not.toBe("Failed");
+
+    const decision = Effect.runSync(
+      session.taskCompleted({ nodeId: "good-task", iteration: 0, output: { ok: true } }),
+    );
+
+    expect(decision._tag).toBe("Finished");
+    expect(decision.result.status).toBe("finished");
+    expect(decision.result.failedChildren).toBe(1);
+    // Canonical state key `nodeId::iteration`, not a bare node id.
+    expect(decision.result.failedChildKeys).toEqual(["bad-task::0"]);
+  });
+
+  test("transient agent failure: finished result counts the masked child", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    // retries:0 so the transient failure is terminal for the task; an agent
+    // task that ends `failed` with a transient code (SESSION_ERROR) is skipped
+    // by unhandledFailureDecision, so the run finishes degraded.
+    const descriptor = makeDescriptor("agent-task", {
+      retries: 0,
+      agent: { id: "agent" },
+    });
+    Effect.runSync(session.submitGraph(makeGraph([descriptor])));
+
+    const decision = Effect.runSync(
+      session.taskFailed({
+        nodeId: "agent-task",
+        iteration: 0,
+        error: { code: "SESSION_ERROR", message: "rate limited" },
+      }),
+    );
+
+    expect(decision._tag).toBe("Finished");
+    expect(decision.result.failedChildren).toBe(1);
+    expect(decision.result.failedChildKeys).toEqual(["agent-task::0"]);
+  });
+
+  test("clean success omits the failedChildren fields entirely", () => {
+    const session = makeWorkflowSession({ nowMs: () => 1_000 });
+    const descriptor = makeDescriptor("only-task");
+    Effect.runSync(session.submitGraph(makeGraph([descriptor])));
+
+    const decision = Effect.runSync(
+      session.taskCompleted({ nodeId: "only-task", iteration: 0, output: { ok: true } }),
+    );
+
+    expect(decision._tag).toBe("Finished");
+    expect(decision.result.failedChildren).toBeUndefined();
+    expect(decision.result.failedChildKeys).toBeUndefined();
+  });
+});

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -8648,6 +8648,24 @@ bunx smithers-orchestrator events --run RUN_ID  # the full event history, includ
 bunx smithers-orchestrator scores RUN_ID     # scorer results when you gate on judged output
 ```
 
+You don't have to re-derive the count by eye. When a `finished` run tolerated at
+least one failed child, the masking is surfaced as a first-class **`failedChildren`**
+signal in three places:
+
+- **`inspect`** adds `failedChildren` (a count) and `failedChildKeys` (the failed
+  task state keys, `nodeId::iteration`) to its JSON next to `runState`, plus a
+  `node …` call-to-action. They are absent when nothing failed, so
+  `failedChildren > 0` is the degraded-run gate.
+- The **`RunResult`** returned by a programmatic run carries the same
+  `failedChildren` / `failedChildKeys` fields (omitted when zero).
+- The **`RunFinished`** event row records `failedChildren` / `failedChildKeys`, so the
+  CLI, Gateway, and DevTools can flag the degraded outcome from the event stream
+  without re-reading every node row.
+
+The run-row `status` stays `finished` (and `RunState` stays `succeeded`) so existing
+`finished === success` callers and `continueOnFail` semantics are unchanged. The
+count is the signal, not a new terminal status.
+
 To avoid the rate-limit failures in the first place, bound fan-out concurrency with `<Parallel maxConcurrency={N}>` so you don't burst past the provider's limit.
 </Warning>
 


### PR DESCRIPTION
Closes #295.

## Problem

Run terminal status is binary (`finished` | `failed`). A run is only `failed` when `unhandledFailureDecision()` finds an *unhandled* task failure, but two large classes of failed children are deliberately tolerated: [`continueOnFail`](https://smithers.sh/components/task) tasks, and agent tasks that fail with a *transient* error (`SESSION_ERROR`, `TASK_TIMEOUT`, `TASK_HEARTBEAT_TIMEOUT`, `TASK_ABORTED`, or `failureRetryable`). A fan-out where most agents hit provider rate limits therefore still reports `finished` → `succeeded`, with **no programmatic signal** that the run finished degraded. Surfaced by the `ru-run-completed-but-failed` agent-fluency eval.

## What this does

Surfaces the masking as a first-class **`failedChildren`** count + **`failedChildKeys`** signal, the issue's stated minimum-viable fix. It deliberately does **not** add a new persisted terminal status — per the maintainer's own note on #295, that is a deliberate run-status-model change (engine + db + gateway + UI) warranting a separate hand-designed PR. The run-row `status` stays `finished` and `RunState` stays `succeeded`, so existing `finished === success` callers and `continueOnFail` semantics are unchanged.

Key insight: at a `finished` terminal, **any** task still in `failed` state is by construction a tolerated/masked failure — an unhandled one would have produced a `Failed` decision and never reached `finishedResult()`. So the count is just the number of `failed` states, no need to re-derive the continueOnFail/transient logic.

- **scheduler** (`makeWorkflowSession.finishedResult`): carries `failedChildren` + `failedChildKeys` on the finished `RunResult`. Keys are canonical state keys (`nodeId::iteration`) so the same `nodeId` failing across loop/Ralph iterations stays distinct.
- **driver / engine**: the fields are added to the public `RunResult` type (so TS callers of `runWorkflow` see them) and threaded onto the `RunFinished` event row, the returned result, the run span, and the finish log.
- **cli**: `smithers inspect` derives the count from persisted node states (no DB migration) and adds a `node …` call-to-action; `smithers events` renders it on the `Run finished` line.
- **docs**: the run-state masking `Warning` now documents the new signal; llms bundles regenerated.

## Surfaces

```jsonc
// smithers inspect RUN_ID  (only on a finished/continued run with failures)
{ "runState": { "state": "succeeded" },
  "failedChildren": 9,
  "failedChildKeys": ["fanout-3::0", "fanout-7::0", ...] }
```
```
# smithers events --run RUN_ID
✓ Run finished (9 failed children)
```

## Tests

- New `packages/scheduler/tests/workflowSession-degraded.test.js`: continueOnFail failure and transient-agent failure both produce a `finished` result carrying `failedChildren`/`failedChildKeys` (state-key format); a clean success omits the fields.
- `pnpm typecheck` green; scheduler / engine / cli / driver / observability suites all pass; `check:docs` / `check:llms` / `check:deps` / `check:effect` green.

## Review

Independently reviewed with `codex review` (GPT-5, two rounds). First pass raised two P2s — (1) the public `RunResult` type wasn't updated, (2) `failedChildKeys` stripped iteration and was ambiguous for loops — both fixed here. Re-review: clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)