### PR TITLE
🐛 fix(smithers): stop backend-inference probe from provisioning pglite schema

### DIFF
--- a/packages/smithers/src/migrateSmithersStore.js
+++ b/packages/smithers/src/migrateSmithersStore.js
@@ -834,20 +834,27 @@ function inferSqliteSourceDbPath(primaryDbPath, workspaceRoot, hasExplicitDbPath
     return primaryDbPath;
 }
 
+// Read-only: opens a raw PGlite instance (no PGLiteSocketServer, no
+// ensureSchema) so probing a candidate store for --from inference never
+// provisions the `_smithers_*` schema into a dataDir it is only meant to
+// inspect. Mirrors inspectPgliteStore's read-only pattern.
 async function pgliteRunCountAt(cwd, workspaceRoot, opts) {
     const dataDir = resolve(cwd, opts.pgliteDataDir ?? join(workspaceRoot, ".smithers", "pg"));
-    if (!existsSync(dataDir)) return 0;
-    let api;
+    if (!existsSync(join(dataDir, "PG_VERSION"))) return 0;
+    let pglite;
     try {
-        api = await createSmithersPostgres({}, { provider: "pglite", dataDir });
-        const pgConn = api.db.connection;
-        return (await pgTableExists(pgConn, "_smithers_runs")) ? await countPgRows(pgConn, "_smithers_runs") : 0;
+        const { PGlite } = await import("@electric-sql/pglite");
+        pglite = await PGlite.create(dataDir);
+        const runsTable = await pglite.query("SELECT to_regclass('_smithers_runs') AS table_name");
+        if (!runsTable.rows?.[0]?.table_name) return 0;
+        const countResult = await pglite.query("SELECT COUNT(*)::int AS count FROM _smithers_runs");
+        return Number(countResult.rows?.[0]?.count ?? 0);
     }
     catch {
         return 0;
     }
     finally {
-        await api?.close?.();
+        try { await pglite?.close?.(); } catch { /* best-effort read-only probe cleanup */ }
     }
 }
 
@@ -955,6 +962,13 @@ async function migratePgToSqlite(opts, context) {
     let sqlite;
     let published = false;
     try {
+        // A pglite source is only ever read here; refuse an uninitialized
+        // dataDir up front instead of booting createSmithersPostgres (which
+        // would provision the `_smithers_*` schema into a store being used
+        // only as a migration source).
+        if (sourceBackend === "pglite" && !existsSync(join(dataDir, "PG_VERSION"))) {
+            throw new SmithersError("CLI_DB_NOT_FOUND", `No ${sourceBackend} Smithers run store found.`, { sourceBackend });
+        }
         sourceApi = await createSmithersPostgres({}, sourceBackend === "postgres"
             ? { provider: "postgres", connectionString: opts.url ?? context.env.SMITHERS_POSTGRES_URL ?? context.env.DATABASE_URL }
             : { provider: "pglite", dataDir });

--- a/packages/smithers/tests/migrateSmithersStore.test.js
+++ b/packages/smithers/tests/migrateSmithersStore.test.js
@@ -567,6 +567,42 @@ describe("migrateSmithersStore", () => {
     }
   });
 
+  test("does not provision an existing-but-uninitialized pglite store while inferring --from", async () => {
+    const cwd = makeWorkspace("smithers-migrate-pglite-probe-no-provision");
+    const pgliteDir = join(cwd, ".smithers", "pg");
+    mkdirSync(pgliteDir, { recursive: true });
+
+    let caught;
+    try {
+      await migrateSmithersStore({ cwd, to: "pglite" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(SmithersError);
+    expect(caught.code).toBe("CLI_DB_NOT_FOUND");
+    // The probe must never boot/ensureSchema the candidate store: no cluster
+    // files should appear in a dataDir it only inspected.
+    expect(existsSync(join(pgliteDir, "PG_VERSION"))).toBe(false);
+  });
+
+  test("refuses to migrate from an uninitialized pglite source without provisioning it", async () => {
+    const cwd = makeWorkspace("smithers-migrate-pglite-source-no-provision");
+    const pgliteDir = join(cwd, ".smithers", "pg");
+    mkdirSync(pgliteDir, { recursive: true });
+
+    let caught;
+    try {
+      await migrateSmithersStore({ cwd, from: "pglite", to: "sqlite" });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(SmithersError);
+    expect(caught.code).toBe("CLI_DB_NOT_FOUND");
+    expect(existsSync(join(pgliteDir, "PG_VERSION"))).toBe(false);
+  });
+
   test("infers --from when exactly one backend store has runs and refuses ambiguous populated stores", async () => {
     const pgliteOnly = makeWorkspace("smithers-migrate-infer-pglite");
     const originalSqlite = await seedPgliteStore(pgliteOnly);


### PR DESCRIPTION
Closes #549

## Root cause

`pgliteRunCountAt` (in `packages/smithers/src/migrateSmithersStore.js`) is used purely as a read-only probe when inferring `--from` for `smithers migrate`: it just wants to know whether a candidate pglite store has a `_smithers_runs` table and, if so, how many rows it has. But it did this by calling `createSmithersPostgres`, which internally runs `ensureSchema` — so simply *checking* a candidate store for inference purposes provisioned the full `_smithers_*` schema into a `dataDir` that may never have been an initialized Smithers store at all.

`migratePgToSqlite` had the same problem: when opening a pglite *source* to migrate from, it went straight to `createSmithersPostgres`, which would provision schema into the source store before migration even started, rather than refusing an uninitialized source outright.

## Approach

- `pgliteRunCountAt` now opens a raw `PGlite` instance directly (via `@electric-sql/pglite`) instead of going through `createSmithersPostgres`/`ensureSchema`, and first checks for a `PG_VERSION` file in `dataDir` to detect whether the cluster is initialized before even opening it — mirroring the existing read-only pattern already used by `inspectPgliteStore`.
- `migratePgToSqlite` now performs the same `PG_VERSION` check up front for a `pglite` source and throws `SmithersError("CLI_DB_NOT_FOUND", ...)` for an uninitialized source instead of booting `createSmithersPostgres` against it.
- Added two regression tests in `packages/smithers/tests/migrateSmithersStore.test.js` asserting that an empty-but-present `.smithers/pg` directory is never provisioned (no `PG_VERSION` file appears) during `--from` inference or during a `pglite -> sqlite` migration attempt against an uninitialized source.

Strategy used: **opus-sandwich**.

Note: this PR will be **restacked** onto a PR train — its base branch may change after it's opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)