### PR TITLE
🐛 fix(electric-proxy): propagate client disconnect to upstream Electric stream

### DIFF
--- a/packages/electric-proxy/src/serveSmithersElectricProxy.js
+++ b/packages/electric-proxy/src/serveSmithersElectricProxy.js
@@ -2,9 +2,10 @@ import { createServer } from "node:http";
 
 /**
  * @param {import("node:http").IncomingMessage} req
+ * @param {AbortSignal} [signal]
  * @returns {Request}
  */
-function toFetchRequest(req) {
+function toFetchRequest(req, signal) {
   const headers = new Headers();
   for (const [key, value] of Object.entries(req.headers)) {
     if (value === undefined) continue;
@@ -13,15 +14,16 @@ function toFetchRequest(req) {
   }
   const host = req.headers.host ?? "electric-proxy.local";
   // Shape reads are GET/OPTIONS only; no body is forwarded.
-  return new Request(`http://${host}${req.url ?? "/"}`, { method: req.method ?? "GET", headers });
+  return new Request(`http://${host}${req.url ?? "/"}`, { method: req.method ?? "GET", headers, signal });
 }
 
 /**
+ * @param {import("node:http").IncomingMessage} req
  * @param {import("node:http").ServerResponse} res
  * @param {Response} response
  * @returns {Promise<void>}
  */
-async function writeFetchResponse(res, response) {
+async function writeFetchResponse(req, res, response) {
   /** @type {Record<string, string>} */
   const headers = {};
   response.headers.forEach((value, key) => {
@@ -33,6 +35,15 @@ async function writeFetchResponse(res, response) {
     return;
   }
   const reader = response.body.getReader();
+  // Electric shape streams are long-lived. If the client disconnects mid-stream,
+  // cancelling the reader flows into wrapBody's cancel path (upstream cancel +
+  // active-slot release) instead of draining the upstream body into a dead socket.
+  // `req` (not `res`) emits `close` reliably on premature disconnect across
+  // both Node and Bun's node:http implementation.
+  const onClose = () => {
+    reader.cancel(new Error("client disconnected")).catch(() => undefined);
+  };
+  req.once("close", onClose);
   try {
     for (;;) {
       const { done, value } = await reader.read();
@@ -44,6 +55,8 @@ async function writeFetchResponse(res, response) {
     // Abort the response so the client sees a truncated stream rather than a
     // silently-complete one when Electric forwarding fails mid-stream.
     res.destroy(error instanceof Error ? error : new Error(String(error)));
+  } finally {
+    req.removeListener("close", onClose);
   }
 }
 
@@ -59,9 +72,11 @@ async function writeFetchResponse(res, response) {
 export function serveSmithersElectricProxy(options) {
   const { proxy } = options;
   const server = createServer((req, res) => {
+    const controller = new AbortController();
+    req.once("close", () => controller.abort());
     void proxy
-      .fetch(toFetchRequest(req))
-      .then((response) => writeFetchResponse(res, response))
+      .fetch(toFetchRequest(req, controller.signal))
+      .then((response) => writeFetchResponse(req, res, response))
       .catch((error) => {
         if (!res.headersSent) {
           res.writeHead(502, { "content-type": "application/json; charset=utf-8" });

--- a/packages/electric-proxy/tests/serveSmithersElectricProxy.test.ts
+++ b/packages/electric-proxy/tests/serveSmithersElectricProxy.test.ts
@@ -36,6 +36,48 @@ describe("serveSmithersElectricProxy (runnable HTTP server)", () => {
     expect(forwardedWhere).toBe("run_id IN ('run-1')");
   });
 
+  test("cancels the upstream Electric stream and releases the slot when the client disconnects mid-stream", async () => {
+    let upstreamCanceled = false;
+    let capturedSignal: AbortSignal | undefined;
+    const proxy = createSmithersElectricProxy({
+      electricUrl: "http://electric.local/v1/shape",
+      authenticate: () => ({ principalId: "p", scopes: ["run:read"], grantedRunIds: ["run-1"] }),
+      fetchClient: async (_url, init) => {
+        capturedSignal = init?.signal ?? undefined;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("event: up\ndata: {}\n\n"));
+              // Stay open — a real Electric shape stream is long-lived.
+            },
+            cancel() {
+              upstreamCanceled = true;
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      },
+    });
+    running = await serveSmithersElectricProxy({ proxy, host: "127.0.0.1" });
+
+    const ac = new AbortController();
+    const response = await fetch(`http://127.0.0.1:${running.port}/v1/shape?table=_smithers_runs`, {
+      headers: { authorization: "Bearer secret" },
+      signal: ac.signal,
+    });
+    const reader = response.body?.getReader();
+    await reader?.read();
+    ac.abort();
+
+    const deadline = Date.now() + 2000;
+    while (!upstreamCanceled && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(upstreamCanceled).toBe(true);
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
   test("serves /healthz and /metrics", async () => {
     const proxy = createSmithersElectricProxy({
       electricUrl: "http://electric.local/v1/shape",


### PR DESCRIPTION
Closes #542

**Root cause**

`packages/electric-proxy/src/serveSmithersElectricProxy.js` is the runnable
Node HTTP server that fronts `createSmithersElectricProxy`. It never wired
client disconnects into the proxy's own cancellation machinery:

- `toFetchRequest` built the outbound `Request` with no `signal`, so
  `request.signal` — which the proxy forwards to `fetchClient`
  (`createSmithersElectricProxy.ts`) — never fired.
- `writeFetchResponse` pumped `response.body` in a loop with no `req`/`res`
  close handling. On client disconnect it kept `reader.read()`-ing (buffering
  into a dead socket), and its catch path destroyed `res` without ever
  calling `reader.cancel()`.

Because real bytes had flowed, the shape slot was marked "draining", and the
TTL sweep explicitly skips draining slots — so an abandoned client's slot and
upstream Electric connection stayed held indefinitely, consuming `activeMax`.
`wrapBody`'s existing `cancel` path already does the right thing (upstream
cancel + slot release); it just was never invoked from this HTTP entry point.
Issue #507 fixed the TTL-reclaim path; this is the client-disconnect path in
the Node serve adapter that #507 didn't cover.

**Fix**

- `toFetchRequest` now accepts an `AbortSignal` and threads it into the
  outbound `Request`.
- The request handler creates an `AbortController` per connection and aborts
  it on the incoming `req`'s `close` event (verified more reliable than
  `res`'s close across both Node and Bun's `node:http`).
- `writeFetchResponse` now also listens for `req`'s `close` event and calls
  `reader.cancel()` on it, so the stream pump flows into `wrapBody`'s cancel
  path (upstream cancel + active-slot release) instead of draining into a
  socket nobody is reading from.
- Added a regression test in
  `packages/electric-proxy/tests/serveSmithersElectricProxy.test.ts` that
  opens a long-lived shape stream, aborts the client fetch mid-stream, and
  asserts the upstream stream is canceled and the forwarded signal aborts.

Strategy used: **opus-sandwich**.

Note: this worktree had an unrelated, already-in-progress fix for issue #527
(sandbox egress CA cert path) sitting uncommitted alongside this one. I split
it out via `jj split` so it isn't bundled into this PR/commit.

This PR will be **restacked onto a PR train** — its base branch may change
before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)