### PR TITLE
🐛 fix(telegram-summary): window undated messages by created_at_ms

### DIFF
--- a/apps/telegram-summary/src/service.ts
+++ b/apps/telegram-summary/src/service.ts
@@ -316,7 +316,7 @@ async function selectMessagesForDigest(db: D1Database, startMs: number, endMs: n
     .prepare(
       `SELECT update_id, chat_id, message_id, author, text, at_ms, url
        FROM messages
-       WHERE at_ms IS NULL OR (at_ms >= ? AND at_ms < ?)
+       WHERE COALESCE(at_ms, created_at_ms) >= ? AND COALESCE(at_ms, created_at_ms) < ?
        ORDER BY COALESCE(at_ms, created_at_ms), update_id
        LIMIT 1200`,
     )

--- a/apps/telegram-summary/tests/service.test.ts
+++ b/apps/telegram-summary/tests/service.test.ts
@@ -243,6 +243,17 @@ describe("service digest", () => {
     expect(result.id).toBeNull();
   });
 
+  test("windows undated messages by created_at_ms so a stale message is not re-summarized", async () => {
+    const env = buildEnv();
+    await seedNoDateMessages(env, 2); // ingested (created_at_ms) at nowMs=1782931300000
+    // Default digest window is 24h; run it 25h after ingestion so the undated
+    // messages' created_at_ms falls before the window start.
+    const result = await runDailyDigest(env, 1782931300000 + 25 * 60 * 60 * 1000);
+    expect(result.status).toBe("empty");
+    expect(result.messageCount).toBe(0);
+    expect(result.id).toBeNull();
+  });
+
   test("creates, renders, and posts a full digest", async () => {
     const env = buildEnv({ DIGEST_WINDOW_HOURS: "48", DIGEST_TOPIC_HINT: "roadmap", TELEGRAM_OUTPUT_THREAD_ID: "12" });
     await seedNoDateMessages(env, 3, 0); // index 0 is the huge message -> transcript truncation


### PR DESCRIPTION
Closes #550

## Root cause

`apps/telegram-summary/src/service.ts`'s digest query previously selected
undated messages (`at_ms IS NULL`) unconditionally, regardless of the
requested time window:

```sql
WHERE at_ms IS NULL OR (at_ms >= ? AND at_ms < ?)
```

This meant a message ingested without a Telegram-provided timestamp (`at_ms`
null, only `created_at_ms` set) would be picked up by *every* digest run
forever, instead of being windowed like dated messages — causing stale
undated messages to be re-summarized in unrelated digest windows.

## Fix

Window undated messages by their ingestion time (`created_at_ms`) using
`COALESCE(at_ms, created_at_ms)` in the `WHERE` clause, matching the
`ORDER BY` clause immediately below it which already used the same
coalesce:

```sql
WHERE COALESCE(at_ms, created_at_ms) >= ? AND COALESCE(at_ms, created_at_ms) < ?
```

Added a regression test in `apps/telegram-summary/tests/service.test.ts`
that seeds undated messages, advances the clock 25h past a 24h digest
window, and asserts they're no longer picked up (previously they always
were).

## Strategy

Implemented via the **opus-sandwich** strategy.

## Note

This PR will be **restacked** onto a PR train — its base branch may change
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
