### PR TITLE
🐛 fix(sandbox): best-effort failure-path bookkeeping so it never masks the primary error

### DIFF
--- a/packages/sandbox/src/execute.js
+++ b/packages/sandbox/src/execute.js
@@ -732,33 +732,67 @@ export async function executeSandbox(options) {
         });
     }
     catch (error) {
-        await adapter.upsertSandbox({
-            runId: runtime.runId,
-            sandboxId: options.sandboxId,
-            runtime: selectedRuntime,
-            remoteRunId: null,
-            workspaceId: handle?.workspaceId ?? null,
-            containerId: handle?.containerId ?? null,
-            configJson,
-            status: "failed",
-            shippedAtMs: createdAtMs,
-            completedAtMs: nowMs(),
-            bundlePath: handle?.resultPath ?? null,
-        });
-        await emitSandboxEvent(runtimeDb, {
-            type: "SandboxFailed",
-            runId: runtime.runId,
-            sandboxId: options.sandboxId,
-            runtime: selectedRuntime,
-            error: errorToJson(error),
-            timestampMs: nowMs(),
-        });
-        runtime.heartbeat({
-            sandboxId: options.sandboxId,
-            stage: "failed",
-            progress: 100,
-            error: error instanceof Error ? error.message : String(error),
-        });
+        // Best-effort failure bookkeeping: a secondary failure here (DB closed
+        // after a cancel, disk/connection loss) must never mask the primary
+        // sandbox error, so each write is caught and logged as a warning
+        // independently, mirroring the finally block's cleanup rationale below.
+        try {
+            await adapter.upsertSandbox({
+                runId: runtime.runId,
+                sandboxId: options.sandboxId,
+                runtime: selectedRuntime,
+                remoteRunId: null,
+                workspaceId: handle?.workspaceId ?? null,
+                containerId: handle?.containerId ?? null,
+                configJson,
+                status: "failed",
+                shippedAtMs: createdAtMs,
+                completedAtMs: nowMs(),
+                bundlePath: handle?.resultPath ?? null,
+            });
+        }
+        catch (bookkeepingError) {
+            logWarning("sandbox failure bookkeeping failed", {
+                runId: runtime.runId,
+                sandboxId: options.sandboxId,
+                runtime: selectedRuntime,
+                error: errorToJson(bookkeepingError),
+            });
+        }
+        try {
+            await emitSandboxEvent(runtimeDb, {
+                type: "SandboxFailed",
+                runId: runtime.runId,
+                sandboxId: options.sandboxId,
+                runtime: selectedRuntime,
+                error: errorToJson(error),
+                timestampMs: nowMs(),
+            });
+        }
+        catch (bookkeepingError) {
+            logWarning("sandbox failure bookkeeping failed", {
+                runId: runtime.runId,
+                sandboxId: options.sandboxId,
+                runtime: selectedRuntime,
+                error: errorToJson(bookkeepingError),
+            });
+        }
+        try {
+            runtime.heartbeat({
+                sandboxId: options.sandboxId,
+                stage: "failed",
+                progress: 100,
+                error: error instanceof Error ? error.message : String(error),
+            });
+        }
+        catch (bookkeepingError) {
+            logWarning("sandbox failure bookkeeping failed", {
+                runId: runtime.runId,
+                sandboxId: options.sandboxId,
+                runtime: selectedRuntime,
+                error: errorToJson(bookkeepingError),
+            });
+        }
         throw error;
     }
     finally {

--- a/packages/sandbox/tests/execute.test.js
+++ b/packages/sandbox/tests/execute.test.js
@@ -697,6 +697,43 @@ describe("executeSandbox", () => {
         }
     });
 
+    test("failure-path bookkeeping does not mask the primary run failure and is surfaced", async () => {
+        const { db, sqlite } = createDb();
+        const runtime = createRuntime(db, { runId: "run-failure-bookkeeping" });
+        let loggedWarnings = 0;
+        const restoreLogger = setSmithersLogRunner({
+            runFork() {
+                loggedWarnings += 1;
+            },
+            async runPromise() { },
+        });
+        try {
+            // The provider closes the real DB mid-run before throwing the primary
+            // failure, so the catch block's own bookkeeping writes (upsert/event/
+            // heartbeat) hit a genuinely closed DB. The primary error must still
+            // surface, not a secondary "database is closed" error.
+            await expect(
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-failure-bookkeeping",
+                    provider: {
+                        id: "db-closed-failure-provider",
+                        run: async () => {
+                            sqlite.close();
+                            throw new Error("primary sandbox failure");
+                        },
+                    },
+                    runtime: undefined,
+                }),
+            ).rejects.toThrow("primary sandbox failure");
+
+            // The bookkeeping failure(s) must be surfaced (logged), not silently swallowed.
+            expect(loggedWarnings).toBeGreaterThanOrEqual(1);
+        }
+        finally {
+            restoreLogger();
+        }
+    });
+
     test("materializes provider bundle paths and rejects invalid provider results", async () => {
         const resultPath = tempDir("smithers-provider-materialized-");
         const materialized = await __executeSandboxInternals.materializeProviderResult(


### PR DESCRIPTION
Closes #524

## Root cause

In `packages/sandbox/src/execute.js`, the `catch` block of `executeSandbox` performed three sequential DB/event writes on the failure path — `adapter.upsertSandbox(...)` (mark sandbox `failed`), `emitSandboxEvent(...)` (emit `SandboxFailed`), and `runtime.heartbeat(...)` (report `stage: "failed"`) — with no error handling around any of them. If the underlying DB was already closed or unreachable (e.g. after a cancel, or a disk/connection failure), any of these bookkeeping writes could throw. Because they ran unguarded inside the `catch`, that secondary failure would propagate instead of the *original* sandbox error, hiding the real cause of the failure from callers.

## Fix

Wrapped each of the three bookkeeping calls in its own `try/catch` so a secondary failure in one write can never suppress another, and — critically — can never mask or replace the primary error being handled. Each bookkeeping failure is logged as a warning (`logWarning("sandbox failure bookkeeping failed", ...)`) so it's still observable, but the original `error` is always the one re-thrown via the existing `throw error;` at the end of the catch block. This mirrors the same best-effort rationale already used in the adjacent `finally` cleanup block.

Added a regression test in `packages/sandbox/tests/execute.test.js` that closes the DB mid-run before the primary provider error is thrown, then asserts the primary error (`"primary sandbox failure"`) is what surfaces from `executeSandbox`, and that the resulting bookkeeping failure is logged rather than swallowed.

Strategy used: **opus-sandwich**.

## Note

This PR will be **restacked** onto a PR train — its base branch may change as part of that process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)