### PR TITLE
fix(cli): keep restore checkpoint target stable

### DIFF
--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -1473,6 +1473,7 @@ export function createSemanticToolDefinitions(options = {}) {
                     nodeId: input.nodeId,
                     iteration: input.iteration,
                     seq: input.seq,
+                    target,
                     stdout: { write: (chunk) => { stdoutText += chunk; } },
                     stderr: { write: (chunk) => { stderrText += chunk; } },
                 });

--- a/apps/cli/src/restore.js
+++ b/apps/cli/src/restore.js
@@ -28,11 +28,25 @@ function defaultRevert(commitId, cwd) {
 }
 
 /**
+ * A durability checkpoint row as returned by `listWorkspaceCheckpoints`.
+ * @typedef {{
+ *   nodeId: string,
+ *   iteration?: number,
+ *   seq: number,
+ *   attempt?: number,
+ *   jjCommitId: string,
+ *   jjCwd: string,
+ *   createdAtMs?: number,
+ * }} Checkpoint
+ */
+
+/**
  * Pick the target checkpoint deterministically: filter by node (+optional
  * iteration/seq), then the chronologically latest (ties broken by attempt then
  * seq, since seq resets per attempt).
- * @param {Array<Record<string, any>>} checkpoints
+ * @param {Array<Checkpoint>} checkpoints
  * @param {{ nodeId: string, iteration?: number, seq?: number }} sel
+ * @returns {Checkpoint | null}
  */
 export function pickTargetCheckpoint(checkpoints, sel) {
     let cands = checkpoints.filter((c) => c.nodeId === sel.nodeId);
@@ -48,12 +62,12 @@ export function pickTargetCheckpoint(checkpoints, sel) {
 
 /**
  * @param {{
- *   adapter: { listWorkspaceCheckpoints: (runId: string) => Promise<Array<Record<string, any>>> },
+ *   adapter?: { listWorkspaceCheckpoints: (runId: string) => Promise<Array<Checkpoint>> },
  *   runId: string,
  *   nodeId: string,
  *   iteration?: number,
  *   seq?: number,
- *   target?: Record<string, any>,
+ *   target?: Checkpoint,
  *   stdout: { write: (s: string) => void },
  *   stderr: { write: (s: string) => void },
  *   revert?: (commitId: string, cwd: string) => Promise<{ success: boolean, error?: string }>,
@@ -64,8 +78,12 @@ export async function runRestoreOnce(opts) {
     const { adapter, runId, nodeId, iteration, seq, stdout, stderr } = opts;
     const revert = opts.revert ?? defaultRevert;
 
-    const target = opts.target ??
-        pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), { nodeId, iteration, seq });
+    // Reuse a preselected target when the caller already picked one (the
+    // semantic tool reports it), so we never re-list and risk selecting a
+    // different checkpoint than the one reported. Otherwise list and pick.
+    const target = opts.target ?? (adapter
+        ? pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), { nodeId, iteration, seq })
+        : null);
     if (!target) {
         stderr.write(`No matching durability checkpoint for run ${runId} node ${nodeId}${seq !== undefined ? ` seq ${seq}` : ""}\n`);
         return { exitCode: 1 };

--- a/apps/cli/src/restore.js
+++ b/apps/cli/src/restore.js
@@ -53,6 +53,7 @@ export function pickTargetCheckpoint(checkpoints, sel) {
  *   nodeId: string,
  *   iteration?: number,
  *   seq?: number,
+ *   target?: Record<string, any>,
  *   stdout: { write: (s: string) => void },
  *   stderr: { write: (s: string) => void },
  *   revert?: (commitId: string, cwd: string) => Promise<{ success: boolean, error?: string }>,
@@ -63,8 +64,8 @@ export async function runRestoreOnce(opts) {
     const { adapter, runId, nodeId, iteration, seq, stdout, stderr } = opts;
     const revert = opts.revert ?? defaultRevert;
 
-    const checkpoints = await adapter.listWorkspaceCheckpoints(runId);
-    const target = pickTargetCheckpoint(checkpoints, { nodeId, iteration, seq });
+    const target = opts.target ??
+        pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), { nodeId, iteration, seq });
     if (!target) {
         stderr.write(`No matching durability checkpoint for run ${runId} node ${nodeId}${seq !== undefined ? ` seq ${seq}` : ""}\n`);
         return { exitCode: 1 };

--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -345,20 +345,25 @@ function makeSemanticAdapter(overrides = {}) {
         deleteFramesAfter: (_runId, _frameNo) => Effect.succeed(undefined),
         listEvents: async (_runId, afterSeq) => afterSeq < 0 ? state.events : [],
         listEventHistory: async () => state.historyEvents,
-        listWorkspaceCheckpoints: async () => [
-            {
-                seq: 0,
-                nodeId: "artifact-node",
-                iteration: 0,
-                attempt: 1,
-                tier: 1,
-                source: "hook",
-                label: "Edit output",
-                jjCwd: "/tmp/work",
-                jjCommitId: "commit-1",
-                createdAtMs: NOW - 1_000,
-            },
-        ],
+        listWorkspaceCheckpoints: async (runId) => {
+            if (typeof state.listWorkspaceCheckpoints === "function") {
+                return state.listWorkspaceCheckpoints(runId);
+            }
+            return [
+                {
+                    seq: 0,
+                    nodeId: "artifact-node",
+                    iteration: 0,
+                    attempt: 1,
+                    tier: 1,
+                    source: "hook",
+                    label: "Edit output",
+                    jjCwd: "/tmp/work",
+                    jjCommitId: "commit-1",
+                    createdAtMs: NOW - 1_000,
+                },
+            ];
+        },
         listWorkspaceStates: async () => [
             {
                 jjCwd: "/tmp/work",
@@ -716,6 +721,44 @@ describe("semantic tool definitions", () => {
             success: false,
         });
         expect(restore.structuredContent.data.error).toBeString();
+    });
+
+    test("restore_checkpoint restores the same checkpoint it reports", async () => {
+        let reads = 0;
+        const harness = makeHarness({
+            listWorkspaceCheckpoints: async () => {
+                reads += 1;
+                if (reads > 1) throw new Error("checkpoint target was selected twice");
+                return [
+                    {
+                        seq: 0,
+                        nodeId: "artifact-node",
+                        iteration: 0,
+                        attempt: 1,
+                        tier: 1,
+                        source: "hook",
+                        label: "Edit output",
+                        jjCwd: "/tmp/work",
+                        jjCommitId: "commit-1",
+                        createdAtMs: NOW - 1_000,
+                    },
+                ];
+            },
+        });
+
+        const restore = await harness.call("restore_checkpoint", {
+            runId: "run-1",
+            nodeId: "artifact-node",
+        });
+
+        expect(reads).toBe(1);
+        expect(restore.structuredContent.data).toMatchObject({
+            runId: "run-1",
+            nodeId: "artifact-node",
+            seq: 0,
+            commitId: "commit-1",
+            cwd: "/tmp/work",
+        });
     });
 
     test("returns structured errors for missing and ambiguous operations", async () => {

--- a/apps/cli/tests/snapshots-restore.test.js
+++ b/apps/cli/tests/snapshots-restore.test.js
@@ -76,6 +76,31 @@ describe("smithers restore", () => {
         expect(out.get()).toContain("Restored");
     });
 
+    test("reuses a preselected target without listing checkpoints again", async () => {
+        const reverted = [];
+        const out = capture();
+        const r = await runRestoreOnce({
+            adapter: {
+                async listWorkspaceCheckpoints() {
+                    throw new Error("checkpoint list should not be read");
+                },
+            },
+            runId: "r1",
+            nodeId: "n1",
+            target: cps[0],
+            stdout: out,
+            stderr: capture(),
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(0);
+        expect(reverted).toEqual([["c0", "/wt"]]);
+        expect(out.get()).toContain("checkpoint #0");
+    });
+
     test("missing checkpoint exits non-zero with a message", async () => {
         const err = capture();
         const r = await runRestoreOnce({

--- a/apps/cli/tests/snapshots-restore.test.js
+++ b/apps/cli/tests/snapshots-restore.test.js
@@ -76,15 +76,12 @@ describe("smithers restore", () => {
         expect(out.get()).toContain("Restored");
     });
 
-    test("reuses a preselected target without listing checkpoints again", async () => {
+    test("reuses a preselected target without an adapter to list from", async () => {
         const reverted = [];
         const out = capture();
         const r = await runRestoreOnce({
-            adapter: {
-                async listWorkspaceCheckpoints() {
-                    throw new Error("checkpoint list should not be read");
-                },
-            },
+            // No adapter: a preselected target must be honored without any
+            // listWorkspaceCheckpoints read, so callers can omit it entirely.
             runId: "r1",
             nodeId: "n1",
             target: cps[0],


### PR DESCRIPTION
## Summary
- pass the checkpoint selected by the semantic restore tool into the restore helper
- keep CLI restore selection behavior unchanged
- cover preselected-target restore and the semantic tool's single-selection path

## Tests
- pnpm --filter ./apps/cli exec bun test --timeout=120000 --max-concurrency=1 tests/snapshots-restore.test.js tests/semantic-tools-unit.test.js
- pnpm --filter ./apps/cli typecheck
- pnpm -r typecheck
- node scripts/check-dependency-boundaries.mjs
- git diff --check