### PR TITLE
🐛 fix(graph): reject duplicate inline Subflow ids in extractGraph

### DIFF
--- a/packages/graph/src/extract.js
+++ b/packages/graph/src/extract.js
@@ -469,8 +469,14 @@ export function extractGraph(root, opts) {
         if (node.tag === "smithers:subflow") {
             const logicalNodeId = requireTaskId(raw, "Subflow");
             const mode = raw.__smithersSubflowMode ?? raw.mode ?? "childRun";
+            const nodeId = logicalNodeId + ancestorScope;
+            if (mode === "inline") {
+                if (seen.has(nodeId)) {
+                    throw new SmithersError("DUPLICATE_ID", `Duplicate Subflow id detected: ${nodeId}`, { id: nodeId });
+                }
+                seen.add(nodeId);
+            }
             if (mode !== "inline") {
-                const nodeId = logicalNodeId + ancestorScope;
                 requireOutput(raw, nodeId, "Subflow");
                 const { retries, retryPolicy } = resolveRetryConfig(raw);
                 const output = resolveOutput(raw);

--- a/packages/graph/tests/extract.test.jsx
+++ b/packages/graph/tests/extract.test.jsx
@@ -721,6 +721,28 @@ describe("extractGraph", () => {
 			]);
 			expect(() => extractGraph(root)).toThrow("Duplicate Subflow id detected");
 		});
+
+		test("rejects duplicate inline subflow id", () => {
+			const root = hostEl("smithers:workflow", {}, [
+				hostEl("smithers:subflow", { id: "sf", mode: "inline", output: "out" }, [
+					hostEl("smithers:task", { id: "a", output: "a_out" }),
+				]),
+				hostEl("smithers:subflow", { id: "sf", mode: "inline", output: "out" }, [
+					hostEl("smithers:task", { id: "b", output: "b_out" }),
+				]),
+			]);
+			expect(() => extractGraph(root)).toThrow("Duplicate Subflow id detected");
+		});
+
+		test("rejects inline subflow id colliding with a task id", () => {
+			const root = hostEl("smithers:workflow", {}, [
+				hostEl("smithers:subflow", { id: "x", mode: "inline", output: "out" }, [
+					hostEl("smithers:task", { id: "inner", output: "inner_out" }),
+				]),
+				hostEl("smithers:task", { id: "x", output: "x_out" }),
+			]);
+			expect(() => extractGraph(root)).toThrow("Duplicate");
+		});
 	});
 
 	describe("sandbox", () => {


### PR DESCRIPTION
Closes #559

## Root cause

`extractGraph` in `packages/graph/src/extract.js` tracks node ids in a `seen` set to reject duplicates, but the duplicate check was only reached for the `mode !== "inline"` branch of `smithers:subflow` nodes — the `nodeId` computation and `requireOutput`/dedup logic lived entirely inside that `if (mode !== "inline")` block. Inline subflows (`mode="inline"`) never had their id added to `seen` and were never checked against it, so two inline `<Subflow id="sf" mode="inline">` siblings (or an inline subflow id colliding with a task id) silently passed through `extractGraph`, producing a malformed graph instead of a clear error.

## Fix

Hoist the `nodeId` computation above the `mode !== "inline"` branch and add an explicit `seen.has(nodeId)` check (throwing `SmithersError("DUPLICATE_ID", ...)`, matching the existing non-inline behavior) before adding it to `seen` when `mode === "inline"`. The non-inline path is unchanged other than no longer redundantly declaring `nodeId`.

Files touched:
- `packages/graph/src/extract.js` — dedup check now covers inline Subflow ids.
- `packages/graph/tests/extract.test.jsx` — two new regression tests: duplicate inline subflow ids, and an inline subflow id colliding with a sibling task id.

## Strategy

Built with the **opus-sandwich** strategy.

## Note

This PR will be **restacked onto a PR train** — its base branch may change as part of that process.