### PR TITLE
🔧 chore(scripts): drop stale find-db.js entry from db-access ratchet

### DIFF
--- a/scripts/check-no-direct-db-access.mjs
+++ b/scripts/check-no-direct-db-access.mjs
@@ -31,7 +31,6 @@ const allowedDirectDbAccess = new Map([
   ["packages/smithers/src/create.js", 3],
   ["packages/smithers/src/external/create-external-smithers.js", 1],
   ["apps/cli/src/index.js", 1],
-  ["apps/cli/src/find-db.js", 1],
 ]);
 
 /** @param {string} path */

--- a/scripts/check-no-direct-db-access.test.mjs
+++ b/scripts/check-no-direct-db-access.test.mjs
@@ -15,7 +15,6 @@ const expectedBaseline = new Map([
   ["packages/smithers/src/create.js", 3],
   ["packages/smithers/src/external/create-external-smithers.js", 1],
   ["apps/cli/src/index.js", 1],
-  ["apps/cli/src/find-db.js", 1],
 ]);
 
 /** @param {(root: string) => void} fn */


### PR DESCRIPTION
Closes #470

## Root cause

`scripts/check-no-direct-db-access.mjs` (the direct-DB-access ratchet run by
`pnpm test`) and its baseline in `scripts/check-no-direct-db-access.test.mjs`
both listed `apps/cli/src/find-db.js` with an expected count of 1 direct
DB-opening call. A prior commit already removed that file's only
direct-DB-opening function (`openSmithersDb`, which called `new
Database(dbPath)`) — `find-db.js` now only calls the gateway-routed
`openSmithersStore`. The actual direct-DB count in that file is 0, so both
the ratchet script and its test were failing on `main`.

## Approach

Removed the stale `["apps/cli/src/find-db.js", 1]` entry from the
`allowedDirectDbAccess` map in `scripts/check-no-direct-db-access.mjs` and
the matching entry from the `expectedBaseline` map in
`scripts/check-no-direct-db-access.test.mjs`, so the ratchet reflects that
one more call site is fully migrated onto the gateway-owned DB path. No
other entries were touched.

Strategy used: **self-workflow** (smithers `ValidationLoop` implement →
validate → review).

Note: this PR will be **restacked** onto a PR train as part of the broader
#470 effort (gateway should fully encapsulate all DB I/O) — its base branch
may change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)