### PR TITLE
🐛 fix(gateway-client): track default handshake client version with package version

### DIFF
--- a/packages/gateway-client/src/SmithersGatewayClient.ts
+++ b/packages/gateway-client/src/SmithersGatewayClient.ts
@@ -56,8 +56,11 @@ declare global {
 // The default `smithers gateway` port, used when there is no browser origin to inherit.
 const DEFAULT_GATEWAY_BASE_URL = "http://127.0.0.1:7331";
 
-// Client version reported in the connect handshake when the caller does not supply one.
-const DEFAULT_CLIENT_VERSION = "0.17.0";
+// Client version reported in the connect handshake when the caller does not
+// supply one. Kept in lock-step with this package's version by scripts/bump.mjs
+// (a release bump rewrites the literal); tests/SmithersGatewayClient.test.ts
+// pins it to package.json so it can't silently drift again.
+const DEFAULT_CLIENT_VERSION = "0.28.0";
 
 // How long a connection must stay alive before streamRunEventsResilient treats
 // it as healthy and resets backoff — see the flap-protection paragraph on that

--- a/packages/gateway-client/tests/SmithersGatewayClient.test.ts
+++ b/packages/gateway-client/tests/SmithersGatewayClient.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SmithersGatewayClient } from "../src/index.ts";
 
 class FakeWebSocket extends EventTarget {
@@ -97,5 +99,15 @@ describe("SmithersGatewayClient", () => {
     } finally {
       globalThis.__SMITHERS_GATEWAY_UI__ = undefined;
     }
+  });
+});
+
+describe("default client version", () => {
+  test("tracks package.json so the connect handshake can't report a stale release", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(import.meta.dir, "../package.json"), "utf8"),
+    ) as { version: string };
+    const client = new SmithersGatewayClient();
+    expect(client.client.version).toBe(pkg.version);
   });
 });

--- a/scripts/bump.mjs
+++ b/scripts/bump.mjs
@@ -59,6 +59,26 @@ if (syncedProvider !== provider) {
   console.log(`  synced DEFAULT_ORCHESTRATOR_VERSION in ${providerPath}`);
 }
 
+// gateway-client reports DEFAULT_CLIENT_VERSION in its connect handshake when
+// the caller supplies none; a test asserts it matches package.json, so sync it
+// here too or a release bump would leave every default client stale.
+const clientPath = join(root, "packages", "gateway-client", "src", "SmithersGatewayClient.ts");
+const clientSource = readFileSync(clientPath, "utf8");
+const syncedClient = clientSource.replace(
+  /(const DEFAULT_CLIENT_VERSION = ")[^"]+(")/,
+  `$1${version}$2`,
+);
+if (!syncedClient.includes(`DEFAULT_CLIENT_VERSION = "${version}"`)) {
+  throw new Error(
+    `bump.mjs could not sync DEFAULT_CLIENT_VERSION in ${clientPath} — the pin pattern no longer matches; update the regex in scripts/bump.mjs`,
+  );
+}
+if (syncedClient !== clientSource) {
+  writeFileSync(clientPath, syncedClient);
+  changed.push(clientPath);
+  console.log(`  synced DEFAULT_CLIENT_VERSION in ${clientPath}`);
+}
+
 execSync("pnpm install --prefer-offline", { cwd: root, stdio: "inherit" });
 
 // publish.mjs refuses to release without the committed versioned llms bundles


### PR DESCRIPTION
Closes #577

The default connect-handshake `clientVersion` was a hardcoded "0.17.0" that had drifted ~11 releases behind the package (0.28.0), making version-skew telemetry in the gateway's auth events misleading. This bumps the constant to the current version and, mirroring the existing `DEFAULT_ORCHESTRATOR_VERSION` pattern, wires `scripts/bump.mjs` to rewrite the literal on every release bump so it can't drift again. A new test in `packages/gateway-client/tests/SmithersGatewayClient.test.ts` pins the default-constructed client's reported version to `package.json`, and would fail against the old stale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)