### PR TITLE
fix(smithers): type exported file tools

### DIFF
--- a/packages/smithers/src/tools/bash.js
+++ b/packages/smithers/src/tools/bash.js
@@ -216,14 +216,17 @@ export async function bashTool(cmd, args = [], opts = undefined) {
   return output;
 }
 
+const bashSchema = z.object({
+  cmd: z.string(),
+  args: z.array(z.string()).optional(),
+  opts: z.object({ cwd: z.string().optional() }).optional(),
+});
+
+/** @type {import("../tools.js").DefinedTool<typeof bashSchema, string>} */
 export const bash = defineTool({
   name: "bash",
   description: "Run an executable with arguments",
-  schema: z.object({
-    cmd: z.string(),
-    args: z.array(z.string()).optional(),
-    opts: z.object({ cwd: z.string().optional() }).optional(),
-  }),
+  schema: bashSchema,
   sideEffect: true,
   idempotent: false,
   execute: async ({ cmd, args, opts }, _ctx) => bashTool(cmd, args, opts),

--- a/packages/smithers/src/tools/defineTool.js
+++ b/packages/smithers/src/tools/defineTool.js
@@ -38,9 +38,13 @@ export function getDefinedToolMetadata(value) {
 }
 
 /**
- * @returns {import("ai").Tool} the ai-sdk tool, tagged with smithers metadata.
- *   Annotated explicitly so the emitted declaration stays portable under
- *   TypeScript 6 (avoids TS2883 references to internal @ai-sdk/provider types).
+ * @template {import("zod").ZodTypeAny} Schema
+ * @template Result
+ * @param {import("../tools.js").DefineToolOptions<Schema, Result>} options
+ * @returns {import("../tools.js").DefinedTool<Schema, Result>} the ai-sdk tool,
+ *   tagged with smithers metadata. Annotated explicitly so the emitted
+ *   declaration stays portable under TypeScript 6 and preserves the narrowed
+ *   schema/output contract.
  */
 export function defineTool(options) {
   const sideEffect = options.sideEffect ?? false;
@@ -50,7 +54,7 @@ export function defineTool(options) {
     warnMissingContextParam(options.name);
   }
 
-  const wrapped = tool({
+  const wrapped = /** @type {import("../tools.js").DefinedTool<Schema, Result> & Record<symbol, unknown>} */ (tool({
     description: options.description ?? options.name,
     inputSchema: zodSchema(options.schema),
     execute: async (args) => {
@@ -78,7 +82,7 @@ export function defineTool(options) {
       }
       return result;
     },
-  });
+  }));
 
   wrapped[smithersToolMetadata] = {
     name: options.name,

--- a/packages/smithers/src/tools/edit.js
+++ b/packages/smithers/src/tools/edit.js
@@ -31,10 +31,13 @@ export async function editFileTool(path, patch) {
   return "ok";
 }
 
+const editSchema = z.object({ path: z.string(), patch: z.string() });
+
+/** @type {import("../tools.js").DefinedTool<typeof editSchema, "ok">} */
 export const edit = defineTool({
   name: "edit",
   description: "Apply a unified diff patch to a file",
-  schema: z.object({ path: z.string(), patch: z.string() }),
+  schema: editSchema,
   sideEffect: true,
   idempotent: false,
   execute: async ({ path, patch }, _ctx) => editFileTool(path, patch),

--- a/packages/smithers/src/tools/grep.js
+++ b/packages/smithers/src/tools/grep.js
@@ -25,9 +25,15 @@ export async function grepTool(pattern, path = ".") {
   return result.stdout;
 }
 
+const grepSchema = z.object({
+  pattern: z.string(),
+  path: z.string().optional(),
+});
+
+/** @type {import("../tools.js").DefinedTool<typeof grepSchema, string>} */
 export const grep = defineTool({
   name: "grep",
   description: "Search for a pattern in files",
-  schema: z.object({ pattern: z.string(), path: z.string().optional() }),
+  schema: grepSchema,
   execute: async ({ pattern, path }) => grepTool(pattern, path),
 });

--- a/packages/smithers/src/tools/read.js
+++ b/packages/smithers/src/tools/read.js
@@ -16,9 +16,12 @@ export async function readFileTool(path) {
   return truncateToBytes(content, maxOutputBytes);
 }
 
+const readSchema = z.object({ path: z.string() });
+
+/** @type {import("../tools.js").DefinedTool<typeof readSchema, string>} */
 export const read = defineTool({
   name: "read",
   description: "Read a file",
-  schema: z.object({ path: z.string() }),
+  schema: readSchema,
   execute: async ({ path }) => readFileTool(path),
 });

--- a/packages/smithers/src/tools/write.js
+++ b/packages/smithers/src/tools/write.js
@@ -25,10 +25,13 @@ export async function writeFileTool(path, content) {
   return "ok";
 }
 
+const writeSchema = z.object({ path: z.string(), content: z.string() });
+
+/** @type {import("../tools.js").DefinedTool<typeof writeSchema, "ok">} */
 export const write = defineTool({
   name: "write",
   description: "Write a file",
-  schema: z.object({ path: z.string(), content: z.string() }),
+  schema: writeSchema,
   sideEffect: true,
   idempotent: false,
   execute: async ({ path, content }, _ctx) => writeFileTool(path, content),


### PR DESCRIPTION
## Summary
- type exported file tool helpers without leaking inferred package-private names in declaration output
- preserve runtime metadata on wrapped tool definitions while keeping exported file tools assignable
- stack the fuzzy picker backspace fix from #481 so Linux workspace tests complete cleanly until that PR lands

## Verification
- `pnpm --filter smithers-orchestrator typecheck`
- `pnpm --filter smithers-orchestrator build`
- `pnpm --filter smithers-orchestrator test`
- `bun test --timeout=120000 --max-concurrency=1 tests/fuzzy-select.test.js` from `apps/cli`
- `pnpm -r typecheck`
- `pnpm -r build`
- `pnpm check:deps`
- `pnpm check:effect`
- `pnpm lint` (existing warnings only)
- `git diff --check origin/main..HEAD`
