### PR TITLE
Fix child subflow output selection

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -4369,18 +4369,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4446,13 +4457,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4496,6 +4510,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6104,8 +6119,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/docs/components/subflow.mdx
+++ b/docs/components/subflow.mdx
@@ -48,18 +48,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -126,13 +137,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -176,3 +190,4 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -4351,18 +4351,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4429,13 +4440,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4479,6 +4493,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6087,8 +6102,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/docs/llms-full-v0.26.1.txt
+++ b/docs/llms-full-v0.26.1.txt
@@ -4369,18 +4369,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4446,13 +4457,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4496,6 +4510,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6104,8 +6119,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4369,18 +4369,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4446,13 +4457,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4496,6 +4510,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6104,8 +6119,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/docs/reference/types.mdx
+++ b/docs/reference/types.mdx
@@ -64,8 +64,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/packages/engine/src/child-workflow.js
+++ b/packages/engine/src/child-workflow.js
@@ -91,6 +91,7 @@ function resolveChildWorkflow(definition, parentWorkflow) {
             opts: resolved.opts ?? {},
             schemaRegistry: resolved.schemaRegistry ?? parentWorkflow?.schemaRegistry,
             zodToKeyName: resolved.zodToKeyName ?? parentWorkflow?.zodToKeyName,
+            ambiguousZodSchemas: resolved.ambiguousZodSchemas ?? parentWorkflow?.ambiguousZodSchemas,
         };
     }
     if (typeof resolved === "function") {
@@ -104,6 +105,7 @@ function resolveChildWorkflow(definition, parentWorkflow) {
             opts: {},
             schemaRegistry: parentWorkflow.schemaRegistry,
             zodToKeyName: parentWorkflow.zodToKeyName,
+            ambiguousZodSchemas: parentWorkflow.ambiguousZodSchemas,
         };
     }
     throw new SmithersError("INVALID_INPUT", "Child workflow must be a Smithers workflow object or function.");

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -2192,6 +2192,48 @@ function resolveTaskOutputs(tasks, workflow) {
     }
 }
 /**
+ * @param {SmithersWorkflow} workflow
+ * @param {Record<string, unknown>} schema
+ * @returns {unknown | undefined}
+ */
+function resolveWorkflowOutputTable(workflow, schema) {
+    const target = workflow.opts?.output;
+    if (target === undefined) {
+        return schema.output;
+    }
+    if (target && typeof target === "object" && workflow.zodToKeyName) {
+        const keyName = workflow.zodToKeyName.get(target);
+        if (keyName && workflow.schemaRegistry) {
+            const entry = workflow.schemaRegistry.get(keyName);
+            if (entry) {
+                return entry.table;
+            }
+        }
+        if (workflow.ambiguousZodSchemas?.has(target)) {
+            throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", "Workflow output is registered under multiple keys. Use createSmithers(...).outputs.<key> or a string output key instead of the shared raw Zod object.");
+        }
+    }
+    if (typeof target === "string") {
+        const entry = workflow.schemaRegistry?.get(target);
+        if (entry) {
+            return entry.table;
+        }
+        if (schema[target]) {
+            return schema[target];
+        }
+    }
+    if (target && typeof target === "object") {
+        try {
+            getTableName(/** @type {any} */ (target));
+            return target;
+        }
+        catch { }
+    }
+    throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", "Workflow output target is not registered in createSmithers().", {
+        output: typeof target === "string" ? target : undefined,
+    });
+}
+/**
  * @param {XmlNode} xml
  * @returns {string}
  */
@@ -5515,7 +5557,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
             ...(failedChildren > 0 ? { failedChildren } : {}),
         }, "engine:run");
         await annotateRunSpan({ status: "finished", ...(failedChildren > 0 ? { failedChildren } : {}) });
-        const outputTable = schema.output;
+        const outputTable = resolveWorkflowOutputTable(workflowRef, schema);
         let output = undefined;
         if (outputTable) {
             output = await Effect.runPromise(loadRunOutputRowsEffect(db, outputTable, runId));

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -31,7 +31,7 @@ import { restoreWorkspaceToLatestCheckpoint } from "./restoreWorkspace.js";
 import { runWithToolContext } from "@smithers-orchestrator/tool-context";
 import { vcsToolingStatus } from "@smithers-orchestrator/vcs/vcsToolingStatus";
 import * as BunContext from "@effect/platform-bun/BunContext";
-import { eq, getTableName } from "drizzle-orm";
+import { eq, getTableName, isTable } from "drizzle-orm";
 import { getTableColumns } from "drizzle-orm/utils";
 import { Cause, Chunk, Duration, Effect, Exit, Fiber, Metric, Queue, Schedule } from "effect";
 import { attemptDuration, cacheHits, cacheMisses, nodeDuration, promptSizeBytes, responseSizeBytes, runDuration, runsResumedTotal, schedulerConcurrencyUtilization, schedulerQueueDepth, schedulerWaitDuration, trackEvent, } from "@smithers-orchestrator/observability/metrics";
@@ -2222,12 +2222,8 @@ function resolveWorkflowOutputTable(workflow, schema) {
             return schema[target];
         }
     }
-    if (target && typeof target === "object") {
-        try {
-            getTableName(/** @type {any} */ (target));
-            return target;
-        }
-        catch { }
+    if (isTable(/** @type {any} */ (target))) {
+        return target;
     }
     throw new SmithersError("UNKNOWN_OUTPUT_SCHEMA", "Workflow output target is not registered in createSmithers().", {
         output: typeof target === "string" ? target : undefined,
@@ -6159,6 +6155,7 @@ export const __engineInternals = {
     iterationsToMap,
     ralphStateFromDriverTransition,
     resolveTaskOutputs,
+    resolveWorkflowOutputTable,
     buildDescriptorMap,
     buildRalphStateMap,
     ralphIterationsFromState,

--- a/packages/engine/tests/engine-internals.test.js
+++ b/packages/engine/tests/engine-internals.test.js
@@ -538,6 +538,60 @@ describe("engine internals: durability, options and graph helpers", () => {
         expect(I.isRetryableTaskFailure({ metaJson: '{"kind":"compute"}', errorJson: '{"code":"INVALID_OUTPUT"}' })).toBe(false);
         expect(I.isRetryableTaskFailure({ metaJson: '{"kind":"agent"}', errorJson: '{"code":"INVALID_OUTPUT"}' })).toBe(true);
     });
+
+    test("resolveWorkflowOutputTable resolves declared outputs and fails fast on unregistered targets", () => {
+        const schemaRef = { schema: true };
+        const registry = new Map([["childResult", { table: outputTable, zodSchema: schemaRef }]]);
+        const zodToKeyName = new Map([[schemaRef, "childResult"]]);
+        const defaultOutput = { defaultOutput: true };
+        const stringKeyTable = { stringKeyTable: true };
+        const schema = { output: defaultOutput, phase: stringKeyTable };
+
+        const base = { schemaRegistry: registry, zodToKeyName, ambiguousZodSchemas: new Set() };
+
+        // No explicit output: falls back to the schema key literally named `output`.
+        expect(I.resolveWorkflowOutputTable({ opts: {}, ...base }, schema)).toBe(defaultOutput);
+
+        // A registered schema object resolves to its table.
+        expect(
+            I.resolveWorkflowOutputTable({ opts: { output: schemaRef }, ...base }, schema),
+        ).toBe(outputTable);
+
+        // A string key resolves via the schema registry first...
+        expect(
+            I.resolveWorkflowOutputTable({ opts: { output: "childResult" }, ...base }, schema),
+        ).toBe(outputTable);
+        // ...then falls back to a raw schema key.
+        expect(
+            I.resolveWorkflowOutputTable({ opts: { output: "phase" }, ...base }, schema),
+        ).toBe(stringKeyTable);
+
+        // A real Drizzle table passes through the isTable() guard.
+        expect(
+            I.resolveWorkflowOutputTable({ opts: { output: outputTable }, ...base }, schema),
+        ).toBe(outputTable);
+
+        // An unregistered, non-table object fails fast with the clear error
+        // instead of being returned as a bogus table (the isTable() fix).
+        const unregistered = { schema: true };
+        expect(() =>
+            I.resolveWorkflowOutputTable({ opts: { output: unregistered }, ...base }, schema),
+        ).toThrow("not registered");
+
+        // A schema object registered under multiple keys reports the ambiguity.
+        const ambiguous = { ambiguous: true };
+        expect(() =>
+            I.resolveWorkflowOutputTable(
+                {
+                    opts: { output: ambiguous },
+                    schemaRegistry: registry,
+                    zodToKeyName: new Map(),
+                    ambiguousZodSchemas: new Set([ambiguous]),
+                },
+                schema,
+            ),
+        ).toThrow("multiple keys");
+    });
 });
 
 describe("engine internals: cancellation maintenance", () => {

--- a/packages/engine/tests/workflow-make-contract.test.jsx
+++ b/packages/engine/tests/workflow-make-contract.test.jsx
@@ -18,6 +18,7 @@ const contractSchemas = {
         autoApproved: z.boolean().optional(),
     }),
     output: z.object({ value: z.number() }),
+    childOutput: z.object({ value: z.number() }),
     phase: z.object({ value: z.number() }),
     result: z.object({ value: z.number() }),
 };
@@ -188,6 +189,37 @@ describe("workflow make contract", () => {
             const childRun = await adapter.getLatestChildRun(result.runId);
             expect(childRun?.parentRunId).toBe(result.runId);
             expect(childRun?.status).toBe("finished");
+        }
+        finally {
+            cleanup();
+        }
+    }, 30_000);
+    test("subflow child runs can return an explicitly declared workflow output", async () => {
+        const { smithers, outputs, tables, db, cleanup } = buildContractSmithers();
+        try {
+            const childWorkflow = smithers(() => (<Workflow name="workflow-make-child-output">
+          <Task id="child-task" output={outputs.childOutput}>
+            {{ value: 11 }}
+          </Task>
+        </Workflow>), { output: outputs.childOutput });
+            const parentWorkflow = smithers(() => (<Workflow name="workflow-make-parent-output">
+          <Subflow id="child-run" output={outputs.result} workflow={childWorkflow}/>
+        </Workflow>));
+
+            const result = await Effect.runPromise(runWorkflow(parentWorkflow, { input: {} }));
+
+            expect(result.status).toBe("finished");
+            const adapter = new SmithersDb(db);
+            const childRun = await adapter.getLatestChildRun(result.runId);
+            expect(childRun?.status).toBe("finished");
+            const rows = await db.select().from(tables.result);
+            expect(rows).toEqual([
+                expect.objectContaining({
+                    runId: result.runId,
+                    nodeId: "child-run",
+                    value: 11,
+                }),
+            ]);
         }
         finally {
             cleanup();

--- a/packages/scheduler/src/SmithersWorkflowOptions.ts
+++ b/packages/scheduler/src/SmithersWorkflowOptions.ts
@@ -36,10 +36,30 @@ export type SmithersAlertPolicy = {
   reactions?: Record<string, SmithersAlertReaction>;
 };
 
+/**
+ * Where a workflow's `RunResult.output` rows are read from. Mirrors the
+ * component-level `OutputTarget` union (see `@smithers-orchestrator/components`
+ * `OutputTarget`), restated locally because `@smithers-orchestrator/scheduler`
+ * is a pure decision engine that must not depend on zod or components:
+ *
+ * - a Zod schema object registered via `createSmithers(...).outputs.<key>` (recommended),
+ * - a Drizzle table object, or
+ * - a string schema key (escape hatch).
+ */
+export type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
+
 export type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
-  /** Explicit workflow-level output table/schema used for RunResult.output. */
-  output?: unknown;
+  /**
+   * Explicit workflow-level output schema/table used to populate
+   * `RunResult.output` (and therefore a parent `Subflow`'s child result). Pass
+   * a `createSmithers(...).outputs.<key>` schema, a Drizzle table, or a string
+   * schema key. Defaults to the child schema key literally named `output`.
+   */
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };

--- a/packages/scheduler/src/SmithersWorkflowOptions.ts
+++ b/packages/scheduler/src/SmithersWorkflowOptions.ts
@@ -39,5 +39,7 @@ export type SmithersAlertPolicy = {
 export type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  /** Explicit workflow-level output table/schema used for RunResult.output. */
+  output?: unknown;
   workflowHash?: string;
 };

--- a/packages/scheduler/src/index.d.ts
+++ b/packages/scheduler/src/index.d.ts
@@ -294,10 +294,31 @@ type SmithersAlertPolicy$1 = {
     rules?: Record<string, SmithersAlertPolicyRule$1>;
     reactions?: Record<string, SmithersAlertReaction$1>;
 };
+/**
+ * Where a workflow's `RunResult.output` rows are read from. Mirrors the
+ * component-level `OutputTarget` union (see `@smithers-orchestrator/components`
+ * `OutputTarget`), restated locally because `@smithers-orchestrator/scheduler`
+ * is a pure decision engine that must not depend on zod or components:
+ *
+ * - a Zod schema object registered via `createSmithers(...).outputs.<key>` (recommended),
+ * - a Drizzle table object, or
+ * - a string schema key (escape hatch).
+ */
+type SmithersWorkflowOutputTarget = {
+    readonly _def: unknown;
+} | {
+    readonly $inferSelect: Record<string, unknown>;
+} | string;
 type SmithersWorkflowOptions$1 = {
     alertPolicy?: SmithersAlertPolicy$1;
     cache?: boolean;
-    output?: unknown;
+    /**
+     * Explicit workflow-level output schema/table used to populate
+     * `RunResult.output` (and therefore a parent `Subflow`'s child result). Pass
+     * a `createSmithers(...).outputs.<key>` schema, a Drizzle table, or a string
+     * schema key. Defaults to the child schema key literally named `output`.
+     */
+    output?: SmithersWorkflowOutputTarget;
     workflowHash?: string;
 };
 

--- a/packages/scheduler/src/index.d.ts
+++ b/packages/scheduler/src/index.d.ts
@@ -297,6 +297,7 @@ type SmithersAlertPolicy$1 = {
 type SmithersWorkflowOptions$1 = {
     alertPolicy?: SmithersAlertPolicy$1;
     cache?: boolean;
+    output?: unknown;
     workflowHash?: string;
 };
 

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -4369,18 +4369,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4446,13 +4457,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4496,6 +4510,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6104,8 +6119,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -4369,18 +4369,29 @@ const child = createSmithers({
   childResult: z.object({ summary: z.string() }),
 });
 
-const childWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-repo">
-    <Sequence>
-      <Task id="scan" output={child.outputs.childResult} agent={scanner}>
-        {`Scan ${ctx.input.repo} and summarize.`}
-      </Task>
-    </Sequence>
-  </child.Workflow>
-));
+const childWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-repo">
+      <Sequence>
+        <Task id="scan" output={child.outputs.childResult} agent={scanner}>
+          {`Scan ${ctx.input.repo} and summarize.`}
+        </Task>
+      </Sequence>
+    </child.Workflow>
+  ),
+  { output: child.outputs.childResult },
+);
 
 export default childWorkflow;
 ```
+
+The second argument to `smithers(build, { output })` declares which schema
+becomes the child's `RunResult.output`: the value a parent `<Subflow>`
+persists. Pass the `createSmithers(...).outputs.<key>` schema (a string schema
+key or a Drizzle table also work). Without it, the child result is read only
+from a schema key literally named `output`, so a child that writes to any other
+key (like `childResult` here) would yield an empty subflow result. Declare it
+whenever the child's result schema is not named `output`.
 
 Import that value into the parent and hand it to `<Subflow workflow={...}>`.
 The parent declares the schema it wants to persist the subflow result under;
@@ -4446,13 +4457,16 @@ const child = createSmithers({
   scanResult: z.object({ summary: z.string() }),
 });
 
-const scanWorkflow = child.smithers((ctx) => (
-  <child.Workflow name="scan-child">
-    <child.Task id="scan" output={child.outputs.scanResult}>
-      {{ summary: `Scanned ${ctx.input.repo}` }}
-    </child.Task>
-  </child.Workflow>
-));
+const scanWorkflow = child.smithers(
+  (ctx) => (
+    <child.Workflow name="scan-child">
+      <child.Task id="scan" output={child.outputs.scanResult}>
+        {{ summary: `Scanned ${ctx.input.repo}` }}
+      </child.Task>
+    </child.Workflow>
+  ),
+  { output: child.outputs.scanResult },
+);
 
 const parent = createSmithers({
   input: z.object({ repo: z.string() }),
@@ -4496,6 +4510,7 @@ value passed through the parent's `<Subflow input={...}>` prop.
 - `childRun` (default) gives the child its own DB row; retry/cache/resume scope it as a unit.
 - `inline` renders the child tree as siblings in the parent plan, sharing its scope.
 - Subflows compose; children may contain `<Subflow>` themselves.
+- Declare the child's result via `smithers(build, { output })` unless its result schema is literally named `output`; that is the schema a parent `<Subflow>` persists.
 
 ---
 
@@ -6104,8 +6119,20 @@ interface SmithersWorkflow<Schema = unknown> {
 type SmithersWorkflowOptions = {
   alertPolicy?: SmithersAlertPolicy;
   cache?: boolean;
+  // Explicit workflow-level output schema/table used to populate
+  // RunResult.output (and therefore a parent <Subflow>'s child result).
+  // Defaults to the schema key literally named `output`.
+  output?: SmithersWorkflowOutputTarget;
   workflowHash?: string;
 };
+
+// A Zod schema (createSmithers(...).outputs.<key>), a Drizzle table, or a
+// string schema key. Restated in @smithers-orchestrator/scheduler, which must
+// not depend on zod or components.
+type SmithersWorkflowOutputTarget =
+  | { readonly _def: unknown }
+  | { readonly $inferSelect: Record<string, unknown> }
+  | string;
 
 type SchemaRegistryEntry = {
   table: any;


### PR DESCRIPTION
## Summary
- add a workflow-level output option that controls final RunResult output selection
- resolve child subflow results from the declared output target instead of requiring a table named `output`
- keep existing behavior for workflows that still use an output table named `output`
- cover a child workflow writing `childOutput` into a parent `result` output

Fixes #456.

## Tests
- `bun test packages/engine/tests/workflow-make-contract.test.jsx`
- `pnpm --filter @smithers-orchestrator/engine typecheck`
- `pnpm --filter @smithers-orchestrator/scheduler typecheck`
- `pnpm --filter @smithers-orchestrator/engine test`
- `pnpm -r typecheck`
- `pnpm check:deps`
- `pnpm check:effect`