### PR TITLE
🐛 fix(pi-plugin): show "Denied" instead of "Denyd" in approve toast

### DIFF
--- a/packages/pi-plugin/src/extension.ts
+++ b/packages/pi-plugin/src/extension.ts
@@ -675,7 +675,8 @@ export function extension(pi: ExtensionAPI) {
         );
         return;
       }
-      ctx.ui.notify(`${action}d ${target.node.nodeId}`, action === "Approve" ? "info" : "warning");
+      const pastTense = action === "Approve" ? "Approved" : "Denied";
+      ctx.ui.notify(`${pastTense} ${target.node.nodeId}`, action === "Approve" ? "info" : "warning");
     },
   });
 

--- a/packages/pi-plugin/tests/extensionUiInterop.test.ts
+++ b/packages/pi-plugin/tests/extensionUiInterop.test.ts
@@ -17,4 +17,12 @@ describe("Pi UI interoperability", () => {
     expect(source).toContain("normalizeState(node.state) === \"waiting-approval\"");
     expect(source).not.toContain("node.state === \"waiting-approval\"");
   });
+
+  test("/smithers-approve toast uses a real past-tense verb, not action + 'd'", () => {
+    const source = readFileSync(resolve(import.meta.dir, "../src/extension.ts"), "utf8");
+
+    // The buggy template `${action}d ...` produced "Denyd" for the "Deny" action.
+    expect(source).not.toContain("`${action}d ");
+    expect(source).toContain("\"Denied\"");
+  });
 });


### PR DESCRIPTION
Closes #586

The /smithers-approve success toast built its label with `${action}d`, so denying an approval printed "Denyd <nodeId>". Map the action to an explicit past-tense verb ("Approved"/"Denied") instead of appending "d". Added a source-pinning test in extensionUiInterop.test.ts that fails against the old template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)