### PR TITLE
🐛 fix(accounts): make stale accounts-lock break atomic and identity-verified

### DIFF
--- a/.smithers/workflows/issue-222-integrations-agent-callable-tool-catalog.tsx
+++ b/.smithers/workflows/issue-222-integrations-agent-callable-tool-catalog.tsx
@@ -1,0 +1,158 @@
+// smithers-source: bespoke
+// smithers-display-name: Issue 222 — OAuth authorization-URL builder
+/** @jsxImportSource smithers-orchestrator */
+import { CodexAgent, createSmithers, Sequence, Task, UI, type AgentLike } from "smithers-orchestrator";
+import { z } from "zod/v4";
+import { ValidationLoop, implementOutputSchema, validateOutputSchema } from "../components/ValidationLoop";
+import { reviewOutputSchema, reviewSynthesisSchema, reviewGate } from "../components/Review";
+
+// Codex-only pool. The shared roles/agents pools lead with Claude, but this
+// worktree's Anthropic org is currently quota-disabled (7-day overage), so we
+// route plan/implement/validate/review entirely through Codex (separate pool).
+const codex = new CodexAgent({ model: "gpt-5.5", skipGitRepoCheck: true });
+const codexPool: AgentLike[] = [codex];
+
+// Issue #222 is an integrations program (72 items). Its named "load-bearing
+// gap" is the delegated per-user OAuth connection plane: auth-code + PKCE,
+// encrypted storage, single-flight refresh, per-tenant scoping. PKCE helpers
+// already landed in packages/accounts (createPkcePair / deriveCodeChallenge).
+// This workflow lands the next minimal, pure brick of that plane — a
+// network-free OAuth 2.0 authorization-code request URL builder that consumes
+// a PKCE challenge and supports per-tenant scoping — TDD-first. It is one
+// self-contained checkbox-worth of progress, not the whole epic.
+
+const inputSchema = z.object({
+  spec: z.string().default(
+    `Add a pure, network-free OAuth 2.0 authorization-code request URL builder to
+\`packages/accounts\`, the next brick of issue #222's delegated per-user OAuth
+connection plane (which already has RFC 7636 PKCE helpers in packages/accounts/src/pkce.js).
+
+TDD — write the failing test FIRST, watch it go red, then implement until green.
+
+NEW SOURCE FILE packages/accounts/src/buildAuthorizationUrl.js (JS with JSDoc,
+mirroring the style of packages/accounts/src/pkce.js — no TypeScript, node:
+built-ins only, NO new dependencies). Export one function:
+
+  buildAuthorizationUrl(request) -> string
+
+It builds an RFC 6749 §4.1.1 authorization-code request URL carrying RFC 7636
+PKCE parameters. \`request\` is an object with:
+  - authorizationEndpoint: string (required) — the provider authorize URL.
+  - clientId: string (required)
+  - redirectUri: string (required)
+  - state: string (required)
+  - codeChallenge: string (required) — from deriveCodeChallenge / createPkcePair.
+  - scope?: string | readonly string[] (optional) — an array is joined with a
+    single space; a string is used verbatim; omitted entirely when absent/empty.
+  - codeChallengeMethod?: "S256" | "plain" (optional, default "S256").
+  - extraParams?: Record<string,string> (optional) — extra query params, e.g. a
+    per-tenant \`audience\` / \`resource\`. Applied on top of the standard params.
+
+Behavior:
+  - Parse authorizationEndpoint with the WHATWG \`URL\`. Throw a TypeError if it
+    is not an absolute http:/https: URL. PRESERVE any query params already on
+    the endpoint (so a provider/tenant-specific authorize URL keeps its params).
+  - Throw a TypeError when clientId, redirectUri, state, or codeChallenge is not
+    a non-empty string.
+  - Set search params: response_type=code, client_id, redirect_uri, state,
+    code_challenge, code_challenge_method, and scope when present. Apply
+    extraParams last (they override standard params by design).
+  - Return \`url.toString()\`.
+
+Then export it from packages/accounts/src/index.js alongside the pkce exports
+(add to the existing \`export { ... } from "./pkce.js";\` line's neighbourhood as
+its own \`export { buildAuthorizationUrl } from "./buildAuthorizationUrl.js";\`).
+Preserve the @smithers-type-exports block byte-for-byte; do NOT hand-edit index.d.ts.
+
+NEW TEST FILE packages/accounts/tests/buildAuthorizationUrl.test.js (mirror the
+style of packages/accounts/tests/pkce.test.js — bun:test describe/test, import
+from "../src/index.js"). Cover, at minimum:
+  - Builds a URL whose query has response_type=code, the given client_id,
+    redirect_uri, state, code_challenge, and code_challenge_method=S256 by
+    default; assert by parsing the result with \`new URL(...)\` and reading
+    searchParams.
+  - scope given as an array is space-joined into a single \`scope\` param; scope
+    given as a string is used verbatim; scope omitted entirely when not provided.
+  - codeChallengeMethod defaults to "S256" and honours an explicit "plain".
+  - extraParams are merged in AND any query params already present on the
+    authorizationEndpoint are preserved (per-tenant scoping).
+  - Integrates with createPkcePair: passing pair.codeChallenge yields a
+    code_challenge param equal to pair.codeChallenge.
+  - Throws for a non-absolute / non-http(s) endpoint and for empty clientId,
+    redirectUri, state, or codeChallenge.
+
+CONSTRAINTS: minimal, idiomatic, one export per file, no new dependencies, no
+unrelated refactors, follow packages/accounts conventions exactly.
+VERIFY by running: \`pnpm -C packages/accounts test\` — the new test must go
+red before the implementation and green after, and the whole accounts suite
+(currently 52 passing) must stay green. Also run \`pnpm -C packages/accounts typecheck\`.`,
+  ),
+});
+
+const { Workflow, smithers, outputs } = createSmithers({
+  input: inputSchema,
+  plan: z.object({
+    plan: z.string().describe("the concrete implementation plan for buildAuthorizationUrl"),
+    testPath: z.string().default("packages/accounts/tests/buildAuthorizationUrl.test.js"),
+  }),
+  implement: implementOutputSchema,
+  validate: validateOutputSchema,
+  review: reviewOutputSchema,
+  reviewSynthesis: reviewSynthesisSchema,
+});
+
+export default smithers((ctx) => {
+  const spec = ctx.input.spec ?? "";
+  const plan = ctx.outputMaybe("plan", { nodeId: "i222:plan" });
+
+  const validate = ctx.outputMaybe("validate", { nodeId: "i222:impl:validate" });
+  const hasValidated = validate !== undefined;
+  const validationPassed = hasValidated && validate.allPassed !== false;
+  const gate = reviewGate(ctx, "i222:impl:review-moderator");
+  const done = validationPassed && gate.approved;
+
+  const feedbackParts: string[] = [];
+  if (validate && !validationPassed && validate.failingSummary) {
+    feedbackParts.push(`VALIDATION FAILED:\n${validate.failingSummary}`);
+  }
+  if (gate.feedback) {
+    feedbackParts.push(`REVIEW PANEL REJECTED:\n${gate.feedback}`);
+  }
+  const feedback = feedbackParts.length > 0 ? feedbackParts.join("\n\n") : null;
+
+  const implementPrompt = plan
+    ? `${spec}\n\n---\nAPPROVED PLAN:\n${plan.plan}`
+    : spec;
+
+  return (
+    <Workflow name="issue-222-integrations-agent-callable-tool-catalog">
+      <UI entry="../ui/implement.tsx" title={"Issue 222 — OAuth authorize URL"} />
+      <Sequence>
+        <Task id="i222:plan" output={outputs.plan} agent={codexPool}>
+          {`You are planning a small, well-scoped, pure addition. Read the spec, then read
+packages/accounts/src/pkce.js, packages/accounts/src/index.js, packages/accounts/tests/pkce.test.js,
+and packages/accounts/src/README.md so the new file matches local conventions exactly. Produce a
+concrete, minimal implementation plan and the test path.
+
+SPEC:
+${spec}`}
+        </Task>
+
+        {plan ? (
+          <ValidationLoop
+            idPrefix="i222:impl"
+            prompt={implementPrompt}
+            implementAgents={codexPool}
+            validateAgents={codexPool}
+            reviewAgents={codexPool}
+            reviewModerator={codexPool}
+            synthesizeReview
+            feedback={feedback}
+            done={done}
+            maxIterations={3}
+          />
+        ) : null}
+      </Sequence>
+    </Workflow>
+  );
+});

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/apps/telegram-summary/src/service.ts
+++ b/apps/telegram-summary/src/service.ts
@@ -316,7 +316,7 @@ async function selectMessagesForDigest(db: D1Database, startMs: number, endMs: n
     .prepare(
       `SELECT update_id, chat_id, message_id, author, text, at_ms, url
        FROM messages
-       WHERE at_ms IS NULL OR (at_ms >= ? AND at_ms < ?)
+       WHERE COALESCE(at_ms, created_at_ms) >= ? AND COALESCE(at_ms, created_at_ms) < ?
        ORDER BY COALESCE(at_ms, created_at_ms), update_id
        LIMIT 1200`,
     )

--- a/apps/telegram-summary/tests/service.test.ts
+++ b/apps/telegram-summary/tests/service.test.ts
@@ -243,6 +243,17 @@ describe("service digest", () => {
     expect(result.id).toBeNull();
   });
 
+  test("windows undated messages by created_at_ms so a stale message is not re-summarized", async () => {
+    const env = buildEnv();
+    await seedNoDateMessages(env, 2); // ingested (created_at_ms) at nowMs=1782931300000
+    // Default digest window is 24h; run it 25h after ingestion so the undated
+    // messages' created_at_ms falls before the window start.
+    const result = await runDailyDigest(env, 1782931300000 + 25 * 60 * 60 * 1000);
+    expect(result.status).toBe("empty");
+    expect(result.messageCount).toBe(0);
+    expect(result.id).toBeNull();
+  });
+
   test("creates, renders, and posts a full digest", async () => {
     const env = buildEnv({ DIGEST_WINDOW_HOURS: "48", DIGEST_TOPIC_HINT: "roadmap", TELEGRAM_OUTPUT_THREAD_ID: "12" });
     await seedNoDateMessages(env, 3, 0); // index 0 is the huge message -> transcript truncation

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -9446,7 +9446,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/llms-full-v0.28.0.txt
+++ b/docs/llms-full-v0.28.0.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/docs/reference/gateway-ui.mdx
+++ b/docs/reference/gateway-ui.mdx
@@ -33,7 +33,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/evals/review-seeded-bugs/SCORECARD.md
+++ b/evals/review-seeded-bugs/SCORECARD.md
@@ -15,9 +15,9 @@ This committed scorecard documents the report shape for the opt-in review seeded
 
 | Metric | Value |
 | --- | ---: |
-| Fixtures | 9 |
-| Planted bugs | 7 |
-| Clean controls | 2 |
+| Fixtures | 16 |
+| Planted bugs | 12 |
+| Clean controls | 4 |
 | Recall | 71.4% |
 | Precision | 62.5% |
 | Mean absolute anchor offset | 1.2 lines |
@@ -30,11 +30,18 @@ This committed scorecard documents the report shape for the opt-in review seeded
 | Fixture | Label | Expected review behavior |
 | --- | --- | --- |
 | `missing-await` | correctness / major | Flag the dropped `await` near `src/order.ts`. |
+| `missing-await-flush` | correctness / major | Flag the dropped await before the buffer save completes. |
 | `off-by-one-boundary` | correctness / major | Flag the excluded boundary page near `src/window.ts`. |
+| `off-by-one-slice` | correctness / major | Flag the decremented slice end that drops the final page item. |
 | `sql-injection` | security / critical | Flag string interpolation in the SQL query. |
+| `sql-injection-like` | security / critical | Flag interpolation of the search term into the LIKE query. |
 | `resource-leak` | performance / major | Flag the removed file-handle close. |
+| `resource-leak-timer` | performance / major | Flag the shutdown callback that no longer clears the interval. |
 | `deleted-null-check` | correctness / major | Flag the removed null fallback. |
+| `deleted-null-check-config` | correctness / major | Flag the removed log-level default fallback. |
 | `tautological-test` | tests / minor | Flag the assertion that can never fail. |
 | `cross-file-signature-mismatch` | correctness / major | Flag the caller still passing seconds after the helper changed to absolute milliseconds. |
 | `clean-error-message` | clean control | Produce no findings. |
 | `clean-refactor` | clean control | Produce no findings. |
+| `clean-rename` | clean control | Produce no findings. |
+| `clean-jsdoc` | clean control | Produce no findings. |

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/base/src/sku.ts
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/base/src/sku.ts
@@ -1,0 +1,3 @@
+export function normalizeSku(value: string): string {
+  return value.trim().toUpperCase();
+}

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/head/src/sku.ts
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/head/src/sku.ts
@@ -1,0 +1,6 @@
+/**
+ * Normalizes SKU input for storage.
+ */
+export function normalizeSku(value: string): string {
+  return value.trim().toUpperCase();
+}

--- a/evals/review-seeded-bugs/corpus/clean-jsdoc/label.json
+++ b/evals/review-seeded-bugs/corpus/clean-jsdoc/label.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "clean-jsdoc",
+  "clean": true,
+  "description": "JSDoc-only documentation addition; a review should not surface findings."
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/base/src/invoice.ts
+++ b/evals/review-seeded-bugs/corpus/clean-rename/base/src/invoice.ts
@@ -1,0 +1,4 @@
+export function formatInvoiceTotal(cents: number): string {
+  const dollars = cents / 100;
+  return `$${dollars.toFixed(2)}`;
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/head/src/invoice.ts
+++ b/evals/review-seeded-bugs/corpus/clean-rename/head/src/invoice.ts
@@ -1,0 +1,4 @@
+export function formatInvoiceTotal(cents: number): string {
+  const amount = cents / 100;
+  return `$${amount.toFixed(2)}`;
+}

--- a/evals/review-seeded-bugs/corpus/clean-rename/label.json
+++ b/evals/review-seeded-bugs/corpus/clean-rename/label.json
@@ -1,0 +1,5 @@
+{
+  "fixture": "clean-rename",
+  "clean": true,
+  "description": "Local variable rename only; a review should not surface findings."
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/base/src/config.ts
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/base/src/config.ts
@@ -1,0 +1,5 @@
+export type Env = { LOG_LEVEL?: string };
+
+export function readLogLevel(env: Env): string {
+  return env.LOG_LEVEL ?? "info";
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/head/src/config.ts
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/head/src/config.ts
@@ -1,0 +1,5 @@
+export type Env = { LOG_LEVEL?: string };
+
+export function readLogLevel(env: Env): string {
+  return env.LOG_LEVEL!;
+}

--- a/evals/review-seeded-bugs/corpus/deleted-null-check-config/label.json
+++ b/evals/review-seeded-bugs/corpus/deleted-null-check-config/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "deleted-null-check-config",
+  "clean": false,
+  "bugClass": "deleted-null-check",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/config.ts",
+  "line": 4,
+  "description": "The default log-level fallback was removed, so an unset LOG_LEVEL can escape as undefined."
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/base/src/logger.ts
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/base/src/logger.ts
@@ -1,0 +1,10 @@
+export type BufferStore = {
+  save(entries: string[]): Promise<void>;
+};
+
+export async function flushBuffer(entries: string[], store: BufferStore): Promise<number> {
+  const batch = [...entries];
+  await store.save(batch);
+  entries.length = 0;
+  return batch.length;
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/head/src/logger.ts
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/head/src/logger.ts
@@ -1,0 +1,10 @@
+export type BufferStore = {
+  save(entries: string[]): Promise<void>;
+};
+
+export async function flushBuffer(entries: string[], store: BufferStore): Promise<number> {
+  const batch = [...entries];
+  store.save(batch);
+  entries.length = 0;
+  return batch.length;
+}

--- a/evals/review-seeded-bugs/corpus/missing-await-flush/label.json
+++ b/evals/review-seeded-bugs/corpus/missing-await-flush/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "missing-await-flush",
+  "clean": false,
+  "bugClass": "missing-await",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/logger.ts",
+  "line": 7,
+  "description": "The buffer save promise is no longer awaited before clearing and returning from flushBuffer."
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/base/src/paginator.ts
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/base/src/paginator.ts
@@ -1,0 +1,5 @@
+export function pageItems<T>(items: T[], page: number, pageSize: number): T[] {
+  const start = Math.max(0, page - 1) * pageSize;
+  const end = start + pageSize;
+  return items.slice(start, end);
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/head/src/paginator.ts
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/head/src/paginator.ts
@@ -1,0 +1,5 @@
+export function pageItems<T>(items: T[], page: number, pageSize: number): T[] {
+  const start = Math.max(0, page - 1) * pageSize;
+  const end = start + pageSize;
+  return items.slice(start, end - 1);
+}

--- a/evals/review-seeded-bugs/corpus/off-by-one-slice/label.json
+++ b/evals/review-seeded-bugs/corpus/off-by-one-slice/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "off-by-one-slice",
+  "clean": false,
+  "bugClass": "off-by-one-boundary",
+  "category": "correctness",
+  "severity": "major",
+  "file": "src/paginator.ts",
+  "line": 4,
+  "description": "The page slice end is decremented, so each non-empty page drops its final item."
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/base/src/poller.ts
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/base/src/poller.ts
@@ -1,0 +1,4 @@
+export function startPoller(poll: () => void): () => void {
+  const timer = setInterval(poll, 1000);
+  return () => clearInterval(timer);
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/head/src/poller.ts
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/head/src/poller.ts
@@ -1,0 +1,4 @@
+export function startPoller(poll: () => void): () => void {
+  const timer = setInterval(poll, 1000);
+  return () => undefined;
+}

--- a/evals/review-seeded-bugs/corpus/resource-leak-timer/label.json
+++ b/evals/review-seeded-bugs/corpus/resource-leak-timer/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "resource-leak-timer",
+  "clean": false,
+  "bugClass": "resource-leak",
+  "category": "performance",
+  "severity": "major",
+  "file": "src/poller.ts",
+  "line": 3,
+  "description": "The poller shutdown callback no longer clears the interval, leaking the timer handle."
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/base/src/search.ts
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/base/src/search.ts
@@ -1,0 +1,10 @@
+export type Db = {
+  query<T>(sql: string, params?: unknown[]): Promise<T[]>;
+};
+
+export async function searchArticles(db: Db, term: string) {
+  return db.query<{ id: string; title: string }>(
+    "select id, title from articles where title like ?",
+    [`%${term}%`],
+  );
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/head/src/search.ts
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/head/src/search.ts
@@ -1,0 +1,9 @@
+export type Db = {
+  query<T>(sql: string, params?: unknown[]): Promise<T[]>;
+};
+
+export async function searchArticles(db: Db, term: string) {
+  return db.query<{ id: string; title: string }>(
+    `select id, title from articles where title like '%${term}%'`,
+  );
+}

--- a/evals/review-seeded-bugs/corpus/sql-injection-like/label.json
+++ b/evals/review-seeded-bugs/corpus/sql-injection-like/label.json
@@ -1,0 +1,10 @@
+{
+  "fixture": "sql-injection-like",
+  "clean": false,
+  "bugClass": "sql-injection",
+  "category": "security",
+  "severity": "critical",
+  "file": "src/search.ts",
+  "line": 7,
+  "description": "User-controlled search terms are interpolated into a LIKE query instead of passed as bound parameters."
+}

--- a/evals/review-seeded-bugs/score.test.ts
+++ b/evals/review-seeded-bugs/score.test.ts
@@ -40,9 +40,12 @@ describe("review seeded-bug corpus", () => {
     const cleanLabels = labels.filter((label) => label.clean);
 
     for (const bugClass of BUG_CLASSES) {
-      expect(bugLabels.filter((label) => label.bugClass === bugClass)).toHaveLength(1);
+      expect(bugLabels.filter((label) => label.bugClass === bugClass).length).toBeGreaterThanOrEqual(1);
     }
     expect(cleanLabels.length).toBeGreaterThanOrEqual(2);
+    expect(labels.length).toBeGreaterThanOrEqual(15);
+    expect(bugLabels.length).toBeGreaterThanOrEqual(12);
+    expect(cleanLabels.length).toBeGreaterThanOrEqual(4);
 
     for (const label of labels) {
       const baseDir = join(corpusDir, label.fixture, "base");

--- a/packages/accounts/src/buildAuthorizationUrl.js
+++ b/packages/accounts/src/buildAuthorizationUrl.js
@@ -1,0 +1,91 @@
+function parseAuthorizationEndpoint(authorizationEndpoint) {
+    if (typeof authorizationEndpoint !== "string") {
+        throw new TypeError("OAuth authorizationEndpoint must be an absolute http(s) URL");
+    }
+
+    let url;
+    try {
+        url = new URL(authorizationEndpoint);
+    } catch {
+        throw new TypeError("OAuth authorizationEndpoint must be an absolute http(s) URL");
+    }
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new TypeError("OAuth authorizationEndpoint must be an absolute http(s) URL");
+    }
+
+    return url;
+}
+
+function validateNonEmptyString(name, value) {
+    if (typeof value !== "string" || value.length === 0) {
+        throw new TypeError(`OAuth ${name} must be a non-empty string`);
+    }
+}
+
+function normalizeScope(scope) {
+    if (Array.isArray(scope)) {
+        const joinedScope = scope.join(" ");
+        return joinedScope.length > 0 ? joinedScope : undefined;
+    }
+
+    if (typeof scope === "string" && scope.length > 0) {
+        return scope;
+    }
+
+    return undefined;
+}
+
+/**
+ * Builds an RFC 6749 authorization-code request URL with RFC 7636 PKCE parameters.
+ *
+ * @param {{
+ *     authorizationEndpoint: string;
+ *     clientId: string;
+ *     redirectUri: string;
+ *     state: string;
+ *     codeChallenge: string;
+ *     scope?: string | readonly string[];
+ *     codeChallengeMethod?: "S256" | "plain";
+ *     extraParams?: Record<string, string>;
+ * }} request
+ * @returns {string}
+ */
+export function buildAuthorizationUrl(request) {
+    const {
+        authorizationEndpoint,
+        clientId,
+        redirectUri,
+        state,
+        codeChallenge,
+        scope,
+        codeChallengeMethod = "S256",
+        extraParams,
+    } = request;
+
+    const url = parseAuthorizationEndpoint(authorizationEndpoint);
+    validateNonEmptyString("clientId", clientId);
+    validateNonEmptyString("redirectUri", redirectUri);
+    validateNonEmptyString("state", state);
+    validateNonEmptyString("codeChallenge", codeChallenge);
+
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", redirectUri);
+    url.searchParams.set("state", state);
+    url.searchParams.set("code_challenge", codeChallenge);
+    url.searchParams.set("code_challenge_method", codeChallengeMethod);
+
+    const normalizedScope = normalizeScope(scope);
+    if (normalizedScope !== undefined) {
+        url.searchParams.set("scope", normalizedScope);
+    }
+
+    if (extraParams !== undefined) {
+        for (const [key, value] of Object.entries(extraParams)) {
+            url.searchParams.set(key, value);
+        }
+    }
+
+    return url.toString();
+}

--- a/packages/accounts/src/index.js
+++ b/packages/accounts/src/index.js
@@ -16,4 +16,5 @@ export { getAccount } from "./getAccount.js";
 export { addAccount } from "./addAccount.js";
 export { removeAccount } from "./removeAccount.js";
 export { accountToProviderEnv } from "./accountToProviderEnv.js";
+export { buildAuthorizationUrl } from "./buildAuthorizationUrl.js";
 export { createCodeVerifier, deriveCodeChallenge, createPkcePair } from "./pkce.js";

--- a/packages/accounts/src/withAccountsLock.js
+++ b/packages/accounts/src/withAccountsLock.js
@@ -1,4 +1,4 @@
-import { closeSync, mkdirSync, openSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, fstatSync, mkdirSync, openSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { accountsFilePath } from "./accountsFilePath.js";
 
@@ -6,6 +6,8 @@ import { accountsFilePath } from "./accountsFilePath.js";
 const LOCK_TIMEOUT_MS = 10_000;
 // Lock-file age past which the holder is presumed crashed and the lock is broken.
 const STALE_LOCK_MS = 30_000;
+// Disambiguates concurrent in-process stale-break attempts' side-path names.
+let breakSeq = 0;
 
 /**
  * Cross-process advisory lock around accounts.json read-modify-write. Smithers
@@ -31,10 +33,12 @@ export function withAccountsLock(env, critical) {
     mkdirSync(dirname(lockPath), { recursive: true });
     const deadline = Date.now() + LOCK_TIMEOUT_MS;
     let fd = -1;
+    let ownedIno = -1;
     for (;;) {
         try {
             // wx === O_CREAT | O_EXCL | O_WRONLY: atomic create-or-fail.
             fd = openSync(lockPath, "wx", 0o600);
+            ownedIno = fstatSync(fd).ino;
             break;
         } catch (cause) {
             if (cause?.code !== "EEXIST") throw cause;
@@ -44,16 +48,53 @@ export function withAccountsLock(env, critical) {
                 );
             }
             // A lock older than STALE_LOCK_MS is orphaned (the holder almost
-            // certainly crashed): break it and retry immediately.
+            // certainly crashed): break it and retry immediately. statSync and
+            // rmSync are not atomic with respect to other waiters, so we
+            // cannot just rmSync(lockPath) here — between our stat and our
+            // remove, another waiter may have already broken this same lock
+            // and a new holder may have created a brand-new one at the same
+            // path, and we must never delete *that*. Instead, rename the
+            // directory entry aside (rename is atomic: only one waiter can
+            // ever win the rename of a given path — a loser gets ENOENT and
+            // retries) and only delete the renamed-aside file once its inode
+            // proves it is the exact file we observed as stale.
+            let lockStat;
             try {
-                const lockStat = statSync(lockPath);
-                if (Date.now() - lockStat.mtimeMs > STALE_LOCK_MS) {
-                    rmSync(lockPath, { force: true });
-                    continue;
-                }
+                lockStat = statSync(lockPath);
             } catch {
                 // Lock vanished between EEXIST and stat: the holder released it. Retry.
                 continue;
+            }
+            if (Date.now() - lockStat.mtimeMs > STALE_LOCK_MS) {
+                const observedIno = lockStat.ino;
+                const sidePath = `${lockPath}.stale.${process.pid}.${breakSeq++}`;
+                try {
+                    renameSync(lockPath, sidePath);
+                } catch (renameCause) {
+                    // Someone else already broke or released this lock. Retry.
+                    if (renameCause?.code === "ENOENT") continue;
+                    throw renameCause;
+                }
+                let sideIno;
+                try {
+                    sideIno = statSync(sidePath).ino;
+                } catch {
+                    continue;
+                }
+                if (sideIno === observedIno) {
+                    // Confirmed: this is the exact file we observed as stale.
+                    rmSync(sidePath, { force: true });
+                    continue;
+                }
+                // We moved a lock created *after* our stat — a fresh lock a
+                // successor acquired in the gap. Restore it instead of
+                // destroying a live holder's lock, then fall through to
+                // respect it via the busy-wait spin below.
+                try {
+                    renameSync(sidePath, lockPath);
+                } catch {
+                    try { rmSync(sidePath, { force: true }); } catch {}
+                }
             }
             // Busy-wait a few milliseconds before retrying. This API is fully
             // synchronous, so the critical section never yields the event loop —
@@ -69,6 +110,14 @@ export function withAccountsLock(env, critical) {
         return critical();
     } finally {
         try { closeSync(fd); } catch {}
-        try { rmSync(lockPath, { force: true }); } catch {}
+        // Only remove the lock file if it is still the exact file we created:
+        // if it was (mistakenly) broken while we were inside the critical
+        // section, a successor may already hold a fresh lock at this path,
+        // and deleting it would admit a second concurrent holder.
+        try {
+            if (ownedIno >= 0 && statSync(lockPath).ino === ownedIno) {
+                rmSync(lockPath, { force: true });
+            }
+        } catch {}
     }
 }

--- a/packages/accounts/tests/accounts.test.js
+++ b/packages/accounts/tests/accounts.test.js
@@ -606,6 +606,68 @@ describe("withAccountsLock in-process contention (EEXIST retry paths)", () => {
         }
     });
 
+    test("does not delete a fresh lock that replaced the stale one it observed (no double holder)", () => {
+        const env = newSmithersHome();
+        const lockPath = lockPathFor(env);
+        const freshContent = "222\nsuccessor\n";
+        // A leftover lock from a crashed holder, aged past STALE_LOCK_MS (30s).
+        writeFileSync(lockPath, "111\n0\n", { mode: 0o600 });
+        const stale = new Date(Date.now() - 60_000);
+        utimesSync(lockPath, stale, stale);
+
+        const realNow = Date.now;
+        const base = realNow();
+        let n = 0;
+        Date.now = () => {
+            n += 1;
+            if (n === 1) return base; // deadline = base + LOCK_TIMEOUT_MS
+            if (n === 2) return base; // EEXIST deadline check -> not timed out
+            if (n === 3) {
+                // Simulate the reported interleave: a concurrent waiter (A)
+                // breaks the same stale lock we just observed and a
+                // concurrent holder (B) acquires a brand-new lock, both in
+                // the gap between our statSync and our staleness verdict.
+                rmSync(lockPath, { force: true });
+                writeFileSync(lockPath, freshContent, { mode: 0o600 });
+                return base; // stale check: base - (base-60000) > 30000 -> true
+            }
+            if (n === 4) return base; // spinUntil = base + 5
+            // n>=5: exit the spin immediately, then time out on the very
+            // next deadline check instead of admitting a second holder.
+            return base + 10_000;
+        };
+        let ran = false;
+        try {
+            expect(() => withAccountsLock(env, () => { ran = true; }))
+                .toThrow(/Timed out acquiring accounts lock/);
+        } finally {
+            Date.now = realNow;
+        }
+        // The fresh lock B acquired must never be admitted a second holder,
+        // and must survive untouched.
+        expect(ran).toBe(false);
+        expect(existsSync(lockPath)).toBe(true);
+        expect(readFileSync(lockPath, "utf8")).toBe(freshContent);
+    });
+
+    test("release does not delete a successor lock after its own lock was broken mid-critical-section", () => {
+        const env = newSmithersHome();
+        const lockPath = lockPathFor(env);
+        const successorContent = "333\nsuccessor\n";
+
+        withAccountsLock(env, () => {
+            // Simulate a concurrent waiter mistakenly judging our still-held
+            // lock stale, breaking it, and a successor acquiring a brand-new
+            // lock — all while we are still inside our own critical section.
+            rmSync(lockPath, { force: true });
+            writeFileSync(lockPath, successorContent, { mode: 0o600 });
+        });
+
+        // Our release must not clobber the successor's fresh lock.
+        expect(existsSync(lockPath)).toBe(true);
+        expect(readFileSync(lockPath, "utf8")).toBe(successorContent);
+    });
+
     test("rethrows a non-EEXIST openSync error (permission denied)", () => {
         if (process.platform === "win32") return;
         // Root bypasses filesystem permission bits, so EACCES won't fire there.

--- a/packages/accounts/tests/buildAuthorizationUrl.test.js
+++ b/packages/accounts/tests/buildAuthorizationUrl.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { buildAuthorizationUrl, createPkcePair } from "../src/index.js";
+
+const BASE_REQUEST = {
+    authorizationEndpoint: "https://provider.example/oauth/authorize",
+    clientId: "smithers-client",
+    redirectUri: "https://app.example/oauth/callback",
+    state: "state-123",
+    codeChallenge: "challenge-123",
+};
+
+describe("buildAuthorizationUrl", () => {
+    test("builds an authorization-code URL with PKCE parameters", () => {
+        const url = new URL(buildAuthorizationUrl(BASE_REQUEST));
+
+        expect(url.origin).toBe("https://provider.example");
+        expect(url.pathname).toBe("/oauth/authorize");
+        expect(url.searchParams.get("response_type")).toBe("code");
+        expect(url.searchParams.get("client_id")).toBe(BASE_REQUEST.clientId);
+        expect(url.searchParams.get("redirect_uri")).toBe(BASE_REQUEST.redirectUri);
+        expect(url.searchParams.get("state")).toBe(BASE_REQUEST.state);
+        expect(url.searchParams.get("code_challenge")).toBe(BASE_REQUEST.codeChallenge);
+        expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    });
+
+    test("space-joins array scopes into one scope parameter", () => {
+        const url = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            scope: ["openid", "profile", "email"],
+        }));
+
+        expect(url.searchParams.get("scope")).toBe("openid profile email");
+    });
+
+    test("uses string scopes verbatim", () => {
+        const url = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            scope: "openid profile offline_access",
+        }));
+
+        expect(url.searchParams.get("scope")).toBe("openid profile offline_access");
+    });
+
+    test("omits scope when it is absent or empty", () => {
+        const withoutScope = new URL(buildAuthorizationUrl(BASE_REQUEST));
+        const withEmptyString = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            scope: "",
+        }));
+        const withEmptyArray = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            scope: [],
+        }));
+
+        expect(withoutScope.searchParams.has("scope")).toBe(false);
+        expect(withEmptyString.searchParams.has("scope")).toBe(false);
+        expect(withEmptyArray.searchParams.has("scope")).toBe(false);
+    });
+
+    test("defaults codeChallengeMethod to S256 and honors explicit plain", () => {
+        const defaultUrl = new URL(buildAuthorizationUrl(BASE_REQUEST));
+        const plainUrl = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            codeChallengeMethod: "plain",
+        }));
+
+        expect(defaultUrl.searchParams.get("code_challenge_method")).toBe("S256");
+        expect(plainUrl.searchParams.get("code_challenge_method")).toBe("plain");
+    });
+
+    test("preserves endpoint query params and applies extra params last", () => {
+        const url = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            authorizationEndpoint: "https://login.example/tenant/authorize?tenant=acme&prompt=consent",
+            extraParams: {
+                audience: "https://api.example",
+                client_id: "tenant-client",
+                response_type: "custom-code",
+            },
+        }));
+
+        expect(url.searchParams.get("tenant")).toBe("acme");
+        expect(url.searchParams.get("prompt")).toBe("consent");
+        expect(url.searchParams.get("audience")).toBe("https://api.example");
+        expect(url.searchParams.get("client_id")).toBe("tenant-client");
+        expect(url.searchParams.get("response_type")).toBe("custom-code");
+        expect(url.searchParams.get("redirect_uri")).toBe(BASE_REQUEST.redirectUri);
+    });
+
+    test("uses createPkcePair codeChallenge as the code_challenge parameter", () => {
+        const pair = createPkcePair();
+        const url = new URL(buildAuthorizationUrl({
+            ...BASE_REQUEST,
+            codeChallenge: pair.codeChallenge,
+        }));
+
+        expect(url.searchParams.get("code_challenge")).toBe(pair.codeChallenge);
+    });
+
+    test("throws TypeError for non-absolute or non-http authorization endpoints", () => {
+        for (const authorizationEndpoint of [
+            "/oauth/authorize",
+            "provider.example/oauth/authorize",
+            "ftp://provider.example/oauth/authorize",
+            "mailto:admin@example.com",
+        ]) {
+            expect(() => buildAuthorizationUrl({
+                ...BASE_REQUEST,
+                authorizationEndpoint,
+            })).toThrow(TypeError);
+        }
+    });
+
+    test("throws TypeError for empty required string fields", () => {
+        for (const field of ["clientId", "redirectUri", "state", "codeChallenge"]) {
+            expect(() => buildAuthorizationUrl({
+                ...BASE_REQUEST,
+                [field]: "",
+            })).toThrow(TypeError);
+        }
+    });
+});

--- a/packages/electric-proxy/bin/smithers-electric-proxy.js
+++ b/packages/electric-proxy/bin/smithers-electric-proxy.js
@@ -12,6 +12,7 @@
  *   node bin/smithers-electric-proxy.js
  */
 import { createSmithersElectricProxy } from "../src/createSmithersElectricProxy.js";
+import { deriveGrantsFromGateway } from "../src/deriveGrantsFromGateway.js";
 import { serveSmithersElectricProxy } from "../src/serveSmithersElectricProxy.js";
 
 /**
@@ -24,33 +25,6 @@ function requireEnv(name) {
     throw new Error(`${name} is required`);
   }
   return value;
-}
-
-/**
- * @param {string} gatewayUrl
- * @param {string} authorization
- * @returns {Promise<import("../src/SmithersElectricProxyOptions.ts").SmithersElectricAuthContext | null>}
- */
-async function deriveGrantsFromGateway(gatewayUrl, authorization) {
-  // listRuns returns exactly the runs the token is authorized to read, so its
-  // result is the authoritative grant set. A 401/403 means no access.
-  const response = await fetch(`${gatewayUrl.replace(/\/+$/, "")}/v1/rpc/listRuns`, {
-    method: "POST",
-    headers: { "content-type": "application/json", authorization },
-    body: JSON.stringify({}),
-  }).catch(() => null);
-  if (!response || !response.ok) return null;
-  const body = /** @type {{ payload?: unknown } | null} */ (await response.json().catch(() => null));
-  const payload = body?.payload;
-  const rows = Array.isArray(payload) ? payload : [];
-  const grantedRunIds = rows
-    .map((row) => (row && typeof row === "object" ? (/** @type {{ runId?: unknown }} */ (row)).runId : undefined))
-    .filter((id) => typeof id === "string");
-  return {
-    principalId: authorization.slice(-12),
-    scopes: ["run:read"],
-    grantedRunIds,
-  };
 }
 
 /**

--- a/packages/electric-proxy/src/deriveGrantsFromGateway.js
+++ b/packages/electric-proxy/src/deriveGrantsFromGateway.js
@@ -1,0 +1,44 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Derives an opaque, stable-per-token principal id. It must stay stable per
+ * token (it also doubles as the rate-limiter key), but must never contain
+ * token substrings — it is embedded verbatim in scope-decision logs and every
+ * emitted proxy event, which feed the observability/OTLP path.
+ *
+ * @param {string} authorization
+ * @returns {string}
+ */
+function derivePrincipalId(authorization) {
+  const salt = process.env.SMITHERS_ELECTRIC_PRINCIPAL_SALT ?? "";
+  const hash = createHash("sha256").update(salt + authorization).digest("hex");
+  return `tok_${hash.slice(0, 16)}`;
+}
+
+/**
+ * @param {string} gatewayUrl
+ * @param {string} authorization
+ * @param {typeof fetch} [fetchClient]
+ * @returns {Promise<import("./SmithersElectricProxyOptions.ts").SmithersElectricAuthContext | null>}
+ */
+export async function deriveGrantsFromGateway(gatewayUrl, authorization, fetchClient = fetch) {
+  // listRuns returns exactly the runs the token is authorized to read, so its
+  // result is the authoritative grant set. A 401/403 means no access.
+  const response = await fetchClient(`${gatewayUrl.replace(/\/+$/, "")}/v1/rpc/listRuns`, {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization },
+    body: JSON.stringify({}),
+  }).catch(() => null);
+  if (!response || !response.ok) return null;
+  const body = /** @type {{ payload?: unknown } | null} */ (await response.json().catch(() => null));
+  const payload = body?.payload;
+  const rows = Array.isArray(payload) ? payload : [];
+  const grantedRunIds = rows
+    .map((row) => (row && typeof row === "object" ? (/** @type {{ runId?: unknown }} */ (row)).runId : undefined))
+    .filter((id) => typeof id === "string");
+  return {
+    principalId: derivePrincipalId(authorization),
+    scopes: ["run:read"],
+    grantedRunIds,
+  };
+}

--- a/packages/electric-proxy/tests/deriveGrantsFromGateway.test.ts
+++ b/packages/electric-proxy/tests/deriveGrantsFromGateway.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { deriveGrantsFromGateway } from "../src/deriveGrantsFromGateway.js";
+
+function fakeFetch(status: number, payload?: unknown): typeof fetch {
+  return (async () =>
+    new Response(status === 200 ? JSON.stringify({ payload }) : "", { status })) as unknown as typeof fetch;
+}
+
+describe("deriveGrantsFromGateway", () => {
+  test("does not leak token material into principalId", async () => {
+    const authorization = "Bearer super-secret-token-abcdef123456";
+    const result = await deriveGrantsFromGateway(
+      "http://gateway.local",
+      authorization,
+      fakeFetch(200, [{ runId: "run-1" }, { runId: "run-2" }]),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.principalId).not.toBe(authorization.slice(-12));
+    expect(result?.principalId).not.toContain(authorization);
+    expect(result?.principalId).not.toContain("super-secret-token");
+  });
+
+  test("principalId is opaque, stable, and distinct per token", async () => {
+    const fetchClient = fakeFetch(200, [{ runId: "run-1" }, { runId: "run-2" }]);
+
+    const first = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-a", fetchClient);
+    const second = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-a", fetchClient);
+    const different = await deriveGrantsFromGateway("http://gateway.local", "Bearer token-b", fetchClient);
+
+    expect(first?.principalId).toMatch(/^tok_[0-9a-f]{16}$/);
+    expect(first?.principalId).toBe(second?.principalId ?? "");
+    expect(first?.principalId).not.toBe(different?.principalId);
+    expect(first?.grantedRunIds).toEqual(["run-1", "run-2"]);
+    expect(first?.scopes).toEqual(["run:read"]);
+  });
+
+  test("returns null on denied/failed auth", async () => {
+    const denied = await deriveGrantsFromGateway("http://gateway.local", "Bearer token", fakeFetch(403));
+    expect(denied).toBeNull();
+
+    const throwingFetch = (async () => {
+      throw new Error("down");
+    }) as unknown as typeof fetch;
+    const failed = await deriveGrantsFromGateway("http://gateway.local", "Bearer token", throwingFetch);
+    expect(failed).toBeNull();
+  });
+});

--- a/packages/gateway-ui/src/ApprovalPanel.tsx
+++ b/packages/gateway-ui/src/ApprovalPanel.tsx
@@ -8,6 +8,8 @@ export type ApprovalPanelProps = {
   filter?: { workflow?: string; runId?: string; limit?: number };
   /** Poll interval (ms) to refresh the pending list. 0 disables. Default 2000. */
   pollMs?: number;
+  /** Called if the submitApproval RPC throws. */
+  onError?: (error: Error) => void;
   className?: string;
   style?: CSSProperties;
 };
@@ -32,10 +34,11 @@ function approvalKey(row: ApprovalRow): string {
  * {@link useGatewayActions}. Drop it in to make a workflow's human gates
  * actionable from your UI.
  */
-export function ApprovalPanel({ filter, pollMs = 2000, className, style }: ApprovalPanelProps) {
+export function ApprovalPanel({ filter, pollMs = 2000, onError, className, style }: ApprovalPanelProps) {
   const { data, loading, error, refetch } = useGatewayApprovals(filter ? { filter } : undefined);
   const actions = useGatewayActions();
   const [busy, setBusy] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<{ key: string; message: string } | null>(null);
   const approvals = (data ?? []) as ApprovalRow[];
 
   // listApprovals is pull-only on the local gateway path, so poll to stay live.
@@ -46,6 +49,7 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
   }, [refetch, pollMs]);
 
   const decide = async (row: ApprovalRow, approved: boolean) => {
+    setSubmitError(null);
     setBusy(approvalKey(row));
     try {
       await actions.submitApproval({
@@ -55,6 +59,10 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
         decision: { approved },
       });
       refetch?.();
+    } catch (cause) {
+      const err = cause instanceof Error ? cause : new Error(String(cause));
+      setSubmitError({ key: approvalKey(row), message: err.message });
+      onError?.(err);
     } finally {
       setBusy(null);
     }
@@ -119,6 +127,9 @@ export function ApprovalPanel({ filter, pollMs = 2000, className, style }: Appro
                 Deny
               </button>
             </div>
+            {submitError?.key === key ? (
+              <div style={{ color: theme.danger, fontSize: 13 }}>{submitError.message}</div>
+            ) : null}
           </div>
         );
       })}

--- a/packages/gateway-ui/tests/hookComponents.test.tsx
+++ b/packages/gateway-ui/tests/hookComponents.test.tsx
@@ -493,6 +493,45 @@ describe("ApprovalPanel", () => {
     await harness.flush(40);
     expect(harness.container.textContent).toContain("No approvals waiting.");
   });
+
+  test("surfaces the submitApproval failure and re-enables the buttons", async () => {
+    const gw = boot({
+      approvals: [{ runId: "run-c", nodeId: "gate", iteration: 0 }],
+      failApprovalSubmit: true,
+    });
+    const harness = await mount(gw, createElement(ApprovalPanel, { pollMs: 0 }));
+    await harness.flush(50);
+    const approveButtons = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    click(approveButtons[0]);
+    await harness.flush(60);
+    expect(harness.container.textContent).toMatch(/Forced failure|failed|error/i);
+    const stillApprove = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    expect((stillApprove[0] as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test("calls onError when submitApproval rejects", async () => {
+    const gw = boot({
+      approvals: [{ runId: "run-c", nodeId: "gate", iteration: 0 }],
+      failApprovalSubmit: true,
+    });
+    const errors: Error[] = [];
+    const harness = await mount(
+      gw,
+      createElement(ApprovalPanel, { pollMs: 0, onError: (e: Error) => errors.push(e) }),
+    );
+    await harness.flush(50);
+    const approveButtons = [...harness.container.querySelectorAll("button")].filter(
+      (b) => b.textContent === "Approve",
+    );
+    click(approveButtons[0]);
+    await harness.flush(60);
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+  });
 });
 
 describe("RunEventLog", () => {

--- a/packages/gateway-ui/tests/inMemoryGateway.ts
+++ b/packages/gateway-ui/tests/inMemoryGateway.ts
@@ -22,6 +22,8 @@ export type SeedState = {
   failPaths?: Set<string>;
   /** When set, the SSE stream endpoint answers with this HTTP status. */
   streamStatus?: number;
+  /** When true, POST /v1/api/approvals/:id (submitApproval) always fails. */
+  failApprovalSubmit?: boolean;
 };
 
 export type InMemoryGateway = {
@@ -54,6 +56,7 @@ export function startInMemoryGateway(seed: SeedState = {}): InMemoryGateway {
     outputs: seed.outputs ?? {},
     failPaths: seed.failPaths ?? new Set<string>(),
     streamStatus: seed.streamStatus ?? 200,
+    failApprovalSubmit: seed.failApprovalSubmit ?? false,
   };
 
   const controllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
@@ -151,6 +154,9 @@ export function startInMemoryGateway(seed: SeedState = {}): InMemoryGateway {
       }
       // POST /v1/api/approvals/:id (submitApproval)
       if (path.startsWith("/v1/api/approvals/") && request.method === "POST") {
+        if (state.failApprovalSubmit) {
+          return fail(500, "BOOM", "Forced failure for approval submit");
+        }
         const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
         gateway.approvalsSubmitted.push(body);
         state.approvals = state.approvals.filter(

--- a/packages/sandbox/src/execute.js
+++ b/packages/sandbox/src/execute.js
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Effect, Metric } from "effect";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
@@ -175,6 +175,22 @@ function diffBundlePatchCount(value) {
     return patches.length;
 }
 /**
+ * @param {string} diff
+ * @returns {number}
+ */
+function unifiedDiffLineCount(diff) {
+    let count = 0;
+    for (const line of diff.split("\n")) {
+        if (line.startsWith("+++") || line.startsWith("---")) {
+            continue;
+        }
+        if (line.startsWith("+") || line.startsWith("-")) {
+            count += 1;
+        }
+    }
+    return count;
+}
+/**
  * @param {unknown} status
  * @returns {status is "finished" | "failed" | "cancelled"}
  */
@@ -268,6 +284,26 @@ function isDiffBundleLike(bundle) {
         typeof source.seq === "number" &&
         typeof source.baseRef === "string" &&
         Array.isArray(source.patches));
+}
+/**
+ * @param {import("./ValidatedSandboxBundle.ts").ValidatedSandboxBundle} validated
+ * @returns {Promise<number>}
+ */
+async function sandboxDiffLineCount(validated) {
+    let total = 0;
+    for (const patchPath of validated.patchFiles) {
+        const content = await readFile(resolveSandboxPath(validated.bundlePath, patchPath), "utf8").catch(() => "");
+        total += unifiedDiffLineCount(content);
+    }
+    const diffBundle = validated.manifest.diffBundle;
+    if (isDiffBundleLike(diffBundle)) {
+        for (const patch of diffBundle.patches) {
+            if (typeof patch?.diff === "string") {
+                total += unifiedDiffLineCount(patch.diff);
+            }
+        }
+    }
+    return total;
 }
 /**
  * @param {import("./ValidatedSandboxBundle.ts").ValidatedSandboxBundle} validated
@@ -382,12 +418,13 @@ async function finalizeSandboxBundle(params) {
     });
     const reviewDiffs = options.reviewDiffs ?? true;
     if (reviewDiffs && totalPatchCount > 0) {
+        const totalDiffLines = await sandboxDiffLineCount(validated);
         await emitSandboxEvent(runtimeDb, {
             type: "SandboxDiffReviewRequested",
             runId: runtime.runId,
             sandboxId: options.sandboxId,
             patchCount: totalPatchCount,
-            totalDiffLines: 0,
+            totalDiffLines,
             timestampMs: nowMs(),
         });
         if (!options.autoAcceptDiffs) {

--- a/packages/sandbox/tests/execute.test.js
+++ b/packages/sandbox/tests/execute.test.js
@@ -1152,4 +1152,50 @@ describe("executeSandbox", () => {
             sqlite.close();
         }
     });
+
+    test("records real totalDiffLines for reviewed sandbox diffs", async () => {
+        const { adapter, db, sqlite } = createDb();
+        const rootDir = tempDir("smithers-sandbox-execute-");
+        const runtime = createRuntime(db, { runId: "run-diff-lines" });
+        try {
+            await withCodeplaneEnv(() =>
+                runInRuntime(runtime, {
+                    sandboxId: "sandbox-diff-lines",
+                    rootDir,
+                    reviewDiffs: true,
+                    autoAcceptDiffs: true,
+                    executeChildWorkflow: async () => {
+                        const patchDir = join(resultPath(rootDir, "run-diff-lines", "sandbox-diff-lines"), "patches");
+                        mkdirSync(patchDir, { recursive: true });
+                        // 2 churn lines (-old / +new)
+                        writeFileSync(
+                            join(patchDir, "0001-change.patch"),
+                            "diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+                            "utf8",
+                        );
+                        // 2 churn lines (two added lines)
+                        writeFileSync(
+                            join(patchDir, "0002-add.patch"),
+                            "diff --git a/other.txt b/other.txt\n--- a/other.txt\n+++ b/other.txt\n@@ -0,0 +1,2 @@\n+line one\n+line two\n",
+                            "utf8",
+                        );
+                        return {
+                            runId: "child-diff-lines",
+                            status: "finished",
+                            output: { changed: true },
+                        };
+                    },
+                }),
+            );
+
+            const events = await adapter.listEvents("run-diff-lines", -1);
+            const reviewRequested = events.find((row) => row.type === "SandboxDiffReviewRequested");
+            const payload = JSON.parse(String(reviewRequested?.payloadJson));
+            expect(payload.patchCount).toBe(2);
+            expect(payload.totalDiffLines).toBe(4);
+        }
+        finally {
+            sqlite.close();
+        }
+    });
 });

--- a/packages/scheduler/src/findDescriptor.js
+++ b/packages/scheduler/src/findDescriptor.js
@@ -1,0 +1,20 @@
+/** @typedef {import("@smithers-orchestrator/graph").TaskDescriptor} TaskDescriptor */
+
+/**
+ * `state.descriptors` holds exactly one entry per nodeId — the CURRENT
+ * iteration — keyed by nodeId. There is no per-iteration history here, so
+ * this is a keyed lookup only: a stale-iteration lookup intentionally
+ * returns undefined. Callers that need a prior failed iteration's
+ * descriptor use the separate `failureDescriptors` map instead.
+ *
+ * @param {Map<string, TaskDescriptor>} descriptors
+ * @param {string} nodeId
+ * @param {number} [iteration]
+ * @returns {TaskDescriptor | undefined}
+ */
+export function findDescriptor(descriptors, nodeId, iteration) {
+    const descriptor = descriptors.get(nodeId);
+    return descriptor && (iteration == null || descriptor.iteration === iteration)
+        ? descriptor
+        : undefined;
+}

--- a/packages/scheduler/src/makeWorkflowSession.js
+++ b/packages/scheduler/src/makeWorkflowSession.js
@@ -5,6 +5,7 @@ import { buildPlanTree } from "./buildPlanTree.js";
 import { buildStateKey } from "./buildStateKey.js";
 import { cloneTaskStateMap } from "./cloneTaskStateMap.js";
 import { computeRetryDelayMs } from "./computeRetryDelayMs.js";
+import { findDescriptor } from "./findDescriptor.js";
 import { parseStateKey } from "./parseStateKey.js";
 import { scheduleTasks } from "./scheduleTasks.js";
 /** @typedef {import("@smithers-orchestrator/graph").TaskDescriptor} TaskDescriptor */
@@ -41,20 +42,6 @@ function descriptorMap(tasks) {
         map.set(task.nodeId, task);
     }
     return map;
-}
-/**
- * @param {SessionState} state
- * @param {string} nodeId
- * @param {number} [iteration]
- * @returns {TaskDescriptor | undefined}
- */
-function findDescriptor(state, nodeId, iteration) {
-    const descriptor = state.descriptors.get(nodeId);
-    if (descriptor && (iteration == null || descriptor.iteration === iteration)) {
-        return descriptor;
-    }
-    return [...state.descriptors.values()].find((candidate) => candidate.nodeId === nodeId &&
-        (iteration == null || candidate.iteration === iteration));
 }
 /**
  * @param {{ readonly nodeId: string; readonly iteration: number }} descriptor
@@ -623,7 +610,7 @@ export function makeWorkflowSession(options = {}) {
     function unhandledFailureDecision(recoveryKeys = new Set()) {
         for (const [key, taskState] of state.states) {
             const parsed = parseStateKey(key);
-            const descriptor = findDescriptor(state, parsed.nodeId, parsed.iteration) ??
+            const descriptor = findDescriptor(state.descriptors, parsed.nodeId, parsed.iteration) ??
                 state.failureDescriptors.get(key);
             if (taskState === "failed" && !descriptor?.continueOnFail) {
                 if (recoveryKeys.has(key)) {
@@ -941,7 +928,7 @@ export function makeWorkflowSession(options = {}) {
             });
         }),
         taskFailed: (failure) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, failure.nodeId, failure.iteration);
+            const descriptor = findDescriptor(state.descriptors, failure.nodeId, failure.iteration);
             if (!descriptor) {
                 // Stale failure for a task that already left the graph (see taskCompleted) —
                 // the task is gone, so its failure is moot. Re-decide on the current graph
@@ -951,7 +938,7 @@ export function makeWorkflowSession(options = {}) {
             return applyFailure(descriptor, failure.error);
         }),
         approvalResolved: (nodeId, resolution) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown approval task ${nodeId}`), "approvalResolved");
             }
@@ -959,7 +946,7 @@ export function makeWorkflowSession(options = {}) {
             return decide();
         }),
         approvalTimedOut: (nodeId) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown approval task ${nodeId}`), "approvalTimedOut");
             }
@@ -985,7 +972,7 @@ export function makeWorkflowSession(options = {}) {
             return decide();
         }),
         timerFired: (nodeId, firedAtMs = nowMs()) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId);
+            const descriptor = findDescriptor(state.descriptors, nodeId);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown timer task ${nodeId}`), "timerFired");
             }
@@ -1015,7 +1002,7 @@ export function makeWorkflowSession(options = {}) {
             }
         }),
         heartbeatTimedOut: (nodeId, iteration, details = {}) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId, iteration);
+            const descriptor = findDescriptor(state.descriptors, nodeId, iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown task ${nodeId}`), "heartbeatTimedOut");
             }
@@ -1027,7 +1014,7 @@ export function makeWorkflowSession(options = {}) {
             }));
         }),
         cacheResolved: (output, _cached) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, output.nodeId, output.iteration);
+            const descriptor = findDescriptor(state.descriptors, output.nodeId, output.iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown cached task ${output.nodeId}`), "cacheResolved");
             }
@@ -1042,7 +1029,7 @@ export function makeWorkflowSession(options = {}) {
             });
         }),
         cacheMissed: (nodeId, iteration) => Effect.sync(() => {
-            const descriptor = findDescriptor(state, nodeId, iteration);
+            const descriptor = findDescriptor(state.descriptors, nodeId, iteration);
             if (!descriptor) {
                 return failedDecision(new SmithersError("NODE_NOT_FOUND", `Unknown cached task ${nodeId}`), "cacheMissed");
             }

--- a/packages/scheduler/tests/findDescriptor.test.js
+++ b/packages/scheduler/tests/findDescriptor.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { findDescriptor } from "../src/findDescriptor.js";
+
+describe("findDescriptor", () => {
+  test("is a keyed lookup, never a linear scan (issue #546)", () => {
+    const descriptors = new Map([
+      ["someOtherKey", { nodeId: "real", iteration: 0 }],
+    ]);
+    expect(findDescriptor(descriptors, "real")).toBeUndefined();
+  });
+
+  test("returns the entry stored under its nodeId", () => {
+    const d = { nodeId: "a", iteration: 0 };
+    const descriptors = new Map([["a", d]]);
+    expect(findDescriptor(descriptors, "a")).toBe(d);
+    expect(findDescriptor(descriptors, "a", 0)).toBe(d);
+  });
+
+  test("stale/mismatched iteration returns undefined", () => {
+    const d = { nodeId: "a", iteration: 3 };
+    const descriptors = new Map([["a", d]]);
+    expect(findDescriptor(descriptors, "a", 2)).toBeUndefined();
+  });
+});

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -9457,7 +9457,7 @@ tokens, never hex-plus-alpha.
 | `RunTree` | The node tree for a run (initial snapshot plus live updates). | `runId`, `onSelectNode`, `activeNodeId` |
 | `RunEventLog` | A scrolling, auto-following event log for a run. | `runId`, `maxEvents`, `follow` |
 | `NodeOutputView` | The output of a single node, fetched on demand. | `runId`, `nodeId`, `iteration` |
-| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs` |
+| `ApprovalPanel` | The pending approval queue with Approve and Deny buttons. | `filter`, `pollMs`, `onError` |
 | `LaunchButton` | A button that launches a workflow run. | `workflow`, `input`, `onLaunched` |
 | `WorkflowPicker` | A select of the workflows registered on the Gateway. | `value`, `onChange`, `hasUiOnly` |
 | `ConnectionBadge` | A live Gateway connection indicator. | none |


### PR DESCRIPTION
Closes #528

## Root cause

`withAccountsLock` (`packages/accounts/src/withAccountsLock.js`) recovers from a stale lock by `statSync`-ing the lock file and, if `mtime` was older than `STALE_LOCK_MS` (30s), unconditionally `rmSync`-ing it. Stat-then-remove is not atomic with respect to other waiters:

1. Lock is stale. Waiters A and C both stat it and see it as stale.
2. A removes it and a successor (B) acquires a brand-new lock via `O_EXCL`.
3. C's `rmSync` (issued after observing the *original* stale lock) now deletes B's fresh lock.
4. A fourth waiter D can now acquire while B is still inside its `accounts.json` read-modify-write critical section.

Two concurrent holders is exactly the lost-update `withAccountsLock` exists to prevent (the second `writeAccounts` rename clobbers the first). The same non-atomicity also let a critical section that legitimately runs past 30s have its still-held lock broken by an impatient waiter.

## Approach

Rename the stale lock aside instead of deleting it in place. A rename on a given path has exactly one winner, so only one waiter can ever claim a given stale lock instance. After renaming, verify the renamed-aside file's inode matches the inode observed at stat time before deleting it:
- **Match** → confirmed the same file that was actually stale; safe to delete.
- **Mismatch** → a successor created a fresh lock in the gap between the stat and the rename; restore it at the original path instead of destroying a live holder's lock, then fall through to the normal busy-wait spin.

The release path applies the same identity check via a captured `ownedIno` (from `fstatSync` at acquisition time), so releasing a lock never clobbers a successor's fresh lock created after this holder's own lock was mistakenly broken mid-critical-section.

Two new regression tests in `packages/accounts/tests/accounts.test.js` pin both halves: the stale-break path must never delete a fresh lock that replaced the one it observed, and the release path must never delete a successor's lock after its own lock was broken mid-critical-section.

Strategy used: **fable-sandwich**.

## Note

This PR will be **restacked** onto a PR train — its base branch may change from `main` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)