### PR TITLE
🐛 fix(memory): preserve original createdAtMs on saveMessage re-save

### DIFF
--- a/packages/memory/src/store/MemoryStoreLive.js
+++ b/packages/memory/src/store/MemoryStoreLive.js
@@ -286,6 +286,11 @@ function makeMemoryStore(db) {
             // crash-resume, deterministic replay, or fork/restore where ids are
             // derived deterministically) must be a safe no-op upsert rather than
             // a UNIQUE-constraint crash. Mirrors setFact's onConflictDoUpdate.
+            // The conflict update deliberately excludes createdAtMs: the ORIGINAL
+            // insert timestamp must survive a re-save so ordering in
+            // listMessages (and downstream oldest-first summarization) stays
+            // stable, even when the re-save omits createdAtMs and would
+            // otherwise fall back to a fresh nowMs().
             yield* writeEffect("memory saveMessage", () => db
                 .insert(smithersMemoryMessages)
                 .values({
@@ -307,7 +312,6 @@ function makeMemoryStore(db) {
                     runId: msg.runId ?? null,
                     nodeId: msg.nodeId ?? null,
                     iteration: msg.iteration ?? null,
-                    createdAtMs,
                 },
             }));
         });

--- a/packages/memory/tests/store.test.js
+++ b/packages/memory/tests/store.test.js
@@ -353,6 +353,37 @@ describe("MemoryStore - Messages", () => {
         // Upsert semantics: the latest content wins (replay-safe overwrite).
         expect(JSON.parse(messages[0].contentJson)).toEqual({ text: "second" });
     });
+    test("saveMessage re-save preserves original createdAtMs and message ordering", async () => {
+        // A re-save that omits createdAtMs (e.g. a replay/crash-resume caller
+        // that only has the original id + content) must not stamp a fresh
+        // nowMs() onto the existing row - that would reorder listMessages
+        // (ordered by createdAtMs) and corrupt conversation/summarization order.
+        const thread = await store.createThread(WF_NS);
+        await store.saveMessage({
+            id: "msg-old",
+            threadId: thread.threadId,
+            role: "user",
+            contentJson: JSON.stringify({ text: "old" }),
+            createdAtMs: 1,
+        });
+        await store.saveMessage({
+            id: "msg-new",
+            threadId: thread.threadId,
+            role: "user",
+            contentJson: JSON.stringify({ text: "new" }),
+            createdAtMs: 2,
+        });
+        await store.saveMessage({
+            id: "msg-old",
+            threadId: thread.threadId,
+            role: "user",
+            contentJson: JSON.stringify({ text: "old-resaved" }),
+        });
+        const messages = await store.listMessages(thread.threadId);
+        expect(messages.map((m) => m.id)).toEqual(["msg-old", "msg-new"]);
+        expect(messages[0].createdAtMs).toBe(1);
+        expect(JSON.parse(messages[0].contentJson)).toEqual({ text: "old-resaved" });
+    });
 });
 describe("Memory namespace codec", () => {
     test("roundtrips percent-encoded ids for enumerated namespace kinds", () => {


### PR DESCRIPTION
Closes #533

## Root cause

`saveMessage` in `packages/memory/src/store/MemoryStoreLive.js` upserts into
`smithersMemoryMessages` via `onConflictDoUpdate`. The conflict-update `set`
clause included `createdAtMs`, so re-saving an existing message id (e.g. a
crash-resume / replay caller that only has the id + updated content, without
re-supplying the original `createdAtMs`) overwrote the row's original insert
timestamp with a fresh `nowMs()`. Since `listMessages` orders by
`createdAtMs`, this silently reordered conversation history and corrupted
downstream oldest-first summarization.

## Fix

Drop `createdAtMs` from the conflict-update `set` clause in
`MemoryStoreLive.js`, mirroring the existing pattern already used by
`setFact`'s `onConflictDoUpdate` (which likewise excludes its own
insert-time-only field from updates). The original insert timestamp is now
preserved across re-saves, while content/threadId/role/runId/etc. still
update as before.

Added a regression test in `packages/memory/tests/store.test.js` that saves
two messages, re-saves the older one with new content and no `createdAtMs`,
and asserts both `listMessages` ordering and the preserved `createdAtMs`
survive.

## Strategy

Built via the **opus-sandwich** strategy.

## Note

This PR will be RESTACKED onto a PR train — its base branch may change after
this is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)