### PR TITLE
✅ test(review): grow seeded-bug corpus to 16 fixtures for #492

### DIFF
--- a/evals/review-seeded-bugs/SCORECARD.md
+++ b/evals/review-seeded-bugs/SCORECARD.md
@@ -15,9 +15,9 @@ This committed scorecard documents the report shape for the opt-in review seeded
 
 | Metric | Value |
 | --- | ---: |
-| Fixtures | 9 |
-| Planted bugs | 7 |
-| Clean controls | 2 |
+| Fixtures | 16 |
+| Planted bugs | 12 |
+| Clean controls | 4 |
 | Recall | 71.4% |
 | Precision | 62.5% |
 | Mean absolute anchor offset | 1.2 lines |
@@ -30,11 +30,18 @@ This committed scorecard documents the report shape for the opt-in review seeded
 | Fixture | Label | Expected review behavior |
 | --- | --- | --- |
 | `missing-await` | correctness / major | Flag the dropped `await` near `src/order.ts`. |
+| `missing-await-flush` | correctness / major | Flag the dropped await before the buffer save completes. |
 | `off-by-one-boundary` | correctness / major | Flag the excluded boundary page near `src/window.ts`. |
+| `off-by-one-slice` | correctness / major | Flag the decremented slice end that drops the final page item. |
 | `sql-injection` | security / critical | Flag string interpolation in the SQL query. |
+| `sql-injection-like` | security / critical | Flag interpolation of the search term into the LIKE query. |
 | `resource-leak` | performance / major | Flag the removed file-handle close. |
+| `resource-leak-timer` | performance / major | Flag the shutdown callback that no longer clears the interval. |
 | `deleted-null-check` | correctness / major | Flag the removed null fallback. |
+| `deleted-null-check-config` | correctness / major | Flag the removed log-level default fallback. |
 | `tautological-test` | tests / minor | Flag the assertion that can never fail. |
 | `cross-file-signature-mismatch` | correctness / major | Flag the caller still passing seconds after the helper changed to absolute milliseconds. |
 | `clean-error-message` | clean control | Produce no findings. |
 | `clean-refactor` | clean control | Produce no findings. |
+| `clean-rename` | clean control | Produce no findings. |
+| `clean-jsdoc` | clean control | Produce no findings. |

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/base/src/sku.ts
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/base/src/sku.ts
@@ -1,0 +1,3 @@
+export function normalizeSku(value: string): string {
+  return value.trim().toUpperCase();
+}

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/head/src/sku.ts
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/head/src/sku.ts
@@ -1,0 +1,6 @@
+/**
+ * Normalizes SKU input for storage.
+ */
+export function normalizeSku(value: string): string {
+  return value.trim().toUpperCase();
+}

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/label.json
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/label.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "clean-jsdoc",
+  "clean": true,
+  "description": "JSDoc-only documentation addition; a review should not surface findings."
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/base/src/invoice.ts
+++ b/evals/review-seeded-bugs/corpus/clean-rename/base/src/invoice.ts
@@ -1,0 +1,4 @@
+export function formatInvoiceTotal(cents: number): string {
+  const dollars = cents / 100;
+  return `$${dollars.toFixed(2)}`;
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/head/src/invoice.ts
+++ b/evals/review-seeded-bugs/corpus/clean-rename/head/src/invoice.ts
@@ -1,0 +1,4 @@
+export function formatInvoiceTotal(cents: number): string {
+  const amount = cents / 100;
+  return `$${amount.toFixed(2)}`;
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/label.json
+++ b/evals/review-seeded-bugs/corpus/clean-rename/label.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "clean-rename",
+  "clean": true,
+  "description": "Local variable rename only; a review should not surface findings."
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/base/src/config.ts
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/base/src/config.ts
@@ -1,0 +1,5 @@
+export type Env = { LOG_LEVEL?: string };
+
+export function readLogLevel(env: Env): string {
+  return env.LOG_LEVEL ?? "info";
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/head/src/config.ts
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/head/src/config.ts
@@ -1,0 +1,5 @@
+export type Env = { LOG_LEVEL?: string };
+
+export function readLogLevel(env: Env): string {
+  return env.LOG_LEVEL!;
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/label.json
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "deleted-null-check-config",
+  "clean": false,
+  "bugClass": "deleted-null-check",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/config.ts",
+  "line": 4,
+  "description": "The default log-level fallback was removed, so an unset LOG_LEVEL can escape as undefined."
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/base/src/logger.ts
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/base/src/logger.ts
@@ -1,0 +1,10 @@
+export type BufferStore = {
+  save(entries: string[]): Promise<void>;
+};
+
+export async function flushBuffer(entries: string[], store: BufferStore): Promise<number> {
+  const batch = [...entries];
+  await store.save(batch);
+  entries.length = 0;
+  return batch.length;
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/head/src/logger.ts
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/head/src/logger.ts
@@ -1,0 +1,10 @@
+export type BufferStore = {
+  save(entries: string[]): Promise<void>;
+};
+
+export async function flushBuffer(entries: string[], store: BufferStore): Promise<number> {
+  const batch = [...entries];
+  store.save(batch);
+  entries.length = 0;
+  return batch.length;
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/label.json
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "missing-await-flush",
+  "clean": false,
+  "bugClass": "missing-await",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/logger.ts",
+  "line": 7,
+  "description": "The buffer save promise is no longer awaited before clearing and returning from flushBuffer."
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/base/src/paginator.ts
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/base/src/paginator.ts
@@ -1,0 +1,5 @@
+export function pageItems<T>(items: T[], page: number, pageSize: number): T[] {
+  const start = Math.max(0, page - 1) * pageSize;
+  const end = start + pageSize;
+  return items.slice(start, end);
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/head/src/paginator.ts
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/head/src/paginator.ts
@@ -1,0 +1,5 @@
+export function pageItems<T>(items: T[], page: number, pageSize: number): T[] {
+  const start = Math.max(0, page - 1) * pageSize;
+  const end = start + pageSize;
+  return items.slice(start, end - 1);
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/label.json
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "off-by-one-slice",
+  "clean": false,
+  "bugClass": "off-by-one-boundary",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/paginator.ts",
+  "line": 4,
+  "description": "The page slice end is decremented, so each non-empty page drops its final item."
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/base/src/poller.ts
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/base/src/poller.ts
@@ -1,0 +1,4 @@
+export function startPoller(poll: () => void): () => void {
+  const timer = setInterval(poll, 1000);
+  return () => clearInterval(timer);
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/head/src/poller.ts
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/head/src/poller.ts
@@ -1,0 +1,4 @@
+export function startPoller(poll: () => void): () => void {
+  const timer = setInterval(poll, 1000);
+  return () => undefined;
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/label.json
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "resource-leak-timer",
+  "clean": false,
+  "bugClass": "resource-leak",
+  "category": "performance",
+  "severity": "major",
+  "file": "src/poller.ts",
+  "line": 3,
+  "description": "The poller shutdown callback no longer clears the interval, leaking the timer handle."
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/base/src/search.ts
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/base/src/search.ts
@@ -1,0 +1,10 @@
+export type Db = {
+  query<T>(sql: string, params?: unknown[]): Promise<T[]>;
+};
+
+export async function searchArticles(db: Db, term: string) {
+  return db.query<{ id: string; title: string }>(
+    "select id, title from articles where title like ?",
+    [`%${term}%`],
+  );
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/head/src/search.ts
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/head/src/search.ts
@@ -1,0 +1,9 @@
+export type Db = {
+  query<T>(sql: string, params?: unknown[]): Promise<T[]>;
+};
+
+export async function searchArticles(db: Db, term: string) {
+  return db.query<{ id: string; title: string }>(
+    `select id, title from articles where title like '%${term}%'`,
+  );
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/label.json
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "sql-injection-like",
+  "clean": false,
+  "bugClass": "sql-injection",
+  "category": "security",
+  "severity": "critical",
+  "file": "src/search.ts",
+  "line": 7,
+  "description": "User-controlled search terms are interpolated into a LIKE query instead of passed as bound parameters."
+}

--- a/evals/review-seeded-bugs/score.test.ts
+++ b/evals/review-seeded-bugs/score.test.ts
@@ -40,9 +40,12 @@ describe("review seeded-bug corpus", () => {
     const cleanLabels = labels.filter((label) => label.clean);
 
     for (const bugClass of BUG_CLASSES) {
-      expect(bugLabels.filter((label) => label.bugClass === bugClass)).toHaveLength(1);
+      expect(bugLabels.filter((label) => label.bugClass === bugClass).length).toBeGreaterThanOrEqual(1);
     }
     expect(cleanLabels.length).toBeGreaterThanOrEqual(2);
+    expect(labels.length).toBeGreaterThanOrEqual(15);
+    expect(bugLabels.length).toBeGreaterThanOrEqual(12);
+    expect(cleanLabels.length).toBeGreaterThanOrEqual(4);
 
     for (const label of labels) {
       const baseDir = join(corpusDir, label.fixture, "base");


### PR DESCRIPTION
Closes #492

## Root cause
The `evals/review-seeded-bugs` recall eval only had a handful of fixtures, which made recall/precision measurements on `open-code-review` noisy and not statistically meaningful. Issue #492 asked for a larger, more representative corpus (both seeded-bug and clean/no-bug cases) so the eval gives a stable signal.

## Approach
Grew the corpus from 10 to 16 fixtures by adding 7 new `base`/`head`/`label.json` triples under `evals/review-seeded-bugs/corpus/`:

- `clean-jsdoc/` — no-bug case, JSDoc-only change (should not be flagged)
- `clean-rename/` — no-bug case, pure identifier rename (should not be flagged)
- `deleted-null-check-config/` — seeded bug: removed null check in `src/config.ts`
- `missing-await-flush/` — seeded bug: missing `await` on a flush in `src/logger.ts`
- `off-by-one-slice/` — seeded bug: off-by-one in `src/paginator.ts` slicing
- `resource-leak-timer/` — seeded bug: timer/interval not cleared in `src/poller.ts`
- `sql-injection-like/` — seeded bug: unsanitized input reaching a query in `src/search.ts`

`evals/review-seeded-bugs/score.test.ts` and `SCORECARD.md` were updated to include the new fixtures in the scored corpus.

Strategy used: **self-workflow** (an isolated worktree agent implemented and validated the fix; this PR agent only committed, pushed, and opened the PR).

Note: this PR will be **restacked onto a PR train** — its base branch may change as part of that process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)