### PR TITLE
test(e2e): cover public subpath exports

### DIFF
--- a/e2e/exports/programmatic-api.test.ts
+++ b/e2e/exports/programmatic-api.test.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "bun:test";
 import * as smithers from "smithers-orchestrator";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 
 // Guards the programmatic run-control + output-reading API on the public barrel.
 // These power embedders that drive durable runs across processes (start a run,
@@ -21,26 +26,44 @@ test("public barrel exposes the programmatic run-control + output API", () => {
   }
 });
 
+// Guards that every documented `smithers-orchestrator/*` facade subpath still
+// resolves at runtime with a non-empty export set. Closes the #300 audit item
+// "No automated guard that every documented public subpath export resolves":
+// most facades resolve purely by file existence through the package.json
+// `./*` -> `./src/*.js` wildcard, so a renamed or deleted facade file breaks a
+// documented import today with no other CI signal.
 test("documented smithers-orchestrator subpaths resolve", async () => {
-  const documentedSubpaths: string[] = [
-    "smithers-orchestrator/control-plane",
+  // Explicit (non-wildcard) export keys are derived from the published package's
+  // exports map, so a newly added explicit facade (as `telegram` and
+  // `cloudflare` recently were) is covered automatically without editing this
+  // test.
+  const facadeExports = JSON.parse(
+    readFileSync(join(HERE, "../../packages/smithers/package.json"), "utf8"),
+  ).exports as Record<string, unknown>;
+  const explicitSubpaths = Object.keys(facadeExports)
+    .filter((key) => key.startsWith("./") && !key.includes("*"))
+    .map((key) => `smithers-orchestrator/${key.slice("./".length)}`);
+
+  // Documented subpaths that resolve only through the `./*` wildcard (by file
+  // existence), so they cannot be enumerated from the exports map and stay a
+  // curated list. Keep in sync with docs/ when a wildcard-backed facade is
+  // documented.
+  const wildcardBackedSubpaths = [
     "smithers-orchestrator/dom/renderer",
     "smithers-orchestrator/gateway",
-    "smithers-orchestrator/gateway-client",
-    "smithers-orchestrator/gateway-react",
-    "smithers-orchestrator/gateway-ui",
-    "smithers-orchestrator/jsx-dev-runtime",
-    "smithers-orchestrator/jsx-runtime",
     "smithers-orchestrator/mdx-plugin",
     "smithers-orchestrator/memory",
     "smithers-orchestrator/observability",
     "smithers-orchestrator/openapi",
-    "smithers-orchestrator/sandbox",
     "smithers-orchestrator/scorers",
     "smithers-orchestrator/serve",
     "smithers-orchestrator/server",
-    "smithers-orchestrator/tools",
   ];
+
+  const documentedSubpaths = [
+    ...new Set([...explicitSubpaths, ...wildcardBackedSubpaths]),
+  ].sort();
+
   for (const specifier of documentedSubpaths) {
     const mod = await import(specifier);
     expect(Object.keys(mod), specifier).not.toHaveLength(0);

--- a/e2e/exports/programmatic-api.test.ts
+++ b/e2e/exports/programmatic-api.test.ts
@@ -20,3 +20,29 @@ test("public barrel exposes the programmatic run-control + output API", () => {
     expect(typeof surface[name]).toBe("function");
   }
 });
+
+test("documented smithers-orchestrator subpaths resolve", async () => {
+  const documentedSubpaths: string[] = [
+    "smithers-orchestrator/control-plane",
+    "smithers-orchestrator/dom/renderer",
+    "smithers-orchestrator/gateway",
+    "smithers-orchestrator/gateway-client",
+    "smithers-orchestrator/gateway-react",
+    "smithers-orchestrator/gateway-ui",
+    "smithers-orchestrator/jsx-dev-runtime",
+    "smithers-orchestrator/jsx-runtime",
+    "smithers-orchestrator/mdx-plugin",
+    "smithers-orchestrator/memory",
+    "smithers-orchestrator/observability",
+    "smithers-orchestrator/openapi",
+    "smithers-orchestrator/sandbox",
+    "smithers-orchestrator/scorers",
+    "smithers-orchestrator/serve",
+    "smithers-orchestrator/server",
+    "smithers-orchestrator/tools",
+  ];
+  for (const specifier of documentedSubpaths) {
+    const mod = await import(specifier);
+    expect(Object.keys(mod), specifier).not.toHaveLength(0);
+  }
+});


### PR DESCRIPTION
## Summary
- add an e2e runtime guard for each documented `smithers-orchestrator/*` facade subpath
- keep the existing programmatic API barrel coverage in the same export-focused test file
- cover #300 public subpath-resolution gap while keeping e2e typecheck inside package boundaries

Part of #300.

## Verification
- `bun test e2e/exports/programmatic-api.test.ts`
- `pnpm -C e2e typecheck`
- `pnpm -r typecheck`
- `pnpm --filter @smithers-orchestrator/e2e test`
- `pnpm lint`
- `pnpm check:effect`
- `pnpm check:deps`
- `git diff --check`