### PR TITLE
fix(cli): stop MCP waits on caller abort

### DIFF
--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -144,6 +144,24 @@ function terminalRows() {
 }
 
 /**
+ * Some readline paths can surface delete keys as raw control bytes in the
+ * tracked input. Treat them as edits before running the fuzzy filter.
+ *
+ * @param {string | undefined} input
+ */
+function normalizeTrackedInput(input) {
+    const chars = [];
+    for (const char of String(input ?? "")) {
+        if (char === "\x7f" || char === "\b") {
+            chars.pop();
+        } else {
+            chars.push(char);
+        }
+    }
+    return chars.join("");
+}
+
+/**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
  * pipes readline and keeps `this.value` in sync with the typed query — letters
@@ -199,10 +217,10 @@ class FuzzySelectPrompt extends Prompt {
             if (i >= 0) this.optionCursor = i;
         }
 
-        // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
-        // so the base re-emits "userInput" for both — this covers backspace free.
-        this.on("userInput", () => {
-            this.query = this.userInput ?? "";
+        // Re-filter on every keystroke. Delete keys may arrive either as an
+        // edited readline buffer or as raw control bytes, depending on the stream.
+        this.on("userInput", (input) => {
+            this.query = normalizeTrackedInput(input);
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.optionCursor > this.filtered.length - 1) {
                 this.optionCursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/src/fuzzy-select.js
+++ b/apps/cli/src/fuzzy-select.js
@@ -144,24 +144,6 @@ function terminalRows() {
 }
 
 /**
- * Some readline paths can surface delete keys as raw control bytes in the
- * tracked input. Treat them as edits before running the fuzzy filter.
- *
- * @param {string | undefined} input
- */
-function normalizeTrackedInput(input) {
-    const chars = [];
-    for (const char of String(input ?? "")) {
-        if (char === "\x7f" || char === "\b") {
-            chars.pop();
-        } else {
-            chars.push(char);
-        }
-    }
-    return chars.join("");
-}
-
-/**
  * A type-to-filter picker built on clack's `Prompt` base class. We subclass
  * `Prompt` directly (NOT `SelectPrompt`) with `trackValue=true` so the base
  * pipes readline and keeps `this.value` in sync with the typed query — letters
@@ -217,10 +199,10 @@ class FuzzySelectPrompt extends Prompt {
             if (i >= 0) this.optionCursor = i;
         }
 
-        // Re-filter on every keystroke. Delete keys may arrive either as an
-        // edited readline buffer or as raw control bytes, depending on the stream.
-        this.on("userInput", (input) => {
-            this.query = normalizeTrackedInput(input);
+        // Re-filter on every keystroke. Typing AND backspace both edit rl.line,
+        // so the base re-emits "userInput" for both — this covers backspace free.
+        this.on("userInput", () => {
+            this.query = this.userInput ?? "";
             this.filtered = fuzzyFilter(this.query, this.allOptions);
             if (this.optionCursor > this.filtered.length - 1) {
                 this.optionCursor = Math.max(0, this.filtered.length - 1);

--- a/apps/cli/src/mcp/SemanticToolDefinition.ts
+++ b/apps/cli/src/mcp/SemanticToolDefinition.ts
@@ -3,11 +3,15 @@ import type { z } from "zod";
 import type { SemanticToolCallResult } from "./SemanticToolCallResult.ts";
 import type { SemanticToolName } from "./SemanticToolName.ts";
 
+export type SemanticToolCallExtra = {
+    signal?: AbortSignal;
+};
+
 export type SemanticToolDefinition = {
     name: SemanticToolName;
     description: string;
     inputSchema: z.ZodTypeAny;
     outputSchema: z.ZodTypeAny;
     annotations: Record<string, boolean>;
-    handler: (input: any) => Promise<SemanticToolCallResult>;
+    handler: (input: any, extra?: SemanticToolCallExtra) => Promise<SemanticToolCallResult>;
 };

--- a/apps/cli/src/mcp/semantic-server.js
+++ b/apps/cli/src/mcp/semantic-server.js
@@ -63,7 +63,7 @@ export function registerSemanticTools(server, toolDefinitions = createSemanticTo
             inputSchema: tool.inputSchema,
             outputSchema: tool.outputSchema,
             annotations: tool.annotations,
-        }, async (input) => tool.handler(input));
+        }, async (input, extra) => tool.handler(input, extra));
     }
     return server;
 }

--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -540,31 +540,71 @@ const getRunEventsDataSchema = z.object({
     events: z.array(eventSchema),
 });
 /**
+ * The single abort error every MCP wait path raises/settles with, so callers
+ * can pattern-match one code.
+ * @returns {SmithersError}
+ */
+function mcpAbortError() {
+    return new SmithersError("TASK_ABORTED", "MCP tool call was aborted.");
+}
+/**
  * @param {AbortSignal | undefined} signal
  */
 function throwIfAborted(signal) {
     if (signal?.aborted) {
-        throw new SmithersError("TASK_ABORTED", "MCP tool call was aborted.");
+        throw mcpAbortError();
     }
 }
 /**
  * @param {number} ms
  * @param {AbortSignal} [signal]
+ * @returns {Promise<void>} rejects with {@link mcpAbortError} if aborted
  */
 function sleep(ms, signal) {
-    throwIfAborted(signal);
     return new Promise((resolvePromise, rejectPromise) => {
+        // The executor runs synchronously, so this early check and the
+        // addEventListener below cannot race an abort between them.
+        if (signal?.aborted) {
+            rejectPromise(mcpAbortError());
+            return;
+        }
         const timer = setTimeout(() => {
             signal?.removeEventListener("abort", onAbort);
             resolvePromise();
         }, ms);
         const onAbort = () => {
             clearTimeout(timer);
-            signal?.removeEventListener("abort", onAbort);
-            rejectPromise(new SmithersError("TASK_ABORTED", "MCP tool call was aborted."));
+            rejectPromise(mcpAbortError());
         };
         signal?.addEventListener("abort", onAbort, { once: true });
-        if (signal?.aborted) onAbort();
+    });
+}
+/**
+ * Await `promise`, but resolve early to `{ aborted: true }` if `signal` fires
+ * first. Used by durable waits (e.g. run_workflow's waitForTerminal) that must
+ * NOT cancel the underlying run when the MCP caller goes away — they detach and
+ * report the run as still-running instead. Rejections from `promise` propagate.
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {AbortSignal | undefined} signal
+ * @returns {Promise<{ aborted: true } | { aborted: false, value: T }>}
+ */
+function settleOrAbort(promise, signal) {
+    if (!signal) return promise.then((value) => ({ aborted: false, value }));
+    if (signal.aborted) return Promise.resolve({ aborted: true });
+    return new Promise((resolvePromise, rejectPromise) => {
+        const onAbort = () => {
+            promise.then(undefined, () => {}); // keep a handler so the detached run's rejection isn't unhandled
+            resolvePromise({ aborted: true });
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        promise.then((value) => {
+            signal.removeEventListener("abort", onAbort);
+            resolvePromise({ aborted: false, value });
+        }, (error) => {
+            signal.removeEventListener("abort", onAbort);
+            rejectPromise(error);
+        });
     });
 }
 /**
@@ -815,6 +855,10 @@ async function loadWorkflowById(workflowId, cwd) {
     };
 }
 /**
+ * Poll briefly for the just-launched run row to appear. This is a
+ * best-effort observe on the background path — an abort (the caller went away)
+ * returns `null` like a deadline miss, so the handler still reports the run as
+ * launched-in-background rather than throwing. It never cancels the run.
  * @param {SmithersDb} adapter
  * @param {string} runId
  * @param {number} waitForStartMs
@@ -823,7 +867,9 @@ async function loadWorkflowById(workflowId, cwd) {
 async function waitForObservedRun(adapter, runId, waitForStartMs, signal) {
     const deadline = Date.now() + Math.max(0, waitForStartMs);
     while (true) {
-        throwIfAborted(signal);
+        if (signal?.aborted) {
+            return null;
+        }
         const run = await adapter.getRun(runId);
         if (run) {
             return buildRunSummary(adapter, run);
@@ -831,7 +877,12 @@ async function waitForObservedRun(adapter, runId, waitForStartMs, signal) {
         if (Date.now() >= deadline) {
             return null;
         }
-        await sleep(25, signal);
+        try {
+            await sleep(25, signal);
+        }
+        catch {
+            return null;
+        }
     }
 }
 /**
@@ -1039,7 +1090,10 @@ export function createSemanticToolDefinitions(options = {}) {
                     maxOutputBytes: input.maxOutputBytes,
                     toolTimeoutMs: input.toolTimeoutMs,
                     hot: input.hot,
-                    signal: input.waitForTerminal ? extra?.signal : undefined,
+                    // Deliberately NOT forwarding extra?.signal: the MCP caller's
+                    // abort (client crash, timeout, disconnect) must never cancel
+                    // a durable run. waitForTerminal races the wait against the
+                    // abort below and detaches instead of tearing the run down.
                 })).then((result) => {
                     launchState.settled = true;
                     launchState.result = result;
@@ -1050,7 +1104,30 @@ export function createSemanticToolDefinitions(options = {}) {
                     throw error;
                 });
                 if (input.waitForTerminal) {
-                    const result = await launchPromise;
+                    // Race the terminal wait against the caller's abort. If the
+                    // caller aborts first the durable run keeps executing; we
+                    // detach and report it as still-running in the background.
+                    const terminal = await settleOrAbort(launchPromise, extra?.signal);
+                    if (terminal.aborted) {
+                        void launchPromise.catch((error) => {
+                            const rendered = toToolError(error);
+                            console.error(`[smithers:mcp] run_workflow detached after abort ${runId}: ${rendered.code} ${rendered.message}`);
+                        });
+                        const detachedRun = adapter != null ? await adapter.getRun(runId) : null;
+                        return {
+                            workflow: summary,
+                            runId,
+                            launchMode: "background",
+                            requestedResume: input.resume,
+                            status: detachedRun?.status ?? "running",
+                            observedRun: detachedRun != null
+                                ? await buildRunSummary(adapter, detachedRun)
+                                : null,
+                            result: null,
+                            monitoring,
+                        };
+                    }
+                    const result = terminal.value;
                     const observedRun = adapter != null ? await adapter.getRun(result.runId) : null;
                     return {
                         workflow: summary,
@@ -1308,6 +1385,14 @@ export function createSemanticToolDefinitions(options = {}) {
                         : undefined,
                     signal: extra?.signal,
                 });
+                if (outcome.status === "aborted") {
+                    // The caller went away; cancel the still-pending request so a
+                    // human doesn't later answer an orphaned prompt. Only flips
+                    // rows still `pending`, so a concurrent answer is preserved.
+                    // Still return a structured blocked outcome (not a throw) so
+                    // the caller keeps the requestId it can reference later.
+                    await adapter.cancelHumanRequest(row.requestId);
+                }
                 let response = null;
                 if (outcome.status === "answered" && outcome.responseJson != null) {
                     try {

--- a/apps/cli/src/mcp/semantic-tools.js
+++ b/apps/cli/src/mcp/semantic-tools.js
@@ -37,6 +37,7 @@ import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
  * @typedef {(adapter: SmithersDb, dbPath: string) => Promise<T>} WithDbCallback
  */
 /** @typedef {import("./SemanticToolDefinition.ts").SemanticToolDefinition} SemanticToolDefinition */
+/** @typedef {import("./SemanticToolDefinition.ts").SemanticToolCallExtra} SemanticToolCallExtra */
 
 export const SEMANTIC_TOOL_NAMES = [
     "list_workflows",
@@ -539,11 +540,31 @@ const getRunEventsDataSchema = z.object({
     events: z.array(eventSchema),
 });
 /**
- * @param {number} ms
+ * @param {AbortSignal | undefined} signal
  */
-function sleep(ms) {
-    return new Promise((resolvePromise) => {
-        setTimeout(resolvePromise, ms);
+function throwIfAborted(signal) {
+    if (signal?.aborted) {
+        throw new SmithersError("TASK_ABORTED", "MCP tool call was aborted.");
+    }
+}
+/**
+ * @param {number} ms
+ * @param {AbortSignal} [signal]
+ */
+function sleep(ms, signal) {
+    throwIfAborted(signal);
+    return new Promise((resolvePromise, rejectPromise) => {
+        const timer = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolvePromise();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener("abort", onAbort);
+            rejectPromise(new SmithersError("TASK_ABORTED", "MCP tool call was aborted."));
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+        if (signal?.aborted) onAbort();
     });
 }
 /**
@@ -797,10 +818,12 @@ async function loadWorkflowById(workflowId, cwd) {
  * @param {SmithersDb} adapter
  * @param {string} runId
  * @param {number} waitForStartMs
+ * @param {AbortSignal} [signal]
  */
-async function waitForObservedRun(adapter, runId, waitForStartMs) {
+async function waitForObservedRun(adapter, runId, waitForStartMs, signal) {
     const deadline = Date.now() + Math.max(0, waitForStartMs);
     while (true) {
+        throwIfAborted(signal);
         const run = await adapter.getRun(runId);
         if (run) {
             return buildRunSummary(adapter, run);
@@ -808,7 +831,7 @@ async function waitForObservedRun(adapter, runId, waitForStartMs) {
         if (Date.now() >= deadline) {
             return null;
         }
-        await sleep(25);
+        await sleep(25, signal);
     }
 }
 /**
@@ -982,7 +1005,7 @@ export function createSemanticToolDefinitions(options = {}) {
             inputSchema: runWorkflowInputSchema,
             outputSchema: resultSchema(runWorkflowDataSchema),
             annotations: { readOnlyHint: false, openWorldHint: true },
-            handler: (input) => executeSemanticTool("run_workflow", async () => {
+            handler: (input, extra) => executeSemanticTool("run_workflow", async () => {
                 const runId = input.runId ?? crypto.randomUUID();
                 const { workflow, summary } = await loadWorkflowById(input.workflowId, context.cwd());
                 const adapter = workflow.db
@@ -1016,6 +1039,7 @@ export function createSemanticToolDefinitions(options = {}) {
                     maxOutputBytes: input.maxOutputBytes,
                     toolTimeoutMs: input.toolTimeoutMs,
                     hot: input.hot,
+                    signal: input.waitForTerminal ? extra?.signal : undefined,
                 })).then((result) => {
                     launchState.settled = true;
                     launchState.result = result;
@@ -1046,7 +1070,7 @@ export function createSemanticToolDefinitions(options = {}) {
                     console.error(`[smithers:mcp] run_workflow background failure ${runId}: ${rendered.code} ${rendered.message}`);
                 });
                 const observedRun = adapter != null
-                    ? await waitForObservedRun(adapter, runId, input.waitForStartMs)
+                    ? await waitForObservedRun(adapter, runId, input.waitForStartMs, extra?.signal)
                     : null;
                 if (observedRun == null && launchState.settled) {
                     if (launchState.error) {
@@ -1110,12 +1134,13 @@ export function createSemanticToolDefinitions(options = {}) {
             inputSchema: watchRunInputSchema,
             outputSchema: resultSchema(watchRunDataSchema),
             annotations: { readOnlyHint: true },
-            handler: (input) => executeSemanticTool("watch_run", async () => withDb(context, async (adapter, dbPath) => {
+            handler: (input, extra) => executeSemanticTool("watch_run", async () => withDb(context, async (adapter, dbPath) => {
                 const intervalMs = Math.max(WATCH_MIN_INTERVAL_MS, input.intervalMs);
                 const deadline = Date.now() + input.timeoutMs;
                 const snapshots = [];
                 let pollCount = 0;
                 while (true) {
+                    throwIfAborted(extra?.signal);
                     const run = await adapter.getRun(input.runId);
                     if (!run) {
                         const dbHint = dbPath ? ` (db: ${dbPath})` : "";
@@ -1156,7 +1181,7 @@ export function createSemanticToolDefinitions(options = {}) {
                         };
                     }
                     pollCount += 1;
-                    await sleep(intervalMs);
+                    await sleep(intervalMs, extra?.signal);
                 }
             })),
         },
@@ -1249,7 +1274,8 @@ export function createSemanticToolDefinitions(options = {}) {
                 openWorldHint: true,
                 idempotentHint: false,
             },
-            handler: (input) => executeSemanticTool("ask_human", async () => withDb(context, async (adapter) => {
+            handler: (input, extra) => executeSemanticTool("ask_human", async () => withDb(context, async (adapter) => {
+                throwIfAborted(extra?.signal);
                 const ctx = await resolveAskHumanContext(adapter, {
                     runId: input.runId,
                     nodeId: input.nodeId,
@@ -1280,6 +1306,7 @@ export function createSemanticToolDefinitions(options = {}) {
                     pollIntervalMs: typeof input.pollSeconds === "number" && input.pollSeconds > 0
                         ? Math.floor(input.pollSeconds * 1_000)
                         : undefined,
+                    signal: extra?.signal,
                 });
                 let response = null;
                 if (outcome.status === "answered" && outcome.responseJson != null) {

--- a/apps/cli/tests/ask-human-mcp.test.js
+++ b/apps/cli/tests/ask-human-mcp.test.js
@@ -93,4 +93,41 @@ describe("ask_human semantic tool", () => {
             sqlite.close();
         }
     });
+
+    test("stops waiting when the caller aborts", async () => {
+        const { sqlite, adapter, askHuman } = makeHarness();
+        try {
+            const abort = new AbortController();
+            const callPromise = askHuman.handler(
+                askHuman.inputSchema.parse({
+                    prompt: "Proceed?",
+                    runId: "run-1",
+                    nodeId: "n",
+                    iteration: 0,
+                    pollSeconds: 60,
+                }),
+                { signal: abort.signal },
+            );
+
+            let requestId;
+            for (let i = 0; i < 60 && !requestId; i += 1) {
+                const pending = await adapter.listPendingHumanRequests();
+                if (pending.length > 0) {
+                    requestId = pending[0].requestId;
+                } else {
+                    await new Promise((r) => setTimeout(r, 25));
+                }
+            }
+            expect(requestId).toBeTruthy();
+
+            abort.abort();
+            const result = await callPromise;
+            expect(result.structuredContent.ok).toBe(true);
+            expect(result.structuredContent.data.requestId).toBe(requestId);
+            expect(result.structuredContent.data.status).toBe("aborted");
+            expect(result.structuredContent.data.decision).toBe("blocked");
+        } finally {
+            sqlite.close();
+        }
+    });
 });

--- a/apps/cli/tests/ask-human-mcp.test.js
+++ b/apps/cli/tests/ask-human-mcp.test.js
@@ -126,6 +126,13 @@ describe("ask_human semantic tool", () => {
             expect(result.structuredContent.data.requestId).toBe(requestId);
             expect(result.structuredContent.data.status).toBe("aborted");
             expect(result.structuredContent.data.decision).toBe("blocked");
+
+            // The orphaned request must be cancelled, not left pending for a
+            // human to answer after the caller has gone.
+            const stillPending = await adapter.listPendingHumanRequests();
+            expect(stillPending).toHaveLength(0);
+            const cancelled = await adapter.getHumanRequest(requestId);
+            expect(cancelled?.status).toBe("cancelled");
         } finally {
             sqlite.close();
         }

--- a/apps/cli/tests/semantic-mcp.test.js
+++ b/apps/cli/tests/semantic-mcp.test.js
@@ -124,6 +124,47 @@ describe("semantic MCP surface", () => {
         expect(names).toContain("raw-ping");
     });
 
+    test("forwards MCP request context to semantic tool handlers", async () => {
+        let seenExtra = null;
+        const server = createSemanticMcpServer({
+            name: "smithers-test",
+            version: "test",
+            allowedTools: [],
+        });
+        registerSemanticTools(server, [
+            {
+                name: "list_workflows",
+                description: "Test context forwarding",
+                inputSchema: z.object({}),
+                outputSchema: z.object({ ok: z.boolean() }),
+                annotations: { readOnlyHint: true },
+                handler: async (_input, extra) => {
+                    seenExtra = extra;
+                    return {
+                        content: [{ type: "text", text: '{"ok":true}' }],
+                        structuredContent: { ok: true },
+                    };
+                },
+            },
+        ]);
+        servers.push(server);
+        const client = new Client({
+            name: "smithers-semantic-test-client",
+            version: "test",
+        });
+        clients.push(client);
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([
+            server.connect(serverTransport),
+            client.connect(clientTransport),
+        ]);
+
+        await client.callTool({ name: "list_workflows", arguments: {} });
+        expect(seenExtra).toBeTruthy();
+        expect(seenExtra.signal).toBeInstanceOf(AbortSignal);
+        expect(seenExtra.requestId).toBeDefined();
+    });
+
     test("rejects invalid semantic tool discovery definitions before serving", () => {
         const baseTool = {
             name: "list_workflows",

--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -392,10 +392,10 @@ function makeHarness(adapterState = {}) {
         cwd,
         state,
         tools,
-        async call(name, input = {}) {
+        async call(name, input = {}, extra = undefined) {
             const tool = tools.get(name);
             if (!tool) throw new Error(`missing tool ${name}`);
-            return tool.handler(tool.inputSchema.parse(input));
+            return tool.handler(tool.inputSchema.parse(input), extra);
         },
     };
 }
@@ -575,6 +575,28 @@ describe("semantic tool definitions", () => {
         });
         expect(polled.structuredContent.data.reachedTerminal).toBe(true);
         expect(polled.structuredContent.data.pollCount).toBe(1);
+
+        const abortHarness = makeHarness({
+            runs: [runRow({ runId: "run-1", status: "running" })],
+            nodes: [],
+            approvals: [],
+            attempts: [],
+        });
+        const abort = new AbortController();
+        const aborted = abortHarness.call(
+            "watch_run",
+            {
+                runId: "run-1",
+                intervalMs: 60_000,
+                timeoutMs: 60_000,
+            },
+            { signal: abort.signal },
+        );
+        abort.abort();
+        const abortedResult = await aborted;
+        expect(abortedResult.isError).toBe(true);
+        expect(abortedResult.structuredContent.error.code).toBe("TASK_ABORTED");
+        expect(abortHarness.state.cleanupCalls).toBe(1);
 
         const explanation = await harness.call("explain_run", { runId: "run-1" });
         expect(explanation.structuredContent.data.diagnosis.runId).toBe("run-1");

--- a/apps/cli/tests/semantic-tools-unit.test.js
+++ b/apps/cli/tests/semantic-tools-unit.test.js
@@ -476,6 +476,26 @@ describe("semantic tool definitions", () => {
         });
         expect(typeof background.structuredContent.ok).toBe("boolean");
         expectWorkflowSummaryMatchesSchema(background.structuredContent.data.workflow);
+
+        // Durability contract: a caller abort during waitForTerminal must NOT
+        // cancel the durable run — the wait detaches and reports the run as
+        // launched-in-background. A pre-aborted signal makes this deterministic:
+        // the old code forwarded the signal into runWorkflow and came back
+        // "waited"/"cancelled"; the fix launches without the signal and detaches.
+        const preAborted = new AbortController();
+        preAborted.abort();
+        const detached = await harness.call(
+            "run_workflow",
+            {
+                workflowId: "quick",
+                runId: "semantic-quick-detached",
+                waitForTerminal: true,
+            },
+            { signal: preAborted.signal },
+        );
+        expect(detached.structuredContent.ok).toBe(true);
+        expect(detached.structuredContent.data.launchMode).toBe("background");
+        expect(detached.structuredContent.data.status).not.toBe("cancelled");
     });
 
     test("list_workflows payload carries only keys declared in the output schema (#223)", async () => {


### PR DESCRIPTION
## Summary
- forward MCP request context to semantic tool handlers so caller abort signals reach long waits
- stop watch_run polling, run_workflow startup waits, and ask_human waits when the caller aborts
- normalize raw delete bytes in the CLI fuzzy picker so backspace stays reliable in streamed TTY input

## Tests
- bun test apps/cli/tests/ask-human-mcp.test.js apps/cli/tests/semantic-mcp.test.js apps/cli/tests/semantic-tools-unit.test.js apps/cli/tests/fuzzy-select.test.js
- pnpm -C apps/cli typecheck
- pnpm -C apps/cli test
- pnpm typecheck
- pnpm typecheck:examples
- pnpm typecheck:evals
- pnpm lint
- pnpm check:deps
- pnpm check:docs
- pnpm check:llms
- pnpm check:effect