### PR TITLE
fix(agents): align OpenClaw session CLI

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -11760,7 +11760,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -11769,6 +11769,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/docs/integrations/cli-agents.mdx
+++ b/docs/integrations/cli-agents.mdx
@@ -47,7 +47,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -56,6 +56,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/docs/llms-full-v0.26.1.txt
+++ b/docs/llms-full-v0.26.1.txt
@@ -11760,7 +11760,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -11769,6 +11769,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -11760,7 +11760,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -11769,6 +11769,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -132,7 +132,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -141,6 +141,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/packages/agents/src/OpenClawAgent.js
+++ b/packages/agents/src/OpenClawAgent.js
@@ -54,6 +54,8 @@ export class OpenClawAgent extends BaseCliAgent {
   /** @type {AgentCapabilityRegistry} */
   capabilities;
   cliEngine = "openclaw";
+  /** @type {string | undefined} */
+  issuedSessionId;
 
   /**
    * @param {OpenClawAgentOptions} [opts]
@@ -69,15 +71,28 @@ export class OpenClawAgent extends BaseCliAgent {
    */
   createOutputInterpreter() {
     let emittedStarted = false;
+    let sessionId = this.issuedSessionId;
     return {
-      onStdoutLine: () => {
+      onStdoutLine: (line) => {
+        sessionId = extractOpenClawSessionId(line) ?? sessionId;
         if (emittedStarted) return [];
         emittedStarted = true;
-        return [{ type: "started", engine: this.cliEngine, title: "OpenClaw" }];
+        return [{
+          type: "started",
+          engine: this.cliEngine,
+          title: "OpenClaw",
+          resume: sessionId,
+        }];
       },
       onExit: (result) => {
+        sessionId = extractOpenClawSessionId(result.stdout) ?? sessionId;
         const started = !emittedStarted
-          ? [{ type: "started", engine: this.cliEngine, title: "OpenClaw" }]
+          ? [{
+            type: "started",
+            engine: this.cliEngine,
+            title: "OpenClaw",
+            resume: sessionId,
+          }]
           : [];
         const ok = !result.exitCode || result.exitCode === 0;
         const answer = ok ? extractOpenClawAnswer(result.stdout) : undefined;
@@ -88,6 +103,7 @@ export class OpenClawAgent extends BaseCliAgent {
             engine: this.cliEngine,
             ok,
             answer: answer || undefined,
+            resume: sessionId,
             error:
               ok
                 ? undefined
@@ -106,10 +122,11 @@ export class OpenClawAgent extends BaseCliAgent {
 
     const resumeSession =
       typeof params.options?.resumeSession === "string" ? params.options.resumeSession : undefined;
-    const session = resumeSession ?? this.opts.session;
+    const session = resumeSession ?? this.opts.sessionId ?? this.opts.session;
+    this.issuedSessionId = session;
 
     pushFlag(args, "--agent", this.opts.agent);
-    pushFlag(args, "--session", session);
+    pushFlag(args, "--session-id", session);
     if (this.opts.continueSession) args.push("--continue");
     pushFlag(args, "--workspace", this.opts.workspace ?? params.cwd);
 
@@ -137,7 +154,7 @@ function extractOpenClawAnswer(stdout) {
   const parsed = parseJson(trimmed);
   if (!isRecord(parsed)) return trimmed;
 
-  for (const key of ["text", "reply", "answer", "message", "output", "content"]) {
+  for (const key of ["text", "reply", "answer", "message", "output", "content", "payloads", "payload"]) {
     const value = parsed[key];
     const text = typeof value === "string" ? value : extractTextFromJsonValue(value);
     if (text) return text;
@@ -145,7 +162,7 @@ function extractOpenClawAnswer(stdout) {
 
   const result = parsed.result;
   if (isRecord(result)) {
-    for (const key of ["text", "reply", "answer", "message", "output", "content"]) {
+    for (const key of ["text", "reply", "answer", "message", "output", "content", "payloads", "payload"]) {
       const value = result[key];
       const text = typeof value === "string" ? value : extractTextFromJsonValue(value);
       if (text) return text;
@@ -162,6 +179,40 @@ function extractOpenClawError(stdout) {
   const parsed = parseJson(stdout.trim());
   if (!isRecord(parsed)) return "";
   return asString(parsed.error) ?? asString(parsed.message) ?? "";
+}
+
+/**
+ * @param {string} stdout
+ */
+function extractOpenClawSessionId(stdout) {
+  const parsed = parseJson(stdout.trim());
+  if (!isRecord(parsed)) return undefined;
+  return extractSessionIdFromRecord(parsed);
+}
+
+/**
+ * @param {Record<string, unknown>} record
+ * @returns {string | undefined}
+ */
+function extractSessionIdFromRecord(record) {
+  const direct = asString(record.sessionId) ?? asString(record.session_id);
+  if (direct) return direct;
+
+  const session = record.session;
+  if (typeof session === "string") return session;
+  if (isRecord(session)) {
+    const nested = extractSessionIdFromRecord(session);
+    if (nested) return nested;
+  }
+
+  for (const key of ["meta", "result", "data"]) {
+    const value = record[key];
+    if (!isRecord(value)) continue;
+    const nested = extractSessionIdFromRecord(value);
+    if (nested) return nested;
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/agents/src/OpenClawAgentOptions.ts
+++ b/packages/agents/src/OpenClawAgentOptions.ts
@@ -10,7 +10,9 @@ import type { BaseCliAgentOptions } from "./BaseCliAgent/BaseCliAgentOptions";
 export type OpenClawAgentOptions = BaseCliAgentOptions & {
   /** OpenClaw agent id. Defaults to OpenClaw's configured default agent. */
   agent?: string;
-  /** Session id to route the message into, when supported by the installed CLI. */
+  /** Session id to route the message into. Emits OpenClaw's `--session-id` flag. */
+  sessionId?: string;
+  /** Legacy alias for sessionId. */
   session?: string;
   /** Workspace/root directory to expose to OpenClaw, when supported by the installed CLI. */
   workspace?: string;

--- a/packages/agents/src/cli-surface/cliAgentSurfaceManifest.js
+++ b/packages/agents/src/cli-surface/cliAgentSurfaceManifest.js
@@ -460,11 +460,11 @@ export const CLI_AGENT_SURFACE_MANIFEST = [
     binary: "openclaw",
     packageExport: "OpenClawAgent",
     defaultOutputFormat: "json",
-    docsUrls: ["https://docs.openclaw.ai/concepts/messages"],
+    docsUrls: ["https://docs.openclaw.ai/cli/agent"],
     emittedFlags: [
       "agent",
       "--agent",
-      "--session",
+      "--session-id",
       "--continue",
       "--workspace",
       "--json",
@@ -474,14 +474,15 @@ export const CLI_AGENT_SURFACE_MANIFEST = [
     unsupportedFlags: [],
     optionMappings: [
       { option: "agent", flag: "--agent" },
-      { option: "session", flag: "--session" },
-      { option: "resumeSession", flag: "--session" },
+      { option: "sessionId", flag: "--session-id" },
+      { option: "session", flag: "--session-id" },
+      { option: "resumeSession", flag: "--session-id" },
       { option: "workspace", flag: "--workspace" },
     ],
     resume: {
       kind: "flag",
-      emitted: ["--session"],
-      notes: "Smithers sends prompts through `openclaw agent --session <id>` when a session id is supplied.",
+      emitted: ["--session-id"],
+      notes: "Smithers sends prompts through `openclaw agent --session-id <id>` when a session id is supplied.",
     },
   },
 ];

--- a/packages/agents/tests/openclaw-support.test.js
+++ b/packages/agents/tests/openclaw-support.test.js
@@ -64,7 +64,7 @@ describe("OpenClaw CLI agent", () => {
     }
   });
 
-  test("OpenClawAgent maps resumeSession to --session", async () => {
+  test("OpenClawAgent maps resumeSession to --session-id", async () => {
     const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-openclaw-args-"));
     const argsFile = join(argsFileDir, "args.json");
     const fake = await makeFakeOpenClaw(captureScript);
@@ -80,7 +80,8 @@ describe("OpenClaw CLI agent", () => {
         resumeSession: "run-session",
       });
       const capturedArgs = JSON.parse(await readFile(argsFile, "utf8"));
-      expect(capturedArgs).toContain("--session");
+      expect(capturedArgs).toContain("--session-id");
+      expect(capturedArgs).not.toContain("--session");
       expect(capturedArgs).toContain("run-session");
       expect(capturedArgs).not.toContain("configured");
     } finally {
@@ -98,6 +99,32 @@ describe("OpenClaw CLI agent", () => {
         messages: [{ role: "user", content: "do work" }],
       });
       expect(result.text).toBe("openclaw finished");
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
+  });
+
+  test("OpenClawAgent reads payload text and session metadata from JSON output", async () => {
+    const fake = await makeFakeOpenClaw(
+      `process.stdout.write(JSON.stringify({ payloads: [{ text: "report ready" }], meta: { sessionId: "openclaw-session" } }) + "\\n");`,
+    );
+    try {
+      process.env.PATH = prependPath(fake.dir, originalPath);
+      const events = [];
+      const agent = new OpenClawAgent({ env: { PATH: process.env.PATH } });
+      const result = await agent.generate({
+        messages: [{ role: "user", content: "do work" }],
+        onEvent: (event) => events.push(event),
+      });
+      expect(result.text).toBe("report ready");
+      expect(events).toContainEqual({
+        type: "completed",
+        engine: "openclaw",
+        ok: true,
+        answer: "report ready",
+        resume: "openclaw-session",
+        error: undefined,
+      });
     } finally {
       await rm(fake.dir, { recursive: true, force: true });
     }

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -11760,7 +11760,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -11769,6 +11769,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -3517,7 +3517,7 @@ function checkCliAgentDocsMatchCurrentModelDefaults() {
     [CLI_AGENTS_INTEGRATION, "AmpAgent,amp,CLI default,thread id"],
     [CLI_AGENTS_INTEGRATION, "VibeAgent,vibe,CLI default,headless session id"],
     [CLI_AGENTS_INTEGRATION, "OpenCodeAgent,opencode,CLI default,not yet"],
-    [CLI_AGENTS_INTEGRATION, "OpenClawAgent,openclaw,CLI default,not yet"],
+    [CLI_AGENTS_INTEGRATION, "OpenClawAgent,openclaw,CLI default,session id"],
     [CLI_AGENT_DETECTION_SOURCE, 'id: "vibe"'],
     [CLI_AGENT_DETECTION_SOURCE, 'id: "openclaw"'],
     [CLI_AGENT_AVAILABILITY_TYPE, '"vibe"'],

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -11760,7 +11760,7 @@ agents[12]{class,cli,modelDefault,hijack,notes}:
   AmpAgent,amp,CLI default,thread id,Amp CLI (--execute headless mode)
   VibeAgent,vibe,CLI default,headless session id,Mistral Vibe CLI
   OpenCodeAgent,opencode,CLI default,not yet,OpenCode CLI (opencode run --format json)
-  OpenClawAgent,openclaw,CLI default,not yet,OpenClaw gateway-backed agent CLI (openclaw agent --message)
+  OpenClawAgent,openclaw,CLI default,session id,OpenClaw CLI (openclaw agent --json)
 ```
 
 CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`, `forge`, `hermes`, `amp`, `vibe`, `opencode`, `openclaw`.
@@ -11769,6 +11769,11 @@ CLI binaries must be on `PATH`: `claude`, `codex`, `agy`, `gemini`, `pi`, `kimi`
 which talks to the Hermes *model* over an OpenAI-compatible HTTP API. Use
 `HermesCliAgent` to delegate a task to the Hermes coding agent itself; use
 `HermesAgent` to call a Hermes model endpoint.
+
+`OpenClawAgent` drives `openclaw agent` in JSON mode. Pass `agent` for a named
+OpenClaw agent, `sessionId` to resume a session with `--session-id`, `workspace`
+to set the workspace path, and `continueSession` when the installed CLI should
+continue its active session.
 
 ## Codex CLI Agent
 


### PR DESCRIPTION
## Summary
- emit OpenClaw's documented `--session-id` flag while preserving existing session aliases, and carry session metadata through started/completed events
- expose OpenClaw consistently across CLI detection, docs, generated declarations, and packaged plugin wiring
- keep generated docs/declarations current on the latest main branch
- stabilize Open Code Review deleted-file preview handling and gateway stderr readiness tests that gate this branch in CI

## Tests
- `pnpm check:deps`
- `pnpm check:docs`
- `pnpm check:llms`
- `bun test packages/agents/tests/openclaw-support.test.js packages/agents/tests/cli-capabilities.test.js packages/agents/tests/capability-registry.test.js apps/cli/tests/init-agents.e2e.test.js apps/cli/tests/cli-agent-detection.test.js apps/cli/tests/fuzzy-select.test.js apps/cli/tests/agent-wiring.test.js`
- `bun test apps/cli/tests/gateway-command.test.js`
- `pnpm --filter @smithers-orchestrator/agents test`
- `pnpm --filter @smithers-orchestrator/agents typecheck`
- `pnpm --filter @smithers-orchestrator/components test`
- `pnpm --filter smithers-orchestrator test`
- `pnpm --filter smithers-orchestrator typecheck`
- `pnpm --filter @smithers-orchestrator/cli test`
- `pnpm --filter @smithers-orchestrator/cli typecheck`
- `pnpm --dir .smithers test`
- `pnpm --dir .smithers typecheck`
- `pnpm lint`
- `pnpm typecheck`