### PR TITLE
fix(vcs): bound jj repo probe

### DIFF
--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -20,9 +20,7 @@ import { Duration, Effect, Fiber, Metric, Stream } from "effect";
 import { vcsDuration } from "@smithers-orchestrator/observability/metrics";
 import { resolveJjBinary } from "./resolveJjBinary.js";
 
-const JJ_POINTER_TIMEOUT_MS = 1_500;
-const JJ_REPO_TIMEOUT_MS = 1_500;
-const WORKSPACE_SNAPSHOT_TIMEOUT_MS = 1_500;
+const JJ_PROBE_TIMEOUT_MS = 1_500;
 /**
  * @param {Stream.Stream<Uint8Array, unknown, never>} stream
  * @returns {Effect.Effect<string, unknown, never>}
@@ -85,15 +83,7 @@ function jjError(res) {
  * @returns {Effect.Effect<string | null, never, import("@effect/platform/CommandExecutor").CommandExecutor>}
  */
 export function getJjPointer(cwd) {
-    return runJj(["log", "-r", "@", "--no-graph", "--template", "change_id"], { cwd }).pipe(Effect.timeoutTo({
-        duration: Duration.millis(JJ_POINTER_TIMEOUT_MS),
-        onSuccess: (res) => res,
-        onTimeout: () => ({
-            code: 124,
-            stdout: "",
-            stderr: `jj pointer timed out after ${JJ_POINTER_TIMEOUT_MS}ms`,
-        }),
-    }), Effect.map((res) => {
+    return withJjTimeout(runJj(["log", "-r", "@", "--no-graph", "--template", "change_id"], { cwd }), "jj pointer").pipe(Effect.map((res) => {
         if (res.code !== 0)
             return null;
         const out = res.stdout.trim();
@@ -101,24 +91,31 @@ export function getJjPointer(cwd) {
     }), Effect.annotateLogs({ cwd: cwd ?? "" }), Effect.withLogSpan("vcs:jj-pointer"));
 }
 /**
- * Wrap a snapshot jj call with a bounded timeout so a slow or hung jj cannot
- * block the agent. On timeout it returns a sentinel non-zero result, which the
- * caller treats as a durability gap rather than a value.
+ * Wrap a jj probe/snapshot call with a bounded timeout so a slow or hung jj
+ * cannot block the agent. On timeout it returns a sentinel non-zero result,
+ * which the caller treats as a failed probe (durability gap / not a repo)
+ * rather than a value, and logs a warning so the silent downgrade is
+ * diagnosable.
  *
  * @param {Effect.Effect<RunJjResult, never, import("@effect/platform/CommandExecutor").CommandExecutor>} effect
  * @param {string} label
  * @returns {Effect.Effect<RunJjResult, never, import("@effect/platform/CommandExecutor").CommandExecutor>}
  */
-function withSnapshotTimeout(effect, label) {
+function withJjTimeout(effect, label) {
     return effect.pipe(Effect.timeoutTo({
-        duration: Duration.millis(WORKSPACE_SNAPSHOT_TIMEOUT_MS),
-        onSuccess: (res) => res,
+        duration: Duration.millis(JJ_PROBE_TIMEOUT_MS),
+        onSuccess: (res) => ({ res, timedOut: false }),
         onTimeout: () => ({
-            code: 124,
-            stdout: "",
-            stderr: `${label} timed out after ${WORKSPACE_SNAPSHOT_TIMEOUT_MS}ms`,
+            res: {
+                code: 124,
+                stdout: "",
+                stderr: `${label} timed out after ${JJ_PROBE_TIMEOUT_MS}ms`,
+            },
+            timedOut: true,
         }),
-    }));
+    }), Effect.tap(({ timedOut }) => timedOut
+        ? Effect.logWarning(`${label} timed out after ${JJ_PROBE_TIMEOUT_MS}ms; treating as failed probe`)
+        : Effect.void), Effect.map(({ res }) => res));
 }
 /**
  * Parse the snapshot values returned by the two jj commands in
@@ -154,14 +151,14 @@ export function parseWorkspaceSnapshot(logStdout, opStdout) {
  */
 export function captureWorkspaceSnapshot(cwd) {
     return Effect.gen(function* () {
-        const logRes = yield* withSnapshotTimeout(runJj(["log", "-r", "@", "--no-graph", "-T", 'commit_id ++ "\\n" ++ change_id'], { cwd }), "jj snapshot log");
+        const logRes = yield* withJjTimeout(runJj(["log", "-r", "@", "--no-graph", "-T", 'commit_id ++ "\\n" ++ change_id'], { cwd }), "jj snapshot log");
         if (logRes.code !== 0) {
             // Attribute the gap: a bare null makes a missing durability snapshot
             // impossible to diagnose. code 124 = timeout (see withSnapshotTimeout).
             yield* Effect.logWarning(`workspace snapshot skipped: jj log exited ${logRes.code}: ${logRes.stderr?.trim() || "(no stderr)"}`);
             return null;
         }
-        const opRes = yield* withSnapshotTimeout(runJj(["--ignore-working-copy", "operation", "log", "--no-graph", "--limit", "1", "-T", "self.id()"], { cwd }), "jj snapshot op");
+        const opRes = yield* withJjTimeout(runJj(["--ignore-working-copy", "operation", "log", "--no-graph", "--limit", "1", "-T", "self.id()"], { cwd }), "jj snapshot op");
         if (opRes.code !== 0) {
             yield* Effect.logWarning(`workspace snapshot skipped: jj operation log exited ${opRes.code}: ${opRes.stderr?.trim() || "(no stderr)"}`);
             return null;
@@ -189,17 +186,9 @@ export function revertToJjPointer(pointer, cwd) {
  * @returns {Effect.Effect<boolean, never, import("@effect/platform/CommandExecutor").CommandExecutor>}
  */
 export function isJjRepo(cwd) {
-    return runJj(["log", "-r", "@", "-n", "1", "--no-graph"], {
+    return withJjTimeout(runJj(["log", "-r", "@", "-n", "1", "--no-graph"], {
         cwd,
-    }).pipe(Effect.timeoutTo({
-        duration: Duration.millis(JJ_REPO_TIMEOUT_MS),
-        onSuccess: (res) => res,
-        onTimeout: () => ({
-            code: 124,
-            stdout: "",
-            stderr: `jj repo check timed out after ${JJ_REPO_TIMEOUT_MS}ms`,
-        }),
-    }), Effect.map((res) => res.code === 0), Effect.annotateLogs({ cwd: cwd ?? "" }), Effect.withLogSpan("vcs:jj-is-repo"));
+    }), "jj repo check").pipe(Effect.map((res) => res.code === 0), Effect.annotateLogs({ cwd: cwd ?? "" }), Effect.withLogSpan("vcs:jj-is-repo"));
 }
 /**
  * Create a new JJ workspace at `path` with a friendly `name`.

--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -21,6 +21,7 @@ import { vcsDuration } from "@smithers-orchestrator/observability/metrics";
 import { resolveJjBinary } from "./resolveJjBinary.js";
 
 const JJ_POINTER_TIMEOUT_MS = 1_500;
+const JJ_REPO_TIMEOUT_MS = 1_500;
 const WORKSPACE_SNAPSHOT_TIMEOUT_MS = 1_500;
 /**
  * @param {Stream.Stream<Uint8Array, unknown, never>} stream
@@ -190,7 +191,15 @@ export function revertToJjPointer(pointer, cwd) {
 export function isJjRepo(cwd) {
     return runJj(["log", "-r", "@", "-n", "1", "--no-graph"], {
         cwd,
-    }).pipe(Effect.map((res) => res.code === 0), Effect.annotateLogs({ cwd: cwd ?? "" }), Effect.withLogSpan("vcs:jj-is-repo"));
+    }).pipe(Effect.timeoutTo({
+        duration: Duration.millis(JJ_REPO_TIMEOUT_MS),
+        onSuccess: (res) => res,
+        onTimeout: () => ({
+            code: 124,
+            stdout: "",
+            stderr: `jj repo check timed out after ${JJ_REPO_TIMEOUT_MS}ms`,
+        }),
+    }), Effect.map((res) => res.code === 0), Effect.annotateLogs({ cwd: cwd ?? "" }), Effect.withLogSpan("vcs:jj-is-repo"));
 }
 /**
  * Create a new JJ workspace at `path` with a friendly `name`.

--- a/packages/vcs/tests/jj-workspace.test.js
+++ b/packages/vcs/tests/jj-workspace.test.js
@@ -177,6 +177,19 @@ exit 1
             expect(ok).toBe(false);
         });
     });
+    test("false when repo check times out", async () => {
+        const script = `
+if [[ "$1" = "log" ]]; then
+  sleep 2
+  exit 0
+fi
+exit 1
+`;
+        await withFakeJj(script, async () => {
+            const ok = await vcs.isJjRepo();
+            expect(ok).toBe(false);
+        });
+    });
     test("forwards cwd to repo check command", async () => {
         const tmpCwd = await fs.mkdtemp(path.join(os.tmpdir(), "jj-repo-"));
         await fs.writeFile(path.join(tmpCwd, ".cwd"), "x");


### PR DESCRIPTION
## Summary
- bound the JJ repo probe with the same 1.5s timeout used by pointer and snapshot calls
- return false on probe timeout so durability startup can continue without a stuck JJ subprocess
- add a fake-JJ regression test for a sleeping repo probe

Part of #300.

## Verification
- `pnpm --filter @smithers-orchestrator/vcs test`
- `pnpm --filter @smithers-orchestrator/vcs typecheck`
- `pnpm -r typecheck`
- `git diff --check origin/main..HEAD`
