### PR TITLE
🐛 fix(gateway-ui): key RunEventLog auto-follow on newest frame seq

### DIFF
--- a/packages/gateway-ui/src/RunEventLog.tsx
+++ b/packages/gateway-ui/src/RunEventLog.tsx
@@ -44,10 +44,11 @@ export function RunEventLog({
 }: RunEventLogProps) {
   const { events, error, streaming } = useGatewayRunEvents(runId, { afterSeq: 0, maxEvents });
   const endRef = useRef<HTMLDivElement | null>(null);
+  const latestSeq = events[events.length - 1]?.seq;
 
   useEffect(() => {
     if (follow) endRef.current?.scrollIntoView({ block: "end" });
-  }, [events.length, follow]);
+  }, [latestSeq, follow]);
 
   return (
     <div

--- a/packages/gateway-ui/tests/hookComponents.test.tsx
+++ b/packages/gateway-ui/tests/hookComponents.test.tsx
@@ -17,7 +17,7 @@ try {
 }
 globalThis.fetch = nativeFetch;
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { act, createElement, type ReactElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { SmithersCollectionsProvider } from "@smithers-orchestrator/gateway-react";
@@ -536,6 +536,41 @@ describe("RunEventLog", () => {
     const harness = await mount(gw, createElement(RunEventLog, { runId: "run-a" }));
     await harness.flush(80);
     expect(harness.container.textContent).toContain("Run event stream failed.");
+  });
+
+  test("keeps following the tail once the event buffer hits maxEvents", async () => {
+    const seed = Array.from({ length: 5 }, (_, i) => ({
+      runId: "run-a",
+      seq: i + 1,
+      event: `node.step-${i + 1}`,
+      payload: { i },
+    }));
+    const gw = boot({ events: { "run-a": seed } });
+    const scrollSpy = spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(() => {});
+    try {
+      const harness = await mount(
+        gw,
+        createElement(RunEventLog, { runId: "run-a", maxEvents: 5, follow: true }),
+      );
+      await harness.flush(60);
+      const callsBeforePush = scrollSpy.mock.calls.length;
+      expect(callsBeforePush).toBeGreaterThan(0);
+
+      gw.pushEvents("run-a", [
+        { runId: "run-a", seq: 6, event: "node.step-6", payload: { i: 5 } },
+        { runId: "run-a", seq: 7, event: "node.step-7", payload: { i: 6 } },
+        { runId: "run-a", seq: 8, event: "node.step-8", payload: { i: 7 } },
+      ]);
+      await harness.flush(60);
+
+      // The buffer stays capped at maxEvents, so events.length never changes,
+      // yet the newest frame keeps replacing the oldest — follow must still fire.
+      expect(harness.container.textContent).toContain("node.step-8");
+      expect(harness.container.textContent).not.toContain("node.step-1");
+      expect(scrollSpy.mock.calls.length).toBeGreaterThan(callsBeforePush);
+    } finally {
+      scrollSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/gateway-ui/tests/inMemoryGateway.ts
+++ b/packages/gateway-ui/tests/inMemoryGateway.ts
@@ -33,6 +33,8 @@ export type InMemoryGateway = {
   };
   launches: Array<{ workflow: string; input: unknown }>;
   approvalsSubmitted: Array<Record<string, unknown>>;
+  /** Append rows to a run's event log after mount and notify SSE subscribers. */
+  pushEvents(runId: string, rows: Array<Record<string, unknown>>): void;
   close(): Promise<void>;
 };
 
@@ -176,6 +178,10 @@ export function startInMemoryGateway(seed: SeedState = {}): InMemoryGateway {
     state,
     launches: [],
     approvalsSubmitted: [],
+    pushEvents(runId, rows) {
+      state.events[runId] = [...(state.events[runId] ?? []), ...rows];
+      broadcast(["events"]);
+    },
     async close() {
       for (const controller of controllers) {
         try {


### PR DESCRIPTION
Closes #548

## Root cause

`RunEventLog`'s auto-follow effect re-scrolled to the tail keyed on
`events.length` (`packages/gateway-ui/src/RunEventLog.tsx`). Once
`useGatewayRunEvents` caps its buffer at `maxEvents`, appending a new
frame drops the oldest one and `events.length` stays constant — so the
effect's dependency never changes, the effect never re-fires, and
auto-follow silently stops scrolling once the log fills up, even though
new events keep arriving.

## Fix

Key the scroll-to-tail effect on the newest frame's `seq`
(`events[events.length - 1]?.seq`) instead of `events.length`. `seq`
strictly increases as new events arrive regardless of whether the
buffer is still growing or already capped, so auto-follow keeps firing
for the life of the run.

## Test

Added `packages/gateway-ui/tests/hookComponents.test.tsx`: "keeps
following the tail once the event buffer hits `maxEvents`" — seeds a
run at the cap, pushes three more frames past it, and asserts
`scrollIntoView` keeps firing and the newest frame renders even though
`events.length` never changes. Extended
`packages/gateway-ui/tests/inMemoryGateway.ts` with a `pushEvents`
helper to append events to a running fixture and broadcast over SSE.

Strategy used: **opus-sandwich**.

## Note

This PR will be **restacked** onto a PR train — its base branch may
change before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)