### PR TITLE
fix(cli): handle fuzzy picker backspace

### DIFF
--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -144,6 +144,26 @@ function terminalRows() {
 }
 
 /**
+ * Some readline implementations keep DEL/BS bytes in `line` for synthetic TTYs.
+ * Treat them as editing commands before filtering so tests and Bun-backed
+ * interactive sessions stay aligned.
+ *
+ * @param {string} input
+ * @returns {string}
+ */
+function normalizeBackspaces(input) {
+    const chars = [];
+    for (const char of String(input ?? "")) {
+        if (char === "\b" || char === "\x7f") {
+            chars.pop();
+        } else {
+            chars.push(char);
+        }
+    }
+    return chars.join("");
+}
+
+/**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
  * pipes readline and keeps `this.value` in sync with the typed query — letters
@@ -196,7 +216,15 @@ class FuzzySelectPrompt extends Prompt {
         // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
         // so the base re-emits "userInput" for both — this covers backspace free.
         this.on("userInput", () => {
-            this.query = this.userInput ?? "";
+            const query = normalizeBackspaces(this.userInput ?? "");
+            if (query !== this.userInput) {
+                this.userInput = query;
+                if (this.rl) {
+                    this.rl.line = query;
+                    this.rl.cursor = query.length;
+                }
+            }
+            this.query = query;
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this._cursor > this.filtered.length - 1) {
                 this._cursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/tests/fuzzy-select.test.js
+++ b/apps/cli/tests/fuzzy-select.test.js
@@ -146,8 +146,14 @@ class FakeInput extends EventEmitter {
         return super.on(event, cb);
     }
     /** Drive the prompt's onKeypress directly, mirroring readline keypress events. */
-    keypress(seq, key) {
-        this.emit("keypress", seq, key);
+    keypress(seq, key = {}) {
+        this.emit("keypress", seq, {
+            sequence: seq,
+            ctrl: false,
+            meta: false,
+            shift: false,
+            ...key,
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- normalize DEL/BS control bytes before fuzzy picker filtering
- keep the readline line buffer aligned after normalization
- make the fake keypress helper include the key metadata that readline normally provides

## Why
The CLI fuzzy picker can keep delete bytes in the tracked query under Bun-backed synthetic TTY input. That leaves the prompt in the no-match validation path after Backspace, so the prompt promise stays pending and the CLI test suite hangs.

## Verification
- `pnpm --filter @smithers-orchestrator/cli exec bun test --timeout=10000 --max-concurrency=1 tests/fuzzy-select.test.js`
- `pnpm --filter @smithers-orchestrator/cli test`
- `pnpm --filter @smithers-orchestrator/cli typecheck`
- `pnpm --filter @smithers-orchestrator/cli build`
- `pnpm -r --no-bail test`
- `pnpm lint` (existing warnings only)
- `git diff --check`