### PR TITLE
🔒 fix(electric-proxy): derive opaque principalId instead of leaking token suffix

### DIFF
--- a/packages/electric-proxy/bin/smithers-electric-proxy.js
+++ b/packages/electric-proxy/bin/smithers-electric-proxy.js
@@ -12,6 +12,7 @@
  *   node bin/smithers-electric-proxy.js
  */
 import { createSmithersElectricProxy } from "../src/createSmithersElectricProxy.js";
+import { deriveGrantsFromGateway } from "../src/deriveGrantsFromGateway.js";
 import { serveSmithersElectricProxy } from "../src/serveSmithersElectricProxy.js";
 
 /**
@@ -24,33 +25,6 @@ function requireEnv(name) {
     throw new Error(`${name} is required`);
   }
   return value;
-}
-
-/**
- * @param {string} gatewayUrl
- * @param {string} authorization
- * @returns {Promise<import("../src/SmithersElectricProxyOptions.ts").SmithersElectricAuthContext | null>}
- */
-async function deriveGrantsFromGateway(gatewayUrl, authorization) {
-  // listRuns returns exactly the runs the token is authorized to read, so its
-  // result is the authoritative grant set. A 401/403 means no access.
-  const response = await fetch(`${gatewayUrl.replace(/\/+$/, "")}/v1/rpc/listRuns`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization },
-    body: JSON.stringify({}),
-  }).catch(() => null);
-  if (!response || !response.ok) return null;
-  const body = /** @type {{ payload?: unknown } | null} */ (await response.json().catch(() => null));
-  const payload = body?.payload;
-  const rows = Array.isArray(payload) ? payload : [];
-  const grantedRunIds = rows
-    .map((row) => (row && typeof row === "object" ? (/** @type {{ runId?: unknown }} */ (row)).runId : undefined))
-    .filter((id) => typeof id === "string");
-  return {
-    principalId: authorization.slice(-12),
-    scopes: ["run:read"],
-    grantedRunIds,
-  };
 }
 
 /**

--- a/packages/electric-proxy/src/deriveGrantsFromGateway.js
+++ b/packages/electric-proxy/src/deriveGrantsFromGateway.js
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derives an opaque, stable-per-token principal id. It must stay stable per
+ * token (it also doubles as the rate-limiter key), but must never contain
+ * token substrings — it is embedded verbatim in scope-decision logs and every
+ * emitted proxy event, which feed the observability/OTLP path.
+ *
+ * @param {string} authorization
+ * @returns {string}
+ */
+function derivePrincipalId(authorization) {
+  const salt = process.env.SMITHERS_ELECTRIC_PRINCIPAL_SALT ?? "";
+  const hash = createHash("sha256").update(salt + authorization).digest("hex");
+  return `tok_${hash.slice(0, 16)}`;
+}
+
+/**
+ * @param {string} gatewayUrl
+ * @param {string} authorization
+ * @param {typeof fetch} [fetchClient]
+ * @returns {Promise<import("./SmithersElectricProxyOptions.ts").SmithersElectricAuthContext | null>}
+ */
+export async function deriveGrantsFromGateway(gatewayUrl, authorization, fetchClient = fetch) {
+  // listRuns returns exactly the runs the token is authorized to read, so its
+  // result is the authoritative grant set. A 401/403 means no access.
+  const response = await fetchClient(`${gatewayUrl.replace(/\/+$/, "")}/v1/rpc/listRuns`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization },
+    body: JSON.stringify({}),
+  }).catch(() => null);
+  if (!response || !response.ok) return null;
+  const body = /** @type {{ payload?: unknown } | null} */ (await response.json().catch(() => null));
+  const payload = body?.payload;
+  const rows = Array.isArray(payload) ? payload : [];
+  const grantedRunIds = rows
+    .map((row) => (row && typeof row === "object" ? (/** @type {{ runId?: unknown }} */ (row)).runId : undefined))
+    .filter((id) => typeof id === "string");
+  return {
+    principalId: derivePrincipalId(authorization),
+    scopes: ["run:read"],
+    grantedRunIds,
+  };
+}

--- a/packages/electric-proxy/tests/deriveGrantsFromGateway.test.ts
+++ b/packages/electric-proxy/tests/deriveGrantsFromGateway.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { deriveGrantsFromGateway } from "../src/deriveGrantsFromGateway.js";
+
+function fakeFetch(status: number, payload?: unknown): typeof fetch {
+  return (async () =>
+    new Response(status === 200 ? JSON.stringify({ payload }) : "", { status })) as unknown as typeof fetch;
+}
+
+describe("deriveGrantsFromGateway", () => {
+  test("does not leak token material into principalId", async () => {
+    const authorization = "Bearer super-secret-token-abcdef123456";
+    const result = await deriveGrantsFromGateway(
+      "http://gateway.local",
+      authorization,
+      fakeFetch(200, [{ runId: "run-1" }, { runId: "run-2" }]),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.principalId).not.toBe(authorization.slice(-12));
+    expect(result?.principalId).not.toContain(authorization);
+    expect(result?.principalId).not.toContain("super-secret-token");
+  });
+
+  test("principalId is opaque, stable, and distinct per token", async () => {
+    const fetchClient = fakeFetch(200, [{ runId: "run-1" }, { runId: "run-2" }]);
+
+    const first = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-a", fetchClient);
+    const second = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-a", fetchClient);
+    const different = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-b", fetchClient);
+
+    expect(first?.principalId).toMatch(/^tok_[0-9a-f]{16}$/);
+    expect(first?.principalId).toBe(second?.principalId ?? "");
+    expect(first?.principalId).not.toBe(different?.principalId);
+    expect(first?.grantedRunIds).toEqual(["run-1", "run-2"]);
+    expect(first?.scopes).toEqual(["run:read"]);
+  });
+
+  test("returns null on denied/failed auth", async () => {
+    const denied = await deriveGrantsFromGateway("http://gateway.local", "Bearer token", fakeFetch(403));
+    expect(denied).toBeNull();
+
+    const throwingFetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    const failed = await deriveGrantsFromGateway("http://gateway.local", "Bearer token", throwingFetch);
+    expect(failed).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #544

**Root cause:** `deriveGrantsFromGateway` in `packages/electric-proxy/bin/smithers-electric-proxy.js` set `principalId: authorization.slice(-12)` — the last 12 characters of the live bearer token. That id is embedded verbatim in scope-decision log lines and every emitted proxy event (`electric.shape.rejected`, `electric.shape.open`, `electric.upstream.error`, `electric.shape.forwarded` in `createSmithersElectricProxy.ts`), which feed the observability/OTLP path. Anyone with log or trace access could read 12 characters of a caller's bearer token, narrowing brute-force search space for a value that should be opaque.

**Approach:**
- Extracted `deriveGrantsFromGateway` out of the bin entry point into a new testable module, `packages/electric-proxy/src/deriveGrantsFromGateway.js`, accepting an injectable `fetchClient` for testing.
- Added `derivePrincipalId`, which computes `principalId` as `tok_<first 16 hex chars of sha256(salt + authorization)>`, salted via the optional `SMITHERS_ELECTRIC_PRINCIPAL_SALT` env var. This keeps the id stable per token (required since it doubles as the rate-limiter key) while making it non-reversible and free of token substrings.
- `packages/electric-proxy/bin/smithers-electric-proxy.js` now imports and calls the extracted function instead of defining it inline.
- Added `packages/electric-proxy/tests/deriveGrantsFromGateway.test.ts` covering: no token leakage into `principalId`, stability/uniqueness per token, and the null-on-denied/failed-auth path.

**Strategy used:** opus-sandwich.

Note: this PR will be RESTACKED onto a PR train — its base branch may change as part of that process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)