### PR TITLE
✨ feat(telegram): inline approval component + Mini App initData verification

### DIFF
--- a/apps/telegram-site/site/approve.html
+++ b/apps/telegram-site/site/approve.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Approve · Smithers</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <style>
+      :root {
+        --bg: var(--tg-theme-bg-color, #ffffff);
+        --text: var(--tg-theme-text-color, #17212b);
+        --hint: var(--tg-theme-hint-color, #707579);
+        --section: var(--tg-theme-section-bg-color, #f3f6f9);
+        --sep: var(--tg-theme-section-separator-color, rgba(0, 0, 0, 0.08));
+        --accent: var(--tg-theme-button-color, #2ca5e0);
+        --accent-text: var(--tg-theme-button-text-color, #ffffff);
+        --destructive: var(--tg-theme-destructive-text-color, #e5484d);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; padding: 18px; background: var(--bg); color: var(--text);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        line-height: 1.5; -webkit-font-smoothing: antialiased;
+      }
+      .eyebrow { font-size: 0.72rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent); font-weight: 600; margin: 0 0 6px; }
+      h1 { font-size: 1.35rem; margin: 0 0 6px; line-height: 1.2; }
+      .summary { color: var(--hint); font-size: 0.95rem; margin: 0 0 18px; white-space: pre-wrap; }
+      .card { background: var(--section); border: 1px solid var(--sep); border-radius: 14px; padding: 16px; margin-bottom: 18px; }
+      .card .row { display: flex; justify-content: space-between; gap: 12px; font-size: 0.9rem; padding: 5px 0; }
+      .card .row + .row { border-top: 1px solid var(--sep); }
+      .card .k { color: var(--hint); } .card .v { font-family: ui-monospace, Menlo, monospace; text-align: right; word-break: break-all; }
+      button { font: inherit; border: 0; border-radius: 11px; padding: 13px 16px; width: 100%; font-weight: 600; cursor: pointer; }
+      .approve { background: var(--accent); color: var(--accent-text); }
+      .reject { background: transparent; color: var(--destructive); margin-top: 10px; }
+      .status { text-align: center; color: var(--hint); font-size: 0.88rem; margin-top: 14px; min-height: 1.2em; }
+      .status.err { color: var(--destructive); }
+    </style>
+  </head>
+  <body>
+    <p class="eyebrow">Smithers · approval</p>
+    <h1 id="title">Approval needed</h1>
+    <p class="summary" id="summary"></p>
+
+    <div class="card">
+      <div class="row"><span class="k">Request</span><span class="v" id="request-id">—</span></div>
+      <div class="row"><span class="k">Approver</span><span class="v" id="approver">—</span></div>
+    </div>
+
+    <button class="approve" id="approve">✅ Approve</button>
+    <button class="reject" id="reject">🚫 Reject</button>
+    <p class="status" id="status"></p>
+
+    <script>
+      // A Telegram Mini App approval UI. It sends the SIGNED initData to the
+      // Smithers /approve endpoint, which verifies it server-side (never trust
+      // initDataUnsafe). Opened from a `web_app` inline button on a smithers
+      // TelegramApproval prompt (miniApp: { url }).
+      var tg = window.Telegram && window.Telegram.WebApp;
+      var params = new URLSearchParams(location.search);
+      var startParam = (tg && tg.initDataUnsafe && tg.initDataUnsafe.start_param) || params.get("startapp") || "";
+      var requestId = startParam || params.get("request") || "demo-request";
+
+      // Reference: title/summary come from the deep link or query for the demo.
+      // In production, look them up server-side by requestId.
+      document.getElementById("title").textContent = params.get("title") || "Deploy release 0.27 to prod?";
+      document.getElementById("summary").textContent = params.get("summary") || "Tests are green. Approve to ship.";
+      document.getElementById("request-id").textContent = requestId;
+
+      var statusEl = document.getElementById("status");
+      function setStatus(text, isError) {
+        statusEl.textContent = text;
+        statusEl.className = "status" + (isError ? " err" : "");
+      }
+
+      if (tg) {
+        tg.ready();
+        tg.expand();
+        var u = tg.initDataUnsafe && tg.initDataUnsafe.user;
+        document.getElementById("approver").textContent = u ? (u.username ? "@" + u.username : String(u.id)) : "—";
+      } else {
+        setStatus("Open this page inside Telegram to approve.", true);
+      }
+
+      function submit(decision) {
+        if (!tg || !tg.initData) {
+          setStatus("Not running inside Telegram — cannot verify.", true);
+          return;
+        }
+        setStatus("Submitting…");
+        fetch("/approve", {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: "tma " + tg.initData },
+          body: JSON.stringify({ requestId: requestId, decision: decision }),
+        })
+          .then(function (res) { return res.json().then(function (body) { return { ok: res.ok, body: body }; }); })
+          .then(function (result) {
+            if (!result.ok || !result.body.ok) {
+              tg.HapticFeedback && tg.HapticFeedback.notificationOccurred("error");
+              setStatus("Rejected by server: " + (result.body.reason || result.body.error || "error"), true);
+              return;
+            }
+            tg.HapticFeedback && tg.HapticFeedback.notificationOccurred("success");
+            setStatus(decision === "approve" ? "Approved. Closing…" : "Rejected. Closing…");
+            setTimeout(function () { tg.close(); }, 700);
+          })
+          .catch(function () {
+            tg.HapticFeedback && tg.HapticFeedback.notificationOccurred("error");
+            setStatus("Network error. Try again.", true);
+          });
+      }
+
+      document.getElementById("approve").addEventListener("click", function () {
+        if (tg && tg.showConfirm) {
+          tg.showConfirm("Approve this request?", function (ok) { if (ok) submit("approve"); });
+        } else {
+          submit("approve");
+        }
+      });
+      document.getElementById("reject").addEventListener("click", function () { submit("reject"); });
+    </script>
+  </body>
+</html>

--- a/apps/telegram-site/site/index.html
+++ b/apps/telegram-site/site/index.html
@@ -95,6 +95,16 @@
       .bub:nth-child(3) { animation-delay: 1.6s; }
       @keyframes rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 
+      /* inline-keyboard mock (approval buttons under a message) */
+      .kbd { display: flex; gap: 6px; margin-top: 10px; }
+      .kbd button, .kbd-wide {
+        font-family: var(--mono); font-size: 0.78rem; border: 1px solid var(--line2); border-radius: 8px;
+        padding: 8px 10px; background: var(--panel2); color: var(--tg-2); font-weight: 600; cursor: default; flex: 1;
+      }
+      .kbd button.ok { color: #2f7d1f; border-color: var(--out-line); background: var(--out); }
+      .kbd button.no { color: #b23; }
+      .kbd-wide { display: block; width: 100%; margin-top: 6px; background: var(--tg-soft); border-color: var(--line2); }
+
       section.block { padding: 58px 0; border-top: 1px solid var(--line); }
       .kicker { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.15em; text-transform: uppercase; color: var(--faint); margin: 0 0 14px; }
       .block h2 { font-size: clamp(1.55rem, 3vw, 2.1rem); font-weight: 690; letter-spacing: -0.015em; max-width: 20ch; }
@@ -148,6 +158,7 @@
         <nav class="links" aria-label="Primary">
           <a href="#why">Why</a>
           <a href="#how">How it works</a>
+          <a href="#approve">Approvals</a>
           <a href="#build">Build your own</a>
           <a class="ghost" href="#start">Deploy</a>
         </nav>
@@ -157,20 +168,20 @@
     <main id="top">
       <section class="wrap hero">
         <div>
-          <p class="eyebrow">Digest bot + Bot API toolkit</p>
-          <h1>Your group moves fast. <span class="hl">Read the part that matters.</span></h1>
+          <p class="eyebrow">Digests · in-app approvals · Bot API toolkit</p>
+          <h1>Your group moves fast. <span class="hl">Read it, and act on it.</span></h1>
           <p class="sub">
-            Smithers posts a daily digest of your Telegram group, powered by a
-            durable, replayable workflow. And it ships a secure Bot API toolkit,
-            so you can wire your own runs to a chat.
+            Smithers posts a daily digest of your Telegram group, and lets you
+            approve a workflow's risky step from the chat with a tap. Both run on
+            durable, replayable workflows, on a secure Bot API toolkit.
           </p>
           <div class="cta">
-            <a class="btn" href="#how">See the digest</a>
-            <a class="btn sec" href="#build">Build a bot</a>
+            <a class="btn" href="#approve">Approve from the chat</a>
+            <a class="btn sec" href="#how">See the digest</a>
           </div>
           <div class="trust">
-            <span><b>Daily digest</b>, on a cron</span>
-            <span><b>Durable</b> workflow behind it</span>
+            <span><b>Approve</b> from the chat</span>
+            <span><b>Durable</b> workflows behind it</span>
             <span><b>Verified</b> inbound</span>
           </div>
         </div>
@@ -229,6 +240,53 @@
         </div>
       </section>
 
+      <section class="block wrap" id="approve">
+        <p class="kicker">Human in the loop</p>
+        <h2>Approve the risky step from your phone.</h2>
+        <p class="lead">
+          When a workflow hits an approval gate, Smithers posts it to the chat
+          with Approve and Reject buttons. Tap one and the run continues. It is a
+          durable, replayable step, so nothing is lost if the process restarts
+          while it waits for you.
+        </p>
+        <div class="two">
+          <div class="chat" role="img" aria-label="A Telegram chat: the Smithers Deploys bot asks to deploy release 0.27 to prod with Approve and Reject buttons and an Open review Mini App button; the next message confirms it was approved by @will.">
+            <div class="cbar">
+              <span class="avatar"><svg viewBox="0 0 24 24" fill="#fff"><path d="M21.9 4.3 18.5 20c-.25 1.14-.93 1.42-1.88.88l-5.2-3.83-2.5 2.4c-.28.28-.51.51-1.05.51l.37-5.3L18 5.6c.42-.37-.09-.58-.66-.21L6.1 12.6l-5.24-1.64c-1.14-.36-1.16-1.14.24-1.68L20.4 2.6c.95-.35 1.78.22 1.5 1.7z"/></svg></span>
+              <div class="who"><b>Smithers Deploys</b><span class="badge">bot</span><small>waits for your call</small></div>
+            </div>
+            <div class="cbody">
+              <div class="bub in">
+                <span class="h">🚦 Approval needed</span>
+                Deploy release 0.27 to prod? Tests are green.
+                <div class="kbd">
+                  <button class="ok">✅ Approve</button>
+                  <button class="no">🚫 Reject</button>
+                </div>
+                <button class="kbd-wide">🔍 Open review</button>
+                <span class="time">14:20</span>
+              </div>
+              <div class="bub in">✅ Approved by @will. Shipping now.<span class="time">14:21</span></div>
+            </div>
+          </div>
+          <article class="aud">
+            <div class="t">one component</div>
+            <h3>Drop it into any workflow</h3>
+            <p>
+              A single component turns an approval into inline buttons and
+              resolves it from the press. The decision matches the built-in
+              approval shape, so the rest of your workflow does not change.
+            </p>
+            <div class="code">&lt;<span class="k">TelegramApproval</span><br />&nbsp;&nbsp;chatId={chatId}<br />&nbsp;&nbsp;request={{ title: <span class="s">"Deploy to prod?"</span> }}<br />&nbsp;&nbsp;output={outputs.decision}<br />/&gt;</div>
+            <p style="margin-top:14px">
+              Need a richer decision? Add a Mini App button to open a web page
+              inside Telegram. Its signed <code style="font-family: var(--mono); color: var(--tg-2)">initData</code>
+              is verified on your server before anything is trusted.
+            </p>
+          </article>
+        </div>
+      </section>
+
       <section class="block wrap" id="build">
         <p class="kicker">Build your own</p>
         <h2>A Bot API toolkit, not a black box.</h2>
@@ -272,9 +330,9 @@
             <p>Webhook secret verification and a chat allowlist ship in the box. Only chats you name get through.</p>
           </div>
           <div class="cell">
-            <div class="ic">⚙ your model</div>
-            <h3>Summarize with anything</h3>
-            <p>The summarizer is pluggable. Point it at the model you already pay for, on the runtime you already use.</p>
+            <div class="ic">✅ in-app approvals</div>
+            <h3>Approve or reject in a tap</h3>
+            <p>Gate a workflow step behind an inline button, or a Mini App with verified <code style="font-family: var(--mono); color: var(--tg-2)">initData</code> for a richer decision. The run waits durably until you answer.</p>
           </div>
         </div>
       </section>

--- a/apps/telegram-site/src/handleApprove.ts
+++ b/apps/telegram-site/src/handleApprove.ts
@@ -1,0 +1,55 @@
+// Reference approval endpoint for the Mini App. The Mini App posts here with
+// `Authorization: tma <initData>`; we verify initData server-side and, in a real
+// deployment, forward the decision to your Smithers gateway
+// (`resolve_approval`) or bot. Here we echo the verified decision so the Mini
+// App can confirm — the deployment wiring is the documented follow-up.
+
+import { verifyTelegramInitData } from "./verifyTelegramInitData.ts";
+
+export type ApproveEnv = {
+  /** Bot token (Wrangler secret). Approvals are disabled until it is set. */
+  TELEGRAM_BOT_TOKEN?: string;
+};
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+export async function handleApprove(request: Request, env: ApproveEnv): Promise<Response> {
+  if (!env.TELEGRAM_BOT_TOKEN) {
+    return json(503, { error: "not_configured", detail: "Set the TELEGRAM_BOT_TOKEN secret to enable approvals." });
+  }
+  const [scheme, initData] = (request.headers.get("authorization") ?? "").split(" ");
+  if (scheme !== "tma" || !initData) {
+    return json(401, { error: "unauthorized", detail: "Expected an 'Authorization: tma <initData>' header." });
+  }
+  const verified = await verifyTelegramInitData(initData, env.TELEGRAM_BOT_TOKEN, { maxAgeSeconds: 3600 });
+  if (!verified.ok) {
+    return json(401, { error: "unauthorized", reason: verified.reason });
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    body = {};
+  }
+  const decision = body.decision === "approve" ? "approve" : body.decision === "reject" ? "reject" : null;
+  if (!decision) {
+    return json(400, { error: "bad_request", detail: "decision must be 'approve' or 'reject'." });
+  }
+
+  // In production: forward { requestId, decision, approver } to the Smithers
+  // gateway resolve_approval (or your bot) here, then return its result.
+  return json(200, {
+    ok: true,
+    decision,
+    requestId: typeof body.requestId === "string" ? body.requestId : null,
+    approver: verified.initData.user
+      ? { id: verified.initData.user.id, username: verified.initData.user.username ?? null }
+      : null,
+  });
+}

--- a/apps/telegram-site/src/verifyTelegramInitData.ts
+++ b/apps/telegram-site/src/verifyTelegramInitData.ts
@@ -1,0 +1,97 @@
+// Reference Telegram Mini App initData verification for a Cloudflare Worker.
+//
+// This mirrors `verifyTelegramWebAppInitData` from
+// `@smithers-orchestrator/integrations/telegram` — it is inlined here so the
+// Worker bundle stays dependency-free and copy-pasteable. It does REAL HMAC
+// verification (no mocks): secret = HMAC_SHA256(key="WebAppData", msg=botToken);
+// authentic iff hex(HMAC_SHA256(key=secret, msg=dataCheckString)) === hash,
+// where dataCheckString is every field except `hash` (the `signature` field
+// STAYS IN), as key=value sorted and newline-joined. Uses Web Crypto so it runs
+// on workerd. Never trust `initDataUnsafe`; verify this raw string server-side.
+
+export type TelegramInitDataUser = {
+  id: number;
+  username?: string;
+  first_name?: string;
+  [key: string]: unknown;
+};
+
+export type VerifiedTelegramInitData = {
+  user: TelegramInitDataUser | null;
+  authDate: number | null;
+  queryId: string | null;
+};
+
+export type VerifyTelegramInitDataResult =
+  | { ok: true; initData: VerifiedTelegramInitData }
+  | { ok: false; reason: string };
+
+const encoder = new TextEncoder();
+
+function bytesToHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Constant-time equality of two equal-length hex strings. */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function parseJson(value: string | null): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function verifyTelegramInitData(
+  initData: string,
+  botToken: string,
+  options: { maxAgeSeconds?: number; nowMs?: number } = {},
+): Promise<VerifyTelegramInitDataResult> {
+  if (!botToken) return { ok: false, reason: "missing_bot_token" };
+  if (!initData) return { ok: false, reason: "empty" };
+
+  const params = new URLSearchParams(initData);
+  const hash = params.get("hash");
+  if (!hash) return { ok: false, reason: "missing_hash" };
+
+  const maxAgeSeconds = options.maxAgeSeconds ?? 3600;
+  const authDateRaw = params.get("auth_date");
+  const authDate = authDateRaw && /^\d+$/.test(authDateRaw) ? Number.parseInt(authDateRaw, 10) : null;
+  if (maxAgeSeconds > 0) {
+    if (authDate == null) return { ok: false, reason: "missing_auth_date" };
+    if (authDate * 1000 + maxAgeSeconds * 1000 < (options.nowMs ?? Date.now())) {
+      return { ok: false, reason: "expired" };
+    }
+  }
+
+  const dataCheckString = [...params.entries()]
+    .filter(([key]) => key !== "hash")
+    .map(([key, value]) => `${key}=${value}`)
+    .sort()
+    .join("\n");
+
+  const webAppDataKey = await crypto.subtle.importKey("raw", encoder.encode("WebAppData"), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const secret = await crypto.subtle.sign("HMAC", webAppDataKey, encoder.encode(botToken));
+  const secretKey = await crypto.subtle.importKey("raw", secret, { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const mac = await crypto.subtle.sign("HMAC", secretKey, encoder.encode(dataCheckString));
+  if (!timingSafeEqualHex(bytesToHex(mac), hash)) {
+    return { ok: false, reason: "bad_signature" };
+  }
+
+  return {
+    ok: true,
+    initData: {
+      user: parseJson(params.get("user")) as TelegramInitDataUser | null,
+      authDate,
+      queryId: params.get("query_id"),
+    },
+  };
+}

--- a/apps/telegram-site/src/worker.ts
+++ b/apps/telegram-site/src/worker.ts
@@ -1,7 +1,11 @@
+import { handleApprove } from "./handleApprove.ts";
+
 export interface TelegramSiteEnv {
   ASSETS: {
     fetch(request: Request): Promise<Response>;
   };
+  /** Bot token (Wrangler secret). Enables the reference /approve Mini App endpoint. */
+  TELEGRAM_BOT_TOKEN?: string;
 }
 
 const HTML_HEADERS = {
@@ -42,6 +46,17 @@ export function createTelegramSiteWorker() {
   return {
     async fetch(request: Request, env: TelegramSiteEnv): Promise<Response> {
       const url = new URL(request.url);
+
+      // Reference Mini App approval endpoint (verifies Telegram initData).
+      if (url.pathname === "/approve") {
+        if (request.method !== "POST") {
+          return new Response("method not allowed", {
+            status: 405,
+            headers: { allow: "POST", "content-type": "text/plain; charset=utf-8" },
+          });
+        }
+        return handleApprove(request, env);
+      }
 
       if (request.method !== "GET" && request.method !== "HEAD") {
         return new Response("method not allowed", {

--- a/apps/telegram-site/tests/worker.test.ts
+++ b/apps/telegram-site/tests/worker.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
 import { createTelegramSiteWorker, type TelegramSiteEnv } from "../src/worker.ts";
 
-function makeEnv(): TelegramSiteEnv {
+const BOT_TOKEN = "424242:TEST-fixture-bot-token";
+
+function makeEnv(overrides: Partial<TelegramSiteEnv> = {}): TelegramSiteEnv {
   return {
     ASSETS: {
       async fetch(request: Request) {
@@ -14,7 +17,39 @@ function makeEnv(): TelegramSiteEnv {
         return new Response("not found", { status: 404 });
       },
     },
+    ...overrides,
   };
+}
+
+/** Build a valid HMAC-signed initData string (independent oracle, no mocks). */
+function signInitData(fields: Record<string, string>, botToken: string): string {
+  const dcs = Object.keys(fields)
+    .sort()
+    .map((key) => `${key}=${fields[key]}`)
+    .join("\n");
+  const secret = createHmac("sha256", "WebAppData").update(botToken).digest();
+  const hash = createHmac("sha256", secret).update(dcs).digest("hex");
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) params.set(key, value);
+  params.set("hash", hash);
+  return params.toString();
+}
+
+const initDataFields = () => ({
+  auth_date: String(Math.floor(Date.now() / 1000)),
+  query_id: "AAApprove",
+  user: JSON.stringify({ id: 7, username: "will" }),
+});
+
+function approveRequest(initData: string | null, body: unknown): Request {
+  return new Request("https://telegram.smithers.sh/approve", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(initData ? { authorization: `tma ${initData}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
 }
 
 describe("telegram site worker", () => {
@@ -36,5 +71,53 @@ describe("telegram site worker", () => {
     const response = await createTelegramSiteWorker().fetch(new Request("https://telegram.smithers.sh/healthz"), makeEnv());
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: true, service: "telegram-site" });
+  });
+});
+
+describe("reference Mini App /approve endpoint", () => {
+  const worker = createTelegramSiteWorker();
+
+  test("accepts a validly signed approval and echoes the decision", async () => {
+    const initData = signInitData(initDataFields(), BOT_TOKEN);
+    const response = await worker.fetch(approveRequest(initData, { requestId: "r-1", decision: "approve" }), makeEnv({ TELEGRAM_BOT_TOKEN: BOT_TOKEN }));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      decision: "approve",
+      requestId: "r-1",
+      approver: { id: 7, username: "will" },
+    });
+  });
+
+  test("rejects a tampered initData with 401 and never leaks the token", async () => {
+    const initData = signInitData(initDataFields(), BOT_TOKEN);
+    const tampered = initData.replace("query_id=AAApprove", "query_id=forged");
+    const response = await worker.fetch(approveRequest(tampered, { requestId: "r-1", decision: "approve" }), makeEnv({ TELEGRAM_BOT_TOKEN: BOT_TOKEN }));
+    expect(response.status).toBe(401);
+    const text = await response.text();
+    expect(text).toContain("bad_signature");
+    expect(text).not.toContain(BOT_TOKEN);
+  });
+
+  test("rejects a missing Authorization header with 401", async () => {
+    const response = await worker.fetch(approveRequest(null, { decision: "approve" }), makeEnv({ TELEGRAM_BOT_TOKEN: BOT_TOKEN }));
+    expect(response.status).toBe(401);
+  });
+
+  test("rejects an unknown decision with 400", async () => {
+    const initData = signInitData(initDataFields(), BOT_TOKEN);
+    const response = await worker.fetch(approveRequest(initData, { decision: "maybe" }), makeEnv({ TELEGRAM_BOT_TOKEN: BOT_TOKEN }));
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 503 when no bot token is configured", async () => {
+    const initData = signInitData(initDataFields(), BOT_TOKEN);
+    const response = await worker.fetch(approveRequest(initData, { decision: "approve" }), makeEnv());
+    expect(response.status).toBe(503);
+  });
+
+  test("rejects non-POST methods on /approve", async () => {
+    const response = await worker.fetch(new Request("https://telegram.smithers.sh/approve"), makeEnv({ TELEGRAM_BOT_TOKEN: BOT_TOKEN }));
+    expect(response.status).toBe(405);
   });
 });

--- a/docs/integrations/telegram.mdx
+++ b/docs/integrations/telegram.mdx
@@ -1,11 +1,16 @@
 ---
 title: Telegram
-description: Use the first-class Smithers Telegram helpers for Bot API calls, webhook ingestion, retries, formatting, and tests.
+description: Bot API calls, webhook ingestion, durable in-chat approvals, and Mini App (Web App) verification for Smithers Telegram bots.
 ---
 
-Smithers ships `@smithers-orchestrator/telegram` for Telegram bots that need to
-run inside serverless functions, workflow tasks, or tests without owning a
-long-lived polling process.
+Smithers ships two Telegram surfaces:
+
+- `@smithers-orchestrator/telegram` for bots that run inside serverless
+  functions, workflow tasks, or tests without owning a long-lived polling
+  process (this page's first half).
+- `@smithers-orchestrator/integrations/telegram` for workflows that wait on
+  Telegram durably: listen for messages, and approve gated steps from the chat
+  with inline buttons or a Mini App ([Approve from the chat](#approve-from-the-chat)).
 
 The package follows the integration shape proven by Eliza's Telegram plugin:
 separate bot lifecycle/API access, normalized incoming messages, formatting
@@ -88,3 +93,100 @@ console.log(telegram.messages[0].message_id);
 ```
 
 Use the fake in local e2e tests when production uses real Telegram credentials.
+
+## Approve from the chat
+
+`<Telegram.Approval>` turns a workflow approval into inline Approve and Reject
+buttons in a chat and resolves it from the button press, using the durable
+long-poll source. No web server, no gateway wiring. The decision has the same
+shape as the core [`<Approval>`](/components/approval) component:
+`{ approved, note, decidedBy, decidedAt }`.
+
+Import `TelegramApproval`, `telegramApprovalSchemas`, and
+`telegramApprovalDecisionSchema` from `@smithers-orchestrator/integrations/telegram`.
+Register the two internal node schemas with `telegramApprovalSchemas`, then drop
+the component in:
+
+```tsx
+import { createSmithers } from "smithers-orchestrator";
+
+const { smithers, Workflow, outputs } = createSmithers({
+  ...telegramApprovalSchemas,
+  decision: telegramApprovalDecisionSchema,
+});
+
+export default smithers(() => (
+  <Workflow name="deploy">
+    <TelegramApproval
+      id="ship"
+      chatId={process.env.TELEGRAM_CHAT_ID}
+      config={{ botToken: process.env.TELEGRAM_BOT_TOKEN }}
+      request={{ title: "Deploy to prod?", summary: "Tests are green." }}
+      output={outputs.decision}
+    />
+  </Workflow>
+));
+```
+
+For a menu instead of Approve and Reject, pass `mode="select"` with `options`;
+the decision becomes `{ selected, notes }`.
+
+For the run to receive the press, a Telegram source must be polling. Run one
+next to your workflow with `makeTelegramSource` (from
+`@smithers-orchestrator/integrations/telegram`) plus `makeIntegrationRuntime`
+and `makeDbCursorStore` (from `@smithers-orchestrator/integrations`):
+
+```ts
+const source = makeTelegramSource({
+  botToken: process.env.TELEGRAM_BOT_TOKEN,
+  cursorStore: makeDbCursorStore(adapter),
+});
+const runtime = makeIntegrationRuntime({ adapter, sources: [source] });
+```
+
+`WaitForEvent` wakes on the first callback query for the chat, so run one
+interactive approval per chat at a time, or pass `threadId` (a forum topic) to
+isolate concurrent approvals. Any chat member can press a button, so keep
+approvals in a private or allowlisted chat.
+
+## Mini App approvals
+
+For a richer decision (read a diff, pick an option, add a note) inside Telegram,
+add a Mini App button. `miniApp` opens a `web_app` page in the chat alongside the
+plain buttons:
+
+```tsx
+<TelegramApproval
+  id="ship"
+  chatId={chatId}
+  request={{ title: "Deploy to prod?" }}
+  miniApp={{ url: "https://telegram.smithers.sh/approve.html" }}
+  output={outputs.decision}
+/>
+```
+
+A Mini App exposes a signed `initData` string. Your backend must verify it
+before trusting the user. Never trust `initDataUnsafe`. Verify it with
+`verifyTelegramWebAppInitData` from `@smithers-orchestrator/integrations/telegram`:
+
+```ts
+// Resolves to the parsed fields, or throws on a bad signature, a stale
+// auth_date, or the wrong token.
+const data = await verifyTelegramWebAppInitData(initData, botToken, {
+  maxAgeSeconds: 3600,
+});
+console.log(data.user?.id);
+```
+
+Verification is HMAC-SHA256 with a crossed key: `secret =
+HMAC_SHA256(key="WebAppData", message=botToken)`, and the data is authentic when
+`hex(HMAC_SHA256(key=secret, message=dataCheckString))` equals the `hash` field,
+where `dataCheckString` is every field except `hash`, formatted `key=value`,
+sorted, and newline-joined. It runs on Web Crypto, so the same call works in the
+Smithers runtime and in a Cloudflare Worker. `verifyTelegramWebAppInitDataSignature`
+verifies the newer Ed25519 `signature` from a third party with only the numeric
+bot id.
+
+A runnable reference (a static Mini App page plus a Worker endpoint that verifies
+`initData` for real) ships in `apps/telegram-site`: `site/approve.html` and
+`src/handleApprove.ts`.

--- a/docs/integrations/telegram.mdx
+++ b/docs/integrations/telegram.mdx
@@ -109,6 +109,11 @@ the component in:
 
 ```tsx
 import { createSmithers } from "smithers-orchestrator";
+import {
+  TelegramApproval,
+  telegramApprovalSchemas,
+  telegramApprovalDecisionSchema,
+} from "@smithers-orchestrator/integrations/telegram";
 
 const { smithers, Workflow, outputs } = createSmithers({
   ...telegramApprovalSchemas,

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -10,6 +10,11 @@
       "import": "./src/index.js",
       "default": "./src/index.js"
     },
+    "./telegram": {
+      "types": "./src/telegram.d.ts",
+      "import": "./src/telegram.js",
+      "default": "./src/telegram.js"
+    },
     "./*": {
       "types": "./src/index.d.ts",
       "import": "./src/*.js",

--- a/packages/integrations/src/telegram.d.ts
+++ b/packages/integrations/src/telegram.d.ts
@@ -1,0 +1,777 @@
+// Public type surface for `@smithers-orchestrator/integrations/telegram`.
+//
+// The bulk of this file is emitted by `tsup --dts-only` from the `src/telegram.js`
+// barrel. tsup/rollup-dts drops the runtime *values* of the modules that have a
+// types-only `.ts` companion (approval.ts / initData.ts / TelegramClient.ts /
+// TelegramSource.ts shadow their `.js` value modules under TS `.js`->`.ts`
+// resolution), so those value declarations are curated by hand in the block at
+// the end of this file. Keep that block in sync with the barrel's `.js` sources.
+import { Effect, Schedule } from 'effect';
+import type { Context, Layer } from 'effect';
+import type { ExternalEvent as CoreExternalEvent } from './core/ExternalEvent.js';
+import type { EventSource as CoreEventSource } from './core/EventSource.js';
+import { SmithersError } from '@smithers-orchestrator/errors/SmithersError';
+import * as zod from 'zod';
+import { z } from 'zod';
+import * as react from 'react';
+import react__default from 'react';
+
+/**
+ * Configuration for the fetch-based Telegram Bot API client. `apiBaseUrl`
+ * exists so tests can point the real client at a fixture server.
+ */
+type TelegramClientConfig$1 = {
+    /** Bot token from @BotFather. Never logged; stripped from error output. */
+    botToken: string;
+    /** @default "https://api.telegram.org" */
+    apiBaseUrl?: string;
+    /** Max automatic retries on 429 rate limits. @default 3 */
+    maxRateLimitRetries?: number;
+    /** Cap on the server-supplied `retry_after` honored per retry (seconds). @default 30 */
+    maxRetryAfterSeconds?: number;
+};
+/** One button of an inline keyboard (Telegram `InlineKeyboardButton`). */
+type TelegramInlineKeyboardButton = {
+    text: string;
+    callback_data?: string;
+    url?: string;
+    web_app?: {
+        url: string;
+    };
+};
+/** Rows of inline-keyboard buttons (Telegram `InlineKeyboardMarkup.inline_keyboard`). */
+type TelegramInlineKeyboard = TelegramInlineKeyboardButton[][];
+type SendMessageSmartOptions = {
+    /**
+     * How to format outgoing text. `"markdown"` (default) converts standard
+     * markdown to MarkdownV2 with escaping and falls back to plain text when
+     * Telegram rejects the entities; `"MarkdownV2"`/`"HTML"` send the text
+     * as-is under that parse mode (still with plain-text fallback); `"none"`
+     * sends raw text with no parse mode.
+     */
+    parseMode?: "markdown" | "MarkdownV2" | "HTML" | "none";
+    /** Attached to the FIRST chunk only. */
+    replyToMessageId?: number;
+    /** Forum-topic thread id, attached to every chunk. */
+    messageThreadId?: number;
+    /** Inline keyboard attached to the LAST chunk only. */
+    inlineKeyboard?: TelegramInlineKeyboard;
+    /** Send a `typing` chat action before the first chunk. @default true */
+    typing?: boolean;
+    disableNotification?: boolean;
+};
+type SendMessageSmartResult = {
+    chatId: string;
+    /** message_id of every sent chunk, in send order. */
+    messageIds: number[];
+    chunkCount: number;
+    /** True when at least one chunk fell back to plain text after a parse 400. */
+    usedPlainTextFallback: boolean;
+};
+type SendDocumentOptions = {
+    /** Caption for the document (converted/escaped like sendMessageSmart). */
+    caption?: string;
+    replyToMessageId?: number;
+    messageThreadId?: number;
+};
+/**
+ * A document to upload: either a URL / existing `file_id` string (sent via
+ * JSON) or raw bytes uploaded as multipart form data.
+ */
+type TelegramDocumentInput = string | {
+    filename: string;
+    content: string | Uint8Array;
+    contentType?: string;
+};
+/** The service behind the `TelegramClient` Context.Tag. */
+type TelegramClientService = {
+    /**
+     * Raw Bot API call: POST `<apiBaseUrl>/bot<token>/<method>` with a JSON
+     * body, returning the `result` field. Retries 429s honoring
+     * `parameters.retry_after`. Fails with a SmithersError (code
+     * `TELEGRAM_API_ERROR`) that never contains the bot token.
+     */
+    call: (method: string, params?: Record<string, unknown>) => Effect.Effect<unknown, SmithersError>;
+    /**
+     * High-level send: chunks at 4096 chars on paragraph/sentence boundaries,
+     * converts markdown → MarkdownV2, falls back to plain text on a 400
+     * "can't parse entities", and shows a typing indicator first.
+     */
+    sendMessageSmart: (chatId: number | string, text: string, options?: SendMessageSmartOptions) => Effect.Effect<SendMessageSmartResult, SmithersError>;
+    /** Edit a sent message in place, with the same MarkdownV2 → plain fallback. */
+    editMessageSmart: (chatId: number | string, messageId: number, text: string, options?: Pick<SendMessageSmartOptions, "parseMode" | "inlineKeyboard">) => Effect.Effect<unknown, SmithersError>;
+    /** Send a document (URL/file_id via JSON, raw content via multipart). */
+    sendDocument: (chatId: number | string, document: TelegramDocumentInput, options?: SendDocumentOptions) => Effect.Effect<unknown, SmithersError>;
+    /** Answer a callback query (inline-keyboard button press). */
+    answerCallbackQuery: (callbackQueryId: string, options?: {
+        text?: string;
+        showAlert?: boolean;
+    }) => Effect.Effect<unknown, SmithersError>;
+    /**
+     * Answer a Mini App inline query: post the `result` back to the chat on the
+     * user's behalf and close the Mini App. `webAppQueryId` is the `query_id`
+     * from a Mini App launched by an inline-keyboard `web_app` button. `result`
+     * is a Bot API `InlineQueryResult`. Returns the `SentWebAppMessage`.
+     */
+    answerWebAppQuery: (webAppQueryId: string, result: Record<string, unknown>) => Effect.Effect<unknown, SmithersError>;
+};
+
+/** One choice an approver can make via an inline button. */
+type TelegramApprovalChoice = {
+    kind: "approve";
+} | {
+    kind: "reject";
+} | {
+    kind: "select";
+    key: string;
+};
+/** An option offered in `mode: "select"`. */
+type TelegramApprovalOption = {
+    /** Stable key, echoed back as the decision's `selected`. Kept short (callback_data is 64 bytes). */
+    key: string;
+    /** Button label shown to the approver. */
+    label: string;
+};
+type TelegramApprovalMode = "approve" | "select";
+/** Spec for building the approval keyboard and mapping the press to a decision. */
+type TelegramApprovalKeyboardSpec = {
+    mode: TelegramApprovalMode;
+    /** Options for `mode: "select"` (required, non-empty). */
+    options?: TelegramApprovalOption[];
+    /** Approve-button label. @default "✅ Approve" */
+    approveText?: string;
+    /** Reject-button label. @default "🚫 Reject" */
+    rejectText?: string;
+    /** When set, adds a Mini App (`web_app`) button opening this HTTPS url. */
+    miniAppUrl?: string;
+    /** Mini App button label. @default "🔍 Open review" */
+    miniAppText?: string;
+};
+/** Decision shape for `mode: "approve"` (matches the core `approvalDecisionSchema`). */
+type TelegramApprovalDecision = {
+    approved: boolean;
+    note: string | null;
+    decidedBy: string | null;
+    decidedAt: string | null;
+};
+/** Decision shape for `mode: "select"` (matches the core `approvalSelectionSchema`). */
+type TelegramApprovalSelection = {
+    selected: string;
+    notes: string | null;
+};
+
+/**
+ * Split `text` into chunks of at most `maxLength` characters, breaking on
+ * paragraph, line, sentence, or word boundaries (in that order of
+ * preference) and only cutting mid-word when a single unbroken run exceeds
+ * the limit. Chunks are trimmed of the boundary whitespace they were split
+ * on; empty chunks are never emitted.
+ * @param {string} text
+ * @param {number} [maxLength]
+ * @returns {string[]}
+ */
+declare function chunkTelegramText(text: string, maxLength?: number): string[];
+/** Telegram's maximum `sendMessage` text length. */
+declare const TELEGRAM_MAX_MESSAGE_LENGTH: 4096;
+
+/**
+ * Register process-wide Telegram config for outbound components.
+ * Pass `null` to clear (tests).
+ * @param {TelegramClientConfig | null} config
+ */
+declare function configureTelegram(config: TelegramClientConfig | null): void;
+/**
+ * Resolve the effective Telegram config: explicit prop > `configureTelegram`
+ * registry > `SMITHERS_TELEGRAM_BOT_TOKEN` env fallback. Throws
+ * `INVALID_INPUT` when no bot token can be found — the error message never
+ * includes any token material.
+ * @param {Partial<TelegramClientConfig> | undefined} [explicit]
+ * @returns {TelegramClientConfig}
+ */
+declare function resolveTelegramConfig(explicit?: Partial<TelegramClientConfig> | undefined): TelegramClientConfig;
+/**
+ * Resolve config and build a client from it (outbound component seam).
+ * @param {Partial<TelegramClientConfig> | undefined} [explicit]
+ */
+declare function resolveTelegramClient(explicit?: Partial<TelegramClientConfig> | undefined): any;
+type TelegramClientConfig = TelegramClientConfig$1;
+
+/** A Telegram user as it appears inside initData's `user`/`receiver` JSON. */
+type TelegramInitDataUser = {
+    id: number;
+    is_bot?: boolean;
+    first_name?: string;
+    last_name?: string;
+    username?: string;
+    language_code?: string;
+    is_premium?: boolean;
+    photo_url?: string;
+    [key: string]: unknown;
+};
+/** The parsed contents of a Mini App `initData` query string. */
+type TelegramInitData = {
+    /** The exact raw query string that was verified. */
+    raw: string;
+    /** HMAC hash field (present on the standard path). */
+    hash: string | null;
+    /** Ed25519 signature field (present on newer clients / third-party path). */
+    signature: string | null;
+    /** `auth_date` as a Unix timestamp in seconds, or null when absent/invalid. */
+    authDate: number | null;
+    /** `query_id` (present only for inline-keyboard / menu-button launches). */
+    queryId: string | null;
+    /** Parsed `user` object, or null when absent/unparseable. */
+    user: TelegramInitDataUser | null;
+    /** Parsed `receiver` object, or null. */
+    receiver: TelegramInitDataUser | null;
+    /** Parsed `chat` object, or null. */
+    chat: Record<string, unknown> | null;
+    /** `chat_type` (private/group/supergroup/channel), or null. */
+    chatType: string | null;
+    /** `chat_instance`, or null. */
+    chatInstance: string | null;
+    /** `start_param` from a `?startapp=` deep link, or null. */
+    startParam: string | null;
+    /** Every decoded key/value pair, for fields not surfaced above. */
+    params: Record<string, string>;
+};
+type VerifyTelegramWebAppInitDataOptions = {
+    /**
+     * Reject `initData` whose `auth_date` is older than this many seconds.
+     * `0` disables the freshness check. @default 3600 (one hour)
+     */
+    maxAgeSeconds?: number;
+    /** Override "now" (epoch ms) for deterministic tests. */
+    nowMs?: number;
+};
+type VerifyTelegramWebAppInitDataSignatureOptions = VerifyTelegramWebAppInitDataOptions & {
+    /**
+     * Ed25519 public key (hex) to verify against. Defaults to Telegram's
+     * production key. Pass the test key for the test datacenter.
+     */
+    publicKeyHex?: string;
+};
+
+/**
+ * Escape plain text for Telegram MarkdownV2 (every reserved character gets a
+ * leading backslash).
+ * @param {string} text
+ * @returns {string}
+ */
+declare function escapeMarkdownV2(text: string): string;
+/**
+ * Convert standard markdown to Telegram MarkdownV2: fenced/inline code,
+ * links, bold (`**` → `*`), strikethrough (`~~` → `~`), italic (`*`/`_` →
+ * `_`), and headers (`#...` → bold — unescaped `#` crashes Telegram), with
+ * everything else escaped. Uses NUL sentinels to protect already-formatted
+ * segments during the final escape pass, then substitutes them back.
+ * @param {string} markdown
+ * @returns {string}
+ */
+declare function convertMarkdownToTelegram(markdown: string): string;
+/**
+ * Strip NUL characters (they collide with the sentinel scheme above and
+ * Telegram rejects them anyway).
+ * @param {string | undefined | null} text
+ * @returns {string}
+ */
+declare function cleanText(text: string | undefined | null): string;
+
+declare const TelegramChatSchema: z.ZodObject<{
+    id: z.ZodNumber;
+    type: z.ZodOptional<z.ZodString>;
+    title: z.ZodOptional<z.ZodString>;
+    username: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+declare const TelegramUserSchema: z.ZodObject<{
+    id: z.ZodNumber;
+    is_bot: z.ZodOptional<z.ZodBoolean>;
+    first_name: z.ZodOptional<z.ZodString>;
+    last_name: z.ZodOptional<z.ZodString>;
+    username: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
+ * Payload delivered for `integration:telegram:message` (and
+ * `integration:telegram:edited_message`): the Bot API Message object.
+ */
+declare const TelegramMessageSchema: z.ZodObject<{
+    message_id: z.ZodNumber;
+    date: z.ZodNumber;
+    chat: z.ZodObject<{
+        id: z.ZodNumber;
+        type: z.ZodOptional<z.ZodString>;
+        title: z.ZodOptional<z.ZodString>;
+        username: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>;
+    from: z.ZodOptional<z.ZodObject<{
+        id: z.ZodNumber;
+        is_bot: z.ZodOptional<z.ZodBoolean>;
+        first_name: z.ZodOptional<z.ZodString>;
+        last_name: z.ZodOptional<z.ZodString>;
+        username: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+    text: z.ZodOptional<z.ZodString>;
+    caption: z.ZodOptional<z.ZodString>;
+    message_thread_id: z.ZodOptional<z.ZodNumber>;
+    is_topic_message: z.ZodOptional<z.ZodBoolean>;
+    reply_to_message: z.ZodOptional<z.ZodObject<{
+        message_id: z.ZodNumber;
+    }, z.core.$loose>>;
+    photo: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        file_id: z.ZodString;
+    }, z.core.$loose>>>;
+    document: z.ZodOptional<z.ZodObject<{
+        file_id: z.ZodString;
+        file_name: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+}, z.core.$loose>;
+/** Payload delivered for `integration:telegram:callback_query`. */
+declare const TelegramCallbackQuerySchema: z.ZodObject<{
+    id: z.ZodString;
+    from: z.ZodObject<{
+        id: z.ZodNumber;
+        is_bot: z.ZodOptional<z.ZodBoolean>;
+        first_name: z.ZodOptional<z.ZodString>;
+        last_name: z.ZodOptional<z.ZodString>;
+        username: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>;
+    data: z.ZodOptional<z.ZodString>;
+    message: z.ZodOptional<z.ZodObject<{
+        message_id: z.ZodNumber;
+        date: z.ZodNumber;
+        chat: z.ZodObject<{
+            id: z.ZodNumber;
+            type: z.ZodOptional<z.ZodString>;
+            title: z.ZodOptional<z.ZodString>;
+            username: z.ZodOptional<z.ZodString>;
+        }, z.core.$loose>;
+        from: z.ZodOptional<z.ZodObject<{
+            id: z.ZodNumber;
+            is_bot: z.ZodOptional<z.ZodBoolean>;
+            first_name: z.ZodOptional<z.ZodString>;
+            last_name: z.ZodOptional<z.ZodString>;
+            username: z.ZodOptional<z.ZodString>;
+        }, z.core.$loose>>;
+        text: z.ZodOptional<z.ZodString>;
+        caption: z.ZodOptional<z.ZodString>;
+        message_thread_id: z.ZodOptional<z.ZodNumber>;
+        is_topic_message: z.ZodOptional<z.ZodBoolean>;
+        reply_to_message: z.ZodOptional<z.ZodObject<{
+            message_id: z.ZodNumber;
+        }, z.core.$loose>>;
+        photo: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            file_id: z.ZodString;
+        }, z.core.$loose>>>;
+        document: z.ZodOptional<z.ZodObject<{
+            file_id: z.ZodString;
+            file_name: z.ZodOptional<z.ZodString>;
+        }, z.core.$loose>>;
+    }, z.core.$loose>>;
+}, z.core.$loose>;
+/** The `web_app_data` field of a message from a reply-keyboard Mini App's `sendData`. */
+declare const TelegramWebAppDataSchema: z.ZodObject<{
+    data: z.ZodString;
+    button_text: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
+ * Payload delivered for `integration:telegram:web_app_data`: the Message that
+ * carries the `web_app_data` field (untrusted `data`, but the sender is
+ * Telegram-guaranteed).
+ */
+declare const TelegramWebAppDataMessageSchema: z.ZodObject<{
+    message_id: z.ZodNumber;
+    date: z.ZodNumber;
+    chat: z.ZodObject<{
+        id: z.ZodNumber;
+        type: z.ZodOptional<z.ZodString>;
+        title: z.ZodOptional<z.ZodString>;
+        username: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>;
+    from: z.ZodOptional<z.ZodObject<{
+        id: z.ZodNumber;
+        is_bot: z.ZodOptional<z.ZodBoolean>;
+        first_name: z.ZodOptional<z.ZodString>;
+        last_name: z.ZodOptional<z.ZodString>;
+        username: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+    text: z.ZodOptional<z.ZodString>;
+    caption: z.ZodOptional<z.ZodString>;
+    message_thread_id: z.ZodOptional<z.ZodNumber>;
+    is_topic_message: z.ZodOptional<z.ZodBoolean>;
+    reply_to_message: z.ZodOptional<z.ZodObject<{
+        message_id: z.ZodNumber;
+    }, z.core.$loose>>;
+    photo: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        file_id: z.ZodString;
+    }, z.core.$loose>>>;
+    document: z.ZodOptional<z.ZodObject<{
+        file_id: z.ZodString;
+        file_name: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+    web_app_data: z.ZodOptional<z.ZodObject<{
+        data: z.ZodString;
+        button_text: z.ZodOptional<z.ZodString>;
+    }, z.core.$loose>>;
+}, z.core.$loose>;
+
+/**
+ * Durable persistence seam for polling-source cursors. The db-backed
+ * implementation (`makeDbCursorStore`) rides `_smithers_integration_cursors`.
+ */
+type CursorStore = {
+    get: (sourceId: string) => Effect.Effect<string | null | undefined, SmithersError>;
+    set: (sourceId: string, cursor: string | null) => Effect.Effect<void, SmithersError>;
+};
+
+/**
+ * Options for `makeTelegramSource`: a getUpdates long-poll EventSource whose
+ * offset cursor is persisted through a CursorStore so restarts never
+ * re-deliver already-seen updates.
+ */
+type MakeTelegramSourceOptions = TelegramClientConfig$1 & {
+    /** EventSource id (also the cursor key + dedupe scope). @default "telegram" */
+    sourceId?: string;
+    /** Durable cursor persistence; use `makeDbCursorStore(adapter)`. */
+    cursorStore?: CursorStore;
+    /**
+     * Long-poll `timeout` parameter passed to getUpdates (seconds; the Bot API
+     * holds the request open until updates arrive or the timeout fires).
+     * @default 25
+     */
+    pollTimeoutSeconds?: number;
+    /** Delay between poll turns (long-polling makes this mostly idle). @default Schedule.spaced("250 millis") */
+    schedule?: Schedule.Schedule<unknown>;
+    /** getUpdates `allowed_updates`. @default ["message", "edited_message", "callback_query"] */
+    allowedUpdates?: string[];
+    /**
+     * When set, updates from chats not in this list are dropped (the offset
+     * still advances so they are acknowledged, not re-polled).
+     */
+    allowedChatIds?: Array<number | string>;
+};
+
+/** Props shared by the Telegram listener components. */
+type TelegramListenerBaseProps<Schema extends z.ZodTypeAny> = {
+    /** Node id (also the output lookup key for render-prop children). */
+    id: string;
+    /** Only wake for this chat (correlationId `chat:<chatId>`). Omit to match any-correlation waits. */
+    chatId?: number | string;
+    /** Only wake for this forum-topic thread (correlationId `chat:<chatId>:thread:<threadId>`; requires chatId). */
+    threadId?: number | string;
+    /** Zod schema override for the delivered payload. */
+    schema?: Schema;
+    timeoutMs?: number;
+    onTimeout?: "fail" | "skip" | "continue";
+    /** Do not block unrelated downstream flow while waiting. */
+    async?: boolean;
+    skipIf?: boolean;
+    dependsOn?: string[];
+    label?: string;
+    meta?: Record<string, unknown>;
+    key?: string;
+    children?: (data: z.infer<Schema>) => react__default.ReactNode;
+    smithersContext?: react__default.Context<unknown>;
+};
+type OnMessageProps$1<Schema extends z.ZodTypeAny> = TelegramListenerBaseProps<Schema> & {
+    /** Listen for edits instead of new messages. */
+    edited?: boolean;
+};
+type OnCallbackQueryProps$1<Schema extends z.ZodTypeAny> = TelegramListenerBaseProps<Schema>;
+
+/**
+ * Durable wait for the next Telegram message in a chat (or forum-topic
+ * thread). Renders the `smithers:wait-for-event` intrinsic on
+ * `integration:telegram:message` (`integration:telegram:edited_message` with
+ * `edited`); the render-prop children receive the zod-parsed Message payload
+ * once `makeTelegramSource` delivers it.
+ *
+ * @template {import("zod").ZodTypeAny} Schema
+ * @param {OnMessageProps<Schema>} props
+ */
+declare function OnMessage<Schema extends zod.ZodTypeAny>(props: OnMessageProps<Schema>): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/**
+ * Durable wait for an inline-keyboard button press (Telegram callback
+ * query) in a chat. Children receive the zod-parsed CallbackQuery payload.
+ *
+ * @template {import("zod").ZodTypeAny} Schema
+ * @param {OnCallbackQueryProps<Schema>} props
+ */
+declare function OnCallbackQuery<Schema extends zod.ZodTypeAny>(props: OnCallbackQueryProps<Schema>): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/**
+ * Durable wait for structured data from a reply-keyboard Mini App
+ * (`Telegram.WebApp.sendData`), which arrives as a message carrying a
+ * `web_app_data` field. Renders `smithers:wait-for-event` on
+ * `integration:telegram:web_app_data`; children receive the zod-parsed Message,
+ * whose `web_app_data.data` holds the payload the Mini App sent.
+ *
+ * @template {import("zod").ZodTypeAny} Schema
+ * @param {OnMessageProps<Schema>} props
+ */
+declare function OnWebAppData<Schema extends zod.ZodTypeAny>(props: OnMessageProps<Schema>): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+type OnMessageProps<Schema extends zod.ZodTypeAny> = OnMessageProps$1<Schema>;
+type OnCallbackQueryProps<Schema extends zod.ZodTypeAny> = OnCallbackQueryProps$1<Schema>;
+
+/** Loose deps spec (mirrors Task's DepsSpec: dep key → zod output schema). */
+type TelegramDepsSpec = Record<string, z.ZodTypeAny>;
+type ResolvedDeps = Record<string, unknown>;
+/** Props shared by every outbound Telegram compute-Task component. */
+type TelegramOutboundBaseProps = {
+    id: string;
+    /** Explicit client config; falls back to configureTelegram()/env. */
+    config?: Partial<TelegramClientConfig$1>;
+    /**
+     * Upstream outputs to consume. The component resolves them itself and
+     * renders a compute Task gated on them via `dependsOn` (Task's own
+     * deps+function-children path would evaluate at render time as a static
+     * payload — see Task.js — so it is deliberately not used here).
+     */
+    deps?: TelegramDepsSpec;
+    /** dep key → node id when they differ. */
+    needs?: Record<string, string>;
+    output?: z.ZodTypeAny;
+    outputSchema?: z.ZodTypeAny;
+    retryPolicy?: unknown;
+    timeoutMs?: number;
+    dependsOn?: string[];
+    async?: boolean;
+    skipIf?: boolean;
+    label?: string;
+    key?: string;
+    smithersContext?: react__default.Context<unknown>;
+};
+type SendMessageProps$1 = TelegramOutboundBaseProps & {
+    chatId: number | string;
+    /** Static message text (standard markdown). */
+    text?: string;
+    /**
+     * Build the message from resolved deps: return the text, or an object of
+     * `{ text, ...SendMessageSmartOptions }` overrides.
+     */
+    children?: (deps: ResolvedDeps) => string | ({
+        text: string;
+    } & SendMessageSmartOptions);
+    parseMode?: SendMessageSmartOptions["parseMode"];
+    replyToMessageId?: number;
+    messageThreadId?: number;
+    inlineKeyboard?: TelegramInlineKeyboard;
+    /** Show the typing indicator before sending. @default true */
+    typing?: boolean;
+    disableNotification?: boolean;
+};
+type EditMessageProps$1 = TelegramOutboundBaseProps & {
+    chatId: number | string;
+    messageId?: number;
+    text?: string;
+    children?: (deps: ResolvedDeps) => string | {
+        text: string;
+        messageId?: number;
+        inlineKeyboard?: TelegramInlineKeyboard;
+    };
+    parseMode?: SendMessageSmartOptions["parseMode"];
+    inlineKeyboard?: TelegramInlineKeyboard;
+};
+type SendDocumentProps$1 = TelegramOutboundBaseProps & {
+    chatId: number | string;
+    document?: TelegramDocumentInput;
+    caption?: string;
+    replyToMessageId?: number;
+    messageThreadId?: number;
+    children?: (deps: ResolvedDeps) => {
+        document: TelegramDocumentInput;
+        caption?: string;
+    };
+};
+type AnswerCallbackQueryProps$1 = TelegramOutboundBaseProps & {
+    callbackQueryId?: string;
+    text?: string;
+    showAlert?: boolean;
+    children?: (deps: ResolvedDeps) => {
+        callbackQueryId: string;
+        text?: string;
+        showAlert?: boolean;
+    };
+};
+
+/**
+ * Send a Telegram message as a durable compute Task: chunks at 4096 chars on
+ * paragraph/sentence boundaries, converts markdown → MarkdownV2 with
+ * plain-text fallback on parse errors, shows a typing indicator, threads
+ * replies (`replyToMessageId`, `messageThreadId`), and attaches an inline
+ * keyboard to the last chunk. Text comes from the `text` prop or is built
+ * from resolved `deps` by the function children.
+ *
+ * @param {SendMessageProps} props
+ */
+declare function SendMessage(props: SendMessageProps): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/**
+ * Edit a previously sent message in place (MarkdownV2 with plain-text
+ * fallback), as a durable compute Task.
+ * @param {EditMessageProps} props
+ */
+declare function EditMessage(props: EditMessageProps): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/**
+ * Send a document (URL/file_id via JSON, raw content via multipart upload)
+ * as a durable compute Task.
+ * @param {SendDocumentProps} props
+ */
+declare function SendDocument(props: SendDocumentProps): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/**
+ * Answer an inline-keyboard callback query (dismisses the client-side
+ * loading state; optionally shows a toast/alert), as a durable compute Task.
+ * Pairs with `<OnCallbackQuery>`.
+ * @param {AnswerCallbackQueryProps} props
+ */
+declare function AnswerCallbackQuery(props: AnswerCallbackQueryProps): react.ReactElement<any, string | react.JSXElementConstructor<any>> | null;
+/** Output shape produced by `<SendMessage>` (sendMessageSmart's result). */
+declare const TelegramSendResultSchema: z.ZodObject<{
+    chatId: z.ZodString;
+    messageIds: z.ZodArray<z.ZodNumber>;
+    chunkCount: z.ZodNumber;
+    usedPlainTextFallback: z.ZodBoolean;
+}, z.core.$strip>;
+type SendMessageProps = SendMessageProps$1;
+type EditMessageProps = EditMessageProps$1;
+type SendDocumentProps = SendDocumentProps$1;
+type AnswerCallbackQueryProps = AnswerCallbackQueryProps$1;
+
+/** The request rendered into the approval prompt. */
+type TelegramApprovalRequest$1 = {
+    /** Short title / question, e.g. "Deploy to prod?". */
+    title: string;
+    /** Optional detail shown under the title (standard markdown). */
+    summary?: string;
+};
+type TelegramApprovalProps$1 = {
+    /** Node id. The decision output is stored under this id. */
+    id: string;
+    /** Chat that receives the prompt and whose button press resolves it. */
+    chatId: number | string;
+    /** Forum-topic thread to scope the prompt + wait to (isolates concurrent approvals). */
+    threadId?: number | string;
+    /** What is being approved. */
+    request: TelegramApprovalRequest$1;
+    /** Where to store the decision (a createSmithers output target). */
+    output?: z.ZodTypeAny;
+    /** Override the decision output schema. Defaults to the approve/select schema. */
+    outputSchema?: z.ZodTypeAny;
+    /** "approve" (Approve/Reject) or "select" (one button per option). @default "approve" */
+    mode?: TelegramApprovalMode;
+    /** Options for `mode: "select"`. */
+    options?: TelegramApprovalOption[];
+    /** Approve-button label (approve mode). */
+    approveText?: string;
+    /** Reject-button label (approve mode). */
+    rejectText?: string;
+    /** Add a Mini App (`web_app`) button opening this HTTPS url for a richer UI. */
+    miniApp?: {
+        url: string;
+        text?: string;
+    };
+    /** Telegram client config; falls back to configureTelegram()/env. */
+    config?: Partial<TelegramClientConfig$1>;
+    /** Prompt/outcome message format. @default "markdown" */
+    parseMode?: SendMessageSmartOptions["parseMode"];
+    /** Max wait for the button press before timing out. */
+    timeoutMs?: number;
+    onTimeout?: "fail" | "skip" | "continue";
+    /** Do not block unrelated downstream flow while waiting. */
+    async?: boolean;
+    skipIf?: boolean;
+    dependsOn?: string[];
+    key?: string;
+    smithersContext?: react__default.Context<unknown>;
+};
+
+/**
+ * Durable Telegram approval. See the file header for the composition.
+ * @param {TelegramApprovalProps} props
+ * @returns {React.ReactElement | null}
+ */
+declare function TelegramApproval(props: TelegramApprovalProps): react__default.ReactElement | null;
+declare namespace telegramApprovalSchemas {
+    export { TelegramSendResultSchema as telegramApprovalPrompt };
+    export { TelegramCallbackQuerySchema as telegramApprovalCallback };
+}
+type TelegramApprovalProps = TelegramApprovalProps$1;
+type TelegramApprovalRequest = TelegramApprovalRequest$1;
+
+export { AnswerCallbackQuery, type AnswerCallbackQueryProps, EditMessage, type EditMessageProps, type MakeTelegramSourceOptions, OnCallbackQuery, type OnCallbackQueryProps, OnMessage, type OnMessageProps, OnWebAppData, SendDocument, type SendDocumentOptions, type SendDocumentProps, SendMessage, type SendMessageProps, type SendMessageSmartOptions, type SendMessageSmartResult, TELEGRAM_MAX_MESSAGE_LENGTH, TelegramApproval, type TelegramApprovalChoice, type TelegramApprovalDecision, type TelegramApprovalKeyboardSpec, type TelegramApprovalMode, type TelegramApprovalOption, type TelegramApprovalProps, type TelegramApprovalRequest, type TelegramApprovalSelection, TelegramCallbackQuerySchema, TelegramChatSchema, type TelegramClientService, type TelegramDocumentInput, type TelegramInitData, type TelegramInitDataUser, type TelegramInlineKeyboard, type TelegramInlineKeyboardButton, TelegramMessageSchema, TelegramSendResultSchema, TelegramUserSchema, TelegramWebAppDataMessageSchema, TelegramWebAppDataSchema, type VerifyTelegramWebAppInitDataOptions, type VerifyTelegramWebAppInitDataSignatureOptions, chunkTelegramText, cleanText, configureTelegram, convertMarkdownToTelegram, escapeMarkdownV2, resolveTelegramClient, resolveTelegramConfig, telegramApprovalSchemas };
+
+// ---------------------------------------------------------------------------
+// Curated value declarations (see the header). These runtime exports are
+// dropped by tsup because their `.js` modules are shadowed by types-only `.ts`
+// companions. Types reference the aliases already inlined above.
+// ---------------------------------------------------------------------------
+
+// src/telegram/approval.js
+declare const telegramApprovalDecisionSchema: z.ZodType<TelegramApprovalDecision>;
+declare const telegramApprovalSelectionSchema: z.ZodType<TelegramApprovalSelection>;
+declare function telegramApprovalCallbackData(choice: TelegramApprovalChoice): string;
+declare function parseTelegramApprovalCallbackData(data: string | undefined | null): TelegramApprovalChoice | null;
+declare function webAppButton(text: string, url: string): TelegramInlineKeyboardButton;
+declare function approvalInlineKeyboard(spec: TelegramApprovalKeyboardSpec): TelegramInlineKeyboard;
+declare function telegramApproverLabel(callbackQuery: { from?: { id?: number | string; username?: string } }): string | null;
+declare function telegramApprovalDecision(callbackQuery: { data?: string; from?: object; message?: { date?: number } }, spec: TelegramApprovalKeyboardSpec): TelegramApprovalDecision | TelegramApprovalSelection;
+
+// src/telegram/initData.js
+declare const TELEGRAM_WEBAPP_ED25519_PUBLIC_KEY_PROD: string;
+declare const TELEGRAM_WEBAPP_ED25519_PUBLIC_KEY_TEST: string;
+declare function parseTelegramInitData(initData: string): TelegramInitData;
+declare function verifyTelegramWebAppInitData(initData: string, botToken: string, options?: VerifyTelegramWebAppInitDataOptions): Promise<TelegramInitData>;
+declare function verifyTelegramWebAppInitDataSignature(initData: string, botId: number | string, options?: VerifyTelegramWebAppInitDataSignatureOptions): Promise<TelegramInitData>;
+
+// src/telegram/TelegramClient.js
+declare const DEFAULT_TELEGRAM_API_BASE_URL: string;
+declare class TelegramApiError extends SmithersError {
+    errorCode: number | null;
+    retryAfterSeconds: number | null;
+    constructor(message: string, options: { method: string; errorCode?: number | null; description?: string | null; retryAfterSeconds?: number | null; cause?: unknown });
+}
+declare function redactBotToken(text: string, botToken: string): string;
+declare function isTelegramApiError(error: unknown): error is TelegramApiError;
+declare const TelegramClient: Context.Tag<TelegramClientService, TelegramClientService>;
+declare function makeTelegramClient(config: TelegramClientConfig): TelegramClientService;
+declare function TelegramClientLive(config: TelegramClientConfig): Layer.Layer<TelegramClientService>;
+
+// src/telegram/TelegramSource.js
+declare const TELEGRAM_SERVICE: "telegram";
+declare const TELEGRAM_MESSAGE_EVENT: string;
+declare const TELEGRAM_EDITED_MESSAGE_EVENT: string;
+declare const TELEGRAM_CALLBACK_QUERY_EVENT: string;
+declare const TELEGRAM_WEB_APP_DATA_EVENT: string;
+declare function telegramChatCorrelationId(chatId: number | string): string;
+declare function telegramThreadCorrelationId(chatId: number | string, threadId: number | string): string;
+declare function telegramUpdateToEvents(sourceId: string, update: Record<string, any>, receivedAtMs: number): CoreExternalEvent[];
+declare function makeTelegramSource(options: MakeTelegramSourceOptions): CoreEventSource;
+
+export {
+    DEFAULT_TELEGRAM_API_BASE_URL,
+    TELEGRAM_CALLBACK_QUERY_EVENT,
+    TELEGRAM_EDITED_MESSAGE_EVENT,
+    TELEGRAM_MESSAGE_EVENT,
+    TELEGRAM_SERVICE,
+    TELEGRAM_WEBAPP_ED25519_PUBLIC_KEY_PROD,
+    TELEGRAM_WEBAPP_ED25519_PUBLIC_KEY_TEST,
+    TELEGRAM_WEB_APP_DATA_EVENT,
+    TelegramApiError,
+    TelegramClient,
+    TelegramClientLive,
+    approvalInlineKeyboard,
+    isTelegramApiError,
+    makeTelegramClient,
+    makeTelegramSource,
+    parseTelegramApprovalCallbackData,
+    parseTelegramInitData,
+    redactBotToken,
+    telegramApprovalCallbackData,
+    telegramApprovalDecision,
+    telegramApprovalDecisionSchema,
+    telegramApprovalSelectionSchema,
+    telegramApproverLabel,
+    telegramChatCorrelationId,
+    telegramThreadCorrelationId,
+    telegramUpdateToEvents,
+    verifyTelegramWebAppInitData,
+    verifyTelegramWebAppInitDataSignature,
+    webAppButton,
+};

--- a/packages/integrations/src/telegram.js
+++ b/packages/integrations/src/telegram.js
@@ -1,11 +1,15 @@
 // @smithers-orchestrator/integrations/telegram — Telegram Bot API surface:
-// fetch-based client Layer, getUpdates long-poll EventSource, and the
-// listener/outbound workflow components.
+// fetch-based client Layer, getUpdates long-poll EventSource, the
+// listener/outbound workflow components, in-app approvals, and Mini App
+// (Web App) initData verification.
+export * from "./telegram/approval.js";
 export * from "./telegram/chunk.js";
 export * from "./telegram/config.js";
+export * from "./telegram/initData.js";
 export * from "./telegram/markdown.js";
 export * from "./telegram/schemas.js";
 export * from "./telegram/TelegramClient.js";
 export * from "./telegram/TelegramSource.js";
 export * from "./telegram/components/OnMessage.js";
 export * from "./telegram/components/SendMessage.js";
+export * from "./telegram/components/TelegramApproval.js";

--- a/packages/integrations/src/telegram/TelegramClient.js
+++ b/packages/integrations/src/telegram/TelegramClient.js
@@ -307,7 +307,12 @@ export function makeTelegramClient(config) {
         ...(options.text ? { text: options.text } : {}),
         ...(options.showAlert ? { show_alert: true } : {}),
     });
-    return { call, sendMessageSmart, editMessageSmart, sendDocument, answerCallbackQuery };
+    /** @type {TelegramClientService["answerWebAppQuery"]} */
+    const answerWebAppQuery = (webAppQueryId, result) => call("answerWebAppQuery", {
+        web_app_query_id: webAppQueryId,
+        result,
+    });
+    return { call, sendMessageSmart, editMessageSmart, sendDocument, answerCallbackQuery, answerWebAppQuery };
 }
 
 /**

--- a/packages/integrations/src/telegram/TelegramClient.ts
+++ b/packages/integrations/src/telegram/TelegramClient.ts
@@ -115,4 +115,14 @@ export type TelegramClientService = {
     callbackQueryId: string,
     options?: { text?: string; showAlert?: boolean },
   ) => Effect.Effect<unknown, SmithersError>;
+  /**
+   * Answer a Mini App inline query: post the `result` back to the chat on the
+   * user's behalf and close the Mini App. `webAppQueryId` is the `query_id`
+   * from a Mini App launched by an inline-keyboard `web_app` button. `result`
+   * is a Bot API `InlineQueryResult`. Returns the `SentWebAppMessage`.
+   */
+  answerWebAppQuery: (
+    webAppQueryId: string,
+    result: Record<string, unknown>,
+  ) => Effect.Effect<unknown, SmithersError>;
 };

--- a/packages/integrations/src/telegram/TelegramSource.js
+++ b/packages/integrations/src/telegram/TelegramSource.js
@@ -13,6 +13,7 @@ export const TELEGRAM_SERVICE = "telegram";
 export const TELEGRAM_MESSAGE_EVENT = integrationEventName(TELEGRAM_SERVICE, "message");
 export const TELEGRAM_EDITED_MESSAGE_EVENT = integrationEventName(TELEGRAM_SERVICE, "edited_message");
 export const TELEGRAM_CALLBACK_QUERY_EVENT = integrationEventName(TELEGRAM_SERVICE, "callback_query");
+export const TELEGRAM_WEB_APP_DATA_EVENT = integrationEventName(TELEGRAM_SERVICE, "web_app_data");
 
 const DEFAULT_ALLOWED_UPDATES = ["message", "edited_message", "callback_query"];
 const DEFAULT_POLL_TIMEOUT_SECONDS = 25;
@@ -86,6 +87,33 @@ export function telegramUpdateToEvents(sourceId, update, receivedAtMs) {
     };
     if (update.message) {
         pushMessageEvents(TELEGRAM_MESSAGE_EVENT, update.message);
+        // A reply-keyboard Mini App's Telegram.WebApp.sendData arrives as a
+        // normal message carrying a web_app_data field. Emit an extra,
+        // separately-deduped event so a run can wait specifically for
+        // structured Mini App data (payload = the same Message).
+        if (update.message.web_app_data) {
+            const chatId = update.message?.chat?.id;
+            if (chatId != null) {
+                events.push({
+                    source: sourceId,
+                    eventName: TELEGRAM_WEB_APP_DATA_EVENT,
+                    correlationId: telegramChatCorrelationId(chatId),
+                    payload: update.message,
+                    dedupeKey: `update:${updateId}:webappdata`,
+                    receivedAtMs,
+                });
+                if (update.message.is_topic_message && update.message.message_thread_id != null) {
+                    events.push({
+                        source: sourceId,
+                        eventName: TELEGRAM_WEB_APP_DATA_EVENT,
+                        correlationId: telegramThreadCorrelationId(chatId, update.message.message_thread_id),
+                        payload: update.message,
+                        dedupeKey: `update:${updateId}:webappdata:thread`,
+                        receivedAtMs,
+                    });
+                }
+            }
+        }
     }
     else if (update.edited_message) {
         pushMessageEvents(TELEGRAM_EDITED_MESSAGE_EVENT, update.edited_message);

--- a/packages/integrations/src/telegram/components/OnMessage.js
+++ b/packages/integrations/src/telegram/components/OnMessage.js
@@ -9,8 +9,8 @@
  */
 // @smithers-type-exports-end
 
-import { TelegramCallbackQuerySchema, TelegramMessageSchema } from "../schemas.js";
-import { TELEGRAM_CALLBACK_QUERY_EVENT, TELEGRAM_EDITED_MESSAGE_EVENT, TELEGRAM_MESSAGE_EVENT } from "../TelegramSource.js";
+import { TelegramCallbackQuerySchema, TelegramMessageSchema, TelegramWebAppDataMessageSchema } from "../schemas.js";
+import { TELEGRAM_CALLBACK_QUERY_EVENT, TELEGRAM_EDITED_MESSAGE_EVENT, TELEGRAM_MESSAGE_EVENT, TELEGRAM_WEB_APP_DATA_EVENT } from "../TelegramSource.js";
 import { renderTelegramListener } from "./listenerInternals.js";
 
 /**
@@ -37,4 +37,18 @@ export function OnMessage(props) {
  */
 export function OnCallbackQuery(props) {
     return renderTelegramListener(TELEGRAM_CALLBACK_QUERY_EVENT, props, props.schema ?? TelegramCallbackQuerySchema);
+}
+
+/**
+ * Durable wait for structured data from a reply-keyboard Mini App
+ * (`Telegram.WebApp.sendData`), which arrives as a message carrying a
+ * `web_app_data` field. Renders `smithers:wait-for-event` on
+ * `integration:telegram:web_app_data`; children receive the zod-parsed Message,
+ * whose `web_app_data.data` holds the payload the Mini App sent.
+ *
+ * @template {import("zod").ZodTypeAny} Schema
+ * @param {OnMessageProps<Schema>} props
+ */
+export function OnWebAppData(props) {
+    return renderTelegramListener(TELEGRAM_WEB_APP_DATA_EVENT, props, props.schema ?? TelegramWebAppDataMessageSchema);
 }

--- a/packages/integrations/src/telegram/components/TelegramApproval.js
+++ b/packages/integrations/src/telegram/components/TelegramApproval.js
@@ -1,0 +1,204 @@
+// @smithers-type-exports-begin
+/** @typedef {import("./TelegramApprovalProps.ts").TelegramApprovalProps} TelegramApprovalProps */
+/** @typedef {import("./TelegramApprovalProps.ts").TelegramApprovalRequest} TelegramApprovalRequest */
+// @smithers-type-exports-end
+
+// Turn a Smithers approval into inline Approve/Reject (or one-button-per-option)
+// controls inside a Telegram chat, resolved durably by the button press. No web
+// server, no gateway wiring — it composes the existing durable primitives:
+//   SendMessage (post the prompt + inline keyboard)
+//     → OnCallbackQuery (durably wait for the press)
+//       → a compute Task that acknowledges the press, edits the message to
+//         stamp the outcome (best-effort), and yields the decision (shaped like
+//         the core approvalDecisionSchema / approvalSelectionSchema).
+//
+// Register the two internal node schemas once via `telegramApprovalSchemas`:
+//   const { smithers, outputs } = createSmithers({
+//     ...telegramApprovalSchemas,
+//     approval: telegramApprovalDecisionSchema,
+//   });
+//
+// WaitForEvent wakes on the first callback_query for the chat/thread correlation
+// and has no predicate, so run one interactive approval per chat at a time, or
+// isolate concurrent approvals with `threadId` (forum topics). Any chat member
+// can press; the private/allowed chat is the trust boundary for Tier 1.
+
+import React from "react";
+import { Effect } from "effect";
+import { Task } from "@smithers-orchestrator/components";
+import { OnCallbackQuery } from "./OnMessage.js";
+import { SendMessage, TelegramSendResultSchema } from "./SendMessage.js";
+import { TelegramCallbackQuerySchema } from "../schemas.js";
+import { resolveTelegramClient } from "../config.js";
+import {
+  approvalInlineKeyboard,
+  telegramApprovalDecision,
+  telegramApprovalDecisionSchema,
+  telegramApprovalSelectionSchema,
+  telegramApproverLabel,
+} from "../approval.js";
+
+/**
+ * Output schemas for the two internal `TelegramApproval` nodes (the prompt send
+ * and the button-press wait). Spread into `createSmithers({...})` so the engine
+ * can persist them.
+ */
+export const telegramApprovalSchemas = {
+  telegramApprovalPrompt: TelegramSendResultSchema,
+  telegramApprovalCallback: TelegramCallbackQuerySchema,
+};
+
+/**
+ * @param {TelegramApprovalRequest} request
+ * @returns {string}
+ */
+function renderPromptText(request) {
+  const title = request?.title?.trim() || "Approval needed";
+  return request?.summary?.trim() ? `**${title}**\n\n${request.summary.trim()}` : `**${title}**`;
+}
+
+/**
+ * @param {import("../approval.ts").TelegramApprovalKeyboardSpec} spec
+ * @param {string} key
+ * @returns {string}
+ */
+function optionLabel(spec, key) {
+  return spec.options?.find((option) => option.key === key)?.label ?? key;
+}
+
+/**
+ * @param {import("../approval.ts").TelegramApprovalKeyboardSpec} spec
+ * @param {any} decision
+ * @returns {string} short toast text (<=200 chars)
+ */
+function ackText(spec, decision) {
+  if (spec.mode === "select") {
+    return decision.selected ? `Selected: ${optionLabel(spec, decision.selected)}` : "Received";
+  }
+  return decision.approved ? "Approved ✅" : "Rejected 🚫";
+}
+
+/**
+ * @param {TelegramApprovalRequest} request
+ * @param {import("../approval.ts").TelegramApprovalKeyboardSpec} spec
+ * @param {any} decision
+ * @param {string | null} by
+ * @returns {string} the edited-message body (standard markdown)
+ */
+function outcomeText(request, spec, decision, by) {
+  const title = request?.title?.trim() || "Approval";
+  const suffix = by ? ` by ${by}` : "";
+  if (spec.mode === "select") {
+    const label = decision.selected ? optionLabel(spec, decision.selected) : "no option";
+    return `**${title}**\n\n✅ Chose ${label}${suffix}`;
+  }
+  const verb = decision.approved ? "✅ Approved" : "🚫 Rejected";
+  return `**${title}**\n\n${verb}${suffix}`;
+}
+
+/**
+ * @param {number | string | undefined} threadId
+ * @returns {number | undefined}
+ */
+function threadIdAsNumber(threadId) {
+  return threadId != null ? Number(threadId) : undefined;
+}
+
+/**
+ * Acknowledge the press and stamp the outcome onto the prompt (both best-effort
+ * so a UI hiccup never fails the approval), then resolve to the decision.
+ * @param {Partial<import("../TelegramClient.ts").TelegramClientConfig> | undefined} config
+ * @param {number | string} chatId
+ * @param {any} callbackQuery
+ * @param {import("../approval.ts").TelegramApprovalKeyboardSpec} spec
+ * @param {TelegramApprovalRequest} request
+ * @param {import("../TelegramClient.ts").SendMessageSmartOptions["parseMode"]} parseMode
+ * @param {any} decision
+ * @returns {Promise<any>}
+ */
+function resolveApprovalDecision(config, chatId, callbackQuery, spec, request, parseMode, decision) {
+  const client = resolveTelegramClient(config);
+  const by = telegramApproverLabel(callbackQuery);
+  const messageId = callbackQuery?.message?.message_id;
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* client
+        .answerCallbackQuery(callbackQuery.id, { text: ackText(spec, decision) })
+        .pipe(Effect.catchAll(() => Effect.void));
+      if (typeof messageId === "number") {
+        yield* client
+          .editMessageSmart(chatId, messageId, outcomeText(request, spec, decision, by), {
+            parseMode,
+            inlineKeyboard: [],
+          })
+          .pipe(Effect.catchAll(() => Effect.void));
+      }
+      return decision;
+    }),
+  );
+}
+
+/**
+ * Durable Telegram approval. See the file header for the composition.
+ * @param {TelegramApprovalProps} props
+ * @returns {React.ReactElement | null}
+ */
+export function TelegramApproval(props) {
+  if (props.skipIf) {
+    return null;
+  }
+  const mode = props.mode ?? "approve";
+  /** @type {import("../approval.ts").TelegramApprovalKeyboardSpec} */
+  const spec = {
+    mode,
+    options: props.options,
+    approveText: props.approveText,
+    rejectText: props.rejectText,
+    miniAppUrl: props.miniApp?.url,
+    miniAppText: props.miniApp?.text,
+  };
+  const keyboard = approvalInlineKeyboard(spec);
+  const parseMode = props.parseMode ?? "markdown";
+  const outputSchema = props.outputSchema ??
+    (mode === "select" ? telegramApprovalSelectionSchema : telegramApprovalDecisionSchema);
+  const askId = `${props.id}:ask`;
+  const waitId = `${props.id}:wait`;
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(SendMessage, {
+      id: askId,
+      chatId: props.chatId,
+      config: props.config,
+      output: TelegramSendResultSchema,
+      messageThreadId: threadIdAsNumber(props.threadId),
+      text: renderPromptText(props.request),
+      inlineKeyboard: keyboard,
+      parseMode,
+      smithersContext: props.smithersContext,
+    }),
+    React.createElement(OnCallbackQuery, {
+      id: waitId,
+      chatId: props.chatId,
+      threadId: props.threadId,
+      dependsOn: [askId],
+      timeoutMs: props.timeoutMs,
+      onTimeout: props.onTimeout,
+      async: props.async,
+      smithersContext: props.smithersContext,
+      children: (/** @type {any} */ callbackQuery) => {
+        const decision = telegramApprovalDecision(callbackQuery, spec);
+        return React.createElement(Task, {
+          id: props.id,
+          output: props.output,
+          outputSchema,
+          dependsOn: [waitId],
+          smithersContext: props.smithersContext,
+          children: () =>
+            resolveApprovalDecision(props.config, props.chatId, callbackQuery, spec, props.request, parseMode, decision),
+        });
+      },
+    }),
+  );
+}

--- a/packages/integrations/src/telegram/components/TelegramApproval.js
+++ b/packages/integrations/src/telegram/components/TelegramApproval.js
@@ -25,6 +25,7 @@
 
 import React from "react";
 import { Effect } from "effect";
+import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 import { Task } from "@smithers-orchestrator/components";
 import { OnCallbackQuery } from "./OnMessage.js";
 import { SendMessage, TelegramSendResultSchema } from "./SendMessage.js";
@@ -97,11 +98,25 @@ function outcomeText(request, spec, decision, by) {
 }
 
 /**
+ * Coerce a forum-topic `threadId` to the numeric `message_thread_id` the Bot API
+ * expects. A non-numeric string would otherwise become `NaN` and get sent
+ * silently, so reject it up front with `INVALID_INPUT`.
  * @param {number | string | undefined} threadId
  * @returns {number | undefined}
  */
 function threadIdAsNumber(threadId) {
-  return threadId != null ? Number(threadId) : undefined;
+  if (threadId == null) {
+    return undefined;
+  }
+  const numeric = Number(threadId);
+  if (!Number.isFinite(numeric)) {
+    throw new SmithersError(
+      "INVALID_INPUT",
+      `Telegram.TelegramApproval threadId must be numeric (a forum-topic message_thread_id); received ${JSON.stringify(threadId)}.`,
+      { threadId },
+    );
+  }
+  return numeric;
 }
 
 /**

--- a/packages/integrations/src/telegram/components/TelegramApprovalProps.ts
+++ b/packages/integrations/src/telegram/components/TelegramApprovalProps.ts
@@ -1,0 +1,53 @@
+import type React from "react";
+import type { z } from "zod";
+import type { TelegramClientConfig, SendMessageSmartOptions } from "../TelegramClient.ts";
+import type {
+  TelegramApprovalMode,
+  TelegramApprovalOption,
+} from "../approval.ts";
+
+/** The request rendered into the approval prompt. */
+export type TelegramApprovalRequest = {
+  /** Short title / question, e.g. "Deploy to prod?". */
+  title: string;
+  /** Optional detail shown under the title (standard markdown). */
+  summary?: string;
+};
+
+export type TelegramApprovalProps = {
+  /** Node id. The decision output is stored under this id. */
+  id: string;
+  /** Chat that receives the prompt and whose button press resolves it. */
+  chatId: number | string;
+  /** Forum-topic thread to scope the prompt + wait to (isolates concurrent approvals). */
+  threadId?: number | string;
+  /** What is being approved. */
+  request: TelegramApprovalRequest;
+  /** Where to store the decision (a createSmithers output target). */
+  output?: z.ZodTypeAny;
+  /** Override the decision output schema. Defaults to the approve/select schema. */
+  outputSchema?: z.ZodTypeAny;
+  /** "approve" (Approve/Reject) or "select" (one button per option). @default "approve" */
+  mode?: TelegramApprovalMode;
+  /** Options for `mode: "select"`. */
+  options?: TelegramApprovalOption[];
+  /** Approve-button label (approve mode). */
+  approveText?: string;
+  /** Reject-button label (approve mode). */
+  rejectText?: string;
+  /** Add a Mini App (`web_app`) button opening this HTTPS url for a richer UI. */
+  miniApp?: { url: string; text?: string };
+  /** Telegram client config; falls back to configureTelegram()/env. */
+  config?: Partial<TelegramClientConfig>;
+  /** Prompt/outcome message format. @default "markdown" */
+  parseMode?: SendMessageSmartOptions["parseMode"];
+  /** Max wait for the button press before timing out. */
+  timeoutMs?: number;
+  onTimeout?: "fail" | "skip" | "continue";
+  /** Do not block unrelated downstream flow while waiting. */
+  async?: boolean;
+  skipIf?: boolean;
+  dependsOn?: string[];
+  key?: string;
+  smithersContext?: React.Context<unknown>;
+};

--- a/packages/integrations/src/telegram/schemas.js
+++ b/packages/integrations/src/telegram/schemas.js
@@ -55,3 +55,20 @@ export const TelegramCallbackQuerySchema = z
     message: TelegramMessageSchema.optional(),
 })
     .passthrough();
+
+/** The `web_app_data` field of a message from a reply-keyboard Mini App's `sendData`. */
+export const TelegramWebAppDataSchema = z
+    .object({
+    data: z.string(),
+    button_text: z.string().optional(),
+})
+    .passthrough();
+
+/**
+ * Payload delivered for `integration:telegram:web_app_data`: the Message that
+ * carries the `web_app_data` field (untrusted `data`, but the sender is
+ * Telegram-guaranteed).
+ */
+export const TelegramWebAppDataMessageSchema = TelegramMessageSchema.extend({
+    web_app_data: TelegramWebAppDataSchema.optional(),
+});

--- a/packages/integrations/tests/telegram-approval.test.js
+++ b/packages/integrations/tests/telegram-approval.test.js
@@ -1,0 +1,192 @@
+// Telegram in-app approvals. Pure-logic units for the callback_data codec /
+// keyboard / decision mapping, plus full durable round-trips driven by the REAL
+// engine against the real fixture Bot API server: post prompt → park on the
+// button press → signal a callback_query → resume → answer + edit + decision.
+// No mocks.
+import { afterAll, describe, expect, test } from "bun:test";
+import React from "react";
+import { Effect } from "effect";
+import { createSmithers, runWorkflow, signalRun } from "smithers-orchestrator";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import {
+  TelegramApproval,
+  approvalInlineKeyboard,
+  parseTelegramApprovalCallbackData,
+  telegramApprovalCallbackData,
+  telegramApprovalDecision,
+  telegramApprovalDecisionSchema,
+  telegramApprovalSchemas,
+  telegramApprovalSelectionSchema,
+  webAppButton,
+} from "../src/telegram.js";
+import { makeTelegramClient } from "../src/telegram/TelegramClient.js";
+import { TELEGRAM_CALLBACK_QUERY_EVENT } from "../src/telegram/TelegramSource.js";
+import { startTelegramFixture } from "./telegram-fixture.js";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const fixture = startTelegramFixture();
+afterAll(() => fixture.stop());
+const telegramConfig = { botToken: fixture.token, apiBaseUrl: fixture.apiBaseUrl };
+
+function makeApi() {
+  const dir = mkdtempSync(join(tmpdir(), "smithers-tg-approval-"));
+  return createSmithers({
+    ...telegramApprovalSchemas,
+    decision: telegramApprovalDecisionSchema,
+    selection: telegramApprovalSelectionSchema,
+  }, { dbPath: join(dir, "db.sqlite") });
+}
+
+/** A delivered callback_query payload as the source would fan it out. */
+function callbackQuery(data) {
+  return {
+    id: "cbq-1",
+    from: { id: 7, username: "will" },
+    data,
+    message: { message_id: 700, date: 1_700_000_000, chat: { id: 777, type: "private" } },
+  };
+}
+
+describe("callback_data codec", () => {
+  test("round-trips approve / reject / select", () => {
+    expect(parseTelegramApprovalCallbackData(telegramApprovalCallbackData({ kind: "approve" }))).toEqual({ kind: "approve" });
+    expect(parseTelegramApprovalCallbackData(telegramApprovalCallbackData({ kind: "reject" }))).toEqual({ kind: "reject" });
+    expect(parseTelegramApprovalCallbackData(telegramApprovalCallbackData({ kind: "select", key: "opt-1" }))).toEqual({ kind: "select", key: "opt-1" });
+  });
+  test("ignores stray / malformed callback data", () => {
+    expect(parseTelegramApprovalCallbackData("something:else")).toBeNull();
+    expect(parseTelegramApprovalCallbackData(undefined)).toBeNull();
+    expect(parseTelegramApprovalCallbackData("sap:z")).toBeNull();
+  });
+  test("rejects option keys that would exceed the 64-byte callback_data limit", () => {
+    expect(() => telegramApprovalCallbackData({ kind: "select", key: "x".repeat(70) })).toThrow(/64-byte/);
+    expect(() => telegramApprovalCallbackData({ kind: "select", key: "a:b" })).toThrow(/no ":"/);
+  });
+});
+
+describe("approvalInlineKeyboard / webAppButton", () => {
+  test("approve mode yields an Approve/Reject row", () => {
+    const keyboard = approvalInlineKeyboard({ mode: "approve" });
+    expect(keyboard[0].map((b) => b.callback_data)).toEqual(["sap:a", "sap:d"]);
+  });
+  test("select mode yields one button per option; miniApp adds a web_app row", () => {
+    const keyboard = approvalInlineKeyboard({
+      mode: "select",
+      options: [{ key: "a", label: "A" }, { key: "b", label: "B" }],
+      miniAppUrl: "https://approve.example.com",
+      miniAppText: "Open",
+    });
+    expect(keyboard).toHaveLength(3);
+    expect(keyboard[0][0]).toMatchObject({ text: "A", callback_data: "sap:s:a" });
+    expect(keyboard[2][0]).toMatchObject({ text: "Open", web_app: { url: "https://approve.example.com" } });
+  });
+  test("web_app buttons require https", () => {
+    expect(() => webAppButton("x", "http://insecure.example.com")).toThrow(/https/);
+  });
+});
+
+describe("telegramApprovalDecision mapping", () => {
+  test("approve press → { approved: true, decidedBy, decidedAt }", () => {
+    const decision = telegramApprovalDecision(callbackQuery("sap:a"), { mode: "approve" });
+    expect(decision).toEqual({
+      approved: true,
+      note: null,
+      decidedBy: "@will",
+      decidedAt: new Date(1_700_000_000 * 1000).toISOString(),
+    });
+  });
+  test("reject press → { approved: false }", () => {
+    expect(telegramApprovalDecision(callbackQuery("sap:d"), { mode: "approve" }).approved).toBe(false);
+  });
+  test("select press → { selected }", () => {
+    expect(telegramApprovalDecision(callbackQuery("sap:s:b"), { mode: "select" })).toEqual({ selected: "b", notes: null });
+  });
+  test("stray press in approve mode is a safe non-approval", () => {
+    const decision = telegramApprovalDecision(callbackQuery("garbage"), { mode: "approve" });
+    expect(decision.approved).toBe(false);
+    expect(decision.note).toBe("unrecognized response");
+  });
+});
+
+describe("TelegramApproval end-to-end through the real engine", () => {
+  async function runApproval({ mode, outputKey, data, options }) {
+    const api = makeApi();
+    const workflow = api.smithers(() => React.createElement(api.Workflow, { name: "tg-approval" },
+      React.createElement(TelegramApproval, {
+        id: "gate",
+        chatId: 777,
+        config: telegramConfig,
+        request: { title: "Deploy to prod?", summary: "Ship release 0.27" },
+        mode,
+        options,
+        output: api.outputs[outputKey],
+      }),
+    ));
+    const first = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+    expect(first.status).toBe("waiting-event");
+
+    // The prompt was posted with the inline keyboard on it.
+    const send = fixture.calls("sendMessage").at(-1);
+    expect(send?.body.reply_markup?.inline_keyboard).toBeTruthy();
+
+    const adapter = new SmithersDb(api.db);
+    await Effect.runPromise(signalRun(adapter, first.runId, TELEGRAM_CALLBACK_QUERY_EVENT, callbackQuery(data), {
+      correlationId: "chat:777",
+      receivedBy: "integration:telegram",
+    }));
+
+    const resumed = await Effect.runPromise(runWorkflow(workflow, { runId: first.runId, resume: true, input: {} }));
+    expect(resumed.status).toBe("finished");
+    return { api };
+  }
+
+  test("approve: posts keyboard, waits, answers, edits, yields approved decision", async () => {
+    const beforeAnswer = fixture.calls("answerCallbackQuery").length;
+    const beforeEdit = fixture.calls("editMessageText").length;
+    const { api } = await runApproval({ mode: "approve", outputKey: "decision", data: "sap:a" });
+    // The press was acknowledged and the message stamped with the outcome.
+    expect(fixture.calls("answerCallbackQuery").length).toBe(beforeAnswer + 1);
+    const edit = fixture.calls("editMessageText").slice(beforeEdit).at(-1);
+    expect(edit?.body.text).toMatch(/Approved/);
+    const rows = api.db.select().from(api.tables.decision).all();
+    expect(rows).toHaveLength(1);
+    expect(Boolean(rows[0].approved)).toBe(true);
+    expect(rows[0].decidedBy).toBe("@will");
+  }, 20_000);
+
+  test("reject: yields a rejected decision", async () => {
+    const { api } = await runApproval({ mode: "approve", outputKey: "decision", data: "sap:d" });
+    const rows = api.db.select().from(api.tables.decision).all();
+    expect(Boolean(rows[0].approved)).toBe(false);
+  }, 20_000);
+
+  test("select: yields the chosen option key", async () => {
+    const { api } = await runApproval({
+      mode: "select",
+      options: [{ key: "a", label: "Roll forward" }, { key: "b", label: "Roll back" }],
+      outputKey: "selection",
+      data: "sap:s:b",
+    });
+    const rows = api.db.select().from(api.tables.selection).all();
+    expect(rows[0].selected).toBe("b");
+  }, 20_000);
+});
+
+describe("answerWebAppQuery", () => {
+  test("posts a Mini App inline result and returns the SentWebAppMessage", async () => {
+    const client = makeTelegramClient(telegramConfig);
+    const before = fixture.calls("answerWebAppQuery").length;
+    const result = await Effect.runPromise(client.answerWebAppQuery("wq-1", {
+      type: "article",
+      id: "1",
+      title: "Approved",
+      input_message_content: { message_text: "Approved via Mini App" },
+    }));
+    const calls = fixture.calls("answerWebAppQuery").slice(before);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body.web_app_query_id).toBe("wq-1");
+    expect(result).toMatchObject({ inline_message_id: "iq-wq-1" });
+  });
+});

--- a/packages/integrations/tests/telegram-approval.test.js
+++ b/packages/integrations/tests/telegram-approval.test.js
@@ -110,6 +110,18 @@ describe("telegramApprovalDecision mapping", () => {
   });
 });
 
+describe("TelegramApproval threadId validation", () => {
+  const baseProps = { id: "gate", chatId: 777, request: { title: "Deploy?" }, config: telegramConfig };
+  test("rejects a non-numeric threadId instead of sending NaN", () => {
+    expect(() => TelegramApproval({ ...baseProps, threadId: "general" })).toThrow(/threadId must be numeric/);
+  });
+  test("accepts a numeric threadId (number or numeric string) and no threadId", () => {
+    expect(() => TelegramApproval({ ...baseProps, threadId: 42 })).not.toThrow();
+    expect(() => TelegramApproval({ ...baseProps, threadId: "42" })).not.toThrow();
+    expect(() => TelegramApproval(baseProps)).not.toThrow();
+  });
+});
+
 describe("TelegramApproval end-to-end through the real engine", () => {
   async function runApproval({ mode, outputKey, data, options }) {
     const api = makeApi();

--- a/packages/integrations/tests/telegram-fixture.js
+++ b/packages/integrations/tests/telegram-fixture.js
@@ -109,6 +109,9 @@ export function startTelegramFixture(options = {}) {
                 case "answerCallbackQuery": {
                     return Response.json({ ok: true, result: true });
                 }
+                case "answerWebAppQuery": {
+                    return Response.json({ ok: true, result: { inline_message_id: `iq-${body.web_app_query_id}` } });
+                }
                 default:
                     return Response.json({ ok: false, error_code: 404, description: `Unknown method ${method}` }, { status: 404 });
             }

--- a/packages/integrations/tests/telegram-init-data.test.js
+++ b/packages/integrations/tests/telegram-init-data.test.js
@@ -1,0 +1,140 @@
+// Mini App initData verification. The valid inputs are signed with an
+// INDEPENDENT oracle (node:crypto for HMAC, Web Crypto for Ed25519) so the test
+// never trusts the code under test to build its own fixtures. No mocks.
+import { describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+import {
+  parseTelegramInitData,
+  verifyTelegramWebAppInitData,
+  verifyTelegramWebAppInitDataSignature,
+} from "../src/telegram/initData.js";
+
+const BOT_TOKEN = "424242:TEST-fixture-bot-token";
+const encoder = new TextEncoder();
+
+/** Data-check-string exactly as Telegram builds it (exclude `hash`, sort, \n-join). */
+function dataCheckString(fields, exclude) {
+  return Object.keys(fields)
+    .filter((key) => !exclude.includes(key))
+    .sort()
+    .map((key) => `${key}=${fields[key]}`)
+    .join("\n");
+}
+
+/** Build a valid HMAC-signed initData string from decoded fields. */
+function signHmacInitData(fields, botToken) {
+  const dcs = dataCheckString(fields, ["hash"]);
+  const secret = createHmac("sha256", "WebAppData").update(botToken).digest();
+  const hash = createHmac("sha256", secret).update(dcs).digest("hex");
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) params.set(key, value);
+  params.set("hash", hash);
+  return params.toString();
+}
+
+function bytesToHex(bytes) {
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function toBase64Url(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+const nowSeconds = 1_800_000_000;
+const nowMs = nowSeconds * 1000;
+const baseFields = () => ({
+  auth_date: String(nowSeconds),
+  query_id: "AAExampleQueryId",
+  user: JSON.stringify({ id: 7, first_name: "Will", username: "will" }),
+});
+
+describe("verifyTelegramWebAppInitData (HMAC)", () => {
+  test("accepts a correctly signed initData and returns parsed fields", async () => {
+    const initData = signHmacInitData(baseFields(), BOT_TOKEN);
+    const parsed = await verifyTelegramWebAppInitData(initData, BOT_TOKEN, { nowMs });
+    expect(parsed.user?.id).toBe(7);
+    expect(parsed.user?.username).toBe("will");
+    expect(parsed.queryId).toBe("AAExampleQueryId");
+    expect(parsed.authDate).toBe(nowSeconds);
+    expect(parsed.hash).toHaveLength(64);
+  });
+
+  test("rejects a tampered field (hash no longer matches)", async () => {
+    const fields = baseFields();
+    const initData = signHmacInitData(fields, BOT_TOKEN);
+    // Swap the user id after signing → data-check-string changes, hash stale.
+    const tampered = initData.replace("%22id%22%3A7", "%22id%22%3A9");
+    expect(tampered).not.toBe(initData);
+    await expect(verifyTelegramWebAppInitData(tampered, BOT_TOKEN, { nowMs })).rejects.toThrow(/signature does not match/);
+  });
+
+  test("rejects when signed with a different bot token", async () => {
+    const initData = signHmacInitData(baseFields(), "999999:some-other-token");
+    await expect(verifyTelegramWebAppInitData(initData, BOT_TOKEN, { nowMs })).rejects.toThrow(/does not match/);
+  });
+
+  test("rejects expired initData and never leaks the token", async () => {
+    const stale = { ...baseFields(), auth_date: String(nowSeconds - 7200) };
+    const initData = signHmacInitData(stale, BOT_TOKEN);
+    const error = await verifyTelegramWebAppInitData(initData, BOT_TOKEN, { maxAgeSeconds: 3600, nowMs }).catch((e) => e);
+    expect(String(error?.message)).toMatch(/expired/);
+    expect(JSON.stringify({ m: error?.message, d: error?.details })).not.toContain(BOT_TOKEN);
+  });
+
+  test("maxAgeSeconds: 0 disables the freshness check", async () => {
+    const stale = { ...baseFields(), auth_date: String(nowSeconds - 999999) };
+    const initData = signHmacInitData(stale, BOT_TOKEN);
+    const parsed = await verifyTelegramWebAppInitData(initData, BOT_TOKEN, { maxAgeSeconds: 0, nowMs });
+    expect(parsed.user?.id).toBe(7);
+  });
+
+  test("rejects initData with no hash field", async () => {
+    await expect(verifyTelegramWebAppInitData("user=%7B%7D&auth_date=1", BOT_TOKEN, { nowMs })).rejects.toThrow(/missing the hash/);
+  });
+
+  test("keeps values containing encoded delimiters intact (URLSearchParams parse)", async () => {
+    // A first_name with an ampersand → %26 inside the user JSON. A decode-first
+    // parser would corrupt this; URLSearchParams handles it.
+    const fields = { ...baseFields(), user: JSON.stringify({ id: 7, first_name: "A&B" }) };
+    const initData = signHmacInitData(fields, BOT_TOKEN);
+    const parsed = await verifyTelegramWebAppInitData(initData, BOT_TOKEN, { nowMs });
+    expect(parsed.user?.first_name).toBe("A&B");
+  });
+});
+
+describe("verifyTelegramWebAppInitDataSignature (Ed25519 third-party)", () => {
+  test("accepts a real Ed25519 signature and rejects a tampered one", async () => {
+    const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+    const publicKeyHex = bytesToHex(new Uint8Array(await crypto.subtle.exportKey("raw", keyPair.publicKey)));
+    const botId = 424242;
+    const fields = baseFields();
+    const message = `${botId}:WebAppData\n${dataCheckString(fields, ["hash", "signature"])}`;
+    const signature = new Uint8Array(await crypto.subtle.sign("Ed25519", keyPair.privateKey, encoder.encode(message)));
+
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(fields)) params.set(key, value);
+    params.set("signature", toBase64Url(signature));
+    const initData = params.toString();
+
+    const parsed = await verifyTelegramWebAppInitDataSignature(initData, botId, { publicKeyHex, nowMs });
+    expect(parsed.user?.id).toBe(7);
+
+    const tampered = initData.replace("query_id=AAExampleQueryId", "query_id=forged");
+    await expect(verifyTelegramWebAppInitDataSignature(tampered, botId, { publicKeyHex, nowMs })).rejects.toThrow(/does not match/);
+  });
+
+  test("rejects initData with no signature field", async () => {
+    await expect(verifyTelegramWebAppInitDataSignature("auth_date=1&user=%7B%7D", 1, { nowMs })).rejects.toThrow(/missing the signature/);
+  });
+});
+
+describe("parseTelegramInitData", () => {
+  test("parses fields without verifying", () => {
+    const initData = signHmacInitData(baseFields(), BOT_TOKEN);
+    const parsed = parseTelegramInitData(initData);
+    expect(parsed.user?.username).toBe("will");
+    expect(parsed.params.query_id).toBe("AAExampleQueryId");
+  });
+});

--- a/packages/integrations/tests/telegram-source.test.js
+++ b/packages/integrations/tests/telegram-source.test.js
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { Chunk, Effect, Schedule, Stream } from "effect";
 import { makeDbCursorStore } from "../src/core/CursorStore.js";
-import { makeTelegramSource, TELEGRAM_CALLBACK_QUERY_EVENT, TELEGRAM_EDITED_MESSAGE_EVENT, TELEGRAM_MESSAGE_EVENT, telegramUpdateToEvents } from "../src/telegram/TelegramSource.js";
+import { makeTelegramSource, TELEGRAM_CALLBACK_QUERY_EVENT, TELEGRAM_EDITED_MESSAGE_EVENT, TELEGRAM_MESSAGE_EVENT, TELEGRAM_WEB_APP_DATA_EVENT, telegramUpdateToEvents } from "../src/telegram/TelegramSource.js";
 import { createTestAdapter } from "./helpers.js";
 import { startTelegramFixture } from "./telegram-fixture.js";
 
@@ -65,6 +65,22 @@ describe("telegramUpdateToEvents", () => {
             dedupeKey: "update:13",
         });
         expect(/** @type {any} */ (callback[0].payload).data).toBe("approve");
+    });
+    test("a message carrying web_app_data also emits a web_app_data event", () => {
+        const events = telegramUpdateToEvents("telegram", {
+            update_id: 14,
+            message: {
+                message_id: 88,
+                date: Math.floor(Date.now() / 1000),
+                chat: { id: 42, type: "private" },
+                web_app_data: { data: '{"decision":"approve"}', button_text: "Review" },
+            },
+        }, 123);
+        // Both the generic message event and the dedicated web_app_data event.
+        expect(events.map((event) => event.eventName)).toEqual([TELEGRAM_MESSAGE_EVENT, TELEGRAM_WEB_APP_DATA_EVENT]);
+        const webAppEvent = events.find((event) => event.eventName === TELEGRAM_WEB_APP_DATA_EVENT);
+        expect(webAppEvent).toMatchObject({ correlationId: "chat:42", dedupeKey: "update:14:webappdata" });
+        expect(/** @type {any} */ (webAppEvent?.payload).web_app_data.data).toBe('{"decision":"approve"}');
     });
 });
 


### PR DESCRIPTION
## What

Adds Telegram inline approvals end to end, on top of the existing digest bot + `apps/telegram-site` landing.

- **`packages/integrations`** — `TelegramApproval` component (posts an approval gate as an inline keyboard, resolves from the button press, matches the built-in approval decision shape) + `verifyTelegramWebAppInitData` for Mini App initData (HMAC/Ed25519). Client/source/OnMessage/schemas wired up; unit tests for the component, initData verification, and source.
- **`apps/telegram-site`** — reference `/approve` Mini App endpoint (`handleApprove` + `verifyTelegramInitData`) served from the worker, an `approve.html` Mini App page, and an `#approve` section on the landing that markets the component. Worker tests cover the new route.
- **docs** — `integrations/telegram.mdx` + `reference/package-configuration.mdx` updates and regenerated `llms-*.txt` bundles.

## Why a PR (not a direct push to main)

Local `main` had diverged ~57 commits from a squash-reconciled `origin/main`; a full rebase conflicted heavily and would risk reintroducing squashed code. These three commits were cherry-picked cleanly onto fresh `origin/main` instead. The only conflict was `telegram-site/site/index.html` (add/add) — resolved by keeping the approval-enhanced version, which is a clean superset of origin's digest-only landing.

## Verification

Cherry-picked clean onto `origin/main`; CI runs the gate (typecheck, `check-docs`/`check-llms`, package tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)