### PR TITLE
🧹 refactor(scheduler): remove unreachable findDescriptor linear-scan fallback

### DIFF
--- a/packages/scheduler/src/findDescriptor.js
+++ b/packages/scheduler/src/findDescriptor.js
@@ -1,0 +1,20 @@
+/** @typedef {import("@smithers-orchestrator/graph").TaskDescriptor} TaskDescriptor */
+
+/**
+ * `state.descriptors` holds exactly one entry per nodeId — the CURRENT
+ * iteration — keyed by nodeId. There is no per-iteration history here, so
+ * this is a keyed lookup only: a stale-iteration lookup intentionally
+ * returns undefined. Callers that need a prior failed iteration's
+ * descriptor use the separate `failureDescriptors` map instead.
+ *
+ * @param {Map<string, TaskDescriptor>} descriptors
+ * @param {string} nodeId
+ * @param {number} [iteration]
+ * @returns {TaskDescriptor | undefined}
+ */
+export function findDescriptor(descriptors, nodeId, iteration) {
+    const descriptor = descriptors.get(nodeId);
+    return descriptor && (iteration == null || descriptor.iteration === iteration)
+        ? descriptor
+        : undefined;
+}

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -5,6 +5,7 @@ import { buildPlanTree } from "./buildPlanTree.js";
 import { buildStateKey } from "./buildStateKey.js";
 import { cloneTaskStateMap } from "./cloneTaskStateMap.js";
 import { computeRetryDelayMs } from "./computeRetryDelayMs.js";
+import { findDescriptor } from "./findDescriptor.js";
 import { parseStateKey } from "./parseStateKey.js";
 import { scheduleTasks } from "./scheduleTasks.js";
 /** @typedef {import("@smithers-orchestrator/graph").TaskDescriptor} TaskDescriptor */
@@ -41,20 +42,6 @@ function descriptorMap(tasks) {
         map.set(task.nodeId, task);
     }
     return map;
-}
-/**
- * @param {SessionState} state
- * @param {string} nodeId
- * @param {number} [iteration]
- * @returns {TaskDescriptor | undefined}
- */
-function findDescriptor(state, nodeId, iteration) {
-    const descriptor = state.descriptors.get(nodeId);
-    if (descriptor && (iteration == null || descriptor.iteration === iteration)) {
-        return descriptor;
-    }
-    return [...state.descriptors.values()].find((candidate) => candidate.nodeId === nodeId &&
-        (iteration == null || candidate.iteration === iteration));
 }
 /**
  * @param {{ readonly nodeId: string; readonly iteration: number }} descriptor
@@ -623,7 +610,7 @@ export function makeWorkflowSession(options = {}) {
     function unhandledFailureDecision(recoveryKeys = new Set()) {
         for (const [key, taskState] of state.states) {
             const parsed = parseStateKey(key);
-            const descriptor = findDescriptor(state, parsed.nodeId, parsed.iteration) ??
+            const descriptor = findDescriptor(state.descriptors, parsed.nodeId, parsed.iteration) ??
                 state.failureDescriptors.get(key);
             if (taskState === "failed" && !descriptor?.continueOnFail) {
                 if (recoveryKeys.has(key)) {
@@ -941,7 +928,7 @@ export function makeWorkflowSession(options = {}) {
             });
         }),
         taskFailed: (failure) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, failure.nodeId, failure.iteration);
+            const descriptor = findDescriptor(state.descriptors, failure.nodeId, failure.iteration);
             if (!descriptor) {
                 // Stale failure for a task that already left the graph (see taskCompleted) —
                 // the task is gone, so its failure is moot. Re-decide on the current graph
@@ -951,7 +938,7 @@ export function makeWorkflowSession(options = {}) {
             return applyFailure(descriptor, failure.error);
         }),
         approvalResolved: (nodeId, resolution) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown approval task ${nodeId}`), "approvalResolved");
             }
@@ -959,7 +946,7 @@ export function makeWorkflowSession(options = {}) {
             return decide();
         }),
         approvalTimedOut: (nodeId) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown approval task ${nodeId}`), "approvalTimedOut");
             }
@@ -985,7 +972,7 @@ export function makeWorkflowSession(options = {}) {
             return decide();
         }),
         timerFired: (nodeId, firedAtMs = nowMs()) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown timer task ${nodeId}`), "timerFired");
             }
@@ -1015,7 +1002,7 @@ export function makeWorkflowSession(options = {}) {
             }
         }),
         heartbeatTimedOut: (nodeId, iteration, details = {}) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId, iteration);
+            const descriptor = findDescriptor(state.descriptors, nodeId, iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown task ${nodeId}`), "heartbeatTimedOut");
             }
@@ -1027,7 +1014,7 @@ export function makeWorkflowSession(options = {}) {
             }));
         }),
         cacheResolved: (output, _cached) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, output.nodeId, output.iteration);
+            const descriptor = findDescriptor(state.descriptors, output.nodeId, output.iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown cached task ${output.nodeId}`), "cacheResolved");
             }
@@ -1042,7 +1029,7 @@ export function makeWorkflowSession(options = {}) {
             });
         }),
         cacheMissed: (nodeId, iteration) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId, iteration);
+            const descriptor = findDescriptor(state.descriptors, nodeId, iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown cached task ${nodeId}`), "cacheMissed");
             }

--- a/packages/scheduler/tests/findDescriptor.test.js
+++ b/packages/scheduler/tests/findDescriptor.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { findDescriptor } from "../src/findDescriptor.js";
+
+describe("findDescriptor", () => {
+  test("is a keyed lookup, never a linear scan (issue #546)", () => {
+    const descriptors = new Map([
+      ["someOtherKey", { nodeId: "real", iteration: 0 }],
+    ]);
+    expect(findDescriptor(descriptors, "real")).toBeUndefined();
+  });
+
+  test("returns the entry stored under its nodeId", () => {
+    const d = { nodeId: "a", iteration: 0 };
+    const descriptors = new Map([["a", d]]);
+    expect(findDescriptor(descriptors, "a")).toBe(d);
+    expect(findDescriptor(descriptors, "a", 0)).toBe(d);
+  });
+
+  test("stale/mismatched iteration returns undefined", () => {
+    const d = { nodeId: "a", iteration: 3 };
+    const descriptors = new Map([["a", d]]);
+    expect(findDescriptor(descriptors, "a", 2)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #546

## Root cause

`findDescriptor` in `packages/scheduler/src/makeWorkflowSession.js` did a keyed
`Map` lookup by `nodeId` first, then fell back to a full linear scan
(`[...state.descriptors.values()].find(...)`) over `state.descriptors` if the
keyed lookup missed. But `state.descriptors` is keyed by `nodeId` itself and
holds exactly one entry per node (the current iteration only — no
per-iteration history). That invariant makes the fallback branch dead code:
any entry the linear scan could find would already have been found by the
keyed lookup on the same `nodeId` key. A stale-iteration lookup is intended to
return `undefined` (callers needing a prior failed iteration's descriptor use
the separate `state.failureDescriptors` map instead), so the fallback wasn't
masking a real behavior difference — it was just unreachable, O(n)-scanning
overhead retained on every call site (`unhandledFailureDecision`,
`taskFailed`, `approvalResolved`, `approvalTimedOut`, `timerFired`,
`heartbeatTimedOut`, `cacheResolved`, `cacheMissed`, etc.).

## Approach

Extracted the keyed-lookup-only logic into a standalone,
independently-testable `packages/scheduler/src/findDescriptor.js` module and
dropped the unreachable linear-scan fallback, documenting the
one-entry-per-nodeId invariant in a doc comment. `makeWorkflowSession.js` now
imports `findDescriptor` instead of defining it inline; all call sites are
unchanged. Added `packages/scheduler/tests/findDescriptor.test.js` covering
the keyed-lookup contract (no linear scan, correct entry returned, stale
iteration returns `undefined`).

Strategy used: **fable-sandwich**.

## Note

This PR will be **restacked** onto a PR train — its base branch may change
after this is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)