### PR TITLE
🐛 fix(agent-eliza): skip unstatable dir entries in loadWorkflowsFromDir

### DIFF
--- a/packages/agent-eliza/src/conventions/loader.js
+++ b/packages/agent-eliza/src/conventions/loader.js
@@ -166,7 +166,18 @@ export async function loadWorkflowsFromDir({ dir, source = "unknown" }) {
   const entries = readdirSync(dir);
   for (const entry of entries) {
     const filePath = join(dir, entry);
-    if (!statSync(filePath).isFile()) continue;
+    let stats;
+    try {
+      stats = statSync(filePath);
+    } catch (err) {
+      diagnostics.push({
+        type: "error",
+        message: `Could not stat directory entry (${source}): ${filePath} (${err instanceof Error ? err.message : String(err)})`,
+        path: filePath,
+      });
+      continue;
+    }
+    if (!stats.isFile()) continue;
     if (!WORKFLOW_EXTENSIONS.has(extname(entry))) continue;
 
     // Read source text and parse frontmatter BEFORE dynamic import. The

--- a/packages/agent-eliza/tests/loader-coverage.test.ts
+++ b/packages/agent-eliza/tests/loader-coverage.test.ts
@@ -13,11 +13,34 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { loadWorkflows, loadWorkflowsFromDir } from "../src/conventions/loader.js";
+
+describe("loadWorkflowsFromDir — dangling symlink", () => {
+  test("skips a dangling symlink with an error diagnostic and still loads sibling workflows", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-loader-cov-"));
+    writeFileSync(
+      join(dir, "valid-wf.js"),
+      `export default { workflow: {}, name: "valid-wf", description: "Valid" };`,
+      "utf8"
+    );
+    const brokenPath = join(dir, "broken.js");
+    symlinkSync(join(dir, "missing-target"), brokenPath);
+
+    const result = await loadWorkflowsFromDir({ dir, source: "test" });
+
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0]!.name).toBe("valid-wf");
+
+    const errors = result.diagnostics.filter((d) => d.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.path).toBe(brokenPath);
+    expect(errors[0]!.message).toMatch(/stat/i);
+  });
+});
 
 describe("loadWorkflowsFromDir — non-object export", () => {
   test("emits 'no recognizable export' error when the module default is not an object", async () => {


### PR DESCRIPTION
Closes #530

## Root cause

`loadWorkflowsFromDir` called `statSync(filePath)` on every directory
entry and immediately threw if it failed. A dangling symlink (a
symlink whose target doesn't exist) makes `statSync` throw `ENOENT`,
so a single broken symlink in a workflow directory aborted loading the
*entire* directory — every sibling workflow file failed to load too,
even though only one entry was actually broken.

## Approach

In `packages/agent-eliza/src/conventions/loader.js`, wrap the
`statSync` call in a try/catch. On failure, push an `error` diagnostic
naming the unstatable path and `continue` to the next entry instead of
letting the exception propagate. Valid sibling workflows in the same
directory now still load, and the bad entry surfaces as a diagnostic
instead of a hard crash.

Added `packages/agent-eliza/tests/loader-coverage.test.ts` coverage:
creates a dangling symlink alongside a valid workflow file and asserts
the valid workflow still loads while the symlink produces exactly one
error diagnostic.

## Strategy

Implemented using the **opus-sandwich** strategy.

## Note

This PR will be **restacked** onto a PR train — its base branch may
change as other issue PRs land ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)