### PR TITLE
🐛 fix(engine): track WatchTree waiters per-resolver, not a single slot

### DIFF
--- a/packages/engine/src/hot/watch.js
+++ b/packages/engine/src/hot/watch.js
@@ -38,7 +38,7 @@ export class WatchTree {
     polling = false;
     pollingDisabled = false;
     currentPollIntervalMs = MIN_POLL_MS;
-    waitResolve = null;
+    waitResolvers = new Set();
     closed = false;
     /**
    * @param {string} rootDir
@@ -81,10 +81,11 @@ export class WatchTree {
             catch { }
         }
         this.watchers = [];
-        // Resolve any pending wait with empty array
-        if (this.waitResolve) {
-            this.waitResolve([]);
-            this.waitResolve = null;
+        // Resolve any pending waits with empty array
+        const resolvers = [...this.waitResolvers];
+        this.waitResolvers.clear();
+        for (const resolveWait of resolvers) {
+            resolveWait([]);
         }
         logInfo("closed hot watch tree", {
             rootDir: this.rootDir,
@@ -131,13 +132,12 @@ export class WatchTree {
                 resume(Effect.succeed(files));
                 return;
             }
-            this.waitResolve = (files) => {
+            const resolver = (files) => {
                 resume(Effect.succeed(files));
             };
+            this.waitResolvers.add(resolver);
             return Effect.sync(() => {
-                if (this.waitResolve) {
-                    this.waitResolve = null;
-                }
+                this.waitResolvers.delete(resolver);
             });
         }).pipe(Effect.annotateLogs({
             rootDir: this.rootDir,
@@ -329,9 +329,10 @@ export class WatchTree {
             changedFileCount: files.length,
             changedFiles: files.join(","),
         }, "hot:watch");
-        if (this.waitResolve) {
-            this.waitResolve(files);
-            this.waitResolve = null;
+        const resolvers = [...this.waitResolvers];
+        this.waitResolvers.clear();
+        for (const resolveWait of resolvers) {
+            resolveWait(files);
         }
     }
 }

--- a/packages/engine/src/index.d.ts
+++ b/packages/engine/src/index.d.ts
@@ -734,7 +734,7 @@ declare class WatchTree {
     polling: boolean;
     pollingDisabled: boolean;
     currentPollIntervalMs: number;
-    waitResolve: null;
+    waitResolvers: Set<any>;
     closed: boolean;
     /** Start watching. Call once. */
     start(): Promise<void>;

--- a/packages/engine/tests/hot-watch.test.js
+++ b/packages/engine/tests/hot-watch.test.js
@@ -41,12 +41,53 @@ describe("WatchTree", () => {
         cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
         const tree = new WatchTree(dir);
         const fiber = Effect.runFork(tree.waitEffect());
-        for (let i = 0; i < 10 && tree.waitResolve === null; i += 1) {
+        for (let i = 0; i < 10 && tree.waitResolvers.size === 0; i += 1) {
             await Bun.sleep(0);
         }
-        expect(tree.waitResolve).toBeFunction();
+        expect(tree.waitResolvers.size).toBe(1);
         await Effect.runPromise(Fiber.interrupt(fiber));
-        expect(tree.waitResolve).toBeNull();
+        expect(tree.waitResolvers.size).toBe(0);
+    });
+    test("two concurrent waiters both resume on flush", async () => {
+        const dir = makeTempDir();
+        cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+        const tree = new WatchTree(dir, { debounceMs: 50 });
+        cleanups.push(() => tree.close());
+        await tree.start();
+        const waitA = tree.wait();
+        const waitB = tree.wait();
+        for (let i = 0; i < 10 && tree.waitResolvers.size < 2; i += 1) {
+            await Bun.sleep(0);
+        }
+        expect(tree.waitResolvers.size).toBe(2);
+        setTimeout(() => {
+            writeFileSync(join(dir, "concurrent.ts"), "export const c = 1;");
+        }, 50);
+        const [changedA, changedB] = await Promise.all([waitA, waitB]);
+        expect(changedA.length).toBeGreaterThan(0);
+        expect(changedB.length).toBeGreaterThan(0);
+        tree.close();
+    });
+    test("interrupting one waiter leaves another waiter's resolver intact", async () => {
+        const dir = makeTempDir();
+        cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+        const tree = new WatchTree(dir, { debounceMs: 50 });
+        cleanups.push(() => tree.close());
+        await tree.start();
+        const fiberA = Effect.runFork(tree.waitEffect());
+        const waitB = tree.wait();
+        for (let i = 0; i < 10 && tree.waitResolvers.size < 2; i += 1) {
+            await Bun.sleep(0);
+        }
+        expect(tree.waitResolvers.size).toBe(2);
+        await Effect.runPromise(Fiber.interrupt(fiberA));
+        expect(tree.waitResolvers.size).toBe(1);
+        setTimeout(() => {
+            writeFileSync(join(dir, "b-only.ts"), "export const b = 1;");
+        }, 50);
+        const changedB = await waitB;
+        expect(changedB.length).toBeGreaterThan(0);
+        tree.close();
     });
     test("detects file changes", async () => {
         const dir = makeTempDir();


### PR DESCRIPTION
Closes #540

## Root cause

`WatchTree` (`packages/engine/src/hot/watch.js`) stored pending waiters in a
single `waitResolve` slot. When two callers concurrently awaited
`waitEffect()`/`wait()` (e.g. two overlapping hot-reload cycles), the second
`Effect.async` registration overwrote the first waiter's resolver in that
slot. Each `Effect.async` cleanup only knew to null out "the" slot, so
whichever waiter's fiber was interrupted or resolved first could stomp on the
other's pending resolver — leaving the first waiter's fiber permanently
unresolved once a file-change flush landed.

## Fix

Replaced the single `waitResolve` slot with a `waitResolvers` Set. Each
`waitEffect()` call now registers its own resolver closure and removes only
that closure on interruption/cleanup. `flush()` and `close()` iterate a
snapshot of all pending resolvers and resolve every one, instead of resolving
a single slot. Updated the `WatchTree` type surface in
`packages/engine/src/index.d.ts` accordingly, and extended
`packages/engine/tests/hot-watch.test.js` with coverage for two concurrent
waiters both resuming on flush, and for interrupting one waiter leaving the
other's resolver intact.

## Strategy

opus-sandwich

## Note

This PR will be RESTACKED onto a PR train — its base branch may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)