### PR TITLE
🐛 fix(agent-eliza): guard scalar frontmatter tags/aliases in loader

### DIFF
--- a/packages/agent-eliza/src/conventions/loader.js
+++ b/packages/agent-eliza/src/conventions/loader.js
@@ -122,8 +122,16 @@ function buildDefinition(filePath, baseDir, exported, source, frontmatter) {
       raw.description ??
       (typeof frontmatter.description === "string" ? frontmatter.description : undefined) ??
       "",
-    tags: raw.tags ?? /** @type {string[] | undefined} */ (frontmatter.tags),
-    aliases: raw.aliases ?? /** @type {string[] | undefined} */ (frontmatter.aliases),
+    tags:
+      raw.tags ??
+      (Array.isArray(frontmatter.tags)
+        ? frontmatter.tags.filter((t) => typeof t === "string")
+        : undefined),
+    aliases:
+      raw.aliases ??
+      (Array.isArray(frontmatter.aliases)
+        ? frontmatter.aliases.filter((a) => typeof a === "string")
+        : undefined),
     disableModelInvocation:
       raw.disableModelInvocation ??
       (typeof frontmatter["disable-model-invocation"] === "boolean"

--- a/packages/agent-eliza/tests/loader-coverage.test.ts
+++ b/packages/agent-eliza/tests/loader-coverage.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { loadWorkflows, loadWorkflowsFromDir } from "../src/conventions/loader.js";
+import { formatWorkflowsForPrompt } from "../src/conventions/formatter.js";
 
 describe("loadWorkflowsFromDir — non-object export", () => {
   test("emits 'no recognizable export' error when the module default is not an object", async () => {
@@ -68,6 +69,37 @@ describe("loadWorkflows — explicit workflowPaths edge cases", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]!.message).toMatch(/no recognizable export/);
     expect(errors[0]!.path).toBe(filePath);
+  });
+});
+
+describe("buildDefinition — scalar frontmatter tags/aliases", () => {
+  test("scalar frontmatter tags/aliases are coerced to undefined, not a raw string", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-loader-cov-"));
+    writeFileSync(
+      join(dir, "scalar-fm.js"),
+      `/* ---\ntags: foo\naliases: bar\n--- */\nexport default { name: "scalar-fm" };\n`,
+      "utf8"
+    );
+
+    const result = await loadWorkflowsFromDir({ dir, source: "test" });
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0]!.tags).toBeUndefined();
+    expect(result.workflows[0]!.aliases).toBeUndefined();
+
+    expect(() => formatWorkflowsForPrompt(result.workflows)).not.toThrow();
+  });
+
+  test("non-string entries in array frontmatter tags are filtered out", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-loader-cov-"));
+    writeFileSync(
+      join(dir, "mixed-fm.js"),
+      `/* ---\ntags: [1, "ok"]\n--- */\nexport default { name: "mixed-fm" };\n`,
+      "utf8"
+    );
+
+    const result = await loadWorkflowsFromDir({ dir, source: "test" });
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0]!.tags).toEqual(["ok"]);
   });
 });
 


### PR DESCRIPTION
Closes #531

## Root cause

In `packages/agent-eliza/src/conventions/loader.js`, `buildDefinition()` read
`frontmatter.tags` / `frontmatter.aliases` straight out of the parsed YAML
frontmatter and cast them to `string[]` without validating the actual runtime
shape. If a workflow's frontmatter declared `tags` or `aliases` as a scalar
(e.g. `tags: foo` instead of `tags: [foo]`), the loader would happily pass the
raw string through as the "array", corrupting downstream consumers (e.g.
`formatWorkflowsForPrompt` in `packages/agent-eliza/src/conventions/formatter.js`)
that assume an actual array and call array methods on it.

## Approach

Guard both fields at the point they're read off frontmatter:
- Only accept the frontmatter value when it's actually `Array.isArray(...)`.
- Filter the array to string entries only, dropping any non-string members
  (e.g. `tags: [1, "ok"]` → `["ok"]`).
- Anything else (a bare scalar, an object, etc.) coerces to `undefined`,
  matching the existing `raw.tags`/`raw.aliases` fallback semantics already
  used elsewhere in `buildDefinition()`.

Added regression coverage in `packages/agent-eliza/tests/loader-coverage.test.ts`
covering both the scalar-frontmatter case and the mixed-type-array case.

## Strategy

Implemented via the "opus-sandwich" strategy.

## Note

This PR will be **restacked** onto a PR train — its base branch may change
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)