### PR TITLE
fix(scheduler): carry timer anchors across continuations

### DIFF
--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -1484,6 +1484,7 @@ async function continueRunAsNew(params) {
         continueAsNewEvery: continuation.continueAsNewEvery ?? null,
         payload: continuation.statePayload ?? null,
         ralph: ralphStateToObject(carriedRalphState),
+        ...(continuation.nextTimerStarts ? { timerStarts: continuation.nextTimerStarts } : {}),
         timestampMs: ts,
     };
     const carriedStateJson = JSON.stringify(continuationEnvelope);
@@ -5022,47 +5023,70 @@ function ralphStateFromDriverTransition(transition) {
     return state;
 }
 /**
- * @param {unknown} input
- * @returns {unknown}
+ * Reads duration-timer anchors off the scheduler transition's dedicated
+ * `timerStarts` field (a sibling of `statePayload`). Kept separate from
+ * `statePayload` so a user-supplied `stateJson` never overwrites the anchors —
+ * exactly how `ralphState` is threaded via `nextRalphState`.
+ * @param {unknown} transition
+ * @returns {Record<string, number> | undefined}
  */
-function continuationPayloadFromInput(input) {
+function timerStartsFromDriverTransition(transition) {
+    const raw = transition &&
+        typeof transition === "object" &&
+        "timerStarts" in transition
+        ? transition.timerStarts
+        : undefined;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return undefined;
+    }
+    const timerStarts = {};
+    for (const [key, value] of Object.entries(raw)) {
+        if (key.length > 0 && typeof value === "number" && Number.isFinite(value)) {
+            timerStarts[key] = value;
+        }
+    }
+    return Object.keys(timerStarts).length > 0 ? timerStarts : undefined;
+}
+/**
+ * Continuation state (ralph iterations, duration-timer anchors) is carried on a
+ * dedicated envelope field so a user-supplied `<ContinueAsNew state={...}>`
+ * payload can never clobber it — mirroring how `ralph` is carried separately
+ * from the user-visible `payload`.
+ * @param {unknown} input
+ * @returns {Record<string, unknown> | undefined}
+ */
+function continuationEnvelopeFromInput(input) {
     const normalized = normalizeInputRow(input);
     const envelope = normalized.__smithersContinuation;
     if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
         return undefined;
     }
-    return "payload" in envelope ? envelope.payload : undefined;
+    return /** @type {Record<string, unknown>} */ (envelope);
 }
 /**
  * @param {Record<string, unknown>} config
- * @returns {unknown}
+ * @returns {Record<string, unknown> | undefined}
  */
-function continuationPayloadFromConfig(config) {
+function continuationEnvelopeFromConfig(config) {
     const continuation = config.continuation;
     if (!continuation || typeof continuation !== "object" || Array.isArray(continuation)) {
         return undefined;
     }
-    return "payload" in continuation ? continuation.payload : undefined;
+    return /** @type {Record<string, unknown>} */ (continuation);
 }
 /**
- * @param {unknown} payload
+ * @param {Record<string, unknown> | undefined} envelope
  * @returns {Map<string, number> | undefined}
  */
-function timerStartsFromContinuationPayload(payload) {
-    const raw = payload &&
-        typeof payload === "object" &&
-        !Array.isArray(payload) &&
-        "timerStarts" in payload
-        ? payload.timerStarts
-        : undefined;
+function timerStartsFromContinuationEnvelope(envelope) {
+    const raw = envelope && "timerStarts" in envelope ? envelope.timerStarts : undefined;
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
         return undefined;
     }
     const timerStarts = new Map();
     for (const [key, value] of Object.entries(raw)) {
-        const startMs = Number(value);
-        if (key.length > 0 && Number.isFinite(startMs)) {
-            timerStarts.set(key, startMs);
+        if (key.length > 0 && typeof value === "number" && Number.isFinite(value)) {
+            timerStarts.set(key, value);
         }
     }
     return timerStarts.size > 0 ? timerStarts : undefined;
@@ -5999,8 +6023,8 @@ async function runWorkflowBodyDriver(workflow, opts) {
         }
         const activeInput = await loadInput(db, inputTable, runId);
         const activeRun = await Effect.runPromise(adapter.getRun(runId));
-        const continuationPayload = continuationPayloadFromInput(activeInput) ??
-            continuationPayloadFromConfig(parseRunConfigJson(activeRun?.configJson));
+        const continuationEnvelope = continuationEnvelopeFromInput(activeInput) ??
+            continuationEnvelopeFromConfig(parseRunConfigJson(activeRun?.configJson));
         budgetTracker = await setupBudgetTracker({
             adapter,
             runId,
@@ -6013,7 +6037,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
             requireStableFinish: true,
             requireRerenderOnOutputChange: opts.requireRerenderOnOutputChange ?? true,
             initialRalphState: ralphState,
-            initialTimerStarts: timerStartsFromContinuationPayload(continuationPayload),
+            initialTimerStarts: timerStartsFromContinuationEnvelope(continuationEnvelope),
             evaluateAspectBudget: (descriptor) => budgetTracker
                 ? evaluateAspectBudget(descriptor.aspects, budgetTracker.snapshot(nowMs()))
                 : null,
@@ -6140,6 +6164,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
                     return { runId, status: "cancelled" };
                 }
                 const nextRalphState = ralphStateFromDriverTransition(transition);
+                const nextTimerStarts = timerStartsFromDriverTransition(transition);
                 const continuationIteration = typeof transition?.iteration === "number"
                     ? transition.iteration
                     : defaultIteration;
@@ -6162,6 +6187,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
                         iteration: continuationIteration,
                         statePayload,
                         nextRalphState,
+                        nextTimerStarts,
                     },
                     ralphState,
                 });
@@ -6363,9 +6389,10 @@ export const __engineInternals = {
     validateRunOptions,
     iterationsToMap,
     ralphStateFromDriverTransition,
-    continuationPayloadFromInput,
-    continuationPayloadFromConfig,
-    timerStartsFromContinuationPayload,
+    timerStartsFromDriverTransition,
+    continuationEnvelopeFromInput,
+    continuationEnvelopeFromConfig,
+    timerStartsFromContinuationEnvelope,
     resolveTaskOutputs,
     resolveWorkflowOutputTable,
     buildDescriptorMap,

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -5022,6 +5022,52 @@ function ralphStateFromDriverTransition(transition) {
     return state;
 }
 /**
+ * @param {unknown} input
+ * @returns {unknown}
+ */
+function continuationPayloadFromInput(input) {
+    const normalized = normalizeInputRow(input);
+    const envelope = normalized.__smithersContinuation;
+    if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+        return undefined;
+    }
+    return "payload" in envelope ? envelope.payload : undefined;
+}
+/**
+ * @param {Record<string, unknown>} config
+ * @returns {unknown}
+ */
+function continuationPayloadFromConfig(config) {
+    const continuation = config.continuation;
+    if (!continuation || typeof continuation !== "object" || Array.isArray(continuation)) {
+        return undefined;
+    }
+    return "payload" in continuation ? continuation.payload : undefined;
+}
+/**
+ * @param {unknown} payload
+ * @returns {Map<string, number> | undefined}
+ */
+function timerStartsFromContinuationPayload(payload) {
+    const raw = payload &&
+        typeof payload === "object" &&
+        !Array.isArray(payload) &&
+        "timerStarts" in payload
+        ? payload.timerStarts
+        : undefined;
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return undefined;
+    }
+    const timerStarts = new Map();
+    for (const [key, value] of Object.entries(raw)) {
+        const startMs = Number(value);
+        if (key.length > 0 && Number.isFinite(startMs)) {
+            timerStarts.set(key, startMs);
+        }
+    }
+    return timerStarts.size > 0 ? timerStarts : undefined;
+}
+/**
  * @template Schema
  * @param {SmithersWorkflow<Schema>} workflow
  * @param {RunOptions} opts
@@ -5951,11 +5997,15 @@ async function runWorkflowBodyDriver(workflow, opts) {
             const maxRalphIteration = [...ralphState.values()].reduce((max, state) => Math.max(max, state.iteration), 0);
             defaultIteration = Math.max(defaultIteration, maxRalphIteration);
         }
+        const activeInput = await loadInput(db, inputTable, runId);
+        const activeRun = await Effect.runPromise(adapter.getRun(runId));
+        const continuationPayload = continuationPayloadFromInput(activeInput) ??
+            continuationPayloadFromConfig(parseRunConfigJson(activeRun?.configJson));
         budgetTracker = await setupBudgetTracker({
             adapter,
             runId,
             eventBus,
-            runStartMs: (await Effect.runPromise(adapter.getRun(runId)))?.createdAtMs ?? nowMs(),
+            runStartMs: activeRun?.createdAtMs ?? nowMs(),
         });
         workflowSession = makeWorkflowSession({
             runId,
@@ -5963,6 +6013,7 @@ async function runWorkflowBodyDriver(workflow, opts) {
             requireStableFinish: true,
             requireRerenderOnOutputChange: opts.requireRerenderOnOutputChange ?? true,
             initialRalphState: ralphState,
+            initialTimerStarts: timerStartsFromContinuationPayload(continuationPayload),
             evaluateAspectBudget: (descriptor) => budgetTracker
                 ? evaluateAspectBudget(descriptor.aspects, budgetTracker.snapshot(nowMs()))
                 : null,
@@ -6056,7 +6107,6 @@ async function runWorkflowBodyDriver(workflow, opts) {
             ...workflowRef,
             build: (ctx) => withWorkflowVersioningRuntime(workflowVersioning, () => workflowRef.build(ctx)),
         };
-        const activeInput = await loadInput(db, inputTable, runId);
         const driver = new ReactWorkflowDriver({
             workflow: driverWorkflow,
             runtime: { runPromise: Effect.runPromise },
@@ -6313,6 +6363,9 @@ export const __engineInternals = {
     validateRunOptions,
     iterationsToMap,
     ralphStateFromDriverTransition,
+    continuationPayloadFromInput,
+    continuationPayloadFromConfig,
+    timerStartsFromContinuationPayload,
     resolveTaskOutputs,
     resolveWorkflowOutputTable,
     buildDescriptorMap,

--- a/packages/engine/tests/engine-internals.test.js
+++ b/packages/engine/tests/engine-internals.test.js
@@ -498,14 +498,20 @@ describe("engine internals: durability, options and graph helpers", () => {
         expect(I.iterationsToMap({ a: 1 })).toEqual(new Map([["a", 1]]));
         expect(I.ralphStateFromDriverTransition({ statePayload: { ralphState: { loop: { iteration: "2", done: true } } } })).toEqual(new Map([["loop", { iteration: 2, done: true }]]));
         expect(I.ralphStateFromDriverTransition({ statePayload: { ralphState: [] } })).toBeUndefined();
-        expect(I.continuationPayloadFromInput({ payload: { __smithersContinuation: { payload: { timerStarts: { "timer::0": "1000" } } } } })).toEqual({
-            timerStarts: { "timer::0": "1000" },
-        });
-        expect(I.continuationPayloadFromConfig({ continuation: { payload: { timerStarts: { "timer::0": 1000 } } } })).toEqual({
+        // timerStarts rides on a dedicated `timerStarts` envelope field, never inside `payload`,
+        // so a user-supplied continue-as-new `state` can't clobber the anchors.
+        expect(I.timerStartsFromDriverTransition({ timerStarts: { "timer::0": 1000, bad: "nope" } })).toEqual({ "timer::0": 1000 });
+        expect(I.timerStartsFromDriverTransition({ statePayload: { timerStarts: { "timer::0": 1000 } } })).toBeUndefined();
+        expect(I.continuationEnvelopeFromInput({ payload: { __smithersContinuation: { timerStarts: { "timer::0": 1000 } } } })).toEqual({
             timerStarts: { "timer::0": 1000 },
         });
-        expect(I.timerStartsFromContinuationPayload({ timerStarts: { "timer::0": "1000", bad: "nope" } })).toEqual(new Map([["timer::0", 1000]]));
-        expect(I.timerStartsFromContinuationPayload({ timerStarts: [] })).toBeUndefined();
+        expect(I.continuationEnvelopeFromConfig({ continuation: { timerStarts: { "timer::0": 1000 } } })).toEqual({
+            timerStarts: { "timer::0": 1000 },
+        });
+        // Numeric strings are rejected (typeof-number only), and non-object shapes yield undefined.
+        expect(I.timerStartsFromContinuationEnvelope({ timerStarts: { "timer::0": 1000, bad: "nope", weird: "1000" } })).toEqual(new Map([["timer::0", 1000]]));
+        expect(I.timerStartsFromContinuationEnvelope({ timerStarts: [] })).toBeUndefined();
+        expect(I.timerStartsFromContinuationEnvelope(undefined)).toBeUndefined();
 
         const state = new Map([
             ["outer", { iteration: 1, done: false }],
@@ -545,6 +551,47 @@ describe("engine internals: durability, options and graph helpers", () => {
         expect(I.isRetryableTaskFailure({ errorJson: '{"code":"AGENT_CONFIG_INVALID"}' })).toBe(false);
         expect(I.isRetryableTaskFailure({ metaJson: '{"kind":"compute"}', errorJson: '{"code":"INVALID_OUTPUT"}' })).toBe(false);
         expect(I.isRetryableTaskFailure({ metaJson: '{"kind":"agent"}', errorJson: '{"code":"INVALID_OUTPUT"}' })).toBe(true);
+    });
+
+    test("duration-timer anchors survive a continue-as-new handoff even when the user supplies continuation state", () => {
+        // Reproduces the clobber bug: an explicit `<ContinueAsNew state={...}>`
+        // sets `stateJson`, which the engine JSON-parses into `payload`. Anchors
+        // must ride the dedicated `timerStarts` field so they are never lost.
+        const userState = { keepMe: 42, timerStarts: { spoofed: 1 } };
+        const transition = {
+            reason: "explicit",
+            stateJson: JSON.stringify(userState),
+            timerStarts: { "timer::0": 1_000, "timer::1": 2_000 },
+        };
+
+        // Extraction reads the dedicated field, unaffected by the user payload.
+        const carried = I.timerStartsFromDriverTransition(transition);
+        expect(carried).toEqual({ "timer::0": 1_000, "timer::1": 2_000 });
+
+        // The envelope the engine writes carries `payload` (user state) AND the
+        // dedicated `timerStarts` field side by side, exactly like `ralph`.
+        const envelope = {
+            payload: JSON.parse(transition.stateJson),
+            ralph: {},
+            timerStarts: carried,
+        };
+
+        // Next run reads the anchors off the dedicated field — the spoofed
+        // `payload.timerStarts` is ignored entirely.
+        const fromInput = I.continuationEnvelopeFromInput({
+            payload: { __smithersContinuation: envelope },
+        });
+        expect(I.timerStartsFromContinuationEnvelope(fromInput)).toEqual(new Map([
+            ["timer::0", 1_000],
+            ["timer::1", 2_000],
+        ]));
+
+        // The config-carried copy of the envelope resolves identically.
+        const fromConfig = I.continuationEnvelopeFromConfig({ continuation: envelope });
+        expect(I.timerStartsFromContinuationEnvelope(fromConfig)).toEqual(new Map([
+            ["timer::0", 1_000],
+            ["timer::1", 2_000],
+        ]));
     });
 
     test("resolveWorkflowOutputTable resolves declared outputs and fails fast on unregistered targets", () => {

--- a/packages/engine/tests/engine-internals.test.js
+++ b/packages/engine/tests/engine-internals.test.js
@@ -498,6 +498,14 @@ describe("engine internals: durability, options and graph helpers", () => {
         expect(I.iterationsToMap({ a: 1 })).toEqual(new Map([["a", 1]]));
         expect(I.ralphStateFromDriverTransition({ statePayload: { ralphState: { loop: { iteration: "2", done: true } } } })).toEqual(new Map([["loop", { iteration: 2, done: true }]]));
         expect(I.ralphStateFromDriverTransition({ statePayload: { ralphState: [] } })).toBeUndefined();
+        expect(I.continuationPayloadFromInput({ payload: { __smithersContinuation: { payload: { timerStarts: { "timer::0": "1000" } } } } })).toEqual({
+            timerStarts: { "timer::0": "1000" },
+        });
+        expect(I.continuationPayloadFromConfig({ continuation: { payload: { timerStarts: { "timer::0": 1000 } } } })).toEqual({
+            timerStarts: { "timer::0": 1000 },
+        });
+        expect(I.timerStartsFromContinuationPayload({ timerStarts: { "timer::0": "1000", bad: "nope" } })).toEqual(new Map([["timer::0", 1000]]));
+        expect(I.timerStartsFromContinuationPayload({ timerStarts: [] })).toBeUndefined();
 
         const state = new Map([
             ["outer", { iteration: 1, done: false }],

--- a/packages/scheduler/src/WorkflowSessionOptions.ts
+++ b/packages/scheduler/src/WorkflowSessionOptions.ts
@@ -17,6 +17,7 @@ export type WorkflowSessionOptions = {
     readonly iteration: number;
     readonly done: boolean;
   }>;
+  readonly initialTimerStarts?: ReadonlyMap<string, number>;
   /**
    * Evaluate a runnable task's Aspects budgets against the run's accumulated
    * usage. Return the first breach, or `null`/`undefined` when within budget.

--- a/packages/scheduler/src/index.d.ts
+++ b/packages/scheduler/src/index.d.ts
@@ -243,6 +243,7 @@ type WorkflowSessionOptions$2 = {
         readonly iteration: number;
         readonly done: boolean;
     }>;
+    readonly initialTimerStarts?: ReadonlyMap<string, number>;
     /**
      * Evaluate a runnable task's Aspects budgets against the run's accumulated
      * usage. Return the first breach, or `null`/`undefined` when within budget.

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -358,7 +358,7 @@ export function makeWorkflowSession(options = {}) {
         /** @type {Map<string, number>} Maps state key → quota reset timestamp (ms) */
         quotaResetTimes: new Map(),
         /** @type {Map<string, number>} Maps state key → duration-timer start (ms), the anchor its deadline is computed from */
-        timerStarts: new Map(),
+        timerStarts: new Map([...(options.initialTimerStarts ?? [])].filter(([, startMs]) => Number.isFinite(startMs))),
         schedule: null,
         cancelled: false,
         lastMountedSignature: null,
@@ -619,7 +619,23 @@ export function makeWorkflowSession(options = {}) {
                 id,
                 { iteration: value.iteration, done: value.done },
             ])),
+            ...timerStartsPayload(),
         };
+    }
+    function timerStartsPayload() {
+        const timerStarts = [...state.timerStarts.entries()]
+            .filter(([, startMs]) => Number.isFinite(startMs))
+            .sort(([left], [right]) => left.localeCompare(right));
+        return timerStarts.length > 0
+            ? { timerStarts: Object.fromEntries(timerStarts) }
+            : {};
+    }
+    function schedulerStatePayload() {
+        const payload = timerStartsPayload();
+        if (Object.keys(payload).length === 0) {
+            return undefined;
+        }
+        return payload;
     }
     /**
    * @param {number} [depth] recursion depth; a safety net for a true decision
@@ -655,11 +671,13 @@ export function makeWorkflowSession(options = {}) {
             };
         }
         if (schedule.continuation) {
+            const statePayload = schedulerStatePayload();
             return {
                 _tag: "ContinueAsNew",
                 transition: {
                     reason: "explicit",
                     stateJson: schedule.continuation.stateJson,
+                    ...(statePayload ? { statePayload } : {}),
                 },
             };
         }

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -619,23 +619,22 @@ export function makeWorkflowSession(options = {}) {
                 id,
                 { iteration: value.iteration, done: value.done },
             ])),
-            ...timerStartsPayload(),
         };
     }
-    function timerStartsPayload() {
+    /**
+     * Duration-timer anchors carried across a continue-as-new boundary. Emitted
+     * as a dedicated `timerStarts` field on the transition (a sibling of
+     * `statePayload`), never folded into the user-visible payload — so an
+     * explicit `<ContinueAsNew state={...}>` can't clobber the anchors.
+     * @returns {Record<string, number> | undefined}
+     */
+    function timerStartsField() {
         const timerStarts = [...state.timerStarts.entries()]
             .filter(([, startMs]) => Number.isFinite(startMs))
             .sort(([left], [right]) => left.localeCompare(right));
         return timerStarts.length > 0
-            ? { timerStarts: Object.fromEntries(timerStarts) }
-            : {};
-    }
-    function schedulerStatePayload() {
-        const payload = timerStartsPayload();
-        if (Object.keys(payload).length === 0) {
-            return undefined;
-        }
-        return payload;
+            ? Object.fromEntries(timerStarts)
+            : undefined;
     }
     /**
    * @param {number} [depth] recursion depth; a safety net for a true decision
@@ -671,13 +670,13 @@ export function makeWorkflowSession(options = {}) {
             };
         }
         if (schedule.continuation) {
-            const statePayload = schedulerStatePayload();
+            const timerStarts = timerStartsField();
             return {
                 _tag: "ContinueAsNew",
                 transition: {
                     reason: "explicit",
                     stateJson: schedule.continuation.stateJson,
-                    ...(statePayload ? { statePayload } : {}),
+                    ...(timerStarts ? { timerStarts } : {}),
                 },
             };
         }
@@ -823,12 +822,14 @@ export function makeWorkflowSession(options = {}) {
                 }
                 state.ralphState.set(ralph.id, { iteration: nextIteration, done: false });
                 if (wantsContinueAsNew) {
+                    const timerStarts = timerStartsField();
                     return {
                         _tag: "ContinueAsNew",
                         transition: {
                             reason: "loop-threshold",
                             iteration: nextIteration,
                             statePayload: ralphStatePayload(),
+                            ...(timerStarts ? { timerStarts } : {}),
                         },
                     };
                 }

--- a/packages/scheduler/tests/workflowSession-service-branches.test.js
+++ b/packages/scheduler/tests/workflowSession-service-branches.test.js
@@ -157,6 +157,41 @@ describe("WorkflowSessionService direct methods", () => {
     expect(afterReDecide).toEqual({ _tag: "Wait", reason: { _tag: "Timer", resumeAtMs: 6_000 } });
   });
 
+  test("duration timer start is carried in continuation state", () => {
+    let now = 1_000;
+    const task = descriptor("timer", { meta: { __timer: true, __timerDuration: "5s" } });
+    const session = makeWorkflowSession({ nowMs: () => now });
+
+    expect(run(session.submitGraph(graph([task], workflow([
+      el("smithers:timer", { id: "timer" }),
+    ]))))).toEqual({ _tag: "Wait", reason: { _tag: "Timer", resumeAtMs: 6_000 } });
+
+    const decision = run(session.submitGraph(graph([task], workflow([
+      el("smithers:parallel", {}, [
+        el("smithers:timer", { id: "timer" }),
+        el("smithers:continue-as-new", {}),
+      ]),
+    ]))));
+
+    expect(decision).toMatchObject({
+      _tag: "ContinueAsNew",
+      transition: {
+        reason: "explicit",
+        statePayload: { timerStarts: { "timer::0": 1_000 } },
+      },
+    });
+
+    now = 4_000;
+    const nextSession = makeWorkflowSession({
+      nowMs: () => now,
+      initialTimerStarts: new Map(Object.entries(decision.transition.statePayload.timerStarts)),
+    });
+
+    expect(run(nextSession.submitGraph(graph([task], workflow([
+      el("smithers:timer", { id: "timer" }),
+    ]))))).toEqual({ _tag: "Wait", reason: { _tag: "Timer", resumeAtMs: 6_000 } });
+  });
+
   test("hotReloaded cancels unmounted in-progress work and runs newly mounted tasks", () => {
     const session = makeWorkflowSession({ nowMs: () => 1_000 });
 

--- a/packages/scheduler/tests/workflowSession-service-branches.test.js
+++ b/packages/scheduler/tests/workflowSession-service-branches.test.js
@@ -177,14 +177,18 @@ describe("WorkflowSessionService direct methods", () => {
       _tag: "ContinueAsNew",
       transition: {
         reason: "explicit",
-        statePayload: { timerStarts: { "timer::0": 1_000 } },
+        timerStarts: { "timer::0": 1_000 },
       },
     });
+    // The anchor lives on the dedicated `timerStarts` field, not inside the
+    // user-visible `statePayload`, so an explicit continue-as-new state cannot
+    // clobber it.
+    expect(decision.transition.statePayload).toBeUndefined();
 
     now = 4_000;
     const nextSession = makeWorkflowSession({
       nowMs: () => now,
-      initialTimerStarts: new Map(Object.entries(decision.transition.statePayload.timerStarts)),
+      initialTimerStarts: new Map(Object.entries(decision.transition.timerStarts)),
     });
 
     expect(run(nextSession.submitGraph(graph([task], workflow([


### PR DESCRIPTION
## Summary
- carry live duration-timer start anchors in scheduler continuation payloads
- restore carried timer anchors when the engine starts a continued run
- cover scheduler export/import and engine payload parsing helpers

## Why
Duration timers are anchored when the scheduler first parks them. If a continuation starts a fresh scheduler session without that anchor, the relative deadline can be recomputed from the new run start and extend the wait. This covers the continuation handoff side of #502.

## Verification
- bun test packages/scheduler/tests/workflowSession-service-branches.test.js
- bun test packages/engine/tests/engine-internals.test.js
- pnpm --filter @smithers-orchestrator/scheduler typecheck
- pnpm --filter @smithers-orchestrator/engine typecheck
- pnpm --filter @smithers-orchestrator/scheduler test
- pnpm --filter @smithers-orchestrator/engine test
- pnpm check:effect
- pnpm check:deps
- pnpm lint
- pnpm -r typecheck
- pnpm check:docs
- pnpm check:llms