### PR TITLE
🧹 fix(server): unwrap cause chain in getNodeOutput malformed-row detection

### DIFF
--- a/packages/db/src/output.js
+++ b/packages/db/src/output.js
@@ -1,7 +1,7 @@
 import { and, eq, getTableName } from "drizzle-orm";
 import { getTableColumns } from "drizzle-orm/utils";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
 import { z } from "zod";
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
@@ -114,8 +114,16 @@ export function selectOutputRowEffect(db, table, key) {
  * @param {_OutputKey} key
  * @returns {Promise<T | undefined>}
  */
-export function selectOutputRow(db, table, key) {
-    return Effect.runPromise(selectOutputRowEffect(db, table, key));
+export async function selectOutputRow(db, table, key) {
+    // Effect.runPromise rejects with a FiberFailure that drops the failure's
+    // `cause` chain; rethrow the SmithersError itself so callers can still
+    // reach the underlying driver error (e.g. a JSON.parse SyntaxError from a
+    // malformed row) through `cause`.
+    const exit = await Effect.runPromiseExit(selectOutputRowEffect(db, table, key));
+    if (Exit.isSuccess(exit)) {
+        return exit.value;
+    }
+    throw Cause.squash(exit.cause);
 }
 /**
  * @param {BunSQLiteDatabase<Record<string, unknown>>} db

--- a/packages/db/tests/db-output-roundtrip.test.js
+++ b/packages/db/tests/db-output-roundtrip.test.js
@@ -128,6 +128,35 @@ describe("output row roundtrip", () => {
             sqlite.close();
         }
     });
+    test("malformed JSON row rejects with the SyntaxError reachable via cause", async () => {
+        const { table, db, sqlite } = createTableAndDb("results", z.object({ payload: z.object({ ok: z.boolean() }) }));
+        try {
+            sqlite.exec("INSERT INTO results (run_id, node_id, iteration, payload) VALUES ('r1', 'n1', 0, '{not json')");
+            let caught;
+            try {
+                await selectOutputRow(db, table, { runId: "r1", nodeId: "n1", iteration: 0 });
+            }
+            catch (error) {
+                caught = error;
+            }
+            expect(caught).toBeDefined();
+            // The rejection must be the SmithersError itself, not a FiberFailure
+            // that severs the cause chain — consumers (getNodeOutput's
+            // looksLikeMalformedOutputRow) walk `cause` to find the SyntaxError.
+            let sawSyntaxError = false;
+            for (let current = caught, depth = 0; current != null && depth < 8; depth += 1) {
+                if (current instanceof SyntaxError) {
+                    sawSyntaxError = true;
+                    break;
+                }
+                current = current.cause;
+            }
+            expect(sawSyntaxError).toBe(true);
+        }
+        finally {
+            sqlite.close();
+        }
+    });
 });
 describe("getAgentOutputSchema", () => {
     test("strips system columns from schema", () => {

--- a/packages/server/src/gatewayRoutes/getNodeOutput.js
+++ b/packages/server/src/gatewayRoutes/getNodeOutput.js
@@ -478,14 +478,28 @@ function byteLengthOfJson(value) {
 }
 
 /**
+ * A malformed output row surfaces as a JSON.parse SyntaxError, but by the time
+ * it reaches here it is buried in the `cause` chain: selectOutputRowEffect wraps
+ * every DB rejection via toSmithersError (code DB_QUERY_FAILED) and runPromise
+ * wraps it again. Walk the chain (as streamDevTools's findDevToolsRouteError
+ * does) so the SyntaxError check actually fires instead of resting entirely on
+ * the wrapped message happening to still mention "json".
+ *
  * @param {unknown} error
  */
 function looksLikeMalformedOutputRow(error) {
-    if (error instanceof SyntaxError) {
-        return true;
+    let current = error;
+    for (let depth = 0; current != null && depth < 8; depth += 1) {
+        if (current instanceof SyntaxError) {
+            return true;
+        }
+        const message = asString(/** @type {{ message?: unknown }} */ (current).message)?.toLowerCase() ?? "";
+        if (message.includes("json") || message.includes("parse") || message.includes("malformed")) {
+            return true;
+        }
+        current = /** @type {{ cause?: unknown }} */ (current).cause;
     }
-    const message = asString(error?.message)?.toLowerCase() ?? "";
-    return message.includes("json") || message.includes("parse") || message.includes("malformed");
+    return false;
 }
 
 /**

--- a/packages/server/src/gatewayRoutes/getNodeOutput.js
+++ b/packages/server/src/gatewayRoutes/getNodeOutput.js
@@ -479,11 +479,11 @@ function byteLengthOfJson(value) {
 
 /**
  * A malformed output row surfaces as a JSON.parse SyntaxError, but by the time
- * it reaches here it is buried in the `cause` chain: selectOutputRowEffect wraps
- * every DB rejection via toSmithersError (code DB_QUERY_FAILED) and runPromise
- * wraps it again. Walk the chain (as streamDevTools's findDevToolsRouteError
- * does) so the SyntaxError check actually fires instead of resting entirely on
- * the wrapped message happening to still mention "json".
+ * it reaches here selectOutputRow has wrapped it in a SmithersError (code
+ * DB_QUERY_FAILED) with the SyntaxError on its `cause` chain. Walk the chain
+ * (as streamDevTools's findDevToolsRouteError does) so the SyntaxError check
+ * fires for any wrapping depth, with the message keywords kept as a fallback
+ * for drivers that report malformed JSON without throwing a SyntaxError.
  *
  * @param {unknown} error
  */

--- a/packages/server/tests/getNodeOutput.test.ts
+++ b/packages/server/tests/getNodeOutput.test.ts
@@ -221,10 +221,10 @@ describe("getNodeOutputRoute status", () => {
   });
 
   test("SyntaxError buried in the cause chain returns MalformedOutputRow", async () => {
-    // Production wraps the JSON.parse SyntaxError (toSmithersError, then
-    // runPromise), so the error reaching classification is not itself a
-    // SyntaxError and its outer message never mentions json/parse/malformed.
-    // Only walking the cause chain classifies it correctly.
+    // selectOutputRow wraps the JSON.parse SyntaxError in a SmithersError
+    // (DB_QUERY_FAILED) with the SyntaxError on `cause`. The wrapper's outer
+    // message deliberately lacks the json/parse/malformed keywords so this
+    // pins the cause-chain walk rather than the message heuristic.
     await expect(
       invokeRoute({
         selectOutputRowImpl: async () => {

--- a/packages/server/tests/getNodeOutput.test.ts
+++ b/packages/server/tests/getNodeOutput.test.ts
@@ -219,6 +219,23 @@ describe("getNodeOutputRoute status", () => {
       }),
     ).rejects.toMatchObject({ code: "MalformedOutputRow" });
   });
+
+  test("SyntaxError buried in the cause chain returns MalformedOutputRow", async () => {
+    // Production wraps the JSON.parse SyntaxError (toSmithersError, then
+    // runPromise), so the error reaching classification is not itself a
+    // SyntaxError and its outer message never mentions json/parse/malformed.
+    // Only walking the cause chain classifies it correctly.
+    await expect(
+      invokeRoute({
+        selectOutputRowImpl: async () => {
+          const wrapped = new Error("DB_QUERY_FAILED: select failed", {
+            cause: new SyntaxError("Unexpected token i in JSON"),
+          });
+          throw wrapped;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "MalformedOutputRow" });
+  });
 });
 
 describe("getNodeOutputRoute input boundaries", () => {


### PR DESCRIPTION
Closes #556

`looksLikeMalformedOutputRow` classified errors with a top-level `instanceof SyntaxError` check that could never match: DB rejections are wrapped by `toSmithersError` before reaching the route. This walks the cause chain (mirroring streamDevTools's `findDevToolsRouteError`) so the SyntaxError check fires at any wrapping depth.

Review found the original version of this PR only half-fixed the problem: `selectOutputRow` used `Effect.runPromise`, whose `FiberFailure` rejection **drops the failure's cause chain entirely**, so the SyntaxError was unreachable no matter how far the classifier walked. Now `selectOutputRow` rethrows the `SmithersError` itself (`runPromiseExit` + `Cause.squash`), keeping the driver error reachable via `cause` for all callers.

Tests:
- `packages/db/tests/db-output-roundtrip.test.js`: real-path regression — malformed JSON in a sqlite json column → `selectOutputRow` rejection has the SyntaxError reachable via `cause` (fails without the db fix).
- `packages/server/tests/getNodeOutput.test.ts`: SyntaxError buried in a cause chain whose outer message lacks json/parse/malformed keywords → `MalformedOutputRow` (fails without the classifier walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)