### PR TITLE
fix(workflows): type Telegram digest workflow

### DIFF
--- a/.smithers/workflows/telegram-daily-digest.tsx
+++ b/.smithers/workflows/telegram-daily-digest.tsx
@@ -673,7 +673,7 @@ async function collectMessages(input: NormalizedInput): Promise<CollectOutput> {
   const range = rangeFor(trimmed.messages);
 
   return {
-    source: source === "auto" ? "none" : source,
+    source,
     messageCount: trimmed.messages.length,
     from: range.from,
     to: range.to,
@@ -747,6 +747,7 @@ function stringArray(value: unknown): string[] {
 
 function normalizeDigestJson(value: unknown, collect: CollectOutput): DigestOutput {
   const record = isRecord(value) ? value : {};
+  const notableLinkItems = record.notableLinks ?? record.notable_links;
   const topics = Array.isArray(record.topics)
     ? record.topics
         .filter(isRecord)
@@ -766,8 +767,8 @@ function normalizeDigestJson(value: unknown, collect: CollectOutput): DigestOutp
           followUps: stringArray(topic.followUps ?? topic.follow_ups),
         }))
     : [];
-  const notableLinks = Array.isArray(record.notableLinks ?? record.notable_links)
-    ? (record.notableLinks ?? record.notable_links)
+  const notableLinks = Array.isArray(notableLinkItems)
+    ? notableLinkItems
         .filter(isRecord)
         .slice(0, 10)
         .map((link) => ({


### PR DESCRIPTION
## Summary
- return the resolved Telegram digest source directly after auto-selection
- reuse a narrowed notable-links payload before mapping digest links
- restore green `.smithers` and workspace typecheck on current main

## Why
The new Telegram digest workflow currently fails `.smithers` typecheck in two places: one dead `"auto"` comparison after source resolution, and one repeated `unknown` expression that TypeScript cannot narrow. This keeps runtime behavior the same while making the authored workflow compile.

## Verification
- `pnpm --filter ./.smithers typecheck`
- `pnpm -r typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm check:deps`
- `pnpm check:effect`
- `pnpm -r build`
- `git diff --check`