### PR TITLE
test(time-travel): stabilize revert DB tests

### DIFF
--- a/packages/time-travel/tests/revert.test.js
+++ b/packages/time-travel/tests/revert.test.js
@@ -15,6 +15,9 @@ function buildDb() {
     ensureSmithersTables(result.db);
     return result;
 }
+
+const DB_TEST_TIMEOUT_MS = 30_000;
+
 describe("revertToJjPointer", () => {
     test("calls jj restore with correct pointer", async () => {
         const result = await Effect.runPromise(revertToJjPointer("abc123").pipe(Effect.provide(BunContext.layer)));
@@ -28,112 +31,127 @@ describe("revertToJjPointer", () => {
 describe("revertToAttempt", () => {
     test("returns error when attempt not found", async () => {
         const { db, cleanup } = buildDb();
-        const adapter = new SmithersDb(db);
-        const events = [];
-        const result = await revertToAttempt(adapter, {
-            runId: "nonexistent",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-            onProgress: (e) => events.push(e),
-        });
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("not found");
-        cleanup();
-    });
+        try {
+            const adapter = new SmithersDb(db);
+            const events = [];
+            const result = await revertToAttempt(adapter, {
+                runId: "nonexistent",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+                onProgress: (e) => events.push(e),
+            });
+            expect(result.success).toBe(false);
+            expect(result.error).toContain("not found");
+        } finally {
+            cleanup();
+        }
+    }, DB_TEST_TIMEOUT_MS);
     test("returns error when attempt has no jjPointer", async () => {
         const { db, cleanup } = buildDb();
-        const adapter = new SmithersDb(db);
-        await adapter.insertRun({
-            runId: "run1",
-            workflowName: "test",
-            status: "finished",
-            createdAtMs: Date.now(),
-        });
-        await adapter.insertAttempt({
-            runId: "run1",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-            state: "finished",
-            startedAtMs: Date.now(),
-            jjPointer: null,
-        });
-        const result = await revertToAttempt(adapter, {
-            runId: "run1",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-        });
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("no jjPointer");
-        cleanup();
-    });
+        try {
+            const adapter = new SmithersDb(db);
+            await adapter.insertRun({
+                runId: "run1",
+                workflowName: "test",
+                status: "finished",
+                createdAtMs: Date.now(),
+            });
+            await adapter.insertAttempt({
+                runId: "run1",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+                state: "finished",
+                startedAtMs: Date.now(),
+                jjPointer: null,
+            });
+            const result = await revertToAttempt(adapter, {
+                runId: "run1",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+            });
+            expect(result.success).toBe(false);
+            expect(result.error).toContain("no jjPointer");
+        } finally {
+            cleanup();
+        }
+    }, DB_TEST_TIMEOUT_MS);
     test("emits RevertStarted and RevertFinished events on success", async () => {
         const { db, cleanup } = buildDb();
-        const adapter = new SmithersDb(db);
-        await adapter.insertRun({
-            runId: "run1",
-            workflowName: "test",
-            status: "finished",
-            createdAtMs: Date.now(),
-        });
-        await adapter.insertAttempt({
-            runId: "run1",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-            state: "finished",
-            startedAtMs: Date.now(),
-            jjPointer: "test-pointer-123",
-        });
-        const events = [];
-        const _result = await revertToAttempt(adapter, {
-            runId: "run1",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-            onProgress: (e) => events.push(e),
-        });
-        const revertStarted = events.find((e) => e.type === "RevertStarted");
-        const revertFinished = events.find((e) => e.type === "RevertFinished");
-        expect(revertStarted).toBeDefined();
-        expect(revertFinished).toBeDefined();
-        if (revertStarted && revertStarted.type === "RevertStarted") {
-            expect(revertStarted.jjPointer).toBe("test-pointer-123");
+        try {
+            const adapter = new SmithersDb(db);
+            await adapter.insertRun({
+                runId: "run1",
+                workflowName: "test",
+                status: "finished",
+                createdAtMs: Date.now(),
+            });
+            await adapter.insertAttempt({
+                runId: "run1",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+                state: "finished",
+                startedAtMs: Date.now(),
+                jjPointer: "test-pointer-123",
+            });
+            const events = [];
+            const _result = await revertToAttempt(adapter, {
+                runId: "run1",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+                onProgress: (e) => events.push(e),
+            });
+            const revertStarted = events.find((e) => e.type === "RevertStarted");
+            const revertFinished = events.find((e) => e.type === "RevertFinished");
+            expect(revertStarted).toBeDefined();
+            expect(revertFinished).toBeDefined();
+            if (revertStarted && revertStarted.type === "RevertStarted") {
+                expect(revertStarted.jjPointer).toBe("test-pointer-123");
+            }
+        } finally {
+            cleanup();
         }
-        cleanup();
-    });
+    }, DB_TEST_TIMEOUT_MS);
 });
 describe("SmithersDb.getAttempt", () => {
     test("returns attempt by composite key", async () => {
         const { db, cleanup } = buildDb();
-        const adapter = new SmithersDb(db);
-        await adapter.insertRun({
-            runId: "run1",
-            workflowName: "test",
-            status: "finished",
-            createdAtMs: Date.now(),
-        });
-        await adapter.insertAttempt({
-            runId: "run1",
-            nodeId: "task1",
-            iteration: 0,
-            attempt: 1,
-            state: "finished",
-            startedAtMs: Date.now(),
-            jjPointer: "ptr-abc",
-        });
-        const attempt = await adapter.getAttempt("run1", "task1", 0, 1);
-        expect(attempt).toBeDefined();
-        expect(attempt?.jjPointer).toBe("ptr-abc");
-        cleanup();
-    });
+        try {
+            const adapter = new SmithersDb(db);
+            await adapter.insertRun({
+                runId: "run1",
+                workflowName: "test",
+                status: "finished",
+                createdAtMs: Date.now(),
+            });
+            await adapter.insertAttempt({
+                runId: "run1",
+                nodeId: "task1",
+                iteration: 0,
+                attempt: 1,
+                state: "finished",
+                startedAtMs: Date.now(),
+                jjPointer: "ptr-abc",
+            });
+            const attempt = await adapter.getAttempt("run1", "task1", 0, 1);
+            expect(attempt).toBeDefined();
+            expect(attempt?.jjPointer).toBe("ptr-abc");
+        } finally {
+            cleanup();
+        }
+    }, DB_TEST_TIMEOUT_MS);
     test("returns undefined for nonexistent attempt", async () => {
         const { db, cleanup } = buildDb();
-        const adapter = new SmithersDb(db);
-        const attempt = await adapter.getAttempt("nonexistent", "task1", 0, 1);
-        expect(attempt).toBeUndefined();
-        cleanup();
-    });
+        try {
+            const adapter = new SmithersDb(db);
+            const attempt = await adapter.getAttempt("nonexistent", "task1", 0, 1);
+            expect(attempt).toBeUndefined();
+        } finally {
+            cleanup();
+        }
+    }, DB_TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
- give DB-backed revert tests per-test 30s budgets for slower Windows runners
- close each test database from finally so assertion failures do not leak SQLite handles into later tests
- rebase on current main after the global time-travel test timeout landed

## Verification
- `bun test packages/time-travel/tests/revert.test.js`
- `pnpm --filter @smithers-orchestrator/time-travel typecheck`
- `pnpm --filter @smithers-orchestrator/time-travel test`
- `pnpm -r typecheck`
- `git diff --check origin/main..HEAD`
