### PR TITLE
fix(cli): repair approval recovery and checks

### DIFF
--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -1361,6 +1361,137 @@ function buildPsCtaCommands(rows) {
     }
     return ctaCommands;
 }
+
+// Run statuses on which `approve`/`deny` may still resolve a gate. `failed` is
+// included so an operator can approve a still-waiting gate before `up --resume`
+// recovery (approveNode never checks run status); only the truly terminal
+// statuses (finished/cancelled/continued) are rejected as RUN_NOT_ACTIVE.
+const ACTIVE_APPROVAL_RUN_STATUSES = new Set([
+    "running",
+    "waiting-approval",
+    "waiting-event",
+    "waiting-timer",
+    "failed",
+]);
+const WAITING_APPROVAL_NODE_STATES = new Set(["waiting-approval", "waiting_approval"]);
+
+/**
+ * @param {string} nodeId
+ * @param {number | null | undefined} iteration
+ * @returns {string}
+ */
+function approvalTargetKey(nodeId, iteration) {
+    return `${nodeId} ${iteration ?? 0}`;
+}
+
+/**
+ * @param {Array<{ nodeId: string; iteration?: number | null }>} targets
+ * @returns {string}
+ */
+function formatApprovalTargetList(targets) {
+    return targets.map((target) => `  ${target.nodeId} (iteration ${target.iteration ?? 0})`).join("\n");
+}
+
+/**
+ * @param {SmithersDb} adapter
+ * @param {string} runId
+ * @param {{ node?: string; iteration?: number }} options
+ * @returns {Promise<
+ *   | { ok: true; nodeId: string; iteration: number }
+ *   | { ok: false; code: string; message: string; exitCode: number }
+ * >}
+ */
+async function resolveApprovalCommandTarget(adapter, runId, options) {
+    const run = await adapter.getRun(runId);
+    if (!run) {
+        return {
+            ok: false,
+            code: "RUN_NOT_FOUND",
+            message: `Run not found: ${runId}`,
+            exitCode: 4,
+        };
+    }
+    const runStatus = String(run.status ?? "unknown");
+    if (!ACTIVE_APPROVAL_RUN_STATUSES.has(runStatus)) {
+        return {
+            ok: false,
+            code: "RUN_NOT_ACTIVE",
+            message: `Run is not active (status: ${runStatus})`,
+            exitCode: 4,
+        };
+    }
+
+    const matchesTarget = (target) => {
+        if (options.node && target.nodeId !== options.node)
+            return false;
+        if (options.iteration != null && (target.iteration ?? 0) !== options.iteration)
+            return false;
+        return true;
+    };
+
+    const pending = (await adapter.listPendingApprovals(runId)).filter(matchesTarget);
+    if (pending.length === 1) {
+        const target = pending[0];
+        return {
+            ok: true,
+            nodeId: target.nodeId,
+            iteration: target.iteration ?? 0,
+        };
+    }
+    if (pending.length > 1) {
+        return {
+            ok: false,
+            code: "AMBIGUOUS_APPROVAL",
+            message: `Multiple pending approvals. Specify --node:\n${formatApprovalTargetList(pending)}`,
+            exitCode: 4,
+        };
+    }
+
+    const waitingNodesRaw = (await adapter.listNodes(runId))
+        .filter((node) => WAITING_APPROVAL_NODE_STATES.has(String(node.state ?? "")))
+        .filter(matchesTarget);
+    // A node can sit in `waiting-approval` with an already-decided approval row
+    // when the real blocker is a pending human request (the deferred-state
+    // bridge re-parks such nodes). Approving there would report a bogus success
+    // and the bridge would just re-park it, so exclude decided rows and point
+    // the operator at `smithers human` instead.
+    const decidedApprovalKeys = new Set((await adapter.listAllDecidedApprovals(runId)).map((approval) => approvalTargetKey(approval.nodeId, approval.iteration)));
+    const waitingNodes = waitingNodesRaw.filter((node) => !decidedApprovalKeys.has(approvalTargetKey(node.nodeId, node.iteration)));
+    if (waitingNodes.length === 1) {
+        const target = waitingNodes[0];
+        return {
+            ok: true,
+            nodeId: target.nodeId,
+            iteration: target.iteration ?? 0,
+        };
+    }
+    if (waitingNodes.length > 1) {
+        return {
+            ok: false,
+            code: "AMBIGUOUS_APPROVAL",
+            message: `Multiple waiting approval nodes. Specify --node:\n${formatApprovalTargetList(waitingNodes)}`,
+            exitCode: 4,
+        };
+    }
+    if (waitingNodesRaw.length > 0) {
+        const target = waitingNodesRaw[0];
+        return {
+            ok: false,
+            code: "APPROVAL_ALREADY_DECIDED",
+            message: `Approval for node ${target.nodeId} (iteration ${target.iteration ?? 0}) is already decided; the gate is waiting on a human request. Resolve it with: smithers human inbox (then smithers human answer <requestId> --value <json>)`,
+            exitCode: 4,
+        };
+    }
+    return {
+        ok: false,
+        code: "NO_PENDING_APPROVALS",
+        message: options.node
+            ? `No pending approval matched node ${options.node} for run: ${runId}`
+            : `No pending approvals for run: ${runId}`,
+        exitCode: 4,
+    };
+}
+
 /**
  * @param {SmithersDb} adapter
  * @param {string} runId
@@ -6442,30 +6573,11 @@ const cli = Cli.create({
         try {
             const { adapter, cleanup } = await findAndOpenDb();
             try {
-                const pending = await adapter.listPendingApprovals(c.args.runId);
-                if (pending.length === 0) {
-                    return fail({ code: "NO_PENDING_APPROVALS", message: `No pending approvals for run: ${c.args.runId}`, exitCode: 4 });
+                const target = await resolveApprovalCommandTarget(adapter, c.args.runId, c.options);
+                if (!target.ok) {
+                    return fail(target);
                 }
-                let nodeId = c.options.node;
-                let target;
-                if (!nodeId) {
-                    if (pending.length > 1) {
-                        const nodeList = pending.map((a) => `  ${a.nodeId} (iteration ${a.iteration})`).join("\n");
-                        return fail({
-                            code: "AMBIGUOUS_APPROVAL",
-                            message: `Multiple pending approvals. Specify --node:\n${nodeList}`,
-                            exitCode: 4,
-                        });
-                    }
-                    target = pending[0];
-                    nodeId = target.nodeId;
-                }
-                else {
-                    target = pending.find((a) => a.nodeId === nodeId);
-                }
-                // Default to the actual iteration of the pending gate so approvals
-                // inside loops (iteration > 0) work without --iteration.
-                const iteration = c.options.iteration ?? target?.iteration ?? 0;
+                const { nodeId, iteration } = target;
                 await Effect.runPromise(approveNode(adapter, c.args.runId, nodeId, iteration, c.options.note, c.options.by));
                 const runAfterApproval = await adapter.getRun(c.args.runId);
                 const isDetached = !runAfterApproval ||
@@ -6594,30 +6706,11 @@ const cli = Cli.create({
         try {
             const { adapter, cleanup } = await findAndOpenDb();
             try {
-                const pending = await adapter.listPendingApprovals(c.args.runId);
-                if (pending.length === 0) {
-                    return fail({ code: "NO_PENDING_APPROVALS", message: `No pending approvals for run: ${c.args.runId}`, exitCode: 4 });
+                const target = await resolveApprovalCommandTarget(adapter, c.args.runId, c.options);
+                if (!target.ok) {
+                    return fail(target);
                 }
-                let nodeId = c.options.node;
-                let target;
-                if (!nodeId) {
-                    if (pending.length > 1) {
-                        const nodeList = pending.map((a) => `  ${a.nodeId} (iteration ${a.iteration})`).join("\n");
-                        return fail({
-                            code: "AMBIGUOUS_APPROVAL",
-                            message: `Multiple pending approvals. Specify --node:\n${nodeList}`,
-                            exitCode: 4,
-                        });
-                    }
-                    target = pending[0];
-                    nodeId = target.nodeId;
-                }
-                else {
-                    target = pending.find((a) => a.nodeId === nodeId);
-                }
-                // Default to the actual iteration of the pending gate so denials
-                // inside loops (iteration > 0) work without --iteration.
-                const iteration = c.options.iteration ?? target?.iteration ?? 0;
+                const { nodeId, iteration } = target;
                 await Effect.runPromise(denyNode(adapter, c.args.runId, nodeId, iteration, c.options.note, c.options.by));
                 return c.ok({ runId: c.args.runId, nodeId, status: "denied" }, {
                     cta: {

--- a/apps/cli/src/why-diagnosis.js
+++ b/apps/cli/src/why-diagnosis.js
@@ -13,6 +13,7 @@ import { formatAge } from "./format.js";
 
 const RECENT_EVENTS_LIMIT = 50;
 const MAX_CTA_COMMANDS = 5;
+const WAITING_APPROVAL_STATES = new Set(["waiting-approval", "waiting_approval"]);
 /**
  * @param {string} nodeId
  * @param {number} iteration
@@ -587,6 +588,21 @@ function buildDiagnosis(params) {
     const status = run.status === "continued" && run.finishedAtMs == null
         ? "running"
         : String(run.status ?? "unknown");
+    if (status === "finished" || status === "cancelled") {
+        const summary = status === "finished"
+            ? "Run is finished, nothing is blocked."
+            : typeof run.finishedAtMs === "number"
+                ? `Run was cancelled at ${new Date(run.finishedAtMs).toISOString()}.`
+                : "Run was cancelled.";
+        return {
+            runId,
+            status,
+            summary,
+            generatedAtMs: nowMs,
+            blockers: [],
+            currentNodeId: firstCurrentNode(nodes),
+        };
+    }
     const descriptorMetadata = parseFrameDescriptorMetadata(lastFrame?.xmlJson);
     const parsedEvents = events.map((row) => ({
         row,
@@ -651,6 +667,40 @@ function buildDiagnosis(params) {
             waitingSince,
             unblocker: approvals.length > 1
                 ? `smithers approve ${runId} --node ${approval.nodeId} --iteration ${approval.iteration ?? 0}`
+                : `smithers approve ${runId}`,
+            context: contextParts.join("\n\n"),
+            ...(retryInsight
+                ? {
+                    attempt: retryInsight.failedCount,
+                    maxAttempts: retryInsight.maxAttempts,
+                }
+                : {}),
+        });
+    }
+    const requestedApprovalKeys = new Set(approvals
+        .filter((approval) => approval.status === "requested")
+        .map((approval) => nodeKey(approval.nodeId, approval.iteration ?? 0)));
+    const waitingApprovalNodesWithoutRequests = nodes.filter((node) => WAITING_APPROVAL_STATES.has(String(node.state ?? "")) &&
+        !requestedApprovalKeys.has(nodeKey(node.nodeId, node.iteration ?? 0)));
+    const totalWaitingApprovalTargets = approvals.filter((approval) => approval.status === "requested").length +
+        waitingApprovalNodesWithoutRequests.length;
+    for (const node of waitingApprovalNodesWithoutRequests) {
+        const iteration = node.iteration ?? 0;
+        const retryInsight = retryInsightsByNode.get(nodeKey(node.nodeId, iteration));
+        const contextParts = [];
+        if (retryInsight && !retryInsight.exhausted) {
+            contextParts.push(describeRetryContext(retryInsight, nowMs));
+        }
+        contextParts.push("No approval request row is recorded for this gate; approve or deny can resolve the waiting node directly.");
+        contextParts.push(`Deny instead: smithers deny ${runId} --node ${node.nodeId} --iteration ${iteration}`);
+        blockers.push({
+            kind: "waiting-approval",
+            nodeId: node.nodeId,
+            iteration,
+            reason: "Approval node is waiting, but no approval request row was recorded",
+            waitingSince: waitingSinceFallback(nowMs, node.updatedAtMs, run.startedAtMs, run.createdAtMs),
+            unblocker: totalWaitingApprovalTargets > 1
+                ? `smithers approve ${runId} --node ${node.nodeId} --iteration ${iteration}`
                 : `smithers approve ${runId}`,
             context: contextParts.join("\n\n"),
             ...(retryInsight

--- a/apps/cli/tests/approval-command.test.js
+++ b/apps/cli/tests/approval-command.test.js
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { createTempRepo, pinSqliteBackend, runSmithers } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+/**
+ * @param {ReturnType<typeof createTempRepo>} repo
+ */
+function openRepoDb(repo) {
+    pinSqliteBackend(repo.dir);
+    const sqlite = new Database(repo.path("smithers.db"));
+    const db = drizzle(sqlite);
+    ensureSmithersTables(db);
+    return {
+        sqlite,
+        adapter: new SmithersDb(db),
+    };
+}
+
+async function insertApprovalRun(adapter, runId, status = "waiting-approval") {
+    const now = Date.now();
+    await adapter.insertRun({
+        runId,
+        workflowName: "approval-command",
+        workflowPath: "workflow.tsx",
+        status,
+        createdAtMs: now - 10_000,
+        startedAtMs: now - 9_000,
+        finishedAtMs: status === "cancelled" ? now - 1_000 : null,
+        heartbeatAtMs: status === "running" ? now : null,
+    });
+    await adapter.insertNode({
+        runId,
+        nodeId: "gate",
+        iteration: 0,
+        state: "waiting-approval",
+        lastAttempt: 1,
+        updatedAtMs: now - 5_000,
+        outputTable: "approval_output",
+        label: "Approval gate",
+    });
+}
+
+async function insertApprovalRow(adapter, runId, overrides = {}) {
+    const now = Date.now();
+    await adapter.insertOrUpdateApproval({
+        runId,
+        nodeId: "gate",
+        iteration: 0,
+        status: "requested",
+        requestedAtMs: now - 6_000,
+        decidedAtMs: null,
+        note: null,
+        decidedBy: null,
+        requestJson: null,
+        decisionJson: null,
+        autoApproved: false,
+        ...overrides,
+    });
+}
+
+describe("smithers approval commands", () => {
+    test("approve resolves a waiting approval node when the request row is missing", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertApprovalRun(adapter, "missing-row-approve");
+
+            const result = runSmithers(["approve", "missing-row-approve", "--node", "gate", "--by", "tester"], {
+                cwd: repo.dir,
+                format: "json",
+            });
+
+            expect(result.exitCode).toBe(0);
+            const approval = await adapter.getApproval("missing-row-approve", "gate", 0);
+            const node = await adapter.getNode("missing-row-approve", "gate", 0);
+            const run = await adapter.getRun("missing-row-approve");
+            expect(approval).toMatchObject({
+                status: "approved",
+                decidedBy: "tester",
+                requestedAtMs: null,
+            });
+            expect(node?.state).toBe("pending");
+            expect(run?.status).toBe("waiting-event");
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("deny resolves a waiting approval node when the request row is missing", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertApprovalRun(adapter, "missing-row-deny");
+
+            const result = runSmithers(["deny", "missing-row-deny", "--node", "gate", "--by", "tester"], {
+                cwd: repo.dir,
+                format: "json",
+            });
+
+            expect(result.exitCode).toBe(0);
+            const approval = await adapter.getApproval("missing-row-deny", "gate", 0);
+            const node = await adapter.getNode("missing-row-deny", "gate", 0);
+            const run = await adapter.getRun("missing-row-deny");
+            expect(approval).toMatchObject({
+                status: "denied",
+                decidedBy: "tester",
+                requestedAtMs: null,
+            });
+            expect(node?.state).toBe("failed");
+            expect(run?.status).toBe("waiting-event");
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("approve rejects terminal runs even when a stale waiting node remains", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertApprovalRun(adapter, "cancelled-approval", "cancelled");
+
+            const result = runSmithers(["approve", "cancelled-approval", "--node", "gate"], {
+                cwd: repo.dir,
+                format: "json",
+            });
+
+            expect(result.exitCode).toBe(4);
+            expect(`${result.stdout}\n${result.stderr}`).toContain("RUN_NOT_ACTIVE");
+            expect(await adapter.getApproval("cancelled-approval", "gate", 0)).toBeUndefined();
+            expect((await adapter.getNode("cancelled-approval", "gate", 0))?.state).toBe("waiting-approval");
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("approve recovers a still-requested gate on a failed run before resume", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertApprovalRun(adapter, "failed-approve", "failed");
+            await insertApprovalRow(adapter, "failed-approve");
+
+            const result = runSmithers(["approve", "failed-approve", "--by", "tester"], {
+                cwd: repo.dir,
+                format: "json",
+            });
+
+            expect(result.exitCode).toBe(0);
+            expect((await adapter.getApproval("failed-approve", "gate", 0))?.status).toBe("approved");
+            expect((await adapter.getNode("failed-approve", "gate", 0))?.state).toBe("pending");
+            // approveNode does not resurrect a failed run; it stays failed until `up --resume`.
+            expect((await adapter.getRun("failed-approve"))?.status).toBe("failed");
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+
+    test("approve refuses a gate whose approval is already decided (human request pending)", async () => {
+        const repo = createTempRepo();
+        const { sqlite, adapter } = openRepoDb(repo);
+        try {
+            await insertApprovalRun(adapter, "decided-approve");
+            await insertApprovalRow(adapter, "decided-approve", {
+                status: "approved",
+                requestedAtMs: null,
+                decidedAtMs: Date.now() - 4_000,
+                decidedBy: "someone",
+            });
+
+            const result = runSmithers(["approve", "decided-approve", "--node", "gate"], {
+                cwd: repo.dir,
+                format: "json",
+            });
+
+            expect(result.exitCode).toBe(4);
+            expect(`${result.stdout}\n${result.stderr}`).toContain("APPROVAL_ALREADY_DECIDED");
+            // The already-decided approval and the waiting node are left untouched.
+            expect((await adapter.getApproval("decided-approve", "gate", 0))?.status).toBe("approved");
+            expect((await adapter.getNode("decided-approve", "gate", 0))?.state).toBe("waiting-approval");
+        }
+        finally {
+            sqlite.close();
+        }
+    });
+});

--- a/apps/cli/tests/why-diagnosis-unit.test.js
+++ b/apps/cli/tests/why-diagnosis-unit.test.js
@@ -642,7 +642,21 @@ describe("why diagnosis unit coverage", () => {
                 finishedAtMs: NOW - 1_000,
                 heartbeatAtMs: null,
             }),
+            nodes: [
+                nodeRow({
+                    nodeId: "stale-finished-gate",
+                    state: "waiting-approval",
+                    updatedAtMs: NOW - 5_000,
+                }),
+            ],
+            approvals: [
+                approvalRow({
+                    nodeId: "stale-finished-gate",
+                    requestedAtMs: NOW - 5_000,
+                }),
+            ],
         }));
+        expect(finished.blockers).toEqual([]);
         expect(renderWhyDiagnosisHuman(finished)).toBe("Run is finished, nothing is blocked.");
 
         const cancelled = await diagnose(makeAdapter({
@@ -651,9 +665,27 @@ describe("why diagnosis unit coverage", () => {
                 finishedAtMs: null,
                 heartbeatAtMs: null,
             }),
+            nodes: [
+                nodeRow({
+                    nodeId: "stale-cancelled-gate",
+                    state: "waiting-approval",
+                    updatedAtMs: NOW - 5_000,
+                }),
+            ],
+            approvals: [
+                approvalRow({
+                    nodeId: "stale-cancelled-gate",
+                    requestedAtMs: NOW - 5_000,
+                }),
+            ],
         }));
         expect(cancelled.summary).toBe("Run was cancelled.");
+        expect(cancelled.blockers).toEqual([]);
         expect(renderWhyDiagnosisHuman(cancelled)).toBe("Run was cancelled.");
+        expect(diagnosisCtaCommands(cancelled).map((entry) => entry.command)).toEqual([
+            "inspect diag-run",
+            "logs diag-run",
+        ]);
 
         const healthy = await diagnose(makeAdapter({
             nodes: [
@@ -686,6 +718,35 @@ describe("why diagnosis unit coverage", () => {
         }));
         expect(unknown.summary).toBe("Run is unknown. No blockers were identified.");
         expect(renderWhyDiagnosisHuman(unknown)).toContain("No blockers were identified.");
+    });
+
+    test("reports waiting approval nodes that are missing approval request rows", async () => {
+        const diagnosis = await diagnose(makeAdapter({
+            run: runRow({
+                status: "waiting-approval",
+                heartbeatAtMs: null,
+            }),
+            nodes: [
+                nodeRow({
+                    nodeId: "mounted-gate",
+                    state: "waiting-approval",
+                    updatedAtMs: NOW - 12_000,
+                }),
+            ],
+            approvals: [],
+        }));
+
+        expect(diagnosis.blockers).toHaveLength(1);
+        expect(diagnosis.blockers[0]).toMatchObject({
+            kind: "waiting-approval",
+            nodeId: "mounted-gate",
+            iteration: 0,
+            reason: "Approval node is waiting, but no approval request row was recorded",
+            unblocker: "smithers approve diag-run",
+        });
+        expect(diagnosis.blockers[0]?.context).toContain("No approval request row is recorded");
+        expect(diagnosis.blockers[0]?.context).toContain("smithers deny diag-run --node mounted-gate --iteration 0");
+        expect(renderWhyDiagnosisHuman(diagnosis)).toContain("Approval node is waiting");
     });
 
     test("reports stale continued runs without a heartbeat", async () => {


### PR DESCRIPTION
## Summary
- let approve/deny resolve waiting approval nodes when the approval request row is missing
- keep `why` from reporting stale approval blockers on finished or cancelled runs
- fix `.smithers` Open Code Review handling for empty deleted files and token telemetry expectations
- repair CLI pre-submit drift: fuzzy-select backspace handling, gateway startup test readiness, OpenClaw plugin runtime packaging, `.smithers` test deps, and package docs

## Tests
- bun test apps/cli/tests/approval-command.test.js apps/cli/tests/why-diagnosis-unit.test.js apps/cli/tests/why-command.test.js apps/cli/tests/fuzzy-select.test.js apps/cli/tests/docs-public-surface-coverage.test.js
- bun test apps/cli/tests/gateway-command.test.js apps/cli/tests/agent-wiring.test.js
- bun test packages/engine/tests/engine-approvals.test.js packages/engine/tests/approvals-internals.test.js
- pnpm check:deps
- pnpm check:docs
- pnpm check:llms
- pnpm --filter @smithers-orchestrator/cli typecheck
- pnpm --filter smithers-workflows typecheck
- pnpm --filter @smithers-orchestrator/cli test
- pnpm --dir .smithers test
- pnpm --dir .smithers typecheck
- node scripts/run-workspace-tests.mjs --shard 3/4 --timeout-minutes 5 --exclude apps/cli,apps/review,packages/accounts,packages/agents,packages/db,packages/engine,packages/sandbox,packages/server,packages/smithers
- pnpm lint
- pnpm typecheck