### PR TITLE
🐛 fix(sandbox): preserve real shippedAtMs through completion/failure upserts

### DIFF
--- a/packages/sandbox/src/execute.js
+++ b/packages/sandbox/src/execute.js
@@ -351,7 +351,7 @@ function isSandboxActive(status) {
  *   options: ExecuteSandboxOptions;
  *   selectedRuntime: string;
  *   configJson: string;
- *   createdAtMs: number;
+ *   shippedAtMs: number | null;
  *   childStartedMs: number;
  *   validated: import("./ValidatedSandboxBundle.ts").ValidatedSandboxBundle;
  *   remoteRunId: string | undefined;
@@ -423,7 +423,7 @@ async function finalizeSandboxBundle(params) {
         containerId: params.containerId,
         configJson,
         status: validated.manifest.status,
-        shippedAtMs: params.createdAtMs,
+        shippedAtMs: params.shippedAtMs,
         completedAtMs: nowMs(),
         bundlePath: validated.bundlePath,
     });
@@ -501,6 +501,7 @@ export async function executeSandbox(options) {
     const requestBundlePath = join(sandboxRoot, "request-bundle");
     let handle = null;
     let providerRequest = null;
+    let shippedAtMs = null;
     try {
         const existingSandboxes = await adapter.listSandboxes(runtime.runId);
         const activeSandboxCount = existingSandboxes.filter((row) => isSandboxActive(row?.status)).length;
@@ -562,6 +563,7 @@ export async function executeSandbox(options) {
                 stage: "shipped",
                 progress: 25,
             });
+            shippedAtMs = nowMs();
             await adapter.upsertSandbox({
                 runId: runtime.runId,
                 sandboxId: options.sandboxId,
@@ -571,7 +573,7 @@ export async function executeSandbox(options) {
                 containerId: null,
                 configJson,
                 status: "shipped",
-                shippedAtMs: nowMs(),
+                shippedAtMs,
                 completedAtMs: null,
                 bundlePath: null,
             });
@@ -609,7 +611,7 @@ export async function executeSandbox(options) {
                 options,
                 selectedRuntime,
                 configJson,
-                createdAtMs,
+                shippedAtMs,
                 childStartedMs,
                 validated,
                 remoteRunId: materialized.remoteRunId ?? validated.manifest.runId,
@@ -650,6 +652,7 @@ export async function executeSandbox(options) {
             stage: "shipped",
             progress: 25,
         });
+        shippedAtMs = nowMs();
         await adapter.upsertSandbox({
             runId: runtime.runId,
             sandboxId: options.sandboxId,
@@ -659,7 +662,7 @@ export async function executeSandbox(options) {
             containerId: sandboxHandle.containerId ?? null,
             configJson,
             status: "shipped",
-            shippedAtMs: nowMs(),
+            shippedAtMs,
             completedAtMs: null,
             bundlePath: null,
         });
@@ -722,7 +725,7 @@ export async function executeSandbox(options) {
             options,
             selectedRuntime,
             configJson,
-            createdAtMs,
+            shippedAtMs,
             childStartedMs,
             validated,
             remoteRunId: child.runId,
@@ -741,7 +744,7 @@ export async function executeSandbox(options) {
             containerId: handle?.containerId ?? null,
             configJson,
             status: "failed",
-            shippedAtMs: createdAtMs,
+            shippedAtMs,
             completedAtMs: nowMs(),
             bundlePath: handle?.resultPath ?? null,
         });

--- a/packages/sandbox/tests/execute.test.js
+++ b/packages/sandbox/tests/execute.test.js
@@ -319,6 +319,43 @@ describe("executeSandbox", () => {
         }
     });
 
+    test("preserves the real shipped timestamp through completion instead of the creation timestamp", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const rootDir = tempDir("smithers-sandbox-execute-shipped-");
+        const runtime = createRuntime(db);
+        const upsertCalls = [];
+        const originalUpsertSandbox = SmithersDb.prototype.upsertSandbox;
+        SmithersDb.prototype.upsertSandbox = function upsertSandboxSpy(row) {
+            upsertCalls.push({ status: row.status, shippedAtMs: row.shippedAtMs });
+            return originalUpsertSandbox.call(this, row);
+        };
+        try {
+            await withCodeplaneEnv(() =>
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-shipped-time",
+                    rootDir,
+                    executeChildWorkflow: async () => {
+                        writeChildLog(rootDir, "child-shipped-time");
+                        return { runId: "child-shipped-time", status: "finished", output: {} };
+                    },
+                }),
+            );
+
+            const shippedCall = upsertCalls.find((call) => call.status === "shipped");
+            const finishedCall = upsertCalls.find((call) => call.status === "finished");
+            expect(shippedCall.shippedAtMs).toEqual(expect.any(Number));
+            expect(finishedCall.shippedAtMs).toBe(shippedCall.shippedAtMs);
+
+            const sandbox = await adapter.getSandbox("parent-run", "sandbox-shipped-time");
+            expect(sandbox.shippedAtMs).toBe(shippedCall.shippedAtMs);
+            expect(Number(sandbox.completedAtMs)).toBeGreaterThanOrEqual(Number(sandbox.shippedAtMs));
+        }
+        finally {
+            SmithersDb.prototype.upsertSandbox = originalUpsertSandbox;
+            sqlite.close();
+        }
+    });
+
     test("rejects sandbox execution when no runtime database is available", async () => {
         const runtime = createRuntime(undefined);
 
@@ -1024,6 +1061,7 @@ describe("executeSandbox", () => {
                 status: "failed",
                 bundlePath: null,
                 workspaceId: null,
+                shippedAtMs: null,
             });
             expect(await eventTypes(adapter, "run-at-capacity")).toEqual(["SandboxFailed"]);
         }


### PR DESCRIPTION
Closes #525

## Root cause

`executeSandbox` in `packages/sandbox/src/execute.js` upserts the sandbox row multiple times as a run progresses through shipped → completed/failed. The `shippedAtMs` column is meant to record the instant the sandbox was actually shipped, but two of the later upserts were writing the wrong value instead of that captured instant:

- The completion path (`finalizeSandboxBundle`, and its caller) was passing `createdAtMs` (the sandbox's creation time) as `shippedAtMs`.
- The failure path's upsert was also passing `createdAtMs` for `shippedAtMs`.

Since the "shipped" upsert had already written a freshly-computed `nowMs()` for `shippedAtMs` in the shipped stage, subsequent completion/failure upserts clobbered that real value with an unrelated timestamp (`createdAtMs`), losing the true "when did this sandbox actually ship" signal.

## Fix

Introduced a `shippedAtMs` local variable in `executeSandbox`, set it once (to `nowMs()`) at the moment the "shipped" stage progress event fires and the shipped-status upsert runs, and threaded that captured value through to `finalizeSandboxBundle` and the failure-path upsert instead of re-deriving or reusing `createdAtMs`. This preserves the real shipped timestamp through every later completion/failure upsert. Covered by updated assertions in `packages/sandbox/tests/execute.test.js`.

## Strategy

opus-sandwich

Note: this PR will be RESTACKED onto a PR train — its base branch may change after this is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
