### PR TITLE
🐛 fix(sandbox): compute real totalDiffLines for SandboxDiffReviewRequested

### DIFF
--- a/packages/sandbox/src/execute.js
+++ b/packages/sandbox/src/execute.js
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Effect, Metric } from "effect";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
@@ -175,6 +175,22 @@ function diffBundlePatchCount(value) {
     return patches.length;
 }
 /**
+ * @param {string} diff
+ * @returns {number}
+ */
+function unifiedDiffLineCount(diff) {
+    let count = 0;
+    for (const line of diff.split("\n")) {
+        if (line.startsWith("+++") || line.startsWith("---")) {
+            continue;
+        }
+        if (line.startsWith("+") || line.startsWith("-")) {
+            count += 1;
+        }
+    }
+    return count;
+}
+/**
  * @param {unknown} status
  * @returns {status is "finished" | "failed" | "cancelled"}
  */
@@ -268,6 +284,26 @@ function isDiffBundleLike(bundle) {
         typeof source.seq === "number" &&
         typeof source.baseRef === "string" &&
         Array.isArray(source.patches));
+}
+/**
+ * @param {import("./ValidatedSandboxBundle.ts").ValidatedSandboxBundle} validated
+ * @returns {Promise<number>}
+ */
+async function sandboxDiffLineCount(validated) {
+    let total = 0;
+    for (const patchPath of validated.patchFiles) {
+        const content = await readFile(resolveSandboxPath(validated.bundlePath, patchPath), "utf8").catch(() => "");
+        total += unifiedDiffLineCount(content);
+    }
+    const diffBundle = validated.manifest.diffBundle;
+    if (isDiffBundleLike(diffBundle)) {
+        for (const patch of diffBundle.patches) {
+            if (typeof patch?.diff === "string") {
+                total += unifiedDiffLineCount(patch.diff);
+            }
+        }
+    }
+    return total;
 }
 /**
  * @param {import("./ValidatedSandboxBundle.ts").ValidatedSandboxBundle} validated
@@ -382,12 +418,13 @@ async function finalizeSandboxBundle(params) {
     });
     const reviewDiffs = options.reviewDiffs ?? true;
     if (reviewDiffs && totalPatchCount > 0) {
+        const totalDiffLines = await sandboxDiffLineCount(validated);
         await emitSandboxEvent(runtimeDb, {
             type: "SandboxDiffReviewRequested",
             runId: runtime.runId,
             sandboxId: options.sandboxId,
             patchCount: totalPatchCount,
-            totalDiffLines: 0,
+            totalDiffLines,
             timestampMs: nowMs(),
         });
         if (!options.autoAcceptDiffs) {

--- a/packages/sandbox/tests/execute.test.js
+++ b/packages/sandbox/tests/execute.test.js
@@ -1152,4 +1152,50 @@ describe("executeSandbox", () => {
             sqlite.close();
         }
     });
+
+    test("records real totalDiffLines for reviewed sandbox diffs", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const rootDir = tempDir("smithers-sandbox-execute-");
+        const runtime = createRuntime(db, { runId: "run-diff-lines" });
+        try {
+            await withCodeplaneEnv(() =>
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-diff-lines",
+                    rootDir,
+                    reviewDiffs: true,
+                    autoAcceptDiffs: true,
+                    executeChildWorkflow: async () => {
+                        const patchDir = join(resultPath(rootDir, "run-diff-lines", "sandbox-diff-lines"), "patches");
+                        mkdirSync(patchDir, { recursive: true });
+                        // 2 churn lines (-old / +new)
+                        writeFileSync(
+                            join(patchDir, "0001-change.patch"),
+                            "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+                            "utf8",
+                        );
+                        // 2 churn lines (two added lines)
+                        writeFileSync(
+                            join(patchDir, "0002-add.patch"),
+                            "diff --git a/other.txt b/other.txt\n--- a/other.txt\n+++ b/other.txt\n@@ -0,0 +1,2 @@\n+line one\n+line two\n",
+                            "utf8",
+                        );
+                        return {
+                            runId: "child-diff-lines",
+                            status: "finished",
+                            output: { changed: true },
+                        };
+                    },
+                }),
+            );
+
+            const events = await adapter.listEvents("run-diff-lines", -1);
+            const reviewRequested = events.find((row) => row.type === "SandboxDiffReviewRequested");
+            const payload = JSON.parse(String(reviewRequested?.payloadJson));
+            expect(payload.patchCount).toBe(2);
+            expect(payload.totalDiffLines).toBe(4);
+        }
+        finally {
+            sqlite.close();
+        }
+    });
 });


### PR DESCRIPTION
Closes #526

**Root cause:** `finalizeSandboxBundle` in `packages/sandbox/src/execute.js` emits the `SandboxDiffReviewRequested` event with `totalDiffLines` hardcoded to `0` inside the `reviewDiffs && totalPatchCount > 0` branch — exactly the case where patches actually exist. Any consumer sizing the review (e.g. deciding whether a diff is trivially small) sees a fabricated zero for every request.

**Approach:**
- Added `unifiedDiffLineCount(diff)` — counts `+`/`-` churn lines in a unified diff, skipping the `+++`/`---` file-header lines.
- Added `sandboxDiffLineCount(validated)` — sums that count across both `validated.patchFiles` (read from disk via `resolveSandboxPath`) and any inline patches on `validated.manifest.diffBundle`.
- `finalizeSandboxBundle` now awaits `sandboxDiffLineCount(validated)` and passes the real total instead of the hardcoded `0`.
- Added a regression test in `packages/sandbox/tests/execute.test.js` asserting `totalDiffLines` reflects real patch churn (2 patch files, 4 total diff lines).

**Strategy used:** opus-sandwich

**Note:** This PR will be RESTACKED onto a PR train — its base branch may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)