### PR TITLE
🐛 fix(vcs): populate WorkspaceInfo.selected in jj workspaceList's -T path

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -9305,7 +9305,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -9294,7 +9294,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/docs/llms-full-v0.28.0.txt
+++ b/docs/llms-full-v0.28.0.txt
@@ -9305,7 +9305,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9305,7 +9305,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/docs/reference/vcs-helpers.mdx
+++ b/docs/reference/vcs-helpers.mdx
@@ -181,7 +181,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -9305,7 +9305,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 

--- a/packages/vcs/src/WorkspaceInfo.ts
+++ b/packages/vcs/src/WorkspaceInfo.ts
@@ -1,5 +1,9 @@
 export type WorkspaceInfo = {
   name: string;
+  /** Not currently populated by `workspaceList` — always `null`. */
   path: string | null;
+  /** Whether this is the current workspace. Populated on modern jj via the
+   * `current_working_copy` template keyword; also correct on the legacy
+   * human-output fallback (`*` marker parsing). */
   selected: boolean;
 };

--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -275,6 +275,9 @@ export function workspaceAdd(name, path, opts = {}) {
 }
 /**
  * List existing workspaces using a JJ template for structured output.
+ * `selected` reflects the current workspace via jj's `current_working_copy`
+ * template keyword. `path` is not populated in this path (no template
+ * keyword exposes the workspace filesystem path).
  * Falls back to parsing human output if `-T` is unavailable.
  *
  * @param {string} [cwd]
@@ -282,7 +285,7 @@ export function workspaceAdd(name, path, opts = {}) {
  */
 export function workspaceList(cwd) {
     return Effect.gen(function* () {
-        let res = yield* runJj(["workspace", "list", "-T", 'name ++ "\\n"'], {
+        let res = yield* runJj(["workspace", "list", "-T", 'name ++ "\\t" ++ if(target.current_working_copy(), "1", "0") ++ "\\n"'], {
             cwd,
         });
         if (res.code === 0) {
@@ -290,7 +293,14 @@ export function workspaceList(cwd) {
                 .split(/\r?\n/)
                 .map((line) => line.trim())
                 .filter(Boolean);
-            return lines.map((name) => ({ name, path: /** @type {string | null} */ (null), selected: false }));
+            return lines
+                .map((line) => {
+                const idx = line.lastIndexOf("\t");
+                const name = idx === -1 ? line : line.slice(0, idx);
+                const flag = idx === -1 ? "" : line.slice(idx + 1);
+                return { name, path: /** @type {string | null} */ (null), selected: flag === "1" };
+            })
+                .filter((row) => row.name.length > 0);
         }
         res = yield* runJj(["workspace", "list"], { cwd });
         if (res.code !== 0)

--- a/packages/vcs/tests/jj-workspace.test.js
+++ b/packages/vcs/tests/jj-workspace.test.js
@@ -316,10 +316,10 @@ describe("workspaceList", () => {
     test("uses -T for structured names output", async () => {
         const script = `
 if [[ "$1" = "workspace" && "$2" = "list" && "$3" = "-T" ]]; then
-  # print only names, one per line
-  echo "default"
-  echo "other"
-  echo "solo"
+  # print name<TAB>selected-flag, one per line
+  printf 'default\\t1\\n'
+  printf 'other\\t0\\n'
+  printf 'solo\\t0\\n'
   exit 0
 fi
 exit 1
@@ -327,7 +327,7 @@ exit 1
         await withFakeJj(script, async () => {
             const rows = await vcs.workspaceList();
             expect(rows).toEqual([
-                { name: "default", path: null, selected: false },
+                { name: "default", path: null, selected: true },
                 { name: "other", path: null, selected: false },
                 { name: "solo", path: null, selected: false },
             ]);

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -9305,7 +9305,7 @@ type WorkspaceInfo = {
 function workspaceList(cwd?: string): VcsEffect<WorkspaceInfo[]>;
 ```
 
-Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output.
+Prefers template output when supported, falls back to parsing the human-readable `jj workspace list` output. `selected` reflects the current workspace (populated via jj's `current_working_copy` template keyword on modern jj, or the `*` marker on the legacy fallback). `path` is not currently populated and is always `null`.
 
 ## `workspaceClose(name, opts?)`
 


### PR DESCRIPTION
Closes #534

## Root cause

`packages/vcs/src/jj.js`'s `workspaceList()` uses a fast templated `jj workspace list -T ...` path for structured output. The template emitted only the workspace `name`, so the mapped `WorkspaceInfo` rows always had `selected: false` — callers had no way to tell which workspace was actually checked out via this path (the human-output fallback parser handled the `*` marker correctly, but the `-T` fast path did not).

## Fix

- `packages/vcs/src/jj.js`: extend the `-T` template to also emit jj's `current_working_copy()` template keyword (`name ++ "\t" ++ if(target.current_working_copy(), "1", "0")`), then parse that flag into `selected` for each row instead of hardcoding `false`.
- `packages/vcs/src/WorkspaceInfo.ts`: document that `selected` is now populated on both the templated and fallback paths, and that `path` remains unpopulated (no jj template keyword exposes it).
- `packages/vcs/tests/jj-workspace.test.js`: updated assertions to cover the newly-populated `selected` flag on the `-T` path.
- Regenerated the `llms-full.txt` doc bundles (`pnpm docs:llms`) since `docs/reference/vcs-helpers.mdx` changed.

## Strategy

Built via the **opus-sandwich** strategy.

Note: this PR will be **restacked onto a PR train** — its base branch may change as a result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)