### PR TITLE
🐛 fix(gateway-ui): surface ApprovalPanel submitApproval failures

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -9446,7 +9446,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/llms-full-v0.28.0.txt
+++ b/docs/llms-full-v0.28.0.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/reference/gateway-ui.mdx
+++ b/docs/reference/gateway-ui.mdx
@@ -33,7 +33,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/packages/gateway-ui/src/ApprovalPanel.tsx
+++ b/packages/gateway-ui/src/ApprovalPanel.tsx
@@ -8,6 +8,8 @@ export type ApprovalPanelProps = {
   filter?: { workflow?: string; runId?: string; limit?: number };
   /** Poll interval (ms) to refresh the pending list. 0 disables. Default 2000. */
   pollMs?: number;
+  /** Called if the submitApproval RPC throws. */
+  onError?: (error: Error) => void;
   className?: string;
   style?: CSSProperties;
 };
@@ -32,10 +34,11 @@ function approvalKey(row: ApprovalRow): string {
  * {@link useGatewayActions}. Drop it in to make a workflow's human gates
  * actionable from your UI.
  */
-export function ApprovalPanel({ filter, pollMs = 2000, className, style }: ApprovalPanelProps) {
+export function ApprovalPanel({ filter, pollMs = 2000, onError, className, style }: ApprovalPanelProps) {
   const { data, loading, error, refetch } = useGatewayApprovals(filter ? { filter } : undefined);
   const actions = useGatewayActions();
   const [busy, setBusy] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<{ key: string; message: string } | null>(null);
   const approvals = (data ?? []) as ApprovalRow[];
 
   // listApprovals is pull-only on the local gateway path, so poll to stay live.
@@ -46,6 +49,7 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
   }, [refetch, pollMs]);
 
   const decide = async (row: ApprovalRow, approved: boolean) => {
+    setSubmitError(null);
     setBusy(approvalKey(row));
     try {
       await actions.submitApproval({
@@ -55,6 +59,10 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
         decision: { approved },
       });
       refetch?.();
+    } catch (cause) {
+      const err = cause instanceof Error ? cause : new Error(String(cause));
+      setSubmitError({ key: approvalKey(row), message: err.message });
+      onError?.(err);
     } finally {
       setBusy(null);
     }
@@ -119,6 +127,9 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
                 Deny
               </button>
             </div>
+            {submitError?.key === key ? (
+              <div style={{ color: theme.danger, fontSize: 13 }}>{submitError.message}</div>
+            ) : null}
           </div>
         );
       })}

--- a/packages/gateway-ui/tests/hookComponents.test.tsx
+++ b/packages/gateway-ui/tests/hookComponents.test.tsx
@@ -493,6 +493,45 @@ describe("ApprovalPanel", () => {
     await harness.flush(40);
     expect(harness.container.textContent).toContain("No approvals waiting.");
   });
+
+  test("surfaces the submitApproval failure and re-enables the buttons", async () => {
+    const gw = boot({
+      approvals: [{ runId: "run-c", nodeId: "gate", iteration: 0 }],
+      failApprovalSubmit: true,
+    });
+    const harness = await mount(gw, createElement(ApprovalPanel, { pollMs: 0 }));
+    await harness.flush(50);
+    const approveButtons = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    click(approveButtons[0]);
+    await harness.flush(60);
+    expect(harness.container.textContent).toMatch(/Forced failure|failed|error/i);
+    const stillApprove = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    expect((stillApprove[0] as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("calls onError when submitApproval rejects", async () => {
+    const gw = boot({
+      approvals: [{ runId: "run-c", nodeId: "gate", iteration: 0 }],
+      failApprovalSubmit: true,
+    });
+    const errors: Error[] = [];
+    const harness = await mount(
+      gw,
+      createElement(ApprovalPanel, { pollMs: 0, onError: (e: Error) => errors.push(e) }),
+    );
+    await harness.flush(50);
+    const approveButtons = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    click(approveButtons[0]);
+    await harness.flush(60);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
 });
 
 describe("RunEventLog", () => {

--- a/packages/gateway-ui/tests/inMemoryGateway.ts
+++ b/packages/gateway-ui/tests/inMemoryGateway.ts
@@ -22,6 +22,8 @@ export type SeedState = {
   failPaths?: Set<string>;
   /** When set, the SSE stream endpoint answers with this HTTP status. */
   streamStatus?: number;
+  /** When true, POST /v1/api/approvals/:id (submitApproval) always fails. */
+  failApprovalSubmit?: boolean;
 };
 
 export type InMemoryGateway = {
@@ -54,6 +56,7 @@ export function startInMemoryGateway(seed: SeedState = {}): InMemoryGateway {
     outputs: seed.outputs ?? {},
     failPaths: seed.failPaths ?? new Set<string>(),
     streamStatus: seed.streamStatus ?? 200,
+    failApprovalSubmit: seed.failApprovalSubmit ?? false,
   };
 
   const controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
@@ -151,6 +154,9 @@ export function startInMemoryGateway(seed: SeedState = {}): InMemoryGateway {
       }
       // POST /v1/api/approvals/:id (submitApproval)
       if (path.startsWith("/v1/api/approvals/") && request.method === "POST") {
+        if (state.failApprovalSubmit) {
+          return fail(500, "BOOM", "Forced failure for approval submit");
+        }
         const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
         gateway.approvalsSubmitted.push(body);
         state.approvals = state.approvals.filter(

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |


### PR DESCRIPTION
Closes #547

## Root cause
`ApprovalPanel` (`packages/gateway-ui/src/ApprovalPanel.tsx`) called `actions.submitApproval(...)` inside a `try/finally` with no `catch`. When the RPC threw (network error, gateway rejection, stale approval, etc.), the exception was swallowed entirely: `busy` was cleared in `finally`, but the user got no feedback that their approve/deny click failed, leaving them to believe the decision went through.

## Approach
- Added a `catch` branch in `decide()` that normalizes the thrown value to an `Error`, stores it in new `submitError` state keyed by the approval row, and renders an inline error message under the affected row's action buttons.
- Added an optional `onError?: (error: Error) => void` prop so host apps can hook the failure into their own toast/logging/telemetry instead of relying solely on the inline message.
- Updated `packages/gateway-ui/tests/hookComponents.test.tsx` and `packages/gateway-ui/tests/inMemoryGateway.ts` to cover the failure path, and updated `docs/reference/gateway-ui.mdx` (plus regenerated `llms-*.txt` bundles) to document the new `onError` prop.

Strategy used: **opus-sandwich**.

This PR will be **restacked** onto a PR train — its base branch may change as sibling issue fixes land ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)