### PR TITLE
🐛 fix(pi-plugin): include full Smithers docs only on demand

### DIFF
--- a/packages/pi-plugin/src/buildSmithersPiSystemPrompt.ts
+++ b/packages/pi-plugin/src/buildSmithersPiSystemPrompt.ts
@@ -61,7 +61,7 @@ function buildTypicalWorkflowGuidance(contract: SmithersAgentContract) {
 
 export function buildSmithersPiSystemPrompt(
   baseSystemPrompt: string,
-  docs: string,
+  docs: string | undefined,
   contract: SmithersAgentContract,
   activeRun?: SmithersPiRunContext,
 ) {
@@ -80,6 +80,7 @@ export function buildSmithersPiSystemPrompt(
     "- `/smithers-runs` - Lists tracked runs and makes the selected run active.",
     "- `/smithers-approve` - Interactive approval flow for nodes waiting on approval.",
     "- `/smithers-cancel [runId]` - Cancels a running workflow with confirmation.",
+    "- `/smithers-docs [prompt]` - Includes the full Smithers docs bundle in the next prompt, or runs the provided prompt with full docs included.",
     "",
     "### UI Features (always active)",
     "- **Header**: Shows run state, the active run ID, engine and sandbox/viewer heartbeat indicators, and reconnect status.",
@@ -95,9 +96,13 @@ export function buildSmithersPiSystemPrompt(
     "### Typical Workflows",
     ...buildTypicalWorkflowGuidance(contract),
     "",
-    "---\n",
-    docs,
+    "### Full Documentation",
+    "Full Smithers docs are not included by default to keep ordinary repo work focused. When the user explicitly invokes `/smithers-docs`, that turn includes the complete Smithers docs bundle.",
   ];
+
+  if (docs) {
+    sections.push("", "---", "", "## Full Smithers Docs (explicitly requested)", "", docs);
+  }
 
   if (activeRun) {
     sections.push("\n## Active Run Context");

--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -25,6 +25,7 @@ type ExtensionAPI = PiExtensionAPI & {
   registerTool: (tool: Record<string, unknown>) => void;
   registerCommand: (name: string, command: Record<string, unknown>) => void;
   registerMessageRenderer: (name: string, renderer: (...args: any[]) => unknown) => void;
+  sendUserMessage: (content: string, options?: Record<string, unknown>) => void | Promise<void>;
 };
 
 type ExtensionContext = {
@@ -58,6 +59,7 @@ let mcpToolsRegistered = false;
 let mcpToolsRegistration: Promise<void> | undefined;
 let pollInterval: ReturnType<typeof setInterval> | undefined;
 let activeRunId: string | undefined;
+let includeSmithersDocsNextTurn = false;
 
 const runs = new Map<string, TrackedRun>();
 
@@ -418,7 +420,8 @@ export function extension(pi: ExtensionAPI) {
   });
 
   pi.on("before_agent_start", async (event: { systemPrompt: string }) => {
-    const docs = loadSmithersDocs();
+    const docs = includeSmithersDocsNextTurn ? loadSmithersDocs() : undefined;
+    includeSmithersDocsNextTurn = false;
     const contract = await ensureSmithersToolContract();
     const active = activeRunId ? runs.get(activeRunId) : undefined;
     return {
@@ -452,6 +455,19 @@ export function extension(pi: ExtensionAPI) {
         run = trackRun(runId);
       }
       await openInspector(ctx, run);
+    },
+  });
+
+  pi.registerCommand("smithers-docs", {
+    description: "Include the full Smithers docs in the next prompt, or pass a prompt to run now",
+    handler: async (args: string, ctx: ExtensionContext) => {
+      includeSmithersDocsNextTurn = true;
+      const prompt = args.trim();
+      if (prompt) {
+        await pi.sendUserMessage(prompt);
+        return;
+      }
+      ctx.ui.notify("Full Smithers docs will be included with your next prompt.", "info");
     },
   });
 

--- a/packages/pi-plugin/tests/buildSmithersPiSystemPrompt.test.ts
+++ b/packages/pi-plugin/tests/buildSmithersPiSystemPrompt.test.ts
@@ -41,6 +41,22 @@ describe("buildSmithersPiSystemPrompt", () => {
     expect(prompt).toContain("`smithers_get_run`");
     expect(prompt).toContain("`smithers_resolve_approval`");
     expect(prompt).not.toContain("`smithers_run_workflow`");
+    expect(prompt).toContain("Docs body");
+  });
+
+  test("full docs are omitted unless explicitly provided", () => {
+    const contract = createSmithersAgentContract({
+      serverName: "smithers",
+      toolSurface: "semantic",
+      tools: [],
+    });
+
+    const prompt = buildSmithersPiSystemPrompt("Base system prompt\n", undefined, contract);
+
+    expect(prompt).toContain("Base system prompt");
+    expect(prompt).toContain("Full Smithers docs are not included by default");
+    expect(prompt).toContain("/smithers-docs");
+    expect(prompt).not.toContain("# Smithers — full documentation");
   });
 
   test("stale Smithers PI aliases are absent", () => {


### PR DESCRIPTION
## Summary
- stop injecting the full Smithers docs bundle into every Pi agent turn by default
- add `/smithers-docs [prompt]` to opt into the full docs for the next turn or an immediate prompted turn
- update Pi prompt coverage so the lean default and explicit-docs path are both tested

## Review notes
This keeps the always-on Smithers prompt to the tool/command guidance plus a pointer to `/smithers-docs`, which should avoid drowning models in the generated docs bundle during normal repo work.

## Tests
- `pnpm -C packages/pi-plugin test`
- `pnpm -C packages/pi-plugin typecheck`
