### PR TITLE
fix(cli): validate preselected restore targets

### DIFF
--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -144,6 +144,23 @@ function terminalRows() {
 }
 
 /**
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeTrackedInput(value) {
+    let result = "";
+    for (const char of String(value ?? "")) {
+        if (char === "\x7f" || char === "\b") {
+            result = result.slice(0, -1);
+        }
+        else {
+            result += char;
+        }
+    }
+    return result;
+}
+
+/**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
  * pipes readline and keeps `this.value` in sync with the typed query — letters
@@ -199,10 +216,10 @@ class FuzzySelectPrompt extends Prompt {
             if (i >= 0) this.optionCursor = i;
         }
 
-        // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
-        // so the base re-emits "userInput" for both — this covers backspace free.
+        // Re-filter on every keystroke. Normalize stray erase characters because
+        // fake streams and some readline paths can leave them in `rl.line`.
         this.on("userInput", () => {
-            this.query = this.userInput ?? "";
+            this.query = normalizeTrackedInput(this.userInput ?? "");
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.optionCursor > this.filtered.length - 1) {
                 this.optionCursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -144,23 +144,6 @@ function terminalRows() {
 }
 
 /**
- * @param {string} value
- * @returns {string}
- */
-function normalizeTrackedInput(value) {
-    let result = "";
-    for (const char of String(value ?? "")) {
-        if (char === "\x7f" || char === "\b") {
-            result = result.slice(0, -1);
-        }
-        else {
-            result += char;
-        }
-    }
-    return result;
-}
-
-/**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
  * pipes readline and keeps `this.value` in sync with the typed query — letters
@@ -216,10 +199,10 @@ class FuzzySelectPrompt extends Prompt {
             if (i >= 0) this.optionCursor = i;
         }
 
-        // Re-filter on every keystroke. Normalize stray erase characters because
-        // fake streams and some readline paths can leave them in `rl.line`.
+        // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
+        // so the base re-emits "userInput" for both — this covers backspace free.
         this.on("userInput", () => {
-            this.query = normalizeTrackedInput(this.userInput ?? "");
+            this.query = this.userInput ?? "";
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.optionCursor > this.filtered.length - 1) {
                 this.optionCursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/src/restore.js
+++ b/apps/cli/src/restore.js
@@ -90,7 +90,11 @@ export async function runRestoreOnce(opts) {
     if (opts.target) {
         target = pickTargetCheckpoint([opts.target], selection);
         if (!target) {
-            stderr.write(`Preselected checkpoint (node ${opts.target.nodeId} seq ${opts.target.seq}) does not match requested run ${runId} node ${nodeId}${iteration !== undefined ? ` iteration ${iteration}` : ""}${seq !== undefined ? ` seq ${seq}` : ""}\n`);
+            // Include the target's own iteration/seq so an iteration-only
+            // mismatch is legible. Checkpoint rows carry no runId, so the
+            // predicate matches on node/iteration/seq only — `run ${runId}` is
+            // context, not something validated here.
+            stderr.write(`Preselected checkpoint (node ${opts.target.nodeId} iteration ${opts.target.iteration ?? 0} seq ${opts.target.seq}) does not match requested node ${nodeId}${iteration !== undefined ? ` iteration ${iteration}` : ""}${seq !== undefined ? ` seq ${seq}` : ""} for run ${runId}\n`);
             return { exitCode: 1 };
         }
     }

--- a/apps/cli/src/restore.js
+++ b/apps/cli/src/restore.js
@@ -61,17 +61,6 @@ export function pickTargetCheckpoint(checkpoints, sel) {
 }
 
 /**
- * @param {Checkpoint} checkpoint
- * @param {{ nodeId: string, iteration?: number, seq?: number }} sel
- * @returns {boolean}
- */
-function matchesCheckpointSelection(checkpoint, sel) {
-    return checkpoint.nodeId === sel.nodeId
-        && (sel.iteration === undefined || Number(checkpoint.iteration) === Number(sel.iteration))
-        && (sel.seq === undefined || Number(checkpoint.seq) === Number(sel.seq));
-}
-
-/**
  * @param {{
  *   adapter?: { listWorkspaceCheckpoints: (runId: string) => Promise<Array<Checkpoint>> },
  *   runId: string,
@@ -91,11 +80,19 @@ export async function runRestoreOnce(opts) {
 
     // Reuse a preselected target when the caller already picked one (the
     // semantic tool reports it), so we never re-list and risk selecting a
-    // different checkpoint than the one reported. Otherwise list and pick.
+    // different checkpoint than the one reported. But still validate it against
+    // the requested node/iteration/seq — a stale or mis-reported target must be
+    // rejected rather than silently reverting the wrong checkpoint. Validation
+    // runs the preselected row through the same predicate as the listing path
+    // (`pickTargetCheckpoint`) so the two can never diverge.
     const selection = { nodeId, iteration, seq };
     let target = null;
     if (opts.target) {
-        target = matchesCheckpointSelection(opts.target, selection) ? opts.target : null;
+        target = pickTargetCheckpoint([opts.target], selection);
+        if (!target) {
+            stderr.write(`Preselected checkpoint (node ${opts.target.nodeId} seq ${opts.target.seq}) does not match requested run ${runId} node ${nodeId}${iteration !== undefined ? ` iteration ${iteration}` : ""}${seq !== undefined ? ` seq ${seq}` : ""}\n`);
+            return { exitCode: 1 };
+        }
     }
     else if (adapter) {
         target = pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), selection);

--- a/apps/cli/src/restore.js
+++ b/apps/cli/src/restore.js
@@ -61,6 +61,17 @@ export function pickTargetCheckpoint(checkpoints, sel) {
 }
 
 /**
+ * @param {Checkpoint} checkpoint
+ * @param {{ nodeId: string, iteration?: number, seq?: number }} sel
+ * @returns {boolean}
+ */
+function matchesCheckpointSelection(checkpoint, sel) {
+    return checkpoint.nodeId === sel.nodeId
+        && (sel.iteration === undefined || Number(checkpoint.iteration) === Number(sel.iteration))
+        && (sel.seq === undefined || Number(checkpoint.seq) === Number(sel.seq));
+}
+
+/**
  * @param {{
  *   adapter?: { listWorkspaceCheckpoints: (runId: string) => Promise<Array<Checkpoint>> },
  *   runId: string,
@@ -81,9 +92,14 @@ export async function runRestoreOnce(opts) {
     // Reuse a preselected target when the caller already picked one (the
     // semantic tool reports it), so we never re-list and risk selecting a
     // different checkpoint than the one reported. Otherwise list and pick.
-    const target = opts.target ?? (adapter
-        ? pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), { nodeId, iteration, seq })
-        : null);
+    const selection = { nodeId, iteration, seq };
+    let target = null;
+    if (opts.target) {
+        target = matchesCheckpointSelection(opts.target, selection) ? opts.target : null;
+    }
+    else if (adapter) {
+        target = pickTargetCheckpoint(await adapter.listWorkspaceCheckpoints(runId), selection);
+    }
     if (!target) {
         stderr.write(`No matching durability checkpoint for run ${runId} node ${nodeId}${seq !== undefined ? ` seq ${seq}` : ""}\n`);
         return { exitCode: 1 };

--- a/apps/cli/tests/snapshots-restore.test.js
+++ b/apps/cli/tests/snapshots-restore.test.js
@@ -98,6 +98,26 @@ describe("smithers restore", () => {
         expect(out.get()).toContain("checkpoint #0");
     });
 
+    test("rejects a preselected target that does not match the requested node", async () => {
+        const reverted = [];
+        const err = capture();
+        const r = await runRestoreOnce({
+            runId: "r1",
+            nodeId: "n2",
+            target: cps[0],
+            stdout: capture(),
+            stderr: err,
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(1);
+        expect(reverted).toEqual([]);
+        expect(err.get()).toContain("No matching durability checkpoint");
+    });
+
     test("missing checkpoint exits non-zero with a message", async () => {
         const err = capture();
         const r = await runRestoreOnce({

--- a/apps/cli/tests/snapshots-restore.test.js
+++ b/apps/cli/tests/snapshots-restore.test.js
@@ -115,7 +115,53 @@ describe("smithers restore", () => {
 
         expect(r.exitCode).toBe(1);
         expect(reverted).toEqual([]);
-        expect(err.get()).toContain("No matching durability checkpoint");
+        // A mis-reported preselected target gets a distinct, actionable message
+        // rather than the generic listing-miss text.
+        expect(err.get()).toContain("Preselected checkpoint");
+        expect(err.get()).toContain("does not match requested run r1 node n2");
+    });
+
+    test("rejects a preselected target whose seq differs from the requested --seq", async () => {
+        const reverted = [];
+        const err = capture();
+        const r = await runRestoreOnce({
+            runId: "r1",
+            nodeId: "n1",
+            seq: 1,
+            target: cps[0], // n1 seq 0 — right node, wrong seq
+            stdout: capture(),
+            stderr: err,
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(1);
+        expect(reverted).toEqual([]);
+        expect(err.get()).toContain("Preselected checkpoint");
+        expect(err.get()).toContain("seq 1");
+    });
+
+    test("honors a preselected target that matches the requested --seq", async () => {
+        const reverted = [];
+        const out = capture();
+        const r = await runRestoreOnce({
+            runId: "r1",
+            nodeId: "n1",
+            seq: 0,
+            target: cps[0], // n1 seq 0 — matches
+            stdout: out,
+            stderr: capture(),
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(0);
+        expect(reverted).toEqual([["c0", "/wt"]]);
+        expect(out.get()).toContain("checkpoint #0");
     });
 
     test("missing checkpoint exits non-zero with a message", async () => {

--- a/apps/cli/tests/snapshots-restore.test.js
+++ b/apps/cli/tests/snapshots-restore.test.js
@@ -118,7 +118,63 @@ describe("smithers restore", () => {
         // A mis-reported preselected target gets a distinct, actionable message
         // rather than the generic listing-miss text.
         expect(err.get()).toContain("Preselected checkpoint");
-        expect(err.get()).toContain("does not match requested run r1 node n2");
+        expect(err.get()).toContain("does not match requested node n2");
+        expect(err.get()).toContain("for run r1");
+    });
+
+    test("rejects a preselected target whose iteration differs, naming both iterations", async () => {
+        const reverted = [];
+        const err = capture();
+        const r = await runRestoreOnce({
+            runId: "r1",
+            nodeId: "n1",
+            iteration: 1,
+            target: cps[0], // n1 iteration 0 — right node, wrong iteration
+            stdout: capture(),
+            stderr: err,
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(1);
+        expect(reverted).toEqual([]);
+        // Both the target's iteration and the requested iteration are named so
+        // an iteration-only mismatch isn't two identical-looking checkpoints.
+        expect(err.get()).toContain("iteration 0");
+        expect(err.get()).toContain("iteration 1");
+    });
+
+    test("a rejected preselect does NOT fall back to listing from the adapter", async () => {
+        const reverted = [];
+        const err = capture();
+        let listed = false;
+        const r = await runRestoreOnce({
+            // An adapter that WOULD supply a matching checkpoint is present, but a
+            // rejected preselect must fail loudly, never silently list-and-pick a
+            // different checkpoint than the one the caller reported.
+            adapter: {
+                async listWorkspaceCheckpoints() {
+                    listed = true;
+                    return cps;
+                },
+            },
+            runId: "r1",
+            nodeId: "n2", // cps[2] (d0) would match if we fell back to listing
+            target: cps[0], // preselected n1 — mismatched, must be rejected
+            stdout: capture(),
+            stderr: err,
+            revert: async (commitId, cwd) => {
+                reverted.push([commitId, cwd]);
+                return { success: true };
+            },
+        });
+
+        expect(r.exitCode).toBe(1);
+        expect(reverted).toEqual([]);
+        expect(listed).toBe(false);
+        expect(err.get()).toContain("Preselected checkpoint");
     });
 
     test("rejects a preselected target whose seq differs from the requested --seq", async () => {


### PR DESCRIPTION
## Summary
- reject preselected restore checkpoints that do not match the requested node, iteration, or seq
- normalize stray erase characters before filtering fuzzy-select input

## Tests
- bun test apps/cli/tests/snapshots-restore.test.js apps/cli/tests/fuzzy-select.test.js --timeout=120000
- pnpm --filter @smithers-orchestrator/cli typecheck
- pnpm --filter @smithers-orchestrator/cli test