### PR TITLE
fix(server): harden JWT verification

### DIFF
--- a/packages/gateway-react/tests/providerParitySuite.ts
+++ b/packages/gateway-react/tests/providerParitySuite.ts
@@ -7,6 +7,8 @@ import {
   type WorkspaceMode,
 } from "@smithers-orchestrator/gateway-client";
 
+type SmithersDataClient = ReturnType<typeof createSmithersDataClient>;
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -25,6 +27,23 @@ async function waitFor(assertion: () => void | boolean | Promise<void | boolean>
   }
   if (lastError) throw lastError;
   throw new Error("Timed out waiting for provider parity assertion.");
+}
+
+async function waitForApprovalNodeReady(
+  client: SmithersDataClient,
+  runId: string,
+  nodeId: string,
+  iteration = 0,
+) {
+  await waitFor(async () => {
+    const nodes = await client.api.getRunTree({ runId });
+    return nodes.some(
+      (node) =>
+        node.id === nodeId &&
+        (node.iteration ?? 0) === iteration &&
+        node.status === "waiting",
+    );
+  });
 }
 
 function cronRow(overrides: Partial<GatewayCronRow> = {}): GatewayCronRow {
@@ -77,6 +96,7 @@ export async function runProviderParitySuite(mode: WorkspaceMode) {
     // "Node pick-plan is not waiting for approval". Gate the decision on the run
     // actually reaching the waiting-approval state so the submit is never racy.
     await waitFor(() => runs.get(approvalRunId)?.status === "waiting-approval");
+    await waitForApprovalNodeReady(client, approvalRunId, "pick-plan");
     const approvalUpdate = approvals.update(approvalKey, (draft) => {
       (draft as { decision?: Record<string, unknown> }).decision = { selected: "balanced", notes: null };
     });

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -1025,7 +1025,11 @@ function decodeBase64UrlJson(value) {
  * @returns {{ ok: true; payload: Record<string, unknown> } | { ok: false; message: string }}
  */
 function verifyJwtToken(token, config) {
-    const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+    const segments = token.split(".");
+    if (segments.length !== 3) {
+        return { ok: false, message: "JWT must have three segments" };
+    }
+    const [encodedHeader, encodedPayload, encodedSignature] = segments;
     if (!encodedHeader || !encodedPayload || !encodedSignature) {
         return { ok: false, message: "JWT must have three segments" };
     }
@@ -1039,14 +1043,16 @@ function verifyJwtToken(token, config) {
     }
     const expectedSignature = createHmac("sha256", config.secret)
         .update(`${encodedHeader}.${encodedPayload}`)
-        .digest("base64url");
-    if (encodedSignature !== expectedSignature) {
+        .digest();
+    if (!/^[A-Za-z0-9_-]+$/.test(encodedSignature)) {
         return { ok: false, message: "JWT signature verification failed" };
     }
     const actualSignature = Buffer.from(encodedSignature, "base64url");
-    const expectedSignatureBuffer = Buffer.from(expectedSignature, "base64url");
-    if (actualSignature.length !== expectedSignatureBuffer.length ||
-        !timingSafeEqual(actualSignature, expectedSignatureBuffer)) {
+    if (actualSignature.toString("base64url") !== encodedSignature) {
+        return { ok: false, message: "JWT signature verification failed" };
+    }
+    if (actualSignature.length !== expectedSignature.length ||
+        !timingSafeEqual(actualSignature, expectedSignature)) {
         return { ok: false, message: "JWT signature verification failed" };
     }
     const now = Math.floor(Date.now() / 1_000);

--- a/packages/server/tests/gateway.test.jsx
+++ b/packages/server/tests/gateway.test.jsx
@@ -30,6 +30,28 @@ function createJwtToken(payload, secret, header = { alg: "HS256", typ: "JWT" }) 
         .digest("base64url");
     return `${encodedHeader}.${encodedPayload}.${signature}`;
 }
+const base64UrlAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+/**
+ * @param {string} token
+ * @param {string} signature
+ */
+function replaceJwtSignature(token, signature) {
+    const [encodedHeader, encodedPayload] = token.split(".");
+    return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+/**
+ * @param {string} value
+ */
+function createNonCanonicalBase64Url(value) {
+    const lastChar = value[value.length - 1];
+    const lastIndex = base64UrlAlphabet.indexOf(lastChar);
+    if (lastIndex < 0) {
+        throw new Error("Expected base64url signature");
+    }
+    const groupStart = lastIndex & ~3;
+    const replacementIndex = groupStart + ((lastIndex + 1) % 4);
+    return `${value.slice(0, -1)}${base64UrlAlphabet[replacementIndex]}`;
+}
 /**
  * @param {Server} server
  * @returns {number}
@@ -512,6 +534,10 @@ describe("Gateway", () => {
             exp: Math.floor(Date.now() / 1_000) + 300,
         };
         const valid = createJwtToken(basePayload, secret);
+        const [, , signature] = valid.split(".");
+        const nonCanonicalSignature = createNonCanonicalBase64Url(signature);
+        expect(Buffer.from(nonCanonicalSignature, "base64url")
+            .equals(Buffer.from(signature, "base64url"))).toBe(true);
         const cases = [
             {
                 token: createJwtToken(basePayload, secret, { alg: "none", typ: "JWT" }),
@@ -520,6 +546,18 @@ describe("Gateway", () => {
             {
                 token: `${valid.slice(0, -1)}${valid.endsWith("a") ? "b" : "a"}`,
                 message: "signature",
+            },
+            {
+                token: replaceJwtSignature(valid, `${signature}=`),
+                message: "signature",
+            },
+            {
+                token: replaceJwtSignature(valid, nonCanonicalSignature),
+                message: "signature",
+            },
+            {
+                token: `${valid}.ignored`,
+                message: "three segments",
             },
             {
                 token: createJwtToken({ ...basePayload, iss: "https://evil.example.com" }, secret),


### PR DESCRIPTION
## Summary

- require JWTs to have exactly three segments before decoding and verification
- validate JWT signatures as canonical base64url, then compare raw HMAC bytes with `timingSafeEqual`
- add regression coverage for padded, non-canonical, and extra-segment tokens
- stabilize existing CI checks for Gateway REST run filtering, DDD editor link handling, and zero-TTL memory deletion

## Tests

- `pnpm install --frozen-lockfile`
- `bun test packages/server/tests/gateway-domain-api.test.ts --timeout=120000`
- `bun test packages/server/tests/gateway.test.jsx --timeout=120000`
- `bun test ./.smithers/ui/ddd-tabs.test.tsx --timeout=120000`
- `pnpm --filter @smithers-orchestrator/server test`
- `pnpm --filter @smithers-orchestrator/server typecheck`
- `pnpm --filter @smithers-orchestrator/memory test`
- `pnpm --filter @smithers-orchestrator/memory typecheck`
- `bun test --coverage --coverage-reporter=lcov --coverage-dir=/tmp/smithers-memory-coverage tests`
- `pnpm --filter ./.smithers typecheck`
- `pnpm check:deps`
- `pnpm check:effect`
- `git diff --check`