### PR TITLE
fix(scripts): keep docs normalizer on CLI tokens

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -177,6 +177,11 @@ const CLOUD_PRODUCT_SPEC = join(root, ".smithers/specs/cloud-execution-product.m
 
 let failed = false;
 
+{
+  const r = spawnSync("bun", ["test", join("scripts", "normalize-bunx.test.ts")], { cwd: root, stdio: "inherit" });
+  if (r.status !== 0) failed = true;
+}
+
 for (const script of ["normalize-bunx.ts", "normalize-placeholders.ts"]) {
   const r = spawnSync("bun", [join("scripts", script), "--check"], { cwd: root, stdio: "inherit" });
   if (r.status !== 0) failed = true;

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -177,6 +177,8 @@ const CLOUD_PRODUCT_SPEC = join(root, ".smithers/specs/cloud-execution-product.m
 
 let failed = false;
 
+// scripts/ lives at the workspace root, which `pnpm -r test` never runs, so the
+// normalize-bunx regression test has no other home; run it from the docs gate.
 {
   const r = spawnSync("bun", ["test", join("scripts", "normalize-bunx.test.ts")], { cwd: root, stdio: "inherit" });
   if (r.status !== 0) failed = true;

--- a/scripts/normalize-bunx.test.ts
+++ b/scripts/normalize-bunx.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeCommands, rewrite } from "./normalize-bunx.ts";
+
+describe("normalize-bunx", () => {
+  test("rewrites bare and runner-prefixed Smithers CLI invocations", () => {
+    expect(normalizeCommands("smithers run workflow.tsx")).toBe(
+      "bunx smithers-orchestrator run workflow.tsx",
+    );
+    expect(normalizeCommands("bunx smithers up workflow.tsx")).toBe(
+      "bunx smithers-orchestrator up workflow.tsx",
+    );
+    expect(normalizeCommands("npx smithers <command>")).toBe(
+      "bunx smithers-orchestrator <command>",
+    );
+    expect(normalizeCommands("$ smithers inspect RUN_ID")).toBe(
+      "$ bunx smithers-orchestrator inspect RUN_ID",
+    );
+  });
+
+  test("leaves package names, slash commands, and path-prefixed bins intact", () => {
+    const commands = [
+      "smithers-orchestrator run workflow.tsx",
+      "./node_modules/.bin/smithers run workflow.tsx",
+      "/usr/local/bin/smithers up",
+      String.raw`C:\tools\smithers run workflow.tsx`,
+      "@smithersai/smithers run workflow.tsx",
+      "my-smithers run workflow.tsx",
+      "foo.smithers run workflow.tsx",
+      "/smithers run workflow.tsx",
+    ];
+
+    for (const command of commands) {
+      expect(normalizeCommands(command)).toBe(command);
+    }
+  });
+
+  test("normalizes only code spans and shell fences", () => {
+    expect(rewrite("Run `smithers run workflow.tsx` from the project root.")).toBe(
+      "Run `bunx smithers-orchestrator run workflow.tsx` from the project root.",
+    );
+    expect(rewrite("The smithers run command appears in prose.")).toBe(
+      "The smithers run command appears in prose.",
+    );
+    expect(rewrite("```bash\nsmithers up workflow.tsx\n```")).toBe(
+      "```bash\nbunx smithers-orchestrator up workflow.tsx\n```",
+    );
+    expect(rewrite("`my-smithers run workflow.tsx`")).toBe("`my-smithers run workflow.tsx`");
+  });
+});

--- a/scripts/normalize-bunx.test.ts
+++ b/scripts/normalize-bunx.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { normalizeCommands, rewrite } from "./normalize-bunx.ts";
+import { normalizeCommands, normalizeInline, rewrite } from "./normalize-bunx.ts";
 
 describe("normalize-bunx", () => {
   test("rewrites bare and runner-prefixed Smithers CLI invocations", () => {
@@ -33,6 +33,18 @@ describe("normalize-bunx", () => {
     for (const command of commands) {
       expect(normalizeCommands(command)).toBe(command);
     }
+  });
+
+  test("normalizeInline rewrites CLI code spans but not prose or path-prefixed bins", () => {
+    expect(normalizeInline("Run `smithers run workflow.tsx` from the project root.")).toBe(
+      "Run `bunx smithers-orchestrator run workflow.tsx` from the project root.",
+    );
+    expect(normalizeInline("The smithers run command appears in prose.")).toBe(
+      "The smithers run command appears in prose.",
+    );
+    expect(normalizeInline("Use `my-smithers run workflow.tsx` from your fork.")).toBe(
+      "Use `my-smithers run workflow.tsx` from your fork.",
+    );
   });
 
   test("normalizes only code spans and shell fences", () => {

--- a/scripts/normalize-bunx.ts
+++ b/scripts/normalize-bunx.ts
@@ -56,16 +56,16 @@ const SUB = KNOWN_SUBCOMMANDS.join("|");
 // A leading `/` means this is a slash command (e.g. Hermes's `/smithers run`),
 // not a CLI invocation, so never rewrite `/smithers <sub>`.
 const CMD_RE = new RegExp(
-  String.raw`(bunx\s+|npx\s+)?(?<![/\w])smithers(?!-orchestrator)(\s+(?:<[^>]+>|(?:${SUB})\b))`,
+  String.raw`(bunx\s+|npx\s+)?(?<![/\\\w@.-])smithers(?!-orchestrator)(\s+(?:<[^>]+>|(?:${SUB})\b))`,
   "g",
 );
 
-function normalizeCommands(text: string): string {
+export function normalizeCommands(text: string): string {
   return text.replace(CMD_RE, (_m, _runner, tail) => `bunx smithers-orchestrator${tail}`);
 }
 
 // Replace bare/bunx/npx smithers commands inside inline code spans only.
-function normalizeInline(line: string): string {
+export function normalizeInline(line: string): string {
   return line.replace(/`([^`]+)`/g, (whole, inner) => {
     const fixed = normalizeCommands(inner);
     return fixed === inner ? whole : `\`${fixed}\``;
@@ -84,7 +84,7 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-function rewrite(original: string): string {
+export function rewrite(original: string): string {
   const lines = original.split("\n");
   const out: string[] = [];
   let inCode = false;
@@ -121,35 +121,37 @@ function rewrite(original: string): string {
 
 // The root README mirrors the docs' house style, but lives outside docs/ so it
 // is appended explicitly (CI must enforce the same canonical CLI form there).
-const files = [...walk(DOCS_ROOT), join(REPO_ROOT, "README.md")];
-const offenders: string[] = [];
-let changed = 0;
+if (import.meta.main) {
+  const files = [...walk(DOCS_ROOT), join(REPO_ROOT, "README.md")];
+  const offenders: string[] = [];
+  let changed = 0;
 
-for (const f of files) {
-  const original = readFileSync(f, "utf8");
-  const next = rewrite(original);
-  if (next === original) continue;
-  const rel = relative(REPO_ROOT, f);
+  for (const f of files) {
+    const original = readFileSync(f, "utf8");
+    const next = rewrite(original);
+    if (next === original) continue;
+    const rel = relative(REPO_ROOT, f);
+    if (CHECK) {
+      offenders.push(rel);
+    } else {
+      writeFileSync(f, next);
+      changed++;
+      console.log(`  ✓ ${rel}`);
+    }
+  }
+
   if (CHECK) {
-    offenders.push(rel);
+    if (offenders.length) {
+      console.error(
+        `\n✗ ${offenders.length} doc file(s) use bare \`smithers\` or \`bunx smithers\` commands.\n` +
+          `  Every CLI invocation must be \`bunx smithers-orchestrator <command>\`.\n` +
+          `  Run \`bun scripts/normalize-bunx.ts\` to fix:\n` +
+          offenders.map((o) => `    ${o}`).join("\n"),
+      );
+      process.exit(1);
+    }
+    console.log("✓ all docs use bunx smithers-orchestrator");
   } else {
-    writeFileSync(f, next);
-    changed++;
-    console.log(`  ✓ ${rel}`);
+    console.log(`\nUpdated ${changed} file(s).`);
   }
-}
-
-if (CHECK) {
-  if (offenders.length) {
-    console.error(
-      `\n✗ ${offenders.length} doc file(s) use bare \`smithers\` or \`bunx smithers\` commands.\n` +
-        `  Every CLI invocation must be \`bunx smithers-orchestrator <command>\`.\n` +
-        `  Run \`bun scripts/normalize-bunx.ts\` to fix:\n` +
-        offenders.map((o) => `    ${o}`).join("\n"),
-    );
-    process.exit(1);
-  }
-  console.log("✓ all docs use bunx smithers-orchestrator");
-} else {
-  console.log(`\nUpdated ${changed} file(s).`);
 }

--- a/scripts/normalize-bunx.ts
+++ b/scripts/normalize-bunx.ts
@@ -21,6 +21,16 @@
  * subcommand (e.g. "the `smithers` skill"), and never touches prose outside
  * code spans (e.g. "the smithers init command").
  *
+ * The lookbehind `(?<![/\\\w@.-])` requires `smithers` to start a fresh token,
+ * so a `smithers` glued to a preceding character is left alone. Each excluded
+ * prefix guards a distinct false positive:
+ *   - `/`  slash commands and POSIX path segments (`/smithers`, Hermes `/smithers run`)
+ *   - `\`  Windows path segments (`C:\tools\smithers run`)
+ *   - word chars  hyphen-free bin/package suffixes (`mysmithers`, `smithers-orchestrator`)
+ *   - `@`  scoped packages and mentions (`@smithersai/smithers`, a `@smithers run` chat mention)
+ *   - `.`  domain- or property-like tokens (`foo.smithers run`)
+ *   - `-`  hyphenated bin names (`my-smithers run`)
+ *
  * Modes:
  *   bun scripts/normalize-bunx.ts          rewrite files in place
  *   bun scripts/normalize-bunx.ts --check  exit 1 and list offenders, write nothing


### PR DESCRIPTION
## Summary
- tighten the docs CLI normalizer boundary so path, scoped-package, dot-prefixed, and hyphen-prefixed `smithers` tokens stay intact
- export the normalizer helpers for direct regression coverage without scanning docs during import
- run the normalizer regression test from the docs gate

## Verification
- `bun test scripts/normalize-bunx.test.ts`
- `bun scripts/normalize-bunx.ts --check`
- `pnpm check:docs`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm -r typecheck`
- `pnpm check:effect`
- `pnpm check:deps`
- `pnpm check:llms`
- `git diff --check`