### PR TITLE
🧹 fix(server): drop dead capitalized Authorization header lookup in assertAuth

### DIFF
--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -426,7 +426,6 @@ function assertAuth(req, authToken) {
     if (!authToken)
         return;
     const header = req.headers["authorization"] ??
-        req.headers["Authorization"] ??
         req.headers["x-smithers-key"];
     const value = Array.isArray(header) ? header[0] : header;
     const token = value?.slice(0, 7).toLowerCase() === "bearer " ? value.slice(7) : value;

--- a/packages/server/tests/server.test.js
+++ b/packages/server/tests/server.test.js
@@ -417,18 +417,6 @@ const fakeAgent = {
             expect(status).toBe(200);
             expect(data.runId).toBeDefined();
         });
-        test("accepts a capitalized Authorization header (Node lowercases it)", async () => {
-            const dbPath = resolve(testDir, "test-auth-cap.db");
-            const workflowPath = writeTestWorkflow("test-auth-cap", dbPath);
-            startTestServer({ authToken: "secret" });
-            const { status, data } = await request("/v1/runs", {
-                method: "POST",
-                body: { workflowPath },
-                headers: { Authorization: "Bearer secret" },
-            });
-            expect(status).toBe(200);
-            expect(data.runId).toBeDefined();
-        });
     });
     describe("POST /v1/runs/:runId/cancel", () => {
         test("cancels an active run", async () => {

--- a/packages/server/tests/server.test.js
+++ b/packages/server/tests/server.test.js
@@ -405,6 +405,30 @@ const fakeAgent = {
             expect(status).toBe(200);
             expect(data.runId).toBeDefined();
         });
+        test("accepts requests via the x-smithers-key header", async () => {
+            const dbPath = resolve(testDir, "test-auth-key.db");
+            const workflowPath = writeTestWorkflow("test-auth-key", dbPath);
+            startTestServer({ authToken: "secret" });
+            const { status, data } = await request("/v1/runs", {
+                method: "POST",
+                body: { workflowPath },
+                headers: { "x-smithers-key": "secret" },
+            });
+            expect(status).toBe(200);
+            expect(data.runId).toBeDefined();
+        });
+        test("accepts a capitalized Authorization header (Node lowercases it)", async () => {
+            const dbPath = resolve(testDir, "test-auth-cap.db");
+            const workflowPath = writeTestWorkflow("test-auth-cap", dbPath);
+            startTestServer({ authToken: "secret" });
+            const { status, data } = await request("/v1/runs", {
+                method: "POST",
+                body: { workflowPath },
+                headers: { Authorization: "Bearer secret" },
+            });
+            expect(status).toBe(200);
+            expect(data.runId).toBeDefined();
+        });
     });
     describe("POST /v1/runs/:runId/cancel", () => {
         test("cancels an active run", async () => {


### PR DESCRIPTION
Closes #557

Node's `IncomingMessage` lowercases all incoming header names, so the capitalized `req.headers["Authorization"]` branch in `assertAuth` could never match. Removed the dead lookup and pinned the auth contract with an `x-smithers-key` header test (the lowercase `Authorization` path was already covered by "accepts requests with valid token"; a capitalized-header variant was dropped in review as a duplicate — fetch lowercases header names client-side, so it exercised nothing new). Full server suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)