### PR TITLE
fix(cli): ship OpenClaw plugin entrypoint

### DIFF
--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -150,11 +150,17 @@ function terminalRows() {
  * (including j/k/h/l) become filter text, while arrow keys still move the cursor.
  *
  * Instance fields we own (separate from base `this.value`/`this._cursor`):
- *  - `query`      live filter text, mirrored from base `this.value`.
- *  - `allOptions` immutable input options.
- *  - `filtered`   current fuzzyFilter(query, allOptions) result.
- *  - `cursor`     index into `filtered` (clamped), NOT into allOptions.
- *  - `maxItems`   windowing budget.
+ *  - `query`        live filter text, mirrored from base `this.value`.
+ *  - `allOptions`   immutable input options.
+ *  - `filtered`     current fuzzyFilter(query, allOptions) result.
+ *  - `optionCursor` index into `filtered` (clamped), NOT into allOptions.
+ *      We deliberately do NOT reuse the base's `_cursor`: @clack/core's
+ *      `Prompt.onKeypress` runs `this._cursor = this.rl?.cursor ?? 0` on every
+ *      tracked keypress (before it emits our "cursor" event), so the base's
+ *      readline text cursor would clobber our option index — arrow-down would
+ *      stick near the top and Enter could return a lower-ranked match. Owning
+ *      `optionCursor` keeps the highlight independent of readline.
+ *  - `maxItems`     windowing budget.
  *
  * Enter, ctrl-c and escape flow to the base: Enter sets state="submit" and we
  * override `this.value` to the highlighted option's value in a `finalize`
@@ -187,10 +193,10 @@ class FuzzySelectPrompt extends Prompt {
         this.filtered = fuzzyFilter("", this.allOptions);
 
         // Position the cursor on the option matching initialValue (default 0).
-        this._cursor = 0;
+        this.optionCursor = 0;
         if (opts.initialValue !== undefined) {
             const i = this.filtered.findIndex((o) => o.value === opts.initialValue);
-            if (i >= 0) this._cursor = i;
+            if (i >= 0) this.optionCursor = i;
         }
 
         // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
@@ -198,8 +204,8 @@ class FuzzySelectPrompt extends Prompt {
         this.on("userInput", () => {
             this.query = this.userInput ?? "";
             this.filtered = fuzzyFilter(this.query, this.allOptions);
-            if (this._cursor > this.filtered.length - 1) {
-                this._cursor = Math.max(0, this.filtered.length - 1);
+            if (this.optionCursor > this.filtered.length - 1) {
+                this.optionCursor = Math.max(0, this.filtered.length - 1);
             }
         });
 
@@ -210,11 +216,11 @@ class FuzzySelectPrompt extends Prompt {
             switch (key) {
                 case "up":
                 case "left":
-                    this._cursor = this._cursor === 0 ? this.filtered.length - 1 : this._cursor - 1;
+                    this.optionCursor = this.optionCursor === 0 ? this.filtered.length - 1 : this.optionCursor - 1;
                     break;
                 case "down":
                 case "right":
-                    this._cursor = this._cursor === this.filtered.length - 1 ? 0 : this._cursor + 1;
+                    this.optionCursor = this.optionCursor === this.filtered.length - 1 ? 0 : this.optionCursor + 1;
                     break;
             }
         });
@@ -225,7 +231,7 @@ class FuzzySelectPrompt extends Prompt {
         // value so the caller receives the selection, not the query string.
         this.on("finalize", () => {
             if (this.state === "submit") {
-                const selected = this.filtered[this._cursor];
+                const selected = this.filtered[this.optionCursor];
                 this.value = selected ? selected.value : undefined;
             }
         });
@@ -257,7 +263,7 @@ function styleOption(option, active) {
  */
 function renderPrompt(self, message) {
     const header = `${pc.gray(S_BAR)}\n${symbol(self.state)}  ${message}\n`;
-    const selectedLabel = self.filtered[self._cursor]?.label;
+    const selectedLabel = self.filtered[self.optionCursor]?.label;
 
     switch (self.state) {
         case "submit":
@@ -280,7 +286,7 @@ function renderPrompt(self, message) {
                 lines.push(`${gutter}  ${pc.dim("No matches")}`);
             } else {
                 const windowed = limitOptions({
-                    cursor: self._cursor,
+                    cursor: self.optionCursor,
                     options: self.filtered,
                     maxItems: self.maxItems,
                     rows: terminalRows(),

--- a/apps/cli/tests/fuzzy-select.test.js
+++ b/apps/cli/tests/fuzzy-select.test.js
@@ -239,6 +239,41 @@ describe("fuzzySelect (interactive)", () => {
         expect(result).toBe("3");
     });
 
+    test("arrow-down twice from an empty query lands on the THIRD option", async () => {
+        // Regression for the @clack/core cursor collision: Prompt.onKeypress runs
+        // `this._cursor = this.rl?.cursor ?? 0` on every keypress BEFORE emitting
+        // "cursor". With an empty query rl.cursor is 0, so a highlight that reused
+        // the base `_cursor` would reset to 0 then +1 on each press and stay stuck
+        // at index 1 forever. Owning `optionCursor` lets it advance past 1.
+        const { promise, input } = startPicker([
+            { value: "1", label: "one" },
+            { value: "2", label: "two" },
+            { value: "3", label: "three" },
+        ]);
+        input.keypress(undefined, { name: "down" });
+        input.keypress(undefined, { name: "down" });
+        input.keypress("\r", { name: "return" });
+        const result = await promise;
+        expect(result).toBe("3");
+    });
+
+    test("Enter after typing returns the top-ranked match, not the one at the text cursor", async () => {
+        // Regression: typing advances rl.cursor to the query length, which the
+        // base copies into `_cursor`. A shared cursor would highlight
+        // filtered[queryLen] instead of the best match. "r" matches both labels
+        // and "review" (shorter, contiguous) outranks "rebase-verify", so the
+        // top-ranked value is "tight". A base-`_cursor` highlight would land on
+        // filtered[1] ("scattered") because rl.cursor is 1 after one keystroke.
+        const { promise, input } = startPicker([
+            { value: "scattered", label: "rebase-verify" },
+            { value: "tight", label: "review" },
+        ]);
+        input.keypress("r", { name: "r" });
+        input.keypress("\r", { name: "return" });
+        const result = await promise;
+        expect(result).toBe("tight");
+    });
+
     test("ctrl-c resolves the clack cancel symbol", async () => {
         const { promise, input } = startPicker([{ value: "a", label: "review" }]);
         input.keypress("\x03", { name: "c" });


### PR DESCRIPTION
## Summary
- add the OpenClaw plugin runtime entrypoint declared by package metadata
- register the Smithers tool contracts through the native OpenClaw plugin
- keep the plugin entrypoint visible to Git and assert it is installed
- decouple fuzzy-select option highlighting from Clack's text cursor so backspace filtering stays stable

## Tests
- pnpm --filter ./apps/cli test
- pnpm --filter ./apps/cli typecheck
- pnpm --filter ./apps/cli build
- pnpm typecheck
- pnpm lint