### PR TITLE
ci: run OpenAPI drift check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,19 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - uses: oven-sh/setup-bun@v2.2.0
+        if: runner.os == 'Linux'
+        with:
+          bun-version: 1.3.13
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm check:effect
 
       - run: pnpm check:deps
+
+      - run: pnpm check:openapi
+        if: runner.os == 'Linux'
 
       - run: pnpm lint
 

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -8204,6 +8204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -8192,6 +8192,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/docs/llms-full-v0.26.1.txt
+++ b/docs/llms-full-v0.26.1.txt
@@ -8204,6 +8204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8204,6 +8204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/docs/reference/package-configuration.mdx
+++ b/docs/reference/package-configuration.mdx
@@ -204,6 +204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "check:effect": "node scripts/check-single-effect-version.mjs",
     "check:deps": "node scripts/check-dependency-boundaries.mjs",
     "check:docs": "node scripts/check-docs.mjs",
+    "check:openapi": "pnpm --filter @smithers-orchestrator/gateway check:openapi",
     "check:llms": "node scripts/check-llms.mjs",
     "fetch:jj": "node scripts/fetch-jj-binaries.mjs",
     "docs:components": "node scripts/generate-component-source.mjs",

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -8204,6 +8204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -8204,6 +8204,7 @@ Defined in the root `package.json` for development:
 | `check:effect` | `node scripts/check-single-effect-version.mjs` | Verify the workspace resolves a single Effect version |
 | `check:deps` | `node scripts/check-dependency-boundaries.mjs` | Verify package dependency boundaries |
 | `check:docs` | `node scripts/check-docs.mjs` | Verify documentation style and API drift guards |
+| `check:openapi` | `pnpm --filter @smithers-orchestrator/gateway check:openapi` | Verify the committed Gateway OpenAPI document is current |
 | `check:llms` | `node scripts/check-llms.mjs` | Verify generated llms docs are current |
 | `fetch:jj` | `node scripts/fetch-jj-binaries.mjs` | Fetch vendored jj binaries for supported platforms |
 | `docs:components` | `node scripts/generate-component-source.mjs` | Embed composite component source as tabs in their docs pages |


### PR DESCRIPTION
## Summary
- add a root `check:openapi` script that delegates to the Gateway package drift guard
- run the OpenAPI drift guard in the Linux typecheck job after Bun is available
- document the new root check and refresh generated llms docs

## Why
The Gateway package already checks that `packages/gateway/openapi.yaml` matches the current RPC registry during package builds. Running the same guard in CI catches stale committed OpenAPI documents earlier, before release or package build paths are the first place to notice drift.

## Verification
- `pnpm check:openapi`
- `pnpm check:llms`
- `node scripts/check-docs.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `pnpm check:deps`
- `pnpm check:effect`
- `pnpm lint` (existing warnings only)
- `pnpm -r typecheck`
- `pnpm --filter @smithers-orchestrator/gateway build`
- `git diff --check`