### PR TITLE
fix(engine): fail timer wake resume mismatches

### DIFF
--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -1865,6 +1865,55 @@ function assertResumeDurabilityMetadata(existingRun, existingConfig, current, wo
     }
 }
 /**
+ * Claim-owner prefix the supervisor stamps on runs it resumes:
+ * apps/cli/src/supervisor.js builds `supervisor:<supervisorId>` when it claims a
+ * run for an unattended resume. The engine keys "unattended timer wake"
+ * detection off this cross-package contract, so keep the two in sync.
+ */
+const SUPERVISOR_CLAIM_OWNER_PREFIX = "supervisor:";
+/**
+ * An unattended timer wake (the supervisor sweeping a due `waiting-timer` run)
+ * that hits a resume-durability mismatch must fail the run instead of leaving it
+ * parked forever while the sweep retries silently. Interactive `--resume`
+ * mismatches still throw without failing the run.
+ *
+ * @param {RunRow | null | undefined} existingRun
+ * @param {RunOptions} opts
+ * @returns {boolean}
+ */
+function shouldFailTimerWakeResume(existingRun, opts) {
+    if (existingRun?.status !== "waiting-timer")
+        return false;
+    return opts.resumeClaim?.claimOwnerId?.startsWith(SUPERVISOR_CLAIM_OWNER_PREFIX) === true;
+}
+/**
+ * @param {SmithersDb} adapter
+ * @param {EventBus} eventBus
+ * @param {string} runId
+ * @param {unknown} error
+ */
+async function markTimerWakeResumeFailed(adapter, eventBus, runId, error) {
+    const errorInfo = errorToJson(error);
+    await cancelPendingTimers(adapter, runId, eventBus, "run-failed");
+    const failedAtMs = nowMs();
+    await Effect.runPromise(adapter.updateRun(runId, {
+        status: "failed",
+        finishedAtMs: failedAtMs,
+        heartbeatAtMs: null,
+        runtimeOwnerId: null,
+        cancelRequestedAtMs: null,
+        hijackRequestedAtMs: null,
+        hijackTarget: null,
+        errorJson: JSON.stringify(errorInfo),
+    }));
+    await Effect.runPromise(eventBus.emitEventWithPersist({
+        type: "RunFailed",
+        runId,
+        error: errorInfo,
+        timestampMs: failedAtMs,
+    }));
+}
+/**
  * @param {AbortController} controller
  * @param {AbortSignal} [signal]
  */
@@ -5629,7 +5678,22 @@ async function runWorkflowBodyDriver(workflow, opts) {
             },
         });
         if (opts.resume && existingRun) {
-            assertResumeDurabilityMetadata(existingRun, existingConfig, runMetadata, resolvedWorkflowPath);
+            try {
+                assertResumeDurabilityMetadata(existingRun, existingConfig, runMetadata, resolvedWorkflowPath);
+            }
+            catch (error) {
+                if (shouldFailTimerWakeResume(existingRun, opts)) {
+                    try {
+                        await markTimerWakeResumeFailed(adapter, eventBus, runId, error);
+                    }
+                    catch {
+                        // If persisting the failed status itself fails (e.g. a
+                        // transient DB error), still surface the original mismatch
+                        // rather than swallowing it behind the write error.
+                    }
+                }
+                throw error;
+            }
         }
         else if (opts.resume && !existingRun) {
             throw new SmithersError("RUN_NOT_FOUND", `Cannot resume run ${runId} because it does not exist.`, { runId });

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -1872,10 +1872,25 @@ function assertResumeDurabilityMetadata(existingRun, existingConfig, current, wo
  */
 const SUPERVISOR_CLAIM_OWNER_PREFIX = "supervisor:";
 /**
- * An unattended timer wake (the supervisor sweeping a due `waiting-timer` run)
- * that hits a resume-durability mismatch must fail the run instead of leaving it
- * parked forever while the sweep retries silently. Interactive `--resume`
- * mismatches still throw without failing the run.
+ * `triggeredBy` the gateway stamps on its default-active timer sweep:
+ * packages/server/src/gateway.js `processDueTimers` resumes each due
+ * `waiting-timer` run through `resumeRunIfNeeded` -> `startRun`, which surfaces
+ * this marker as `config.gatewayTriggeredBy`. That sweep carries no
+ * `resumeClaim`, so the engine keys "unattended timer wake" detection off this
+ * cross-package contract too — keep the two in sync.
+ */
+const GATEWAY_TIMER_TRIGGERED_BY = "timer:gateway";
+/**
+ * An unattended timer wake that hits a resume-durability mismatch must fail the
+ * run instead of leaving it parked forever while the waker retries silently.
+ * Two default-active wakers reach this path on a source-changed run:
+ *   - the supervisor sweep (apps/cli/src/supervisor.js), which claims the run and
+ *     resumes it with a `supervisor:<id>` `resumeClaim.claimOwnerId`; and
+ *   - the gateway timer sweep (packages/server/src/gateway.js `processDueTimers`),
+ *     which resumes with no `resumeClaim` but `config.gatewayTriggeredBy ===
+ *     "timer:gateway"` and whose `startRun.catch` only broadcasts a transient
+ *     failed event without persisting `status: failed` (issue #494).
+ * Interactive `--resume` mismatches still throw without failing the run.
  *
  * @param {RunRow | null | undefined} existingRun
  * @param {RunOptions} opts
@@ -1884,7 +1899,9 @@ const SUPERVISOR_CLAIM_OWNER_PREFIX = "supervisor:";
 function shouldFailTimerWakeResume(existingRun, opts) {
     if (existingRun?.status !== "waiting-timer")
         return false;
-    return opts.resumeClaim?.claimOwnerId?.startsWith(SUPERVISOR_CLAIM_OWNER_PREFIX) === true;
+    if (opts.resumeClaim?.claimOwnerId?.startsWith(SUPERVISOR_CLAIM_OWNER_PREFIX) === true)
+        return true;
+    return opts.config?.gatewayTriggeredBy === GATEWAY_TIMER_TRIGGERED_BY;
 }
 /**
  * @param {SmithersDb} adapter

--- a/packages/engine/tests/durability.test.jsx
+++ b/packages/engine/tests/durability.test.jsx
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { EventBus } from "../src/events.js";
-import { runWorkflow, Task, Workflow } from "smithers-orchestrator";
+import { runWorkflow, Task, Timer, Workflow } from "smithers-orchestrator";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
 import { nowMs } from "@smithers-orchestrator/scheduler/nowMs";
@@ -189,6 +189,63 @@ describe("Durability", () => {
         const adapter = new SmithersDb(db);
         const run = await adapter.getRun(runId);
         expect(run?.status).toBe("finished");
+        rmSync(dir, { recursive: true, force: true });
+        cleanup();
+    });
+    test("supervised timer resume mismatch fails the parked run", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-timer-resume-metadata-"));
+        const workflowPath = join(dir, "workflow.tsx");
+        writeFileSync(workflowPath, "export default 'v1';\n", "utf8");
+        const { smithers, db, cleanup } = createTestSmithers(outputSchemas);
+        const adapter = new SmithersDb(db);
+        const runId = "timer-resume-metadata";
+        const workflow = smithers(() => (<Workflow name="timer-resume-metadata">
+        <Timer id="hold" duration="1h"/>
+      </Workflow>));
+        const first = await Effect.runPromise(runWorkflow(workflow, {
+            input: {},
+            runId,
+            workflowPath,
+        }));
+        expect(first.status).toBe("waiting-timer");
+        const claimOwnerId = "supervisor:timer-test";
+        const claimHeartbeatAtMs = nowMs();
+        const claimed = await adapter.claimRunForResume({
+            runId,
+            expectedStatus: "waiting-timer",
+            expectedRuntimeOwnerId: null,
+            expectedHeartbeatAtMs: null,
+            staleBeforeMs: claimHeartbeatAtMs,
+            claimOwnerId,
+            claimHeartbeatAtMs,
+            requireStale: true,
+        });
+        expect(claimed).toBe(true);
+        writeFileSync(workflowPath, "export default 'v2';\n", "utf8");
+        const resumed = await Effect.runPromise(runWorkflow(workflow, {
+            input: {},
+            runId,
+            resume: true,
+            workflowPath,
+            resumeClaim: {
+                claimOwnerId,
+                claimHeartbeatAtMs,
+                restoreRuntimeOwnerId: null,
+                restoreHeartbeatAtMs: null,
+            },
+        }));
+        expect(resumed.status).toBe("failed");
+        expect(resumed.error?.code).toBe("RESUME_METADATA_MISMATCH");
+        const run = await adapter.getRun(runId);
+        expect(run?.status).toBe("failed");
+        expect(run?.runtimeOwnerId).toBeNull();
+        expect(JSON.parse(run?.errorJson ?? "{}")?.code).toBe("RESUME_METADATA_MISMATCH");
+        const node = await adapter.getNode(runId, "hold", 0);
+        expect(node?.state).toBe("cancelled");
+        const eventTypes = (await adapter.listEvents(runId, -1, 50)).map((event) => event.type);
+        expect(eventTypes).toContain("TimerCancelled");
+        expect(eventTypes).toContain("NodeCancelled");
+        expect(eventTypes).toContain("RunFailed");
         rmSync(dir, { recursive: true, force: true });
         cleanup();
     });

--- a/packages/engine/tests/durability.test.jsx
+++ b/packages/engine/tests/durability.test.jsx
@@ -249,4 +249,48 @@ describe("Durability", () => {
         rmSync(dir, { recursive: true, force: true });
         cleanup();
     });
+    test("gateway timer-sweep resume mismatch fails the parked run", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "smithers-gateway-timer-resume-metadata-"));
+        const workflowPath = join(dir, "workflow.tsx");
+        writeFileSync(workflowPath, "export default 'v1';\n", "utf8");
+        const { smithers, db, cleanup } = createTestSmithers(outputSchemas);
+        const adapter = new SmithersDb(db);
+        const runId = "gateway-timer-resume-metadata";
+        const workflow = smithers(() => (<Workflow name="gateway-timer-resume-metadata">
+        <Timer id="hold" duration="1h"/>
+      </Workflow>));
+        const first = await Effect.runPromise(runWorkflow(workflow, {
+            input: {},
+            runId,
+            workflowPath,
+        }));
+        expect(first.status).toBe("waiting-timer");
+        // The gateway timer sweep (packages/server/src/gateway.js processDueTimers ->
+        // resumeRunIfNeeded -> startRun) resumes with NO resumeClaim, only
+        // config.gatewayTriggeredBy === "timer:gateway". A source change since the
+        // run parked must fail it loudly rather than leave it on `waiting-timer` for
+        // the default-active sweep to re-drive forever (issue #494).
+        writeFileSync(workflowPath, "export default 'v2';\n", "utf8");
+        const resumed = await Effect.runPromise(runWorkflow(workflow, {
+            input: {},
+            runId,
+            resume: true,
+            workflowPath,
+            config: { gatewayTriggeredBy: "timer:gateway" },
+        }));
+        expect(resumed.status).toBe("failed");
+        expect(resumed.error?.code).toBe("RESUME_METADATA_MISMATCH");
+        const run = await adapter.getRun(runId);
+        expect(run?.status).toBe("failed");
+        expect(run?.runtimeOwnerId).toBeNull();
+        expect(JSON.parse(run?.errorJson ?? "{}")?.code).toBe("RESUME_METADATA_MISMATCH");
+        const node = await adapter.getNode(runId, "hold", 0);
+        expect(node?.state).toBe("cancelled");
+        const eventTypes = (await adapter.listEvents(runId, -1, 50)).map((event) => event.type);
+        expect(eventTypes).toContain("TimerCancelled");
+        expect(eventTypes).toContain("NodeCancelled");
+        expect(eventTypes).toContain("RunFailed");
+        rmSync(dir, { recursive: true, force: true });
+        cleanup();
+    });
 });

--- a/packages/server/tests/gateway-timers.test.jsx
+++ b/packages/server/tests/gateway-timers.test.jsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource smithers-orchestrator */
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
+import { sleep } from "../../smithers/tests/helpers.js";
 let createSmithers;
 let Gateway;
 let SmithersDb;
@@ -154,5 +155,40 @@ describe("Gateway timer sweep", () => {
         gateway.activeRuns.set("active-run", { abort: { abort() { } } });
         await gateway.processDueTimers();
         expect(resumed).toEqual([]);
+    });
+    test("fails a due run whose source changed instead of re-sweeping it forever", async () => {
+        const dbPath = makeDbPath("source-changed");
+        dbPaths.push(dbPath);
+        const dir = mkdtempSync(join(tmpdir(), "smithers-gateway-timer-source-"));
+        const entryFile = join(dir, "workflow.tsx");
+        // The workflow source as it stands now: its content hash will not match the
+        // run's recorded durability hash, exactly as when the source changed since
+        // the run parked on its <Timer>.
+        writeFileSync(entryFile, "export default 'v2';\n", "utf8");
+        const { workflow, db } = createTimerHostWorkflow(dbPath);
+        gateway = new Gateway();
+        gateway.register("report", workflow, { entryFile });
+        const adapter = new SmithersDb(db);
+        await seedWaitingTimerRun(adapter, "source-changed-run", "report", Date.now() - 1_000);
+        // Drive the REAL sweep chain (processDueTimers -> resumeRunIfNeeded ->
+        // startRun -> engine runWorkflow), no monkeypatched resume. On the mismatch
+        // the run must be persisted `failed`, not rethrown transiently while the row
+        // stays `waiting-timer` for the next sweep to re-drive forever (issue #494).
+        await gateway.processDueTimers();
+        // startRun resolves before the background resume settles; poll for the row.
+        let run = await adapter.getRun("source-changed-run");
+        for (let i = 0; i < 200 && run?.status === "waiting-timer"; i += 1) {
+            await sleep(25);
+            run = await adapter.getRun("source-changed-run");
+        }
+        expect(run?.status).toBe("failed");
+        expect(JSON.parse(run?.errorJson ?? "{}")?.code).toBe("RESUME_METADATA_MISMATCH");
+        const eventTypes = (await adapter.listEvents("source-changed-run", -1, 50)).map((event) => event.type);
+        expect(eventTypes).toContain("RunFailed");
+        // A second sweep must not resurrect the now-failed run (no silent re-park loop).
+        await gateway.processDueTimers();
+        const after = await adapter.getRun("source-changed-run");
+        expect(after?.status).toBe("failed");
+        rmSync(dir, { recursive: true, force: true });
     });
 });


### PR DESCRIPTION
## Summary
- fail unattended timer wake resumes when durable metadata no longer matches the parked run
- cancel pending timer state before writing the terminal run failure
- add regression coverage for supervisor and Gateway timer wake paths
- normalize fuzzy picker backspace handling and keep selection state separate from readline cursor state
- keep Gateway and Open Code Review tests synchronized with runtime readiness and token telemetry
- ship the OpenClaw plugin runtime entry that the installer copies into the extension

Fixes #494.

## Tests
- bun test packages/engine/tests/durability.test.jsx
- bun test apps/cli/tests/supervisor-core.test.js
- bun test packages/server/tests/gateway-timers.test.jsx
- bun test packages/engine/tests/deferred-contract.test.js
- bun test apps/cli/tests/fuzzy-select.test.js --timeout=120000 --max-concurrency=1
- bun test apps/cli/tests/agent-wiring.test.js apps/cli/tests/gateway-command.test.js apps/cli/tests/fuzzy-select.test.js apps/cli/tests/published-deps-declared.test.js --timeout=120000 --max-concurrency=1
- bun test ./.smithers/tests/open-code-review.test.ts ./.smithers/tests/open-code-review-ui.e2e.test.ts --timeout=120000 --max-concurrency=1
- pnpm typecheck
- pnpm lint
- pnpm test