### PR TITLE
🐛 fix(engine): carry rootDir/maxOutputBytes/taskContext into JSON-repair and schema-retry generate 

### DIFF
--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -4173,6 +4173,14 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                             options: undefined,
                             abortSignal: taskSignal,
                             prompt: jsonPrompt,
+                            rootDir: taskRoot,
+                            taskContext: {
+                                runId,
+                                nodeId: desc.nodeId,
+                                iteration: desc.iteration,
+                                attempt: attemptNo,
+                            },
+                            maxOutputBytes: toolConfig.maxOutputBytes,
                             timeout: desc.timeoutMs ? { totalMs: desc.timeoutMs } : undefined,
                             onStdout: (text) => {
                                 recordInternalHeartbeat();
@@ -4419,6 +4427,12 @@ async function legacyExecuteTask(adapter, db, runId, desc, descriptorMap, inputT
                 abortSignal: taskSignal,
                 messages: retryMessages,
                 rootDir: taskRoot,
+                taskContext: {
+                    runId,
+                    nodeId: desc.nodeId,
+                    iteration: desc.iteration,
+                    attempt: attemptNo,
+                },
                 maxOutputBytes: toolConfig.maxOutputBytes,
                 timeout: desc.timeoutMs ? { totalMs: desc.timeoutMs } : undefined,
                 onStdout: (text) => {

--- a/packages/engine/tests/json-repair-execution-context.e2e.test.jsx
+++ b/packages/engine/tests/json-repair-execution-context.e2e.test.jsx
@@ -1,0 +1,90 @@
+/** @jsxImportSource smithers-orchestrator */
+import { describe, expect, test } from "bun:test";
+import { Task, Workflow, runWorkflow } from "smithers-orchestrator";
+import { createTestSmithers } from "../../smithers/tests/helpers.js";
+import { z } from "zod";
+import { Effect } from "effect";
+
+const TIMEOUT_MS = 30_000;
+
+describe("JSON-repair and schema-retry generate calls carry the same execution context", () => {
+    test("the JSON-repair follow-up generate call receives rootDir/maxOutputBytes/taskContext matching the primary call", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers({
+            out: z.object({ value: z.number() }),
+        });
+        const calls = [];
+        const agent = {
+            id: "forgets-json",
+            tools: {},
+            generate: async (args) => {
+                calls.push(args);
+                if (calls.length === 1) {
+                    // No extractable JSON in the response: forces the repair turn.
+                    return { text: "I finished the work but forgot to emit JSON." };
+                }
+                // The repair turn's response.
+                return { text: '{"value":1}' };
+            },
+        };
+        const workflow = smithers(() => (
+            <Workflow name="json-repair-context">
+                <Task id="t" output={outputs.out} agent={agent}>
+                    do work
+                </Task>
+            </Workflow>
+        ));
+        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+        expect(result.status).toBe("finished");
+        expect(calls.length).toBe(2);
+        const [primaryCall, repairCall] = calls;
+        expect(primaryCall.rootDir).toBeDefined();
+        expect(repairCall.rootDir).toBe(primaryCall.rootDir);
+        expect(primaryCall.maxOutputBytes).toBeDefined();
+        expect(repairCall.maxOutputBytes).toBe(primaryCall.maxOutputBytes);
+        expect(primaryCall.taskContext).toBeDefined();
+        expect(repairCall.taskContext).toEqual(primaryCall.taskContext);
+        cleanup();
+    }, TIMEOUT_MS);
+
+    test("the schema-validation retry generate call receives taskContext matching the primary call", async () => {
+        const { smithers, outputs, cleanup } = createTestSmithers({
+            out: z.object({ value: z.number() }),
+        });
+        const calls = [];
+        const agent = {
+            id: "wrong-schema-then-right",
+            tools: {},
+            generate: async (args) => {
+                calls.push(args);
+                if (calls.length === 1) {
+                    // Parseable JSON, but it fails the zod schema: forces the
+                    // schema-validation retry turn.
+                    return {
+                        text: '{"value":"not-a-number"}',
+                        output: { value: "not-a-number" },
+                        response: { messages: [{ role: "assistant", content: '{"value":"not-a-number"}' }] },
+                    };
+                }
+                return {
+                    text: '{"value":1}',
+                    output: { value: 1 },
+                    response: { messages: [{ role: "assistant", content: '{"value":1}' }] },
+                };
+            },
+        };
+        const workflow = smithers(() => (
+            <Workflow name="schema-retry-context">
+                <Task id="t" output={outputs.out} agent={agent}>
+                    do work
+                </Task>
+            </Workflow>
+        ));
+        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+        expect(result.status).toBe("finished");
+        expect(calls.length).toBe(2);
+        const [primaryCall, retryCall] = calls;
+        expect(primaryCall.taskContext).toBeDefined();
+        expect(retryCall.taskContext).toEqual(primaryCall.taskContext);
+        cleanup();
+    }, TIMEOUT_MS);
+});


### PR DESCRIPTION
Closes #535

## Root cause

`packages/engine/src/engine.js` builds the primary agent `generate()` call
with `rootDir`, `maxOutputBytes`, and a `taskContext` (runId/nodeId/iteration/attempt)
derived from the task descriptor. When the primary response either has no
extractable JSON (JSON-repair follow-up turn) or fails schema validation
(schema-validation retry turn), the engine issues a second `generate()` call
to fix it up — but that follow-up call was built without carrying the same
`rootDir`/`maxOutputBytes`/`taskContext` options through, so repair/retry
turns silently ran with a different execution context (wrong working
directory scoping, no output-size cap, and no task/run identity for tracing)
than the primary turn.

## Approach

Threaded the same `rootDir`, `taskContext`, and `maxOutputBytes` fields from
the primary `generate()` call site into both follow-up call sites in
`engine.js`:
- the JSON-repair follow-up generate call
- the schema-validation retry generate call

Added `packages/engine/tests/json-repair-execution-context.e2e.test.jsx`,
a real-engine e2e (fake in-process agent, no mocks) asserting the repair
and retry calls receive `rootDir`/`maxOutputBytes`/`taskContext` equal to
the primary call's.

Strategy used: opus-sandwich.

Note: this PR will be RESTACKED onto a PR train — its base branch may change
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)