### PR TITLE
🧹 refactor(agents): drop dead hints property from PiAgent.buildCommand

### DIFF
--- a/packages/agents/src/PiAgent.js
+++ b/packages/agents/src/PiAgent.js
@@ -510,10 +510,6 @@ export class PiAgent extends BaseCliAgent {
                 options: params.options,
                 mode,
             }),
-            hints: {
-                provider: this.opts.provider,
-                model: this.opts.model ?? this.model,
-            },
             outputFormat: mode,
         };
     }

--- a/packages/agents/tests/pi-support.test.js
+++ b/packages/agents/tests/pi-support.test.js
@@ -198,6 +198,26 @@ process.stdout.write(lines.join("\\n") + "\\n");
             await rm(argsFileDir, { recursive: true, force: true });
         }
     }, 15_000);
+    test("PiAgent buildCommand omits the dead hints property; diagnosticHints carries the data", async () => {
+        const agent = new PiAgent({
+            mode: "json",
+            provider: "openai",
+            model: "gpt-5.4-mini",
+            apiKey: "pi-test-key",
+        });
+        const commandSpec = await agent.buildCommand({
+            prompt: "Ping?",
+            cwd: "/tmp",
+        });
+        expect(commandSpec.command).toBe("pi");
+        expect(commandSpec).not.toHaveProperty("hints");
+        // Diagnostics data lives on diagnosticHints(), which the preflight path reads.
+        expect(agent.diagnosticHints()).toEqual({
+            provider: "openai",
+            model: "gpt-5.4-mini",
+            apiKey: "pi-test-key",
+        });
+    });
     test("PiAgent json mode includes --print", async () => {
         const argsFileDir = await mkdtemp(join(tmpdir(), "smithers-pi-json-print-"));
         const argsFile = join(argsFileDir, "args.json");


### PR DESCRIPTION
Closes #568

`PiAgent.buildCommand` returned a `hints: { provider, model }` property that no code reads — diagnostics flow through `this.diagnosticHints?.()` instead, and the property was also absent from the JSDoc `@returns` type. This removes the dead payload so the returned object and its annotation agree. Added a test in pi-support.test.js pinning that `buildCommand` omits `hints` while `diagnosticHints()` still carries provider/model/apiKey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)