### PR TITLE
fix(review): verify OIDC PR claims

### DIFF
--- a/.smithers/tests/open-code-review-ui.e2e.test.ts
+++ b/.smithers/tests/open-code-review-ui.e2e.test.ts
@@ -149,7 +149,13 @@ browserTest("Open Code Review UI renders a real workflow run", async () => {
     await page.waitForSelector('[data-testid="ocr-preview-panel"] >> text=src/app.test.ts', { timeout: 20_000 });
     await page.waitForSelector('[data-testid="ocr-preview-panel"] >> text=default_path', { timeout: 20_000 });
     await page.waitForSelector('[data-testid="ocr-comments-panel"] >> text=Guard against null before trimming.', { timeout: 20_000 });
-    expect(await page.locator('[data-testid="ocr-kpi-tokens"]').textContent()).toContain("0");
+    // The tokens KPI is computed from run events, not the seeded fixture summary
+    // (openCodeReviewRunFixture totalTokens: 321) — assert it renders the computed
+    // value and never the raw fixture number. Scope both checks to the KPI element
+    // so an incidental "321" elsewhere (a hash, id, or timestamp) can't flip them.
+    const tokensKpi = await page.locator('[data-testid="ocr-kpi-tokens"]').textContent();
+    expect(tokensKpi).toContain("0");
+    expect(tokensKpi).not.toContain("321");
 
     expect(errors).toEqual([]);
   } finally {

--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -143,6 +143,18 @@ function terminalRows() {
     return process.stdout.rows || 24;
 }
 
+function normalizeQueryInput(value) {
+    const out = [];
+    for (const char of String(value ?? "")) {
+        if (char === "\x7f" || char === "\b") {
+            out.pop();
+        } else {
+            out.push(char);
+        }
+    }
+    return out.join("");
+}
+
 /**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
@@ -173,7 +185,7 @@ class FuzzySelectPrompt extends Prompt {
         // defaults it to false when omitted, so we pass it explicitly. With it
         // the base tracks typed input into `userInput` and emits "cursor" for
         // arrow keys. We intentionally do NOT forward `initialValue`: the base
-        // would type it into the query box. We start the query empty and use
+        // can type it into the query box. We start the query empty and use
         // initialValue only to position the initial cursor (below).
         // `validate` is passed via options because v1 made `opts` private.
         super(
@@ -191,9 +203,9 @@ class FuzzySelectPrompt extends Prompt {
         this.maxItems = opts.maxItems;
         this.query = "";
         this.filtered = fuzzyFilter("", this.allOptions);
+        this.optionCursor = 0;
 
         // Position the cursor on the option matching initialValue (default 0).
-        this.optionCursor = 0;
         if (opts.initialValue !== undefined) {
             const i = this.filtered.findIndex((o) => o.value === opts.initialValue);
             if (i >= 0) this.optionCursor = i;
@@ -202,7 +214,7 @@ class FuzzySelectPrompt extends Prompt {
         // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
         // so the base re-emits "userInput" for both — this covers backspace free.
         this.on("userInput", () => {
-            this.query = this.userInput ?? "";
+            this.query = normalizeQueryInput(this.userInput);
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.optionCursor > this.filtered.length - 1) {
                 this.optionCursor = Math.max(0, this.filtered.length - 1);
@@ -270,7 +282,7 @@ function renderPrompt(self, message) {
             // Collapse to the selected label, dim, no list.
             return `${header}${pc.gray(S_BAR)}  ${pc.dim(selectedLabel ?? "")}`;
         case "cancel": {
-            // Strikethrough the would-be selection (or the query if no match).
+            // Strikethrough the candidate selection (or the query if no match).
             const cancelled = selectedLabel ?? self.query ?? "";
             return `${header}${pc.gray(S_BAR)}  ${pc.strikethrough(pc.dim(cancelled))}\n${pc.gray(S_BAR)}`;
         }

--- a/apps/cli/tests/fuzzy-select.test.js
+++ b/apps/cli/tests/fuzzy-select.test.js
@@ -194,6 +194,27 @@ describe("fuzzySelect (interactive)", () => {
         expect(result).toBe("c");
     });
 
+    test("keeps the TOP match highlighted after a query narrows to several matches", async () => {
+        // Regression: the base Prompt owns `_cursor` and overwrites it with the
+        // readline text-cursor (= query length) on every keystroke. Tracking the
+        // highlighted option in a separate `optionCursor` keeps the top fuzzy
+        // match selected. With the old `_cursor` field, typing an N-char query
+        // landed the highlight on filtered index N (clamped), so Enter here
+        // returned "rebase" (index 1) instead of the top match "review".
+        const { promise, input } = startPicker([
+            { value: "a", label: "review" },
+            { value: "b", label: "rebase" },
+            { value: "c", label: "commit" },
+        ]);
+        // Type "re" → both "review" and "rebase" survive; "review" ranks first.
+        input.keypress("r", { name: "r" });
+        input.keypress("e", { name: "e" });
+        // No arrow movement: the highlight must stay on the top match.
+        input.keypress("\r", { name: "return" });
+        const result = await promise;
+        expect(result).toBe("a");
+    });
+
     test("typing 'j' appends to the query instead of moving the cursor", async () => {
         const { promise, input } = startPicker([
             { value: "x", label: "jot" },
@@ -243,7 +264,7 @@ describe("fuzzySelect (interactive)", () => {
         // Regression for the @clack/core cursor collision: Prompt.onKeypress runs
         // `this._cursor = this.rl?.cursor ?? 0` on every keypress BEFORE emitting
         // "cursor". With an empty query rl.cursor is 0, so a highlight that reused
-        // the base `_cursor` would reset to 0 then +1 on each press and stay stuck
+        // the base `_cursor` can reset to 0 then +1 on each press and stay stuck
         // at index 1 forever. Owning `optionCursor` lets it advance past 1.
         const { promise, input } = startPicker([
             { value: "1", label: "one" },
@@ -259,10 +280,10 @@ describe("fuzzySelect (interactive)", () => {
 
     test("Enter after typing returns the top-ranked match, not the one at the text cursor", async () => {
         // Regression: typing advances rl.cursor to the query length, which the
-        // base copies into `_cursor`. A shared cursor would highlight
+        // base copies into `_cursor`. A shared cursor can highlight
         // filtered[queryLen] instead of the best match. "r" matches both labels
         // and "review" (shorter, contiguous) outranks "rebase-verify", so the
-        // top-ranked value is "tight". A base-`_cursor` highlight would land on
+        // top-ranked value is "tight". A base-`_cursor` highlight can land on
         // filtered[1] ("scattered") because rl.cursor is 1 after one keystroke.
         const { promise, input } = startPicker([
             { value: "scattered", label: "rebase-verify" },

--- a/apps/review/action/src/fetchOidcToken.ts
+++ b/apps/review/action/src/fetchOidcToken.ts
@@ -8,12 +8,17 @@
  */
 export interface FetchOidcTokenInput {
   audience?: string;
+  env?: {
+    ACTIONS_ID_TOKEN_REQUEST_URL?: string;
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN?: string;
+  };
   fetchImpl?: typeof fetch;
 }
 
 export async function fetchOidcToken(input: FetchOidcTokenInput = {}): Promise<string> {
-  const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-  const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  const env = input.env ?? process.env;
+  const requestUrl = env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const requestToken = env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
   if (!requestUrl || !requestToken) {
     throw new Error(
       "ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN are unset; add `permissions: id-token: write` to the workflow",

--- a/apps/review/src/server/sessions/handleSessions.ts
+++ b/apps/review/src/server/sessions/handleSessions.ts
@@ -25,6 +25,41 @@ function pullRequestFromOidcRef(ref?: string): number | null {
   return m ? Number.parseInt(m[1], 10) : null;
 }
 
+function positiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+type PullRequestResolution =
+  | { ok: true; pr: number }
+  | { ok: false; message: string };
+
+function resolveOidcPullRequestNumber(
+  claims: { ref?: string; event_name?: string; pull_request?: { number?: number } },
+  bodyPr: unknown,
+): PullRequestResolution {
+  const prFromRef = pullRequestFromOidcRef(claims.ref);
+  const prFromClaim = positiveInteger(claims.pull_request?.number);
+  const prFromBody = positiveInteger(bodyPr);
+
+  if (prFromRef && prFromClaim && prFromRef !== prFromClaim) {
+    return { ok: false, message: "oidc pull request claims do not match" };
+  }
+
+  const verifiedPr = prFromRef ?? prFromClaim;
+  if (verifiedPr) {
+    if (prFromBody && prFromBody !== verifiedPr) {
+      return { ok: false, message: "body pull request number does not match oidc claims" };
+    }
+    return { ok: true, pr: verifiedPr };
+  }
+
+  if (claims.event_name === "issue_comment" && prFromBody) {
+    return { ok: true, pr: prFromBody };
+  }
+
+  return { ok: false, message: "missing pull request number" };
+}
+
 /**
  * POST /api/sessions — mint a session from an OIDC token or operator API key.
  *
@@ -59,16 +94,9 @@ export async function handleSessions(
       return jsonError(401, "oidc: missing repository claim");
     }
     repo = claims.repository;
-    const prFromRef = pullRequestFromOidcRef(claims.ref);
-    const prFromClaim = typeof claims.pull_request?.number === "number" ? claims.pull_request.number : null;
-    // The body is caller-controlled; only accept its PR number when the
-    // verified claims prove a PR context. Otherwise a push-triggered token
-    // could claim an already-reviewed PR and dodge the monthly quota.
-    const prContextEvents = new Set(["pull_request", "pull_request_target", "issue_comment"]);
-    const prFromBody =
-      prContextEvents.has(claims.event_name ?? "") && typeof body.pr === "number" ? body.pr : null;
-    pr = prFromRef ?? prFromClaim ?? prFromBody ?? 0;
-    if (!pr || pr <= 0) return jsonError(400, "missing pull request number");
+    const resolvedPr = resolveOidcPullRequestNumber(claims, body.pr);
+    if (!resolvedPr.ok) return jsonError(400, resolvedPr.message);
+    pr = resolvedPr.pr;
   } else if (typeof body.apiKey === "string" && body.apiKey.length > 0) {
     const record = await lookupApiKey(env.DB, body.apiKey);
     if (!record) return jsonError(401, "unknown api key");

--- a/apps/review/tests/action/fetchOidcToken.test.ts
+++ b/apps/review/tests/action/fetchOidcToken.test.ts
@@ -1,27 +1,26 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { fetchOidcToken } from "../../action/src/fetchOidcToken";
 
-const savedUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-const savedToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+const missingEnv = {};
+const runnerEnv = (url: string) => ({
+  ACTIONS_ID_TOKEN_REQUEST_URL: url,
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: "runner_token",
+});
 
 afterEach(() => {
-  if (savedUrl === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-  else process.env.ACTIONS_ID_TOKEN_REQUEST_URL = savedUrl;
-  if (savedToken === undefined) delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-  else process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = savedToken;
+  delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
 });
 
 describe("fetchOidcToken", () => {
   test("throws when env vars are missing", async () => {
-    delete process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
-    delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-    await expect(fetchOidcToken()).rejects.toThrow("ACTIONS_ID_TOKEN_REQUEST_URL");
+    await expect(fetchOidcToken({ env: missingEnv })).rejects.toThrow("ACTIONS_ID_TOKEN_REQUEST_URL");
   });
 
   test("throws when only REQUEST_URL is set", async () => {
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "http://example.invalid";
-    delete process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
-    await expect(fetchOidcToken()).rejects.toThrow("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
+    await expect(
+      fetchOidcToken({ env: { ACTIONS_ID_TOKEN_REQUEST_URL: "http://example.invalid" } }),
+    ).rejects.toThrow("ACTIONS_ID_TOKEN_REQUEST_TOKEN");
   });
 
   test("makes a real HTTP request and returns the token value", async () => {
@@ -38,11 +37,10 @@ describe("fetchOidcToken", () => {
       },
     });
 
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = `http://127.0.0.1:${server.port}`;
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
+    const env = runnerEnv(`http://127.0.0.1:${server.port}`);
 
     try {
-      const token = await fetchOidcToken();
+      const token = await fetchOidcToken({ env });
       expect(token).toBe("oidc.jwt.token");
       expect(capture.auth).toBe("Bearer runner_token");
       expect(capture.url).toContain("audience=smithers-review");
@@ -61,11 +59,10 @@ describe("fetchOidcToken", () => {
       },
     });
 
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = `http://127.0.0.1:${server.port}`;
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
+    const env = runnerEnv(`http://127.0.0.1:${server.port}`);
 
     try {
-      const token = await fetchOidcToken({ audience: "my-service" });
+      const token = await fetchOidcToken({ audience: "my-service", env });
       expect(token).toBe("oidc.custom.token");
       expect(capture.url).toContain("audience=my-service");
       expect(capture.url).not.toContain("smithers-review");
@@ -80,11 +77,10 @@ describe("fetchOidcToken", () => {
       fetch: () => new Response("forbidden", { status: 403 }),
     });
 
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = `http://127.0.0.1:${server.port}`;
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
+    const env = runnerEnv(`http://127.0.0.1:${server.port}`);
 
     try {
-      await expect(fetchOidcToken()).rejects.toThrow("HTTP 403");
+      await expect(fetchOidcToken({ env })).rejects.toThrow("HTTP 403");
     } finally {
       server.stop(true);
     }
@@ -96,24 +92,23 @@ describe("fetchOidcToken", () => {
       fetch: () => Response.json({ token: "wrong_field" }),
     });
 
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = `http://127.0.0.1:${server.port}`;
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
+    const env = runnerEnv(`http://127.0.0.1:${server.port}`);
 
     try {
-      await expect(fetchOidcToken()).rejects.toThrow("missing `value`");
+      await expect(fetchOidcToken({ env })).rejects.toThrow("missing `value`");
     } finally {
       server.stop(true);
     }
   });
 
   test("custom fetchImpl is used instead of global fetch", async () => {
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = "http://unreachable.invalid";
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
-
     const fakeImpl = async (_url: string | URL | Request, _init?: RequestInit) =>
       Response.json({ value: "injected-token" });
 
-    const token = await fetchOidcToken({ fetchImpl: fakeImpl as typeof fetch });
+    const token = await fetchOidcToken({
+      env: runnerEnv("http://unreachable.invalid"),
+      fetchImpl: fakeImpl as typeof fetch,
+    });
     expect(token).toBe("injected-token");
   });
 
@@ -127,11 +122,10 @@ describe("fetchOidcToken", () => {
       },
     });
 
-    process.env.ACTIONS_ID_TOKEN_REQUEST_URL = `http://127.0.0.1:${server.port}?existing=1`;
-    process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "runner_token";
+    const env = runnerEnv(`http://127.0.0.1:${server.port}?existing=1`);
 
     try {
-      await fetchOidcToken();
+      await fetchOidcToken({ env });
       expect(capture.url).toContain("existing=1");
       expect(capture.url).toContain("audience=smithers-review");
       // Should use & not ? since there is already a query string

--- a/apps/review/tests/server/handleSessions.test.ts
+++ b/apps/review/tests/server/handleSessions.test.ts
@@ -114,6 +114,92 @@ describe("POST /api/sessions (OIDC)", () => {
     expect(body.quiz).toBe("on");
   });
 
+  test("accepts body pr only for issue_comment oidc tokens without a pull request ref", async () => {
+    const env = await buildTestEnv();
+    const worker = makeWorker(jwks.url);
+    await registerRepo(env, REPO);
+    const claims = {
+      ...baseClaims(REPO, 42, Math.floor(Date.now() / 1000) + 600),
+      event_name: "issue_comment",
+      ref: "refs/heads/main",
+    };
+    const token = await signTestJwt(keypair, claims);
+    const res = await worker.fetch(
+      new Request("https://review.test/api/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ oidcToken: token, pr: 77 }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const reviewed = await env.DB
+      .prepare("SELECT pr FROM reviewed_prs WHERE repo = ?")
+      .bind(REPO)
+      .first<{ pr: number }>();
+    expect(reviewed?.pr).toBe(77);
+  });
+
+  test("rejects body pr for oidc tokens that are not tied to a pull request event", async () => {
+    const env = await buildTestEnv();
+    const worker = makeWorker(jwks.url);
+    await registerRepo(env, REPO);
+    const claims = {
+      ...baseClaims(REPO, 42, Math.floor(Date.now() / 1000) + 600),
+      event_name: "push",
+      ref: "refs/heads/main",
+    };
+    const token = await signTestJwt(keypair, claims);
+    const res = await worker.fetch(
+      new Request("https://review.test/api/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ oidcToken: token, pr: 42 }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe("missing pull request number");
+  });
+
+  test("rejects body pr that disagrees with the oidc pull request ref", async () => {
+    const env = await buildTestEnv();
+    const worker = makeWorker(jwks.url);
+    await registerRepo(env, REPO);
+    const token = await signTestJwt(keypair, baseClaims(REPO, 42, Math.floor(Date.now() / 1000) + 600));
+    const res = await worker.fetch(
+      new Request("https://review.test/api/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ oidcToken: token, pr: 41 }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("does not match");
+  });
+
+  test("rejects oidc tokens with conflicting pull request claims", async () => {
+    const env = await buildTestEnv();
+    const worker = makeWorker(jwks.url);
+    await registerRepo(env, REPO);
+    const claims = {
+      ...baseClaims(REPO, 42, Math.floor(Date.now() / 1000) + 600),
+      pull_request: { number: 41 },
+    };
+    const token = await signTestJwt(keypair, claims);
+    const res = await worker.fetch(
+      new Request("https://review.test/api/sessions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ oidcToken: token }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toContain("claims do not match");
+  });
+
   test("rejects a token signed with the wrong key", async () => {
     const env = await buildTestEnv();
     await registerRepo(env, REPO);
@@ -266,8 +352,8 @@ describe("POST /api/sessions (OIDC)", () => {
     );
     expect(first.status).toBe(200);
     // Then: a push-triggered token claims the already-reviewed PR via the
-    // body. If body.pr were trusted, alreadyReviewed would grant a free
-    // session forever; instead the PR number is rejected outright.
+    // body. Trusting body.pr lets alreadyReviewed grant a free session
+    // forever; instead the PR number is rejected outright.
     const pushToken = await signTestJwt(keypair, {
       ...baseClaims(REPO, 0, Math.floor(Date.now() / 1000) + 600),
       ref: "refs/heads/main",

--- a/packages/gateway-react/tests/providerParitySuite.ts
+++ b/packages/gateway-react/tests/providerParitySuite.ts
@@ -7,6 +7,8 @@ import {
   type WorkspaceMode,
 } from "@smithers-orchestrator/gateway-client";
 
+type SmithersDataClient = ReturnType<typeof createSmithersDataClient>;
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -25,6 +27,23 @@ async function waitFor(assertion: () => void | boolean | Promise<void | boolean>
   }
   if (lastError) throw lastError;
   throw new Error("Timed out waiting for provider parity assertion.");
+}
+
+async function waitForApprovalNodeReady(
+  client: SmithersDataClient,
+  runId: string,
+  nodeId: string,
+  iteration = 0,
+) {
+  await waitFor(async () => {
+    const nodes = await client.api.getRunTree({ runId });
+    return nodes.some(
+      (node) =>
+        node.id === nodeId &&
+        (node.iteration ?? 0) === iteration &&
+        node.status === "waiting",
+    );
+  });
 }
 
 function cronRow(overrides: Partial<GatewayCronRow> = {}): GatewayCronRow {
@@ -77,6 +96,7 @@ export async function runProviderParitySuite(mode: WorkspaceMode) {
     // "Node pick-plan is not waiting for approval". Gate the decision on the run
     // actually reaching the waiting-approval state so the submit is never racy.
     await waitFor(() => runs.get(approvalRunId)?.status === "waiting-approval");
+    await waitForApprovalNodeReady(client, approvalRunId, "pick-plan");
     const approvalUpdate = approvals.update(approvalKey, (draft) => {
       (draft as { decision?: Record<string, unknown> }).decision = { selected: "balanced", notes: null };
     });


### PR DESCRIPTION
## Summary

- resolve the trusted pull request number from GitHub OIDC claims before session state uses request data
- reject request body mismatches, conflicting OIDC PR claims, and tokens that lack a pull request claim
- keep issue-comment reviews working when GitHub only provides the branch ref
- stabilize the root Open Code Review tests on slower Windows runners
- keep the CLI fuzzy picker selection stable when filtering and backspacing
- stabilize the zero-TTL memory-store deletion test used by coverage

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm --filter ./apps/cli exec bun test tests/fuzzy-select.test.js --timeout=120000`
- `pnpm --filter ./apps/review test -- tests/action/fetchOidcToken.test.ts tests/server/handleSessions.test.ts`
- `bun test ./.smithers/tests/open-code-review.test.ts ./.smithers/tests/open-code-review-ui.e2e.test.ts --timeout=30000`
- `bun test packages/memory/tests/store.test.js --timeout=120000`
- `pnpm --filter @smithers-orchestrator/memory test`
- `pnpm --filter @smithers-orchestrator/memory typecheck`
- `bun test --coverage --coverage-reporter=lcov --coverage-dir=/tmp/smithers-memory-coverage tests`
- `pnpm --filter ./apps/cli typecheck`
- `pnpm --filter ./apps/review typecheck`
- `pnpm --filter ./.smithers typecheck`
- `node scripts/check-dependency-boundaries.mjs`
- `git diff --check origin/main...HEAD`