### PR TITLE
Fix fuzzy select backspace handling

### DIFF
--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -143,6 +143,18 @@ function terminalRows() {
     return process.stdout.rows || 24;
 }
 
+function normalizeQueryValue(value) {
+    let query = "";
+    for (const char of String(value ?? "")) {
+        if (char === "\x7f" || char === "\b") {
+            query = query.slice(0, -1);
+            continue;
+        }
+        query += char;
+    }
+    return query;
+}
+
 /**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
@@ -193,7 +205,7 @@ class FuzzySelectPrompt extends Prompt {
         // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
         // so the base re-emits "value" for both — this covers backspace for free.
         this.on("value", () => {
-            this.query = this.value ?? "";
+            this.query = normalizeQueryValue(this.value);
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.cursor > this.filtered.length - 1) {
                 this.cursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/tests/cli-flag-validation.test.js
+++ b/apps/cli/tests/cli-flag-validation.test.js
@@ -202,7 +202,8 @@ describe("--annotations streaming via stdin", () => {
         expect(result.json?.logFile).toBeString();
 
         let status;
-        for (let attempt = 0; attempt < 240; attempt += 1) {
+        let lastReadError;
+        for (let attempt = 0; attempt < 600; attempt += 1) {
             if (existsSync(repo.path("smithers.db"))) {
                 const sqlite = new Database(repo.path("smithers.db"), { readonly: true });
                 try {
@@ -221,6 +222,7 @@ describe("--annotations streaming via stdin", () => {
                         if (!transient) {
                             throw err;
                         }
+                        lastReadError = message;
                     }
                 }
                 finally {
@@ -232,9 +234,16 @@ describe("--annotations streaming via stdin", () => {
             }
             await Bun.sleep(50);
         }
-        expect(status).toBe("finished");
+        if (status !== "finished") {
+            const logTail = existsSync(result.json.logFile)
+                ? readFileSync(result.json.logFile, "utf8").slice(-2000)
+                : "";
+            throw new Error(
+                `detached run did not finish; status=${status ?? "none"}; lastReadError=${lastReadError ?? "none"}; logTail=${logTail}`,
+            );
+        }
         expect(readFileSync(result.json.logFile, "utf8")).not.toContain("INVALID_JSON");
-    }, 15_000);
+    }, 45_000);
 
     test("detached runs return monitoring guidance so the agent can offer the user a way to watch", () => {
         const repo = createTempRepo();


### PR DESCRIPTION
## Summary
- normalize Backspace control characters in the fuzzy-select query
- keep the filter from getting stuck in the empty-state path after Backspace
- restore the interactive Backspace regression from a 120s timeout to a fast pass
- give the detached annotations test enough time under coverage and print its log tail on timeout

## Tests
- `pnpm --filter @smithers-orchestrator/cli exec bun test --timeout=120000 --max-concurrency=1 tests/fuzzy-select.test.js`
- `bun test --timeout=120000 apps/cli/tests/cli-flag-validation.test.js`
- `bun test --coverage --coverage-reporter=lcov --coverage-dir=/tmp/smithers-cli-flag-coverage --timeout=120000 --max-concurrency=1 apps/cli/tests/cli-flag-validation.test.js`
- `pnpm --filter @smithers-orchestrator/cli typecheck`
- `pnpm --filter @smithers-orchestrator/cli test`
- `pnpm check:deps`
- `pnpm check:effect`