### PR TITLE
🐛 fix(tui): size graph connector column from arrow string

### DIFF
--- a/packages/tui/src/modes/GraphMode.tsx
+++ b/packages/tui/src/modes/GraphMode.tsx
@@ -5,6 +5,7 @@ import { useOverlayOpen } from "../OverlayContext.tsx";
 import { nodeGlyph, nodeGlyphColor, isModifiedKeyEvent } from "./treeUtils.ts";
 import {
   computeGraphLayout,
+  connectorArrow,
   edgesForConnector,
   hasIncomingEdge,
 } from "./graphUtils.ts";
@@ -16,8 +17,6 @@ const CARD_SLOT = CARD_H + ROW_GAP;
 const COMPACT_WIDTH = 100;
 const CARD_W_NORMAL = 20;
 const CARD_W_COMPACT = 14;
-const ARROW_W_NORMAL = 5;  // " ──▶" padded to 5
-const ARROW_W_COMPACT = 3; // " → " padded to 3
 
 // ─── NodeCard ────────────────────────────────────────────────────────────────
 
@@ -63,15 +62,16 @@ function NodeCard({
 function ConnectorColumn({
   numSlots,
   connEdges,
-  arrowWidth,
   compact,
 }: {
   numSlots: number;
   connEdges: Array<{ fromRow: number; toRow: number }>;
-  arrowWidth: number;
   compact: boolean;
 }) {
-  const arrow = compact ? " →  " : " ──▶ ";
+  const arrow = connectorArrow(compact);
+  // Cell width is derived from the arrow so the glyph can never overflow its
+  // column (see #582); a blank slot fills the same width with spaces.
+  const arrowWidth = arrow.length;
   const blank = " ".repeat(arrowWidth);
 
   const slots = Array.from({ length: numSlots }, (_, toRow) =>
@@ -142,7 +142,6 @@ export function GraphView({
   const { width } = useTerminalDimensions();
   const compact = width < COMPACT_WIDTH;
   const cardWidth = compact ? CARD_W_COMPACT : CARD_W_NORMAL;
-  const arrowWidth = compact ? ARROW_W_COMPACT : ARROW_W_NORMAL;
 
   const layout = useMemo(
     () => computeGraphLayout(nodes, root),
@@ -253,7 +252,6 @@ export function GraphView({
           key={`conn-${c}`}
           numSlots={numSlots}
           connEdges={connEdges}
-          arrowWidth={arrowWidth}
           compact={compact}
         />,
       );

--- a/packages/tui/src/modes/graphUtils.ts
+++ b/packages/tui/src/modes/graphUtils.ts
@@ -129,6 +129,17 @@ export function edgesForConnector(
 }
 
 /**
+ * The connector arrow drawn between two graph columns. Compact terminals
+ * (< COMPACT_WIDTH cols) use a narrower glyph. Callers size the connector
+ * `<box>`/`<text>` cells from this string's length so the arrow can never
+ * overflow its column (see #582): every glyph here is a single-column BMP
+ * character, so `.length` equals the rendered width.
+ */
+export function connectorArrow(compact: boolean): string {
+  return compact ? " → " : " ──▶ ";
+}
+
+/**
  * For a given connector slot (= row in the right column),
  * does any edge arrive at this slot from the left column?
  */

--- a/packages/tui/tests/graph-mode.test.ts
+++ b/packages/tui/tests/graph-mode.test.ts
@@ -3,6 +3,7 @@ import type { GatewayRunNode } from "@smithers-orchestrator/gateway-client";
 import {
   computeColumnDepths,
   computeGraphLayout,
+  connectorArrow,
   edgesForConnector,
   hasIncomingEdge,
 } from "../src/modes/graphUtils.ts";
@@ -138,6 +139,30 @@ describe("graphUtils – edgesForConnector", () => {
     const layout = computeGraphLayout([a, b], null);
     const conn = edgesForConnector(layout.edges, layout.positions, 0);
     expect(conn).toHaveLength(0);
+  });
+});
+
+describe("graphUtils – connectorArrow", () => {
+  // Regression for #582: the compact arrow was " →  " (4 chars) rendered into a
+  // width-3 connector column, so arrow rows overflowed and were one cell wider
+  // than blank rows, skewing the graph. The arrow must fit its own column
+  // exactly in both modes, so callers can size the cell from `.length`.
+  it("compact arrow is exactly 3 columns wide (no overflow)", () => {
+    expect(connectorArrow(true)).toBe(" → ");
+    expect(connectorArrow(true).length).toBe(3);
+  });
+
+  it("normal arrow is exactly 5 columns wide", () => {
+    expect(connectorArrow(false)).toBe(" ──▶ ");
+    expect(connectorArrow(false).length).toBe(5);
+  });
+
+  it("arrow width matches the blank filler it aligns with in both modes", () => {
+    for (const compact of [true, false]) {
+      const arrow = connectorArrow(compact);
+      const blank = " ".repeat(arrow.length);
+      expect(arrow.length).toBe(blank.length);
+    }
   });
 });
 

--- a/packages/tui/tests/graph-mode.test.ts
+++ b/packages/tui/tests/graph-mode.test.ts
@@ -156,14 +156,6 @@ describe("graphUtils – connectorArrow", () => {
     expect(connectorArrow(false)).toBe(" ──▶ ");
     expect(connectorArrow(false).length).toBe(5);
   });
-
-  it("arrow width matches the blank filler it aligns with in both modes", () => {
-    for (const compact of [true, false]) {
-      const arrow = connectorArrow(compact);
-      const blank = " ".repeat(arrow.length);
-      expect(arrow.length).toBe(blank.length);
-    }
-  });
 });
 
 describe("graphUtils – hasIncomingEdge", () => {


### PR DESCRIPTION
Closes #582

The compact graph connector arrow was ` →  ` (4 chars) but rendered into a width-3 column, so in compact mode (terminal < 100 cols) arrow rows overflowed and were one cell wider than blank rows, skewing the graph alignment. This introduces a `connectorArrow(compact)` helper in `graphUtils.ts` and derives the connector cell width from `arrow.length`, so the glyph and its column can never drift. Added `graphUtils – connectorArrow` unit tests pinning the 3-/5-column widths (the compact case would fail on the old 4-char string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)