### PR TITLE
🐛 fix(engine): bound durable-deferred-bridge deferredResolutions map with LRU cap

### DIFF
--- a/packages/engine/src/effect/durable-deferred-bridge.js
+++ b/packages/engine/src/effect/durable-deferred-bridge.js
@@ -112,7 +112,28 @@ async function markWaitForEventResolved(adapter, runId, nodeId, iteration, signa
         await decrementAsyncEventWaitPending();
     }
 }
+/**
+ * Upper bound on stored-but-not-yet-consumed deferred resolutions. A run that
+ * is cancelled or abandoned after its resolution is stored but before the
+ * scheduler's next pass consumes it (see `awaitBridgeDeferred`) would
+ * otherwise leak its entry for the life of the process; this cap is a
+ * backstop that bounds the module-level map across the many runs handled by
+ * a long-running gateway. Exported for tests.
+ * @type {number}
+ */
+export const DEFERRED_RESOLUTIONS_MAX = 4096;
+/**
+ * Insertion-ordered LRU map of stored deferred resolutions keyed by
+ * execution id. A plain `Map` preserves insertion order, so the
+ * least-recently-used entry is always the first key.
+ * @type {Map<string, Exit.Exit<any, any>>}
+ */
 const deferredResolutions = new Map();
+/**
+ * Current number of stored deferred resolutions. Exported for tests.
+ * @returns {number}
+ */
+export const deferredResolutionsSize = () => deferredResolutions.size;
 /**
  * @template Success, Error
  * @param {string} executionId
@@ -134,7 +155,15 @@ const awaitBridgeDeferred = async (executionId, _deferred) => {
  * @param {Exit.Exit<Success["Type"], Error["Type"]>} exit
  */
 const resolveBridgeDeferred = async (executionId, _deferred, exit) => {
+    deferredResolutions.delete(executionId);
     deferredResolutions.set(executionId, exit);
+    while (deferredResolutions.size > DEFERRED_RESOLUTIONS_MAX) {
+        const oldest = deferredResolutions.keys().next().value;
+        if (oldest === undefined) {
+            break;
+        }
+        deferredResolutions.delete(oldest);
+    }
 };
 /**
  * @param {_SmithersDb} adapter

--- a/packages/engine/tests/durable-deferred-bridge-cache-bound.test.js
+++ b/packages/engine/tests/durable-deferred-bridge-cache-bound.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+    DEFERRED_RESOLUTIONS_MAX,
+    bridgeApprovalResolve,
+    deferredResolutionsSize,
+} from "../src/effect/durable-deferred-bridge.js";
+
+describe("deferredResolutions is bounded", () => {
+    test("does not grow past the LRU cap across many stored-but-never-consumed resolutions", async () => {
+        const adapter = {};
+        const total = DEFERRED_RESOLUTIONS_MAX + 50;
+        for (let i = 0; i < total; i += 1) {
+            // distinct runId per iteration => distinct execution id; never
+            // consumed via awaitBridgeDeferred, simulating a run that was
+            // cancelled or abandoned after its resolution was stored.
+            await bridgeApprovalResolve(adapter, `run-${i}`, "node", 0, {
+                approved: true,
+            });
+        }
+
+        expect(deferredResolutionsSize()).toBeLessThanOrEqual(
+            DEFERRED_RESOLUTIONS_MAX,
+        );
+    });
+});


### PR DESCRIPTION
Closes #539

## Root cause

`packages/engine/src/effect/durable-deferred-bridge.js` keeps a module-level
`deferredResolutions` `Map<executionId, Exit>` that records a run's resolved
`Exit` so `awaitBridgeDeferred` can pick it up on the next scheduler pass. If a
run is cancelled or abandoned after its resolution is stored but before it is
consumed, that entry is never deleted — it leaks for the life of the process.
On a long-running gateway handling many runs, this map grows unbounded.

## Approach

- Added `DEFERRED_RESOLUTIONS_MAX` (4096) as an LRU cap.
- `resolveBridgeDeferred` now re-inserts the key (to refresh recency in the
  insertion-ordered `Map`) and evicts the oldest entries once the cap is
  exceeded.
- Exported `deferredResolutionsSize()` for test observability.
- Added `packages/engine/tests/durable-deferred-bridge-cache-bound.test.js`,
  which stores `DEFERRED_RESOLUTIONS_MAX + 50` distinct, never-consumed
  resolutions and asserts the map never exceeds the cap.

Strategy used: opus-sandwich.

This PR will be RESTACKED onto a PR train — its base branch may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)