### PR TITLE
🐛 fix(memory): map Summarizer agent.run rejection to SmithersError

### DIFF
--- a/packages/memory/src/Summarizer.js
+++ b/packages/memory/src/Summarizer.js
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 /** @typedef {import("./MemoryProcessor.ts").MemoryProcessor} MemoryProcessor */
 /** @typedef {import("./store/MemoryStore.ts").MemoryStore} MemoryStore */
 /** @typedef {import("@smithers-orchestrator/errors/SmithersError").SmithersError} SmithersError */
@@ -70,7 +71,13 @@ export function Summarizer(agent) {
                     "",
                     oldMessages.map(renderMessage).join("\n"),
                 ].join("\n");
-                const result = yield* Effect.tryPromise(() => agent.run(prompt));
+                const result = yield* Effect.tryPromise({
+                    try: () => agent.run(prompt),
+                    catch: (cause) => toSmithersError(cause, "memory summarizer agent run", {
+                        code: "AGENT_CLI_ERROR",
+                        details: { threadId: thread.threadId },
+                    }),
+                });
                 const summary = extractSummary(result);
                 // Save the summary BEFORE deleting the old messages so there is no
                 // data-loss window: if the summary write fails the originals are

--- a/packages/memory/tests/processors.test.js
+++ b/packages/memory/tests/processors.test.js
@@ -1,8 +1,9 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
 import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { isSmithersError } from "@smithers-orchestrator/errors";
 import { createMemoryStore } from "../src/store/index.js";
 import { TtlGarbageCollector, TokenLimiter, Summarizer, } from "../src/processors.js";
 const WF_NS = { kind: "workflow", id: "test-proc" };
@@ -336,5 +337,43 @@ describe("Summarizer", () => {
         // Converges to exactly one summary followed by the two recent messages.
         expect(final.filter((m) => m.role === "system")).toHaveLength(1);
         expect(final.map((m) => m.id).filter((id) => id.startsWith("msg-"))).toEqual(["msg-3", "msg-4"]);
+    });
+    test("agent.run rejection surfaces as a typed SmithersError, not UnknownException", async () => {
+        const sqlite = new Database(":memory:");
+        const db = drizzle(sqlite);
+        ensureSmithersTables(db);
+        const store = createMemoryStore(db);
+        const thread = await store.createThread(WF_NS);
+        for (const [index, role, content] of [
+            [1, "user", "Can you check the rollout?"],
+            [2, "assistant", "I will check it."],
+            [3, "user", "Any update?"],
+            [4, "assistant", "The rollout is healthy."],
+        ]) {
+            await store.saveMessage({
+                id: `msg-${index}`,
+                threadId: thread.threadId,
+                role,
+                contentJson: JSON.stringify(content),
+                createdAtMs: index,
+            });
+        }
+
+        const summarizer = Summarizer({
+            run: async () => {
+                throw new Error("agent boom");
+            },
+        });
+
+        const exit = await Effect.runPromiseExit(summarizer.processEffect(store));
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        const failure = Exit.isFailure(exit)
+            ? Cause.failureOption(exit.cause)
+            : undefined;
+        expect(failure?._tag).toBe("Some");
+        const error = failure?._tag === "Some" ? failure.value : undefined;
+        expect(isSmithersError(error)).toBe(true);
+        expect(error?.code).toBe("AGENT_CLI_ERROR");
     });
 });


### PR DESCRIPTION
Closes #532

## Root cause

`Summarizer` in `packages/memory/src/Summarizer.js` wrapped the agent call with `Effect.tryPromise(() => agent.run(prompt))`, using the single-function-argument form. That form has no `catch` mapper, so when `agent.run(prompt)` rejects, Effect surfaces it as an untyped `UnknownException` instead of a `SmithersError`. Any caller pattern-matching on `SmithersError` codes (retry/backoff logic, error reporting, etc.) silently fails to recognize agent-run failures during summarization.

## Fix

- `packages/memory/src/Summarizer.js`: switched to the `{ try, catch }` form of `Effect.tryPromise`, routing the rejection through `toSmithersError` (from `@smithers-orchestrator/errors/toSmithersError`) with `code: "AGENT_CLI_ERROR"` and `details: { threadId }` for traceability.
- `packages/memory/tests/processors.test.js`: added a regression test that fails the agent's `run` and asserts the resulting `Effect` exit is a failure whose cause is a typed `SmithersError` with code `AGENT_CLI_ERROR`, not an `UnknownException`.

## Strategy

Built using the **opus-sandwich** strategy.

## Notes

This PR will be **restacked** onto a PR train as part of a batch of related issue fixes in this repo — its base branch may change from `main` to another in-flight branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)