### PR TITLE
🐛 fix(sandbox): point sandbox-exec CA at real requestPath, not /workspace

### DIFF
--- a/packages/sandbox/src/effect/process-runner.js
+++ b/packages/sandbox/src/effect/process-runner.js
@@ -3,7 +3,7 @@ import { isAbsolute, join } from "node:path";
 import { spawnCaptureEffect } from "@smithers-orchestrator/driver/child-process";
 import { SmithersError } from "@smithers-orchestrator/errors/SmithersError";
 import { Effect } from "effect";
-import { normalizeSandboxEgressConfig, sandboxEgressEnv } from "../egress.js";
+import { normalizeSandboxEgressConfig, sandboxEgressEnv, SANDBOX_EGRESS_CA_BUNDLE_RELATIVE_PATH } from "../egress.js";
 
 const DEFAULT_SANDBOX_COMMAND_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_SANDBOX_OUTPUT_BYTES = 5 * 1024 * 1024;
@@ -403,6 +403,10 @@ export function sandboxExecArgs(command, handle) {
     const tempPath = join(handle.sandboxRoot, "tmp");
     const sandboxEnv = {
         ...normalizeSandboxEnv(handle.env, { includeDefaultPath: true }),
+        // sandbox-exec has no /workspace remap (unlike docker/bwrap), so the
+        // caCertPem default of /workspace/.smithers/egress/ca.crt dangles;
+        // re-point it at the real on-disk CA under handle.requestPath.
+        ...sandboxEgressEnv(handle.egress, { caCertPath: join(handle.requestPath, SANDBOX_EGRESS_CA_BUNDLE_RELATIVE_PATH) }),
         HOME: tempPath,
         TMPDIR: tempPath,
     };

--- a/packages/sandbox/tests/transport-runners.test.js
+++ b/packages/sandbox/tests/transport-runners.test.js
@@ -297,6 +297,52 @@ describe("sandbox transport runners", () => {
         );
     });
 
+    test("sandbox-exec re-points the caCertPem NODE_EXTRA_CA_CERTS at the real on-disk requestPath CA", () => {
+        const handle = {
+            runtime: "bubblewrap",
+            runId: "run",
+            sandboxId: "sandbox",
+            sandboxRoot: "/tmp/sandbox",
+            requestPath: "/tmp/sandbox/request",
+            resultPath: "/tmp/sandbox/result",
+            allowNetwork: true,
+            egress: {
+                caCertPem: "-----BEGIN CERTIFICATE-----\nproxy-ca\n-----END CERTIFICATE-----\n",
+            },
+            env: {
+                HTTPS_PROXY: "http://127.0.0.1:8080",
+                NODE_EXTRA_CA_CERTS: "/workspace/.smithers/egress/ca.crt",
+            },
+        };
+
+        const args = sandboxExecArgs("npm test", handle);
+        expect(args).toContain("NODE_EXTRA_CA_CERTS=/tmp/sandbox/request/.smithers/egress/ca.crt");
+        expect(args).not.toContain("NODE_EXTRA_CA_CERTS=/workspace/.smithers/egress/ca.crt");
+        expect(args).toContain("HTTPS_PROXY=http://127.0.0.1:8080");
+        expect(args[1]).toContain('(subpath "/tmp/sandbox/request")');
+    });
+
+    test("sandbox-exec preserves a user-supplied caCertPath under egress unchanged", () => {
+        const handle = {
+            runtime: "bubblewrap",
+            runId: "run",
+            sandboxId: "sandbox",
+            sandboxRoot: "/tmp/sandbox",
+            requestPath: "/tmp/sandbox/request",
+            resultPath: "/tmp/sandbox/result",
+            allowNetwork: true,
+            egress: {
+                caCertPath: "/etc/ssl/custom-ca.crt",
+            },
+            env: {
+                NODE_EXTRA_CA_CERTS: "/etc/ssl/custom-ca.crt",
+            },
+        };
+
+        const args = sandboxExecArgs("npm test", handle);
+        expect(args).toContain("NODE_EXTRA_CA_CERTS=/etc/ssl/custom-ca.crt");
+    });
+
     test("sandbox controls fail closed when a runtime cannot enforce them", () => {
         expect(() =>
             dockerArgs("run", {


### PR DESCRIPTION
Closes #527

## Root cause
`sandboxExecArgs()` in `packages/sandbox/src/effect/process-runner.js` built the sandbox-exec profile's `NODE_EXTRA_CA_CERTS` from the default `caCertPem` path, `/workspace/.smithers/egress/ca.crt`. That `/workspace` prefix is a remap that only exists for the docker/bwrap sandbox runtimes (which bind-mount the request dir at `/workspace`); `sandbox-exec` has no such remap, so the path pointed at a directory that never exists inside the profile. `NODE_EXTRA_CA_CERTS` ended up dangling, and any sandboxed process doing TLS through the egress proxy silently failed cert verification instead of trusting the proxy's CA.

## Approach
`sandboxExecArgs()` now re-derives the CA cert path from `handle.requestPath` (the real on-disk sandbox root for this handle) joined with the new `SANDBOX_EGRESS_CA_BUNDLE_RELATIVE_PATH` constant exported from `packages/sandbox/src/egress.js`, and passes it through `sandboxEgressEnv()` so an explicit `egress.caCertPath` override still wins. Added two tests in `packages/sandbox/tests/transport-runners.test.js`: one asserting the CA path is rewritten to the real `requestPath`-relative location (and the old dangling `/workspace/...` value is gone), and one asserting a user-supplied `caCertPath` passes through unchanged.

Strategy used: **fable-sandwich**.

Note: this PR will be RESTACKED onto a PR train — its base branch may change from `main` to another in-flight branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)