### PR TITLE
🐛 fix(gateway-client): confirm streamRunEvents subscribe already honors AbortSignal (#506)

### DIFF
--- a/packages/gateway-client/tests/gateway-client.test.ts
+++ b/packages/gateway-client/tests/gateway-client.test.ts
@@ -456,6 +456,25 @@ describe("SmithersGatewayClient WebSocket helpers", () => {
     expect(ws.closeCalls).toBe(1);
   });
 
+  test("aborts streamRunEvents while the subscribe request is pending post-handshake", async () => {
+    const WebSocket = fakeWebSocketCtor();
+    const client = new SmithersGatewayClient({ WebSocket });
+    const controller = new AbortController();
+
+    const iterator = client.streamRunEvents({ runId: "run-1" }, { signal: controller.signal });
+    const next = iterator.next();
+    const ws = FakeWebSocket.instances[0];
+    ws.open();
+    await waitForSent(ws, 1);
+    ws.receive({ type: "res", id: ws.lastRequest().id, ok: true, payload: {} });
+    await waitForSent(ws, 2);
+
+    controller.abort();
+
+    await expect(next).rejects.toThrow("Gateway stream subscribe aborted.");
+    expect(ws.closeCalls).toBe(1);
+  });
+
   test("filters run stream events by stream id and closes after iterator return", async () => {
     const WebSocket = fakeWebSocketCtor();
     const client = new SmithersGatewayClient({ WebSocket });


### PR DESCRIPTION
Closes #506

## Root cause

Issue #506 flagged a narrow gap: the caller's `AbortSignal` looked like it might be ignored during the `streamRunEvents` subscribe RPC (`packages/gateway-client/src/SmithersGatewayClient.ts`), so an aborting caller could hang if the gateway stalled between the WebSocket handshake and the subscribe response.

Investigation found this is already handled. In `subscribedStream` (the shared body of `streamRunEvents`/`streamDevTools`, `SmithersGatewayClient.ts` ~line 315), the subscribe request is raced against the signal:

```ts
const subscribed = await raceSignal(
  connection.request(method, params),
  options.signal,
  "Gateway stream subscribe aborted.",
);
```

`raceSignal` was introduced in `f637a0af95` (well before this issue was filed), and `git log -S"raceSignal("` confirms no later commit touched this path. `connect()` and `connection.events()` already honored the signal too, so the entire abort path — connect, subscribe, and event streaming — was already covered.

## Approach

Rather than ship a no-op diff, this PR adds a regression test (`packages/gateway-client/tests/gateway-client.test.ts`) that opens a `streamRunEvents` iterator, lets the handshake complete, then aborts the signal while the subscribe RPC is still pending (post-handshake, pre-subscribe-response) — the exact window the issue described. The test asserts the iterator rejects with `"Gateway stream subscribe aborted."` and the socket is closed, locking in the existing behavior so it can't silently regress.

Strategy used: **opus-sandwich**.

This PR will be RESTACKED onto a PR train — its base branch may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)