### PR TITLE
fix(devtools): include approval and human task kinds

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -10291,7 +10291,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -344,7 +344,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/docs/llms-full-v0.26.1.txt
+++ b/docs/llms-full-v0.26.1.txt
@@ -10291,7 +10291,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10291,7 +10291,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -680,7 +680,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/packages/devtools/src/DevToolsNode.ts
+++ b/packages/devtools/src/DevToolsNode.ts
@@ -11,7 +11,7 @@ export type DevToolsNode = {
   /** Task-specific fields extracted from renderer raw props */
   task?: {
     nodeId: string;
-    kind: "agent" | "compute" | "static";
+    kind: "agent" | "compute" | "static" | "human" | "approval";
     agent?: string;
     label?: string;
     outputTableName?: string;

--- a/packages/devtools/src/index.d.ts
+++ b/packages/devtools/src/index.d.ts
@@ -11,7 +11,7 @@ type DevToolsNode$7 = {
     /** Task-specific fields extracted from renderer raw props */
     task?: {
         nodeId: string;
-        kind: "agent" | "compute" | "static";
+        kind: "agent" | "compute" | "static" | "human" | "approval";
         agent?: string;
         label?: string;
         outputTableName?: string;

--- a/packages/pi-plugin/src/runtime/DevToolsStore.ts
+++ b/packages/pi-plugin/src/runtime/DevToolsStore.ts
@@ -623,12 +623,7 @@ export class DevToolsStore {
         seq: delta.baseSeq,
         root: undefined as unknown as DevToolsNode,
       };
-      // applyDelta's JSDoc snapshot type carries a narrower node `kind` union than
-      // protocol's DevToolsSnapshot; the assertion bridges that drift (TS6 flags it).
-      this.liveSnapshot = applyDelta(
-        base as Parameters<typeof applyDelta>[0],
-        delta as Parameters<typeof applyDelta>[1],
-      ) as SnapshotWithRunState;
+      this.liveSnapshot = applyDelta(base, delta) as SnapshotWithRunState;
       this.liveLatestFrameNo = Math.max(this.liveLatestFrameNo, this.liveSnapshot.frameNo, delta.seq);
       this.recordMountedFramesFromDelta(delta, this.liveLatestFrameNo);
       if (this.runId) {

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -10291,7 +10291,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -10291,7 +10291,7 @@ type DevToolsNode = {
   type: "workflow" | "task" | "sequence" | "parallel" | /* …see protocol */;
   name: string;
   props: Record<string, unknown>;
-  task?: { nodeId: string; kind: "agent" | "compute" | "static"; /* … */ };
+  task?: { nodeId: string; kind: "agent" | "compute" | "static" | "human" | "approval"; /* … */ };
   children: DevToolsNode[];
   depth: number;
 };


### PR DESCRIPTION
## Summary
- extend the devtools task kind type to include approval and human nodes
- keep the tracked declaration file aligned with the source type

## Why
The protocol package already exposes approval and human task kinds. Pi plugin imports protocol snapshots and uses devtools applyDelta, so the narrower devtools declaration rejects current snapshots during recursive typecheck.

## Tests
- `pnpm --filter @smithers-orchestrator/devtools typecheck`
- `pnpm --filter @smithers-orchestrator/pi-plugin typecheck`
- `pnpm --filter @smithers-orchestrator/devtools test`
- `pnpm -r typecheck`
- `pnpm check:deps`
- `pnpm check:effect`
- `git diff --check`