### PR TITLE
✨ feat(gateway): cross-run score comparison RPCs (unblocks multi#5 / Smithers Cloud evals)

### DIFF
--- a/.smithers/workflows/ticket-fleet.tsx
+++ b/.smithers/workflows/ticket-fleet.tsx
@@ -809,9 +809,22 @@ function applySync(
     }
     if (verdict.isMeta && verdict.subTickets.length && !ticket.isEpicDir) {
       // Decompose: write per-item tickets, open per-item issues, park the parent in .epics/.
+      // Idempotency guard: sync-apply retries replay the cached sync-plan snapshot, so a
+      // prior (crashed-then-retried) attempt may have already decomposed this epic. If the
+      // parent is already parked in .epics/ (source gone, dest present), the sub-tickets were
+      // written and their issues opened — re-running would ENOENT on the rename AND open
+      // DUPLICATE issues. Skip.
+      const epicSrc = join(ticketsDir, ticket.ticketPath);
+      const epicDst = join(ticketsDir, ".epics", basename(ticket.ticketPath));
+      if (!existsSync(epicSrc) && existsSync(epicDst)) {
+        details.push("decompose skipped (already parked) " + ticket.ticketPath);
+        continue;
+      }
       for (const sub of verdict.subTickets.slice(0, 24)) {
-        const created = createIssue(sub.title, sub.body + "\n\n---\nSplit from `.smithers/tickets/" + ticket.ticketPath + "` by ticket-fleet.");
         const fileName = slugify(ticket.slug) + "--" + slugify(sub.title) + ".md";
+        // Skip a sub-ticket already written by a prior attempt (its issue is already open).
+        if (existsSync(join(ticketsDir, "smithers", fileName))) continue;
+        const created = createIssue(sub.title, sub.body + "\n\n---\nSplit from `.smithers/tickets/" + ticket.ticketPath + "` by ticket-fleet.");
         if (!input.dryRun) {
           writeFileSync(join(ticketsDir, "smithers", fileName),
             "# " + sub.title + "\n\nGitHub: " + created.url + "\n\nParent: " + ticket.ticketPath + "\n\n" + sub.body + "\n", "utf8");
@@ -819,7 +832,7 @@ function applySync(
       }
       if (!input.dryRun) {
         mkdirSync(join(ticketsDir, ".epics"), { recursive: true });
-        renameSync(join(ticketsDir, ticket.ticketPath), join(ticketsDir, ".epics", basename(ticket.ticketPath)));
+        if (existsSync(epicSrc)) renameSync(epicSrc, epicDst);
       }
       if (ticket.linkedIssue && !input.dryRun) {
         ghCommentIssue(input.repo, ticket.linkedIssue,

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -12109,12 +12109,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -7599,6 +7599,7 @@ const cli = Cli.create({
                     return fail(parsedOverrides.error);
                 const inputOverrides = parsedOverrides.value;
                 const resetNodes = c.options.node ? [c.options.node] : undefined;
+                const resolvedReplayWorkflowPath = resolve(c.args.workflow);
                 const result = await replayFromCheckpoint(adapter, {
                     parentRunId: c.options.runId,
                     frameNo: c.options.frame,
@@ -7606,6 +7607,12 @@ const cli = Cli.create({
                     resetNodes,
                     branchLabel: c.options.label,
                     restoreVcs: c.options.restoreVcs,
+                    // Re-bless durable metadata to the workflow being replayed so a
+                    // replay that carries an edited workflow resumes (mirrors `fork`);
+                    // otherwise the resume guard rejects it with RESUME_METADATA_MISMATCH.
+                    workflowPath: resolvedReplayWorkflowPath,
+                    workflowHash: await readWorkflowGraphHash(resolvedReplayWorkflowPath),
+                    entryWorkflowHash: await readWorkflowEntryHash(resolvedReplayWorkflowPath),
                 });
                 reportReplayResult({
                     result,

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -428,6 +428,8 @@
               "rpc/list-approvals",
               "rpc/list-docs",
               "rpc/list-scores",
+              "rpc/list-scores-for-runs",
+              "rpc/get-score-detail",
               "rpc/list-accounts",
               "rpc/list-memory-facts",
               "rpc/list-prompts",

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -351,12 +351,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/docs/llms-full-v0.28.0.txt
+++ b/docs/llms-full-v0.28.0.txt
@@ -12109,12 +12109,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12109,12 +12109,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -694,12 +694,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/docs/rpc/get-score-detail.mdx
+++ b/docs/rpc/get-score-detail.mdx
@@ -1,0 +1,18 @@
+---
+title: getScoreDetail
+description: Gateway RPC for reading one persisted score with decoded detail fields.
+maturity: stable
+apiVersion: v1
+---
+
+- Method: `getScoreDetail`
+- Scope: `score:read`
+- Transports: HTTP RPC, WebSocket RPC
+- Request: `{ runId, scoreId }`
+- Response: `ScoreDetail`
+
+The response includes the score's comparison fields plus decoded `meta`,
+`input`, `output`, `groundTruth`, and `context` JSON values. `scoreId` is an
+exact persisted score id owned by `runId`.
+
+Errors are versioned as `v1` and include `InvalidRequest`, `Unauthorized`, `Forbidden`, `RunNotFound`, `ScoreNotFound`, and `Internal`.

--- a/docs/rpc/list-scores-for-runs.mdx
+++ b/docs/rpc/list-scores-for-runs.mdx
@@ -1,0 +1,19 @@
+---
+title: listScoresForRuns
+description: Gateway RPC for comparing scorer and eval results across runs.
+maturity: stable
+apiVersion: v1
+---
+
+- Method: `listScoresForRuns`
+- Scope: `score:read`
+- Transports: HTTP RPC, WebSocket RPC
+- Request: `{ runIds, nodeId?, scorerId?, scorerName?, source?, order?, offset?, limit? }`
+- Response: `{ rows: ComparisonScoreRow[], total }`
+
+`runIds` accepts up to 30 entries. The Gateway trims each id, removes duplicates
+in first-seen order, merges scores from every distinct backing store, and then
+applies one deterministic global sort and pagination window. `order` defaults
+to `scoredAtAsc`; `limit` defaults to 500 and cannot exceed 500.
+
+Errors are versioned as `v1` and include `InvalidRequest`, `Unauthorized`, `Forbidden`, `RunNotFound`, and `Internal`.

--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -3410,6 +3410,98 @@ export class SmithersDb {
          ORDER BY scored_at_ms ASC`, nodeId ? [runId, nodeId] : [runId]));
     }
     /**
+   * Count scorer rows across a bounded set of runs. Every caller-supplied value
+   * is bound as a placeholder; only the fixed filter column names are composed
+   * into the statement.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   * }} query
+   * @returns {RunnableEffect<number, SmithersError>}
+   */
+    countScorerResultsForRuns(query) {
+        if (query.runIds.length === 0) {
+            return this.read("count scorer results for no runs", () => Promise.resolve(0));
+        }
+        const params = [...query.runIds];
+        const predicates = [`run_id IN (${query.runIds.map(() => "?").join(", ")})`];
+        for (const [column, value] of [
+            ["node_id", query.nodeId],
+            ["scorer_id", query.scorerId],
+            ["scorer_name", query.scorerName],
+            ["source", query.source],
+        ]) {
+            if (value !== undefined) {
+                predicates.push(`${column} = ?`);
+                params.push(value);
+            }
+        }
+        return this.read("count scorer results for runs", async () => {
+            const row = await this.internalStorage.queryOne(`SELECT COUNT(*) AS count
+         FROM _smithers_scorers
+         WHERE ${predicates.join(" AND ")}`, params);
+            return Number(row?.count ?? 0);
+        });
+    }
+    /**
+   * Fetch one globally-sortable candidate page of scorer rows for a set of
+   * runs. The server merges candidates from distinct stores and applies the
+   * final global offset/limit.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   *   order: "scoredAtAsc" | "scoredAtDesc";
+   *   offset: number;
+   *   limit: number;
+   * }} query
+   * @returns {RunnableEffect<Array<Record<string, unknown>>, SmithersError>}
+   */
+    listScorerResultsForRuns(query) {
+        if (query.runIds.length === 0) {
+            return this.read("list scorer results for no runs", () => Promise.resolve([]));
+        }
+        const params = [...query.runIds];
+        const predicates = [`run_id IN (${query.runIds.map(() => "?").join(", ")})`];
+        for (const [column, value] of [
+            ["node_id", query.nodeId],
+            ["scorer_id", query.scorerId],
+            ["scorer_name", query.scorerName],
+            ["source", query.source],
+        ]) {
+            if (value !== undefined) {
+                predicates.push(`${column} = ?`);
+                params.push(value);
+            }
+        }
+        const direction = query.order === "scoredAtAsc" ? "ASC" : "DESC";
+        params.push(query.limit, query.offset);
+        return this.read("list scorer results for runs", () => this.internalStorage.queryAll(`SELECT id, run_id, node_id, iteration, attempt,
+                scorer_id, scorer_name, source, score, reason, scored_at_ms,
+                latency_ms, duration_ms
+         FROM _smithers_scorers
+         WHERE ${predicates.join(" AND ")}
+         ORDER BY scored_at_ms ${direction}, run_id ASC, node_id ASC,
+                  iteration ASC, attempt ASC, scorer_id ASC, id ASC
+         LIMIT ? OFFSET ?`, params));
+    }
+    /**
+   * Read one scorer row by its exact persisted id, scoped to its owning run.
+   * @param {string} runId
+   * @param {string} scoreId
+   * @returns {RunnableEffect<Record<string, unknown> | undefined, SmithersError>}
+   */
+    getScorerResult(runId, scoreId) {
+        return this.read(`get scorer result ${scoreId}`, () => this.internalStorage.queryOne(`SELECT *
+         FROM _smithers_scorers
+         WHERE run_id = ? AND id = ?`, [runId, scoreId]));
+    }
+    /**
    * @param {string} runId
    * @returns {RunnableEffect<RunRow | undefined, SmithersError>}
    */

--- a/packages/db/src/index.d.ts
+++ b/packages/db/src/index.d.ts
@@ -1433,6 +1433,59 @@ declare class SmithersDb {
    */
     listScorerResults(runId: string, nodeId?: string): RunnableEffect<Array<Record<string, unknown>>, SmithersError$1>;
     /**
+   * Count scorer rows across a bounded set of runs. Every caller-supplied value
+   * is bound as a placeholder; only the fixed filter column names are composed
+   * into the statement.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   * }} query
+   * @returns {RunnableEffect<number, SmithersError>}
+   */
+    countScorerResultsForRuns(query: {
+        runIds: string[];
+        nodeId?: string;
+        scorerId?: string;
+        scorerName?: string;
+        source?: string;
+    }): RunnableEffect<number, SmithersError$1>;
+    /**
+   * Fetch one globally-sortable candidate page of scorer rows for a set of
+   * runs. The server merges candidates from distinct stores and applies the
+   * final global offset/limit.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   *   order: "scoredAtAsc" | "scoredAtDesc";
+   *   offset: number;
+   *   limit: number;
+   * }} query
+   * @returns {RunnableEffect<Array<Record<string, unknown>>, SmithersError>}
+   */
+    listScorerResultsForRuns(query: {
+        runIds: string[];
+        nodeId?: string;
+        scorerId?: string;
+        scorerName?: string;
+        source?: string;
+        order: "scoredAtAsc" | "scoredAtDesc";
+        offset: number;
+        limit: number;
+    }): RunnableEffect<Array<Record<string, unknown>>, SmithersError$1>;
+    /**
+   * Read one scorer row by its exact persisted id, scoped to its owning run.
+   * @param {string} runId
+   * @param {string} scoreId
+   * @returns {RunnableEffect<Record<string, unknown> | undefined, SmithersError>}
+   */
+    getScorerResult(runId: string, scoreId: string): RunnableEffect<Record<string, unknown> | undefined, SmithersError$1>;
+    /**
    * @param {string} runId
    * @returns {RunnableEffect<RunRow | undefined, SmithersError>}
    */

--- a/packages/db/tests/scorer-cross-run.test.js
+++ b/packages/db/tests/scorer-cross-run.test.js
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { SmithersDb } from "../src/adapter.js";
+import { ensureSmithersTables } from "../src/ensure.js";
+
+let sqlite;
+
+afterEach(() => {
+  sqlite?.close();
+  sqlite = undefined;
+});
+
+function createDb() {
+  sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  ensureSmithersTables(db);
+  return new SmithersDb(db);
+}
+
+describe("cross-run scorer persistence queries", () => {
+  test("counts, filters, orders, pages, and reads exact persisted ids", async () => {
+    const adapter = createDb();
+    const now = 1_700_000_000_000;
+    await adapter.insertRun({ runId: "r1", workflowName: "wf", status: "finished", createdAtMs: now });
+    await adapter.insertRun({ runId: "r2", workflowName: "wf", status: "finished", createdAtMs: now + 1 });
+    await adapter.insertScorerResult({ id: "s1", runId: "r1", nodeId: "n1", iteration: 0, attempt: 0, scorerId: "sc", scorerName: "Scorer", source: "live", score: 0.9, scoredAtMs: now, metaJson: '{"rubric":"quality"}' });
+    await adapter.insertScorerResult({ id: "s2", runId: "r2", nodeId: "n2", iteration: 0, attempt: 0, scorerId: "sc", scorerName: "Scorer", source: "live", score: 0.8, scoredAtMs: now + 1 });
+    await adapter.insertScorerResult({ id: "s3", runId: "r2", nodeId: "n1", iteration: 0, attempt: 0, scorerId: "other", scorerName: "Other", source: "batch", score: 0.7, scoredAtMs: now + 2 });
+
+    expect(await adapter.countScorerResultsForRuns({ runIds: ["r1", "r2"] })).toBe(3);
+    expect(await adapter.countScorerResultsForRuns({ runIds: ["r1", "r2"], nodeId: "n1", scorerId: "sc", scorerName: "Scorer", source: "live" })).toBe(1);
+    expect(await adapter.countScorerResultsForRuns({ runIds: [] })).toBe(0);
+
+    const desc = await adapter.listScorerResultsForRuns({ runIds: ["r1", "r2"], order: "scoredAtDesc", offset: 0, limit: 2 });
+    expect(desc.map((row) => row.id)).toEqual(["s3", "s2"]);
+    for (const detailColumn of ["metaJson", "inputJson", "outputJson", "groundTruthJson", "contextJson"]) {
+      expect(desc[0]).not.toHaveProperty(detailColumn);
+    }
+    const page = await adapter.listScorerResultsForRuns({ runIds: ["r1", "r2"], source: "live", order: "scoredAtAsc", offset: 1, limit: 1 });
+    expect(page.map((row) => row.id)).toEqual(["s2"]);
+    expect(await adapter.listScorerResultsForRuns({ runIds: [], order: "scoredAtAsc", offset: 0, limit: 1 })).toEqual([]);
+    expect((await adapter.getScorerResult("r1", "s1"))?.metaJson).toBe('{"rubric":"quality"}');
+    expect(await adapter.getScorerResult("r2", "s1")).toBeUndefined();
+  });
+});

--- a/packages/gateway-client/src/GatewayRpcTypeMap.ts
+++ b/packages/gateway-client/src/GatewayRpcTypeMap.ts
@@ -18,6 +18,8 @@ import type {
   ListApprovalsResponse,
   ListMemoryFactsRequest,
   ListPromptsRequest,
+  ListScoresForRunsRequest,
+  GetScoreDetailRequest,
   ListRunsRequest,
   ListScoresRequest,
   ListTicketsRequest,
@@ -49,6 +51,8 @@ import type {
 import type { GatewayCronRow } from "./sync/GatewayCronRow.ts";
 import type { GatewayMemoryFactRow } from "./sync/GatewayMemoryFactRow.ts";
 import type { GatewayPromptRow } from "./sync/GatewayPromptRow.ts";
+import type { GatewayComparisonScoreRow } from "./sync/GatewayComparisonScoreRow.ts";
+import type { GatewayScoreDetail } from "./sync/GatewayScoreDetail.ts";
 import type { GatewayScoreRow } from "./sync/GatewayScoreRow.ts";
 import type { GatewayTicketRow } from "./sync/GatewayTicketRow.ts";
 
@@ -79,6 +83,8 @@ export type GatewayRpcRequestMap = {
   listMemoryFacts: ListMemoryFactsRequest;
   listPrompts: ListPromptsRequest;
   listScores: ListScoresRequest;
+  listScoresForRuns: ListScoresForRunsRequest;
+  getScoreDetail: GetScoreDetailRequest;
   listTickets: ListTicketsRequest;
   createTicket: CreateTicketRequest;
   updateTicket: UpdateTicketRequest;
@@ -114,6 +120,8 @@ export type GatewayRpcResponseMap = {
   listMemoryFacts: GatewayMemoryFactRow[];
   listPrompts: GatewayPromptRow[];
   listScores: GatewayScoreRow[];
+  listScoresForRuns: { rows: GatewayComparisonScoreRow[]; total: number };
+  getScoreDetail: GatewayScoreDetail;
   listTickets: GatewayTicketRow[];
   createTicket: GatewayTicketRow;
   updateTicket: GatewayTicketRow;

--- a/packages/gateway-client/src/data/SmithersApi.ts
+++ b/packages/gateway-client/src/data/SmithersApi.ts
@@ -1,11 +1,13 @@
 import type {
   CancelRunRequest,
   CancelRunResponse,
+  ListScoresForRunsRequest,
   CronCreateRequest,
   CronDeleteRequest,
   CronListRequest,
   CronRunRequest,
   GetRunRequest,
+  GetScoreDetailRequest,
   GetSchemaSignatureResponse,
   HijackRunRequest,
   HijackRunResponse,
@@ -34,12 +36,14 @@ import type {
   SubmitSignalRequest,
 } from "@smithers-orchestrator/gateway/rpc";
 import type { GatewayCronRow } from "../sync/GatewayCronRow.ts";
+import type { GatewayComparisonScoreRow } from "../sync/GatewayComparisonScoreRow.ts";
 import type { GatewayMemoryFactRow } from "../sync/GatewayMemoryFactRow.ts";
 import type { GatewayPromptRow } from "../sync/GatewayPromptRow.ts";
 import type { GatewayRunEventRow } from "../sync/GatewayRunEventRow.ts";
 import type { GatewayRunNode } from "../sync/GatewayRunNode.ts";
 import type { GatewayRunRow } from "../sync/GatewayRunRow.ts";
 import type { GatewayRunSummaryRow } from "../sync/GatewayRunSummaryRow.ts";
+import type { GatewayScoreDetail } from "../sync/GatewayScoreDetail.ts";
 import type { GatewayScoreRow } from "../sync/GatewayScoreRow.ts";
 import type { GatewayTicketRow } from "../sync/GatewayTicketRow.ts";
 import type { ApiMutationResult } from "./ApiMutationResult.ts";
@@ -69,6 +73,8 @@ export type SmithersApi = {
   listPrompts(): Promise<ListPromptsResponse>;
   listMemoryFacts(params?: ListMemoryFactsRequest): Promise<GatewayMemoryFactRow[]>;
   listScores(params?: ListScoresRequest): Promise<GatewayScoreRow[]>;
+  listScoresForRuns(params: ListScoresForRunsRequest): Promise<{ rows: GatewayComparisonScoreRow[]; total: number }>;
+  getScoreDetail(params: GetScoreDetailRequest): Promise<GatewayScoreDetail>;
   listTickets(params?: ListTicketsRequest): Promise<GatewayTicketRow[]>;
   createTicket(params: CreateTicketRequest): Promise<ApiMutationResult<GatewayTicketRow>>;
   updateTicket(params: UpdateTicketRequest): Promise<ApiMutationResult<GatewayTicketRow>>;

--- a/packages/gateway-client/src/data/createSmithersDataClient.ts
+++ b/packages/gateway-client/src/data/createSmithersDataClient.ts
@@ -1,5 +1,7 @@
 import type {
   CancelRunResponse,
+  ListScoresForRunsRequest,
+  ListScoresForRunsResponse,
   CreateTicketRequest,
   CronCreateRequest,
   CronDeleteRequest,
@@ -7,6 +9,8 @@ import type {
   CronRunRequest,
   DeleteTicketRequest,
   GetSchemaSignatureResponse,
+  GetScoreDetailRequest,
+  GetScoreDetailResponse,
   HijackRunResponse,
   LaunchRunResponse,
   ListApprovalsRequest,
@@ -130,6 +134,19 @@ function listScoresSearch(params: ListScoresRequest = { runId: "" }) {
   const search = new URLSearchParams();
   append(search, "runId", params.runId);
   append(search, "nodeId", params.nodeId);
+  return search;
+}
+
+function listScoresForRunsSearch(params: ListScoresForRunsRequest) {
+  const search = new URLSearchParams();
+  for (const runId of params.runIds) search.append("runId", runId);
+  if (params.nodeId !== undefined) search.set("nodeId", params.nodeId);
+  if (params.scorerId !== undefined) search.set("scorerId", params.scorerId);
+  if (params.scorerName !== undefined) search.set("scorerName", params.scorerName);
+  if (params.source !== undefined) search.set("source", params.source);
+  if (params.order !== undefined) search.set("order", params.order);
+  if (params.offset !== undefined) search.set("offset", String(params.offset));
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
   return search;
 }
 
@@ -417,6 +434,14 @@ export function createSmithersDataClient(options: CreateSmithersDataClientOption
         return request("GET", withSearch("/v1/api/memory-facts", search));
       },
       listScores: (params = { runId: "" }) => params.runId ? request("GET", withSearch("/v1/api/scores", listScoresSearch(params))) : Promise.resolve([]),
+      listScoresForRuns: (params: ListScoresForRunsRequest) => request<ListScoresForRunsResponse>(
+        "GET",
+        withSearch("/v1/api/scores/compare", listScoresForRunsSearch(params)),
+      ),
+      getScoreDetail: (params: GetScoreDetailRequest) => request<GetScoreDetailResponse>(
+        "GET",
+        `/v1/api/scores/${encodeURIComponent(params.runId)}/${encodeURIComponent(params.scoreId)}`,
+      ),
       listTickets: (params = {}) => request("GET", withSearch("/v1/api/tickets", listTicketsSearch(params))),
       createTicket: (params: CreateTicketRequest) => mutate("POST", "/v1/api/tickets", params),
       updateTicket: (params: UpdateTicketRequest) => mutate("PATCH", `/v1/api/tickets/${encodeURIComponent(params.path)}`, params),

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -35,6 +35,8 @@ export type { GatewayCronRow } from "./sync/GatewayCronRow.ts";
 export type { GatewayDocRow } from "./data/GatewayDocRow.ts";
 export type { GatewayMemoryFactRow } from "./sync/GatewayMemoryFactRow.ts";
 export type { GatewayPromptRow } from "./sync/GatewayPromptRow.ts";
+export type { GatewayComparisonScoreRow } from "./sync/GatewayComparisonScoreRow.ts";
+export type { GatewayScoreDetail } from "./sync/GatewayScoreDetail.ts";
 export type { GatewayScoreRow } from "./sync/GatewayScoreRow.ts";
 export type { GatewayDocKind, GatewayTicketRow } from "./sync/GatewayTicketRow.ts";
 export type { GatewayRunEventRow } from "./sync/GatewayRunEventRow.ts";
@@ -52,6 +54,12 @@ export type { SmithersDataClient } from "./data/SmithersDataClient.ts";
 export type { SmithersStreamEvent } from "./data/SmithersStreamEvent.ts";
 export type { SmithersStreamError } from "./data/SmithersStreamError.ts";
 export type { WorkspaceMode } from "./data/WorkspaceMode.ts";
+export type {
+  ListScoresForRunsRequest,
+  ListScoresForRunsResponse,
+  GetScoreDetailRequest,
+  GetScoreDetailResponse,
+} from "@smithers-orchestrator/gateway/rpc";
 export { createSmithersCollections } from "./data/createSmithersCollections.ts";
 export { createSmithersDataClient } from "./data/createSmithersDataClient.ts";
 export { mapSmithersElectricRow } from "./data/mapSmithersElectricRow.ts";

--- a/packages/gateway-client/src/sync/GatewayComparisonScoreRow.ts
+++ b/packages/gateway-client/src/sync/GatewayComparisonScoreRow.ts
@@ -1,0 +1,13 @@
+import type { GatewayScoreRow } from "./GatewayScoreRow.ts";
+
+/**
+ * One score row returned by the cross-run `listScoresForRuns` query.
+ *
+ * The stable score id is included so callers can fetch the larger detail row
+ * on demand. Persisted JSON detail fields are deliberately excluded from this
+ * list shape. The query takes explicit scorer-producing run ids; it does not
+ * discover child case runs from an eval wrapper or align experiments/cases.
+ */
+export type GatewayComparisonScoreRow = GatewayScoreRow & {
+  scoreId: string;
+};

--- a/packages/gateway-client/src/sync/GatewayScoreDetail.ts
+++ b/packages/gateway-client/src/sync/GatewayScoreDetail.ts
@@ -1,0 +1,15 @@
+import type { GatewayComparisonScoreRow } from "./GatewayComparisonScoreRow.ts";
+
+/**
+ * A single persisted score with its JSON payloads decoded by the gateway.
+ *
+ * Each detail value is always present. SQL NULL and stored JSON null are both
+ * represented as JavaScript `null` at the wire boundary.
+ */
+export type GatewayScoreDetail = GatewayComparisonScoreRow & {
+  meta: unknown;
+  input: unknown;
+  output: unknown;
+  groundTruth: unknown;
+  context: unknown;
+};

--- a/packages/gateway-client/src/sync/GatewayScoreRow.ts
+++ b/packages/gateway-client/src/sync/GatewayScoreRow.ts
@@ -16,7 +16,8 @@
  *  - `attempt`     — `_smithers_scorers.attempt`.
  *  - `scorerId`    — `_smithers_scorers.scorer_id`.
  *  - `scorerName`  — `_smithers_scorers.scorer_name` (the human label).
- *  - `source`      — `_smithers_scorers.source` (e.g. 'scorer', 'eval').
+ *  - `source`      — `_smithers_scorers.source` (`live` or `batch` for new rows;
+ *                    the public field remains `string` for legacy rows).
  *  - `score`       — `_smithers_scorers.score` (the numeric verdict).
  *  - `reason`      — `_smithers_scorers.reason` (null when none recorded).
  *  - `scoredAtMs`  — `_smithers_scorers.scored_at_ms`.

--- a/packages/gateway-client/tests/data/dataClientApi.test.ts
+++ b/packages/gateway-client/tests/data/dataClientApi.test.ts
@@ -82,6 +82,101 @@ describe("createSmithersDataClient api requests", () => {
     client.close();
   });
 
+  test("listScoresForRuns repeats runId values and encodes every filter, order, and page field with auth", async () => {
+    const { client, calls } = capturingClient({ ok: true, data: { rows: [], total: 0 } }, "score-token");
+
+    expect(await client.api.listScoresForRuns({
+      runIds: ["run one", "run/two", "run-three"],
+      nodeId: "node/one",
+      scorerId: "score:exact",
+      scorerName: "Exact match",
+      source: "batch",
+      order: "scoredAtDesc",
+      offset: 0,
+      limit: 25,
+    })).toEqual({ rows: [], total: 0 });
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    const url = urlOf(call);
+    expect(call.method).toBe("GET");
+    expect(url.pathname).toBe("/v1/api/scores/compare");
+    expect(url.searchParams.getAll("runId")).toEqual(["run one", "run/two", "run-three"]);
+    expect(url.searchParams.get("nodeId")).toBe("node/one");
+    expect(url.searchParams.get("scorerId")).toBe("score:exact");
+    expect(url.searchParams.get("scorerName")).toBe("Exact match");
+    expect(url.searchParams.get("source")).toBe("batch");
+    expect(url.searchParams.get("order")).toBe("scoredAtDesc");
+    expect(url.searchParams.get("offset")).toBe("0");
+    expect(url.searchParams.get("limit")).toBe("25");
+    expect(call.headers.get("authorization")).toBe("Bearer score-token");
+    client.close();
+  });
+
+  test("listScoresForRuns with no runIds still authenticates and validates through the gateway", async () => {
+    const { client, calls } = capturingClient({ ok: true, data: { rows: [], total: 0 } }, "score-token");
+    expect(await client.api.listScoresForRuns({ runIds: [] })).toEqual({ rows: [], total: 0 });
+    expect(calls).toHaveLength(1);
+    expect(urlOf(calls[0]!).pathname).toBe("/v1/api/scores/compare");
+    expect(urlOf(calls[0]!).searchParams.getAll("runId")).toEqual([]);
+    expect(calls[0]!.headers.get("authorization")).toBe("Bearer score-token");
+    client.close();
+  });
+
+  test("listScoresForRuns leaves server defaults untouched when optional fields are omitted", async () => {
+    const { client, calls } = capturingClient({ ok: true, data: { rows: [], total: 0 } });
+    await client.api.listScoresForRuns({ runIds: ["run-1"] });
+    const search = urlOf(calls[0]!).searchParams;
+    expect(search.getAll("runId")).toEqual(["run-1"]);
+    expect(search.has("order")).toBe(false);
+    expect(search.has("offset")).toBe(false);
+    expect(search.has("limit")).toBe(false);
+    client.close();
+  });
+
+  test("getScoreDetail URL-encodes both persisted identities and returns decoded detail", async () => {
+    const persisted = {
+      scoreId: "score /?#",
+      runId: "run /?#",
+      nodeId: "node-1",
+      iteration: 0,
+      attempt: 1,
+      scorerId: "exact",
+      scorerName: "Exact",
+      source: "eval",
+      score: 1,
+      reason: null,
+      scoredAtMs: 123,
+      latencyMs: null,
+      durationMs: 10,
+      meta: { model: "judge" },
+      input: { prompt: "hello" },
+      output: "hello",
+      groundTruth: "hello",
+      context: null,
+    };
+    const { client, calls } = capturingClient({ ok: true, data: persisted }, "detail-token");
+
+    const detail = await client.api.getScoreDetail({ runId: "run /?#", scoreId: "score /?#" });
+    expect(detail).toEqual(persisted);
+    expect(detail.context).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(urlOf(calls[0]!).pathname).toBe("/v1/api/scores/run%20%2F%3F%23/score%20%2F%3F%23");
+    expect(calls[0]!.headers.get("authorization")).toBe("Bearer detail-token");
+    client.close();
+  });
+
+  test("listScores keeps its original per-run endpoint and array response", async () => {
+    const { client, calls } = capturingClient({ ok: true, data: [] });
+    expect(await client.api.listScores({ runId: "run-1", nodeId: "node-1" })).toEqual([]);
+    expect(calls).toHaveLength(1);
+    const url = urlOf(calls[0]!);
+    expect(url.pathname).toBe("/v1/api/scores");
+    expect(url.searchParams.get("runId")).toBe("run-1");
+    expect(url.searchParams.get("nodeId")).toBe("node-1");
+    client.close();
+  });
+
   test("listRunEvents normalizes and filters raw event rows", async () => {
     const { client } = capturingClient({
       ok: true,

--- a/packages/gateway-client/tests/data/electric-row-parity.test.ts
+++ b/packages/gateway-client/tests/data/electric-row-parity.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { SmithersDb } from "@smithers-orchestrator/db/adapter";
 import {
   serializeApprovalRow,
+  serializeComparisonScoreRow,
   serializeCronRow,
   serializeDocRow,
   serializeMemoryFactRow,
@@ -11,6 +12,11 @@ import {
   serializeTicketRow,
 } from "@smithers-orchestrator/gateway/api";
 import { createSmithersPostgres } from "smithers-orchestrator";
+import type {
+  GatewayComparisonScoreRow,
+  GatewayScoreDetail,
+  GatewayScoreRow,
+} from "../../src/index.ts";
 import { mapSmithersElectricRow } from "../../src/data/mapSmithersElectricRow.ts";
 
 const cleanups: Array<() => Promise<void> | void> = [];
@@ -120,7 +126,13 @@ describe("Electric row-shape parity", () => {
     expect(mapSmithersElectricRow("approvals", await rawOne(connection, "SELECT * FROM _smithers_approvals WHERE run_id = $1", [runId]))).toEqual(apiApproval);
     expect(mapSmithersElectricRow("docs", await rawOne(connection, "SELECT * FROM _smithers_docs WHERE path = $1", ["docs/readme.md"]))).toEqual(apiDoc);
     expect(mapSmithersElectricRow("tickets", await rawOne(connection, "SELECT * FROM _smithers_docs WHERE path = $1", ["tickets/t-1.md"]))).toEqual(apiTicket);
-    expect(mapSmithersElectricRow("scores", await rawOne(connection, "SELECT * FROM _smithers_scorers WHERE run_id = $1", [runId]))).toEqual(apiScore);
+    const electricScore = await rawOne(connection, "SELECT * FROM _smithers_scorers WHERE run_id = $1", [runId]);
+    expect(mapSmithersElectricRow("scores", electricScore)).toEqual(apiScore);
+    const comparisonScore = serializeComparisonScoreRow(electricScore);
+    expect(comparisonScore).toEqual({ scoreId: "score-row-1", ...apiScore });
+    for (const detailField of ["meta", "input", "output", "groundTruth", "context"]) {
+      expect(comparisonScore).not.toHaveProperty(detailField);
+    }
     expect(mapSmithersElectricRow("memoryFacts", await rawOne(connection, "SELECT * FROM _smithers_memory_facts WHERE namespace = $1 AND key = $2", ["workspace", "preference"]))).toEqual(apiMemory);
     expect(mapSmithersElectricRow("crons", await rawOne(connection, "SELECT * FROM _smithers_cron WHERE cron_id = $1", ["cron-parity"]))).toEqual(apiCron);
   }, 120_000);
@@ -143,5 +155,54 @@ describe("Electric row-shape parity", () => {
       iteration: 0,
       childIds: [],
     });
+  });
+
+  test("cross-run comparison rows add only scoreId to the existing score row", () => {
+    const score: GatewayScoreRow = {
+      runId: "run-parity",
+      nodeId: "task1",
+      iteration: 0,
+      attempt: 1,
+      scorerId: "score:exact",
+      scorerName: "Exact",
+      source: "eval",
+      score: 1,
+      reason: null,
+      scoredAtMs: 1_718_000_000_007,
+      latencyMs: 12,
+      durationMs: 34,
+    };
+    const comparison: GatewayComparisonScoreRow = { scoreId: "score-row-1", ...score };
+
+    expect(comparison).toEqual({ scoreId: "score-row-1", ...score });
+    expect(Object.keys(comparison).sort()).toEqual([
+      "attempt",
+      "durationMs",
+      "iteration",
+      "latencyMs",
+      "nodeId",
+      "reason",
+      "runId",
+      "score",
+      "scoreId",
+      "scoredAtMs",
+      "scorerId",
+      "scorerName",
+      "source",
+    ]);
+    for (const detailField of ["meta", "input", "output", "groundTruth", "context"]) {
+      expect(comparison).not.toHaveProperty(detailField);
+    }
+
+    const detail: GatewayScoreDetail = {
+      ...comparison,
+      meta: null,
+      input: { prompt: "hello" },
+      output: "hello",
+      groundTruth: "hello",
+      context: null,
+    };
+    expect(detail.meta).toBeNull();
+    expect(detail.input).toEqual({ prompt: "hello" });
   });
 });

--- a/packages/gateway-client/tests/gateway-client.test.ts
+++ b/packages/gateway-client/tests/gateway-client.test.ts
@@ -104,6 +104,8 @@ const typedRpcRequestMethods = {
   listMemoryFacts: "listMemoryFacts",
   listPrompts: "listPrompts",
   listScores: "listScores",
+  listScoresForRuns: "listScoresForRuns",
+  getScoreDetail: "getScoreDetail",
   listTickets: "listTickets",
   createTicket: "createTicket",
   updateTicket: "updateTicket",

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -11467,7 +11467,7 @@ paths:
                           description: "Human scorer name."
                         source:
                           type: string
-                          description: "Where the score came from (e.g. 'scorer', 'eval')."
+                          description: "Persisted score provenance (`live` or `batch` for production scorer rows)."
                         score:
                           type: number
                           description: "The scorer's numeric verdict."
@@ -11514,7 +11514,7 @@ paths:
                     attempt: 0
                     scorerId: correctness
                     scorerName: correctness
-                    source: scorer
+                    source: live
                     score: 0.92
                     scoredAtMs: 1710000000000
         400:
@@ -11800,6 +11800,1107 @@ paths:
                           - Unauthorized
                           - Forbidden
                           - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+  /v1/rpc/listScoresForRuns:
+    post:
+      operationId: listScoresForRuns
+      summary: "List Scores For Runs"
+      description: "List and globally page persisted scorer rows across up to 30 explicit run ids. The caller must supply the scorer-producing run ids; this does not expand an eval wrapper into child case runs or provide experiment/case alignment."
+      tags:
+        - "Gateway RPC"
+      security:
+        -
+          bearerAuth:
+            - score:read
+      x-smithers-api-version: v1
+      x-smithers-maturity: stable
+      x-smithers-transport: "http+websocket"
+      x-smithers-required-scope: score:read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - method
+                - params
+              additionalProperties: false
+              properties:
+                id:
+                  type: string
+                  description: "Optional caller request id."
+                method:
+                  const: listScoresForRuns
+                params:
+                  type: object
+                  properties:
+                    runIds:
+                      type: array
+                      description: "Up to 30 run-id entries to compare. The server trims values and deduplicates them in first-seen order."
+                      items:
+                        type: string
+                        minLength: 1
+                        maxLength: 256
+                      maxItems: 30
+                    nodeId:
+                      type: string
+                      description: "Optional exact, case-sensitive node id filter."
+                    scorerId:
+                      type: string
+                      description: "Optional exact, case-sensitive scorer id filter."
+                    scorerName:
+                      type: string
+                      description: "Optional exact, case-sensitive scorer name filter."
+                    source:
+                      type: string
+                      enum:
+                        - live
+                        - batch
+                      description: "Optional exact production score provenance filter."
+                    order:
+                      type: string
+                      enum:
+                        - scoredAtAsc
+                        - scoredAtDesc
+                      default: scoredAtAsc
+                      description: "Primary score timestamp order."
+                    offset:
+                      type: integer
+                      minimum: 0
+                      maximum: 9999
+                      default: 0
+                      description: "Global result offset after merging distinct stores. The offset plus limit may not exceed the 10,000-row comparison window."
+                    limit:
+                      type: integer
+                      minimum: 1
+                      maximum: 500
+                      default: 500
+                      description: "Maximum globally merged rows to return. The offset plus limit may not exceed the 10,000-row comparison window."
+                  required:
+                    - runIds
+                  additionalProperties: false
+            example:
+              id: listScoresForRuns-1
+              method: listScoresForRuns
+              params:
+                runIds:
+                  - run_01
+                  - run_02
+                order: scoredAtDesc
+                offset: 0
+                limit: 500
+      responses:
+        200:
+          description: "List Scores For Runs response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - payload
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: true
+                  apiVersion:
+                    const: v1
+                  payload:
+                    type: object
+                    properties:
+                      rows:
+                        type: array
+                        description: "Globally ordered persisted scorer rows."
+                        items:
+                          type: object
+                          properties:
+                            scoreId:
+                              type: string
+                              description: "Exact persisted score id."
+                            runId:
+                              type: string
+                              description: "Run id the score belongs to."
+                            nodeId:
+                              type: string
+                              description: "Node id the score was produced for."
+                            iteration:
+                              type: integer
+                              minimum: 0
+                              description: "Node iteration the score belongs to."
+                            attempt:
+                              type: integer
+                              minimum: 0
+                              description: "Node attempt the score belongs to."
+                            scorerId:
+                              type: string
+                              description: "Stable scorer id."
+                            scorerName:
+                              type: string
+                              description: "Human scorer name."
+                            source:
+                              type: string
+                              description: "Persisted score source."
+                            score:
+                              type: number
+                              description: "The scorer's numeric verdict."
+                            reason:
+                              type:
+                                - string
+                                - "null"
+                              description: "Optional human reason for the score."
+                            scoredAtMs:
+                              type: integer
+                              minimum: 0
+                              description: "Unix epoch milliseconds when the score was recorded."
+                            latencyMs:
+                              type:
+                                - number
+                                - "null"
+                              description: "Optional scorer latency in milliseconds."
+                            durationMs:
+                              type:
+                                - number
+                                - "null"
+                              description: "Optional node duration in milliseconds."
+                          required:
+                            - scoreId
+                            - runId
+                            - nodeId
+                            - iteration
+                            - attempt
+                            - scorerId
+                            - scorerName
+                            - source
+                            - score
+                            - scoredAtMs
+                          additionalProperties: false
+                      total:
+                        type: integer
+                        minimum: 0
+                        description: "Total filtered row count before global pagination."
+                    required:
+                      - rows
+                      - total
+                    additionalProperties: false
+              example:
+                type: res
+                id: listScoresForRuns-1
+                ok: true
+                apiVersion: v1
+                payload:
+                  rows:
+                    -
+                      scoreId: run_01:review:correctness
+                      runId: run_01
+                      nodeId: review
+                      iteration: 0
+                      attempt: 0
+                      scorerId: correctness
+                      scorerName: correctness
+                      source: live
+                      score: 0.92
+                      scoredAtMs: 1710000000000
+                  total: 1
+        400:
+          description: "The request shape is invalid."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        401:
+          description: "Authentication failed or the token expired."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        403:
+          description: "The token is missing the required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        404:
+          description: "The run does not exist."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        500:
+          description: "The Gateway encountered an internal error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+  /v1/rpc/getScoreDetail:
+    post:
+      operationId: getScoreDetail
+      summary: "Get Score Detail"
+      description: "Read one exact persisted score row with its JSON detail columns decoded."
+      tags:
+        - "Gateway RPC"
+      security:
+        -
+          bearerAuth:
+            - score:read
+      x-smithers-api-version: v1
+      x-smithers-maturity: stable
+      x-smithers-transport: "http+websocket"
+      x-smithers-required-scope: score:read
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - method
+                - params
+              additionalProperties: false
+              properties:
+                id:
+                  type: string
+                  description: "Optional caller request id."
+                method:
+                  const: getScoreDetail
+                params:
+                  type: object
+                  properties:
+                    runId:
+                      type: string
+                      minLength: 1
+                      maxLength: 256
+                      description: "Owning run id (trimmed by the server)."
+                    scoreId:
+                      type: string
+                      minLength: 1
+                      maxLength: 256
+                      description: "Exact persisted score id (trimmed by the server)."
+                  required:
+                    - runId
+                    - scoreId
+                  additionalProperties: false
+            example:
+              id: getScoreDetail-1
+              method: getScoreDetail
+              params:
+                runId: run_01
+                scoreId: run_01:review:correctness
+      responses:
+        200:
+          description: "Get Score Detail response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - payload
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: true
+                  apiVersion:
+                    const: v1
+                  payload:
+                    type: object
+                    properties:
+                      scoreId:
+                        type: string
+                        description: "Exact persisted score id."
+                      runId:
+                        type: string
+                        description: "Run id the score belongs to."
+                      nodeId:
+                        type: string
+                        description: "Node id the score was produced for."
+                      iteration:
+                        type: integer
+                        minimum: 0
+                        description: "Node iteration the score belongs to."
+                      attempt:
+                        type: integer
+                        minimum: 0
+                        description: "Node attempt the score belongs to."
+                      scorerId:
+                        type: string
+                        description: "Stable scorer id."
+                      scorerName:
+                        type: string
+                        description: "Human scorer name."
+                      source:
+                        type: string
+                        description: "Persisted score source."
+                      score:
+                        type: number
+                        description: "The scorer's numeric verdict."
+                      reason:
+                        type:
+                          - string
+                          - "null"
+                        description: "Optional human reason for the score."
+                      scoredAtMs:
+                        type: integer
+                        minimum: 0
+                        description: "Unix epoch milliseconds when the score was recorded."
+                      latencyMs:
+                        type:
+                          - number
+                          - "null"
+                        description: "Optional scorer latency in milliseconds."
+                      durationMs:
+                        type:
+                          - number
+                          - "null"
+                        description: "Optional node duration in milliseconds."
+                      meta:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      input:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      output:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      groundTruth:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      context:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                    required:
+                      - scoreId
+                      - runId
+                      - nodeId
+                      - iteration
+                      - attempt
+                      - scorerId
+                      - scorerName
+                      - source
+                      - score
+                      - scoredAtMs
+                      - meta
+                      - input
+                      - output
+                      - groundTruth
+                      - context
+                    additionalProperties: false
+              example:
+                type: res
+                id: getScoreDetail-1
+                ok: true
+                apiVersion: v1
+                payload:
+                  scoreId: run_01:review:correctness
+                  runId: run_01
+                  nodeId: review
+                  iteration: 0
+                  attempt: 0
+                  scorerId: correctness
+                  scorerName: correctness
+                  source: live
+                  score: 0.92
+                  scoredAtMs: 1710000000000
+                  meta:
+                    rubric: correctness
+                  input:
+                    prompt: "Review this."
+                  output:
+                    verdict: pass
+                  groundTruth: null
+                  context: null
+        400:
+          description: "The request shape is invalid."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - ScoreNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        401:
+          description: "Authentication failed or the token expired."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - ScoreNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        403:
+          description: "The token is missing the required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - ScoreNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        404:
+          description: "The score does not exist on the requested run."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - ScoreNotFound
+                          - Internal
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+                      refresh:
+                        type: string
+        500:
+          description: "The Gateway encountered an internal error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - type
+                  - id
+                  - ok
+                  - apiVersion
+                  - error
+                additionalProperties: false
+                properties:
+                  type:
+                    const: res
+                  id:
+                    type: string
+                  ok:
+                    const: false
+                  apiVersion:
+                    const: v1
+                  error:
+                    type: object
+                    required:
+                      - version
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      version:
+                        const: v1
+                      code:
+                        type: string
+                        enum:
+                          - InvalidRequest
+                          - Unauthorized
+                          - Forbidden
+                          - RunNotFound
+                          - ScoreNotFound
                           - Internal
                       message:
                         type: string
@@ -17453,6 +18554,844 @@ paths:
                           - ticket:read
                           - ticket:write
                           - observability:read
+  /v1/api/scores/compare:
+    get:
+      operationId: apiListScoresForRuns
+      summary: "List scores across runs."
+      description: "REST domain API wrapper over the listScoresForRuns Gateway RPC internals."
+      tags:
+        - "Gateway REST"
+      security:
+        -
+          bearerAuth:
+            - score:read
+      x-smithers-api-version: v1
+      x-smithers-required-scope: score:read
+      x-smithers-rpc-method: listScoresForRuns
+      parameters:
+        -
+          name: runId
+          in: query
+          description: "Run id entry. Repeat this query parameter for each run to compare."
+          required: false
+          schema:
+            type: array
+            description: "Up to 30 run-id entries to compare. The server trims values and deduplicates them in first-seen order."
+            items:
+              type: string
+              minLength: 1
+              maxLength: 256
+            maxItems: 30
+          style: form
+          explode: true
+        -
+          name: nodeId
+          in: query
+          description: "Optional exact, case-sensitive node id filter."
+          required: false
+          schema:
+            type: string
+            description: "Optional exact, case-sensitive node id filter."
+        -
+          name: scorerId
+          in: query
+          description: "Optional exact, case-sensitive scorer id filter."
+          required: false
+          schema:
+            type: string
+            description: "Optional exact, case-sensitive scorer id filter."
+        -
+          name: scorerName
+          in: query
+          description: "Optional exact, case-sensitive scorer name filter."
+          required: false
+          schema:
+            type: string
+            description: "Optional exact, case-sensitive scorer name filter."
+        -
+          name: source
+          in: query
+          description: "Optional score provenance filter."
+          required: false
+          schema:
+            type: string
+            enum:
+              - live
+              - batch
+            description: "Optional exact production score provenance filter."
+        -
+          name: order
+          in: query
+          description: "Primary score timestamp order."
+          required: false
+          schema:
+            type: string
+            enum:
+              - scoredAtAsc
+              - scoredAtDesc
+            default: scoredAtAsc
+            description: "Primary score timestamp order."
+        -
+          name: offset
+          in: query
+          description: "Global result offset."
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 9999
+            default: 0
+            description: "Global result offset after merging distinct stores. The offset plus limit may not exceed the 10,000-row comparison window."
+        -
+          name: limit
+          in: query
+          description: "Maximum globally merged rows to return."
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 500
+            description: "Maximum globally merged rows to return. The offset plus limit may not exceed the 10,000-row comparison window."
+      responses:
+        200:
+          description: "Gateway REST response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - data
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: true
+                  data:
+                    type: object
+                    properties:
+                      rows:
+                        type: array
+                        description: "Globally ordered persisted scorer rows."
+                        items:
+                          type: object
+                          properties:
+                            scoreId:
+                              type: string
+                              description: "Exact persisted score id."
+                            runId:
+                              type: string
+                              description: "Run id the score belongs to."
+                            nodeId:
+                              type: string
+                              description: "Node id the score was produced for."
+                            iteration:
+                              type: integer
+                              minimum: 0
+                              description: "Node iteration the score belongs to."
+                            attempt:
+                              type: integer
+                              minimum: 0
+                              description: "Node attempt the score belongs to."
+                            scorerId:
+                              type: string
+                              description: "Stable scorer id."
+                            scorerName:
+                              type: string
+                              description: "Human scorer name."
+                            source:
+                              type: string
+                              description: "Persisted score source."
+                            score:
+                              type: number
+                              description: "The scorer's numeric verdict."
+                            reason:
+                              type:
+                                - string
+                                - "null"
+                              description: "Optional human reason for the score."
+                            scoredAtMs:
+                              type: integer
+                              minimum: 0
+                              description: "Unix epoch milliseconds when the score was recorded."
+                            latencyMs:
+                              type:
+                                - number
+                                - "null"
+                              description: "Optional scorer latency in milliseconds."
+                            durationMs:
+                              type:
+                                - number
+                                - "null"
+                              description: "Optional node duration in milliseconds."
+                          required:
+                            - scoreId
+                            - runId
+                            - nodeId
+                            - iteration
+                            - attempt
+                            - scorerId
+                            - scorerName
+                            - source
+                            - score
+                            - scoredAtMs
+                          additionalProperties: false
+                      total:
+                        type: integer
+                        minimum: 0
+                        description: "Total filtered row count before global pagination."
+                    required:
+                      - rows
+                      - total
+                    additionalProperties: false
+                  txid:
+                    type: string
+                    pattern: "^\\d+$"
+                  seq:
+                    type: integer
+                    minimum: 0
+        400:
+          description: "Invalid request."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        401:
+          description: "Authentication failed."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        403:
+          description: "Missing required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        404:
+          description: "Route or resource not found."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        500:
+          description: "Internal server error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+  /v1/api/scores/{runId}/{scoreId}:
+    get:
+      operationId: apiGetScoreDetail
+      summary: "Read one score with decoded detail."
+      description: "REST domain API wrapper over the getScoreDetail Gateway RPC internals."
+      tags:
+        - "Gateway REST"
+      security:
+        -
+          bearerAuth:
+            - score:read
+      x-smithers-api-version: v1
+      x-smithers-required-scope: score:read
+      x-smithers-rpc-method: getScoreDetail
+      parameters:
+        -
+          name: runId
+          in: path
+          description: "Owning run id."
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 256
+            description: "Owning run id (trimmed by the server)."
+        -
+          name: scoreId
+          in: path
+          description: "Exact persisted score id."
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 256
+            description: "Exact persisted score id (trimmed by the server)."
+      responses:
+        200:
+          description: "Gateway REST response."
+          headers:
+            X-Smithers-API-Version:
+              schema:
+                type: string
+                enum:
+                  - v1
+              description: "Stable Smithers Gateway API version."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - data
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: true
+                  data:
+                    type: object
+                    properties:
+                      scoreId:
+                        type: string
+                        description: "Exact persisted score id."
+                      runId:
+                        type: string
+                        description: "Run id the score belongs to."
+                      nodeId:
+                        type: string
+                        description: "Node id the score was produced for."
+                      iteration:
+                        type: integer
+                        minimum: 0
+                        description: "Node iteration the score belongs to."
+                      attempt:
+                        type: integer
+                        minimum: 0
+                        description: "Node attempt the score belongs to."
+                      scorerId:
+                        type: string
+                        description: "Stable scorer id."
+                      scorerName:
+                        type: string
+                        description: "Human scorer name."
+                      source:
+                        type: string
+                        description: "Persisted score source."
+                      score:
+                        type: number
+                        description: "The scorer's numeric verdict."
+                      reason:
+                        type:
+                          - string
+                          - "null"
+                        description: "Optional human reason for the score."
+                      scoredAtMs:
+                        type: integer
+                        minimum: 0
+                        description: "Unix epoch milliseconds when the score was recorded."
+                      latencyMs:
+                        type:
+                          - number
+                          - "null"
+                        description: "Optional scorer latency in milliseconds."
+                      durationMs:
+                        type:
+                          - number
+                          - "null"
+                        description: "Optional node duration in milliseconds."
+                      meta:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      input:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      output:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      groundTruth:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                      context:
+                        description: "Any JSON value."
+                        nullable: true
+                        oneOf:
+                          -
+                            type: object
+                            additionalProperties: true
+                          -
+                            type: array
+                            items:
+                              nullable: true
+                          -
+                            type: string
+                          -
+                            type: number
+                          -
+                            type: boolean
+                          -
+                            type: "null"
+                    required:
+                      - scoreId
+                      - runId
+                      - nodeId
+                      - iteration
+                      - attempt
+                      - scorerId
+                      - scorerName
+                      - source
+                      - score
+                      - scoredAtMs
+                      - meta
+                      - input
+                      - output
+                      - groundTruth
+                      - context
+                    additionalProperties: false
+                  txid:
+                    type: string
+                    pattern: "^\\d+$"
+                  seq:
+                    type: integer
+                    minimum: 0
+        400:
+          description: "Invalid request."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        401:
+          description: "Authentication failed."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        403:
+          description: "Missing required scope."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        404:
+          description: "Route or resource not found."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
+        500:
+          description: "Internal server error."
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                  - error
+                additionalProperties: false
+                properties:
+                  ok:
+                    const: false
+                  error:
+                    type: object
+                    required:
+                      - code
+                      - message
+                    additionalProperties: true
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                      requiredScope:
+                        type: string
+                        enum:
+                          - run:read
+                          - run:write
+                          - run:admin
+                          - approval:submit
+                          - signal:submit
+                          - cron:read
+                          - cron:write
+                          - account:read
+                          - memory:read
+                          - prompt:read
+                          - score:read
+                          - ticket:read
+                          - ticket:write
+                          - observability:read
   /v1/api/tickets:
     get:
       operationId: apiListTickets
@@ -19969,6 +21908,7 @@ components:
         - Unauthorized
         - Forbidden
         - RunNotFound
+        - ScoreNotFound
         - RUN_NOT_ACTIVE
         - CronNotFound
         - TicketNotFound

--- a/packages/gateway/scripts/generate-openapi.ts
+++ b/packages/gateway/scripts/generate-openapi.ts
@@ -5,8 +5,10 @@ import {
   GATEWAY_RPC_DEFINITIONS,
   GATEWAY_RPC_ERRORS,
   SMITHERS_API_VERSION,
+  getGatewayRpcDefinition,
   getRequiredScopeForGatewayMethod,
   type GatewayRpcDefinition,
+  type GatewayRpcMethod,
   type JsonSchema,
 } from "../src/rpc/index.js";
 import { GATEWAY_SCOPE_DESCRIPTIONS, GATEWAY_SCOPE_VALUES } from "../src/auth/scopes.js";
@@ -37,8 +39,19 @@ type GatewayApiRouteDefinition = {
   requiredScope: GatewayScope;
   requestSchema?: JsonSchema;
   responseSchema?: JsonSchema;
+  parameters?: readonly GatewayApiParameterDefinition[];
   mutation?: boolean;
   sse?: boolean;
+};
+
+type GatewayApiParameterDefinition = {
+  name: string;
+  in: "path" | "query";
+  description: string;
+  required?: boolean;
+  schema: JsonSchema;
+  style?: "form" | "simple";
+  explode?: boolean;
 };
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -52,10 +65,25 @@ function scopeForRpc(method: string): GatewayScope {
   return getRequiredScopeForGatewayMethod(method) ?? "run:read";
 }
 
+function requireRpcDefinition(method: GatewayRpcMethod): GatewayRpcDefinition {
+  const definition = getGatewayRpcDefinition(method);
+  if (!definition) throw new Error(`Missing Gateway RPC definition: ${method}`);
+  return definition;
+}
+
+function requireRequestProperty(definition: GatewayRpcDefinition, property: string): JsonSchema {
+  const schema = definition.requestSchema.properties?.[property];
+  if (!schema) throw new Error(`Missing ${definition.method} request property: ${property}`);
+  return schema;
+}
+
 const objectSchema = {
   type: "object",
   additionalProperties: true,
 } satisfies JsonSchema;
+
+const listScoresForRunsRpc = requireRpcDefinition("listScoresForRuns");
+const getScoreDetailRpc = requireRpcDefinition("getScoreDetail");
 
 const gatewayApiRoutes: readonly GatewayApiRouteDefinition[] = [
   { method: "get", path: "/v1/api/runs", operationId: "apiListRuns", summary: "List runs.", rpcMethod: "listRuns", requiredScope: scopeForRpc("listRuns"), responseSchema: { type: "array", items: objectSchema } },
@@ -75,6 +103,46 @@ const gatewayApiRoutes: readonly GatewayApiRouteDefinition[] = [
   { method: "get", path: "/v1/api/docs", operationId: "apiListDocs", summary: "List docs.", rpcMethod: "listDocs", requiredScope: scopeForRpc("listDocs"), responseSchema: { type: "array", items: objectSchema } },
   { method: "get", path: "/v1/api/prompts", operationId: "apiListPrompts", summary: "List prompts.", rpcMethod: "listPrompts", requiredScope: scopeForRpc("listPrompts"), responseSchema: { type: "array", items: objectSchema } },
   { method: "get", path: "/v1/api/scores", operationId: "apiListScores", summary: "List scores for a run.", rpcMethod: "listScores", requiredScope: scopeForRpc("listScores"), responseSchema: { type: "array", items: objectSchema } },
+  {
+    method: "get",
+    path: "/v1/api/scores/compare",
+    operationId: "apiListScoresForRuns",
+    summary: "List scores across runs.",
+    rpcMethod: "listScoresForRuns",
+    requiredScope: scopeForRpc("listScoresForRuns"),
+    responseSchema: listScoresForRunsRpc.responseSchema,
+    parameters: [
+      {
+        name: "runId",
+        in: "query",
+        description: "Run id entry. Repeat this query parameter for each run to compare.",
+        required: false,
+        schema: requireRequestProperty(listScoresForRunsRpc, "runIds"),
+        style: "form",
+        explode: true,
+      },
+      { name: "nodeId", in: "query", description: "Optional exact, case-sensitive node id filter.", schema: requireRequestProperty(listScoresForRunsRpc, "nodeId") },
+      { name: "scorerId", in: "query", description: "Optional exact, case-sensitive scorer id filter.", schema: requireRequestProperty(listScoresForRunsRpc, "scorerId") },
+      { name: "scorerName", in: "query", description: "Optional exact, case-sensitive scorer name filter.", schema: requireRequestProperty(listScoresForRunsRpc, "scorerName") },
+      { name: "source", in: "query", description: "Optional score provenance filter.", schema: requireRequestProperty(listScoresForRunsRpc, "source") },
+      { name: "order", in: "query", description: "Primary score timestamp order.", schema: requireRequestProperty(listScoresForRunsRpc, "order") },
+      { name: "offset", in: "query", description: "Global result offset.", schema: requireRequestProperty(listScoresForRunsRpc, "offset") },
+      { name: "limit", in: "query", description: "Maximum globally merged rows to return.", schema: requireRequestProperty(listScoresForRunsRpc, "limit") },
+    ],
+  },
+  {
+    method: "get",
+    path: "/v1/api/scores/{runId}/{scoreId}",
+    operationId: "apiGetScoreDetail",
+    summary: "Read one score with decoded detail.",
+    rpcMethod: "getScoreDetail",
+    requiredScope: scopeForRpc("getScoreDetail"),
+    responseSchema: getScoreDetailRpc.responseSchema,
+    parameters: [
+      { name: "runId", in: "path", description: "Owning run id.", required: true, schema: requireRequestProperty(getScoreDetailRpc, "runId") },
+      { name: "scoreId", in: "path", description: "Exact persisted score id.", required: true, schema: requireRequestProperty(getScoreDetailRpc, "scoreId") },
+    ],
+  },
   { method: "get", path: "/v1/api/tickets", operationId: "apiListTickets", summary: "List work docs.", rpcMethod: "listTickets", requiredScope: scopeForRpc("listTickets"), responseSchema: { type: "array", items: objectSchema } },
   { method: "get", path: "/v1/api/memory-facts", operationId: "apiListMemoryFacts", summary: "List memory facts.", rpcMethod: "listMemoryFacts", requiredScope: scopeForRpc("listMemoryFacts"), responseSchema: { type: "array", items: objectSchema } },
   { method: "get", path: "/v1/api/crons", operationId: "apiCronList", summary: "List cron schedules.", rpcMethod: "cronList", requiredScope: scopeForRpc("cronList"), responseSchema: { type: "array", items: objectSchema } },
@@ -270,6 +338,19 @@ function buildApiPath(definition: GatewayApiRouteDefinition) {
     "x-smithers-api-version": SMITHERS_API_VERSION,
     "x-smithers-required-scope": definition.requiredScope,
     ...(definition.rpcMethod ? { "x-smithers-rpc-method": definition.rpcMethod } : {}),
+    ...(definition.parameters?.length
+      ? {
+          parameters: definition.parameters.map((parameter) => ({
+            name: parameter.name,
+            in: parameter.in,
+            description: parameter.description,
+            required: parameter.required ?? parameter.in === "path",
+            schema: parameter.schema,
+            ...(parameter.style ? { style: parameter.style } : {}),
+            ...(parameter.explode !== undefined ? { explode: parameter.explode } : {}),
+          })),
+        }
+      : {}),
     responses: {
       "200": {
         description: definition.sse ? "Invalidation event stream." : "Gateway REST response.",

--- a/packages/gateway/src/api/index.d.ts
+++ b/packages/gateway/src/api/index.d.ts
@@ -82,6 +82,71 @@ declare function serializeRunEventRow<Row extends Record<string, unknown>>(row: 
 declare function serializeRunRow<Row extends Record<string, unknown>>(row: Row): Row;
 
 /**
+ * Type-only declarations for the stable v1 Gateway RPC contract. The runtime
+ * catalog (schemas, error definitions, lookup helpers) lives in `index.js`,
+ * which re-exports every type here via its `@smithers-type-exports` block.
+ *
+ * This file deliberately does NOT share a basename with `index.js`: a
+ * same-basename `.js`/`.ts` pair both compile to one `.d.ts` and the type-only
+ * twin silently drops every value export from the `.js`.
+ */
+
+/**
+ * One scorer/eval result row (the `_smithers_scorers` table, snake→camel cased).
+ * `score` is the scorer's verdict; `latencyMs`/`durationMs` are the only timing
+ * metrics the table carries (there is NO token/cost data — those tiles are
+ * computed client-side and em-dashed when absent).
+ */
+type GatewayScoreRow = {
+    runId: string;
+    nodeId: string;
+    iteration: number;
+    attempt: number;
+    scorerId: string;
+    scorerName: string;
+    source: string;
+    score: number;
+    reason?: string | null;
+    scoredAtMs: number;
+    latencyMs?: number | null;
+    durationMs?: number | null;
+};
+/** One cross-run score row, including the exact persisted score identity. */
+type GatewayComparisonScoreRow$1 = GatewayScoreRow & {
+    scoreId: string;
+};
+/**
+ * One exact persisted score with its JSON detail columns decoded. Every detail
+ * field is present; a SQL NULL (or stored JSON `null`) is returned as JSON null.
+ */
+type GatewayScoreDetail$1 = GatewayComparisonScoreRow$1 & {
+    meta: unknown;
+    input: unknown;
+    output: unknown;
+    groundTruth: unknown;
+    context: unknown;
+};
+
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayComparisonScoreRow} GatewayComparisonScoreRow */
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayComparisonScoreRow}
+ */
+declare function serializeComparisonScoreRow(row: Record<string, unknown>): GatewayComparisonScoreRow;
+type GatewayComparisonScoreRow = GatewayComparisonScoreRow$1;
+
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayScoreDetail} GatewayScoreDetail */
+/**
+ * Serialize an already-decoded score detail row. JSON parsing deliberately
+ * stays in the server so malformed persistence can fail explicitly instead of
+ * being hidden by a wire serializer.
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayScoreDetail}
+ */
+declare function serializeScoreDetailRow(row: Record<string, unknown>): GatewayScoreDetail;
+type GatewayScoreDetail = GatewayScoreDetail$1;
+
+/**
  * @template {Record<string, unknown>} Row
  * @param {Row} row
  * @returns {Row}
@@ -102,4 +167,4 @@ declare function serializeTicketRow<Row extends Record<string, unknown>>(row: Ro
  */
 declare function serializeWorkflowRow<Row extends Record<string, unknown>>(row: Row): Row;
 
-export { apiCollectionNames, serializeAccountRow, serializeApprovalRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow };
+export { apiCollectionNames, serializeAccountRow, serializeApprovalRow, serializeComparisonScoreRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreDetailRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow };

--- a/packages/gateway/src/api/index.js
+++ b/packages/gateway/src/api/index.js
@@ -7,6 +7,8 @@ export { serializeMemoryFactRow } from "./serializeMemoryFactRow.js";
 export { serializePromptRow } from "./serializePromptRow.js";
 export { serializeRunEventRow } from "./serializeRunEventRow.js";
 export { serializeRunRow } from "./serializeRunRow.js";
+export { serializeComparisonScoreRow } from "./serializeComparisonScoreRow.js";
+export { serializeScoreDetailRow } from "./serializeScoreDetailRow.js";
 export { serializeScoreRow } from "./serializeScoreRow.js";
 export { serializeTicketRow } from "./serializeTicketRow.js";
 export { serializeWorkflowRow } from "./serializeWorkflowRow.js";

--- a/packages/gateway/src/api/serializeComparisonScoreRow.js
+++ b/packages/gateway/src/api/serializeComparisonScoreRow.js
@@ -1,0 +1,16 @@
+import { normalizeApiRow } from "./normalizeApiRow.js";
+import { serializeScoreRow } from "./serializeScoreRow.js";
+
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayComparisonScoreRow} GatewayComparisonScoreRow */
+
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayComparisonScoreRow}
+ */
+export function serializeComparisonScoreRow(row) {
+  const normalized = normalizeApiRow(row);
+  return /** @type {GatewayComparisonScoreRow} */ (/** @type {unknown} */ ({
+    scoreId: normalized.scoreId ?? normalized.id,
+    ...serializeScoreRow(row),
+  }));
+}

--- a/packages/gateway/src/api/serializeScoreDetailRow.js
+++ b/packages/gateway/src/api/serializeScoreDetailRow.js
@@ -1,0 +1,23 @@
+import { normalizeApiRow } from "./normalizeApiRow.js";
+import { serializeComparisonScoreRow } from "./serializeComparisonScoreRow.js";
+
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayScoreDetail} GatewayScoreDetail */
+
+/**
+ * Serialize an already-decoded score detail row. JSON parsing deliberately
+ * stays in the server so malformed persistence can fail explicitly instead of
+ * being hidden by a wire serializer.
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayScoreDetail}
+ */
+export function serializeScoreDetailRow(row) {
+  const normalized = normalizeApiRow(row);
+  return /** @type {GatewayScoreDetail} */ (/** @type {unknown} */ ({
+    ...serializeComparisonScoreRow(row),
+    meta: normalized.meta ?? null,
+    input: normalized.input ?? null,
+    output: normalized.output ?? null,
+    groundTruth: normalized.groundTruth ?? null,
+    context: normalized.context ?? null,
+  }));
+}

--- a/packages/gateway/src/index.d.ts
+++ b/packages/gateway/src/index.d.ts
@@ -1,20 +1,6 @@
-/**
- * @param {string} scope
- * @returns {scope is GatewayScope}
- */
-declare function isGatewayScope(scope: string): scope is GatewayScope$2;
-/**
- * @param {readonly string[]} grantedScopes
- * @param {GatewayScope} requiredScope
- * @param {string} [methodName]
- * @returns {boolean}
- */
-declare function hasGatewayScope(grantedScopes: readonly string[], requiredScope: GatewayScope$2, methodName?: string): boolean;
 /** @typedef {(typeof GATEWAY_SCOPE_VALUES)[number]} GatewayScope */
-declare const GATEWAY_SCOPE_VALUES: readonly ["run:read", "run:write", "run:admin", "approval:submit", "signal:submit", "cron:read", "cron:write", "account:read", "memory:read", "prompt:read", "score:read", "ticket:read", "ticket:write", "observability:read"];
-/** @type {Record<GatewayScope, string>} */
-declare const GATEWAY_SCOPE_DESCRIPTIONS: Record<GatewayScope$2, string>;
-type GatewayScope$2 = (typeof GATEWAY_SCOPE_VALUES)[number];
+declare const GATEWAY_SCOPE_VALUES$2: readonly ["run:read", "run:write", "run:admin", "approval:submit", "signal:submit", "cron:read", "cron:write", "account:read", "memory:read", "prompt:read", "score:read", "ticket:read", "ticket:write", "observability:read"];
+type GatewayScope$4 = (typeof GATEWAY_SCOPE_VALUES$2)[number];
 
 /**
  * Type-only declarations for the stable v1 Gateway RPC contract. The runtime
@@ -26,8 +12,8 @@ type GatewayScope$2 = (typeof GATEWAY_SCOPE_VALUES)[number];
  * twin silently drops every value export from the `.js`.
  */
 
-type SmithersApiVersion$2 = "v1";
-type JsonSchema$2 = {
+type SmithersApiVersion$3 = "v1";
+type JsonSchema$3 = {
     readonly type?: string | readonly string[];
     readonly description?: string;
     readonly enum?: readonly unknown[];
@@ -35,37 +21,41 @@ type JsonSchema$2 = {
     readonly format?: string;
     readonly minimum?: number;
     readonly maximum?: number;
+    readonly minLength?: number;
+    readonly maxLength?: number;
+    readonly minItems?: number;
+    readonly maxItems?: number;
     readonly default?: unknown;
     readonly nullable?: boolean;
-    readonly items?: JsonSchema$2;
-    readonly properties?: Record<string, JsonSchema$2>;
+    readonly items?: JsonSchema$3;
+    readonly properties?: Record<string, JsonSchema$3>;
     readonly required?: readonly string[];
-    readonly additionalProperties?: boolean | JsonSchema$2;
-    readonly oneOf?: readonly JsonSchema$2[];
-    readonly anyOf?: readonly JsonSchema$2[];
+    readonly additionalProperties?: boolean | JsonSchema$3;
+    readonly oneOf?: readonly JsonSchema$3[];
+    readonly anyOf?: readonly JsonSchema$3[];
 };
-type GatewayRpcErrorCode$2 = "InvalidRequest" | "InvalidInput" | "Unauthorized" | "Forbidden" | "RunNotFound" | "RUN_NOT_ACTIVE" | "CronNotFound" | "TicketNotFound" | "NodeNotFound" | "IterationNotFound" | "NodeHasNoOutput" | "FrameOutOfRange" | "SeqOutOfRange" | "Busy" | "AlreadyDecided" | "RateLimited" | "PayloadTooLarge" | "BackpressureDisconnect" | "UnsupportedSandbox" | "VcsError" | "RewindFailed" | "Internal";
-type GatewayRpcErrorDefinition$2 = {
-    readonly version: SmithersApiVersion$2;
-    readonly code: GatewayRpcErrorCode$2;
+type GatewayRpcErrorCode$3 = "InvalidRequest" | "InvalidInput" | "Unauthorized" | "Forbidden" | "RunNotFound" | "ScoreNotFound" | "RUN_NOT_ACTIVE" | "CronNotFound" | "TicketNotFound" | "NodeNotFound" | "IterationNotFound" | "NodeHasNoOutput" | "FrameOutOfRange" | "SeqOutOfRange" | "Busy" | "AlreadyDecided" | "RateLimited" | "PayloadTooLarge" | "BackpressureDisconnect" | "UnsupportedSandbox" | "VcsError" | "RewindFailed" | "Internal";
+type GatewayRpcErrorDefinition$3 = {
+    readonly version: SmithersApiVersion$3;
+    readonly code: GatewayRpcErrorCode$3;
     readonly httpStatus: number;
     readonly description: string;
 };
-type GatewayRpcDefinition$2 = {
-    readonly version: SmithersApiVersion$2;
-    readonly method: GatewayRpcMethod$2;
+type GatewayRpcDefinition$3 = {
+    readonly version: SmithersApiVersion$3;
+    readonly method: GatewayRpcMethod$3;
     readonly title: string;
     readonly description: string;
     readonly maturity: "stable";
     readonly transport: "http" | "websocket" | "http+websocket";
-    readonly requiredScope: GatewayScope$2;
-    readonly requestSchema: JsonSchema$2;
-    readonly responseSchema: JsonSchema$2;
-    readonly errors: readonly GatewayRpcErrorCode$2[];
+    readonly requiredScope: GatewayScope$4;
+    readonly requestSchema: JsonSchema$3;
+    readonly responseSchema: JsonSchema$3;
+    readonly errors: readonly GatewayRpcErrorCode$3[];
     readonly exampleRequest: unknown;
     readonly exampleResponse: unknown;
 };
-type GatewayRpcMethod$2 = "launchRun" | "resumeRun" | "cancelRun" | "pauseRun" | "hijackRun" | "rewindRun" | "submitApproval" | "submitSignal" | "getRun" | "listRuns" | "getSchemaSignature" | "listWorkflows" | "listApprovals" | "listDocs" | "streamRunEvents" | "streamDevTools" | "getDevToolsSnapshot" | "getNodeOutput" | "getNodeDiff" | "whatHappened" | "cronList" | "cronCreate" | "cronDelete" | "cronRun" | "listAccounts" | "listMemoryFacts" | "listPrompts" | "listScores" | "listTickets" | "createTicket" | "updateTicket" | "deleteTicket";
+type GatewayRpcMethod$3 = "launchRun" | "resumeRun" | "cancelRun" | "pauseRun" | "hijackRun" | "rewindRun" | "submitApproval" | "submitSignal" | "getRun" | "listRuns" | "getSchemaSignature" | "listWorkflows" | "listApprovals" | "listDocs" | "streamRunEvents" | "streamDevTools" | "getDevToolsSnapshot" | "getNodeOutput" | "getNodeDiff" | "whatHappened" | "cronList" | "cronCreate" | "cronDelete" | "cronRun" | "listAccounts" | "listMemoryFacts" | "listPrompts" | "listScores" | "listScoresForRuns" | "getScoreDetail" | "listTickets" | "createTicket" | "updateTicket" | "deleteTicket";
 type LaunchRunRequest$1 = {
     workflow: string;
     input?: Record<string, unknown>;
@@ -353,6 +343,45 @@ type ListScoresRequest$1 = {
     nodeId?: string;
 };
 type ListScoresResponse$1 = GatewayScoreRow$1[];
+/** One cross-run score row, including the exact persisted score identity. */
+type GatewayComparisonScoreRow$2 = GatewayScoreRow$1 & {
+    scoreId: string;
+};
+/**
+ * Batch score rows for explicit run ids. Callers must already know the scorer-
+ * producing run ids: this does not expand an eval wrapper run into child case
+ * runs or provide experiment/case alignment.
+ */
+type ListScoresForRunsRequest$1 = {
+    runIds: string[];
+    nodeId?: string;
+    scorerId?: string;
+    scorerName?: string;
+    source?: "live" | "batch";
+    order?: "scoredAtAsc" | "scoredAtDesc";
+    offset?: number;
+    limit?: number;
+};
+type ListScoresForRunsResponse$1 = {
+    rows: GatewayComparisonScoreRow$2[];
+    total: number;
+};
+type GetScoreDetailRequest$1 = {
+    runId: string;
+    scoreId: string;
+};
+/**
+ * One exact persisted score with its JSON detail columns decoded. Every detail
+ * field is present; a SQL NULL (or stored JSON `null`) is returned as JSON null.
+ */
+type GatewayScoreDetail$2 = GatewayComparisonScoreRow$2 & {
+    meta: unknown;
+    input: unknown;
+    output: unknown;
+    groundTruth: unknown;
+    context: unknown;
+};
+type GetScoreDetailResponse$1 = GatewayScoreDetail$2;
 /**
  * A doc kind stored in `_smithers_docs`; the tickets surface uses `ticket`. The
  * runtime `DOC_KINDS` tuple in `index.js` (which feeds every ticket-RPC schema
@@ -395,50 +424,127 @@ type DeleteTicketRequest$1 = {
 };
 
 /**
+ * @param {string} scope
+ * @returns {scope is GatewayScope}
+ */
+declare function isGatewayScope(scope: string): scope is GatewayScope$3;
+/**
+ * @param {readonly string[]} grantedScopes
+ * @param {GatewayScope} requiredScope
+ * @param {string} [methodName]
+ * @returns {boolean}
+ */
+declare function hasGatewayScope(grantedScopes: readonly string[], requiredScope: GatewayScope$3, methodName?: string): boolean;
+/** @typedef {(typeof GATEWAY_SCOPE_VALUES)[number]} GatewayScope */
+declare const GATEWAY_SCOPE_VALUES$1: readonly ["run:read", "run:write", "run:admin", "approval:submit", "signal:submit", "cron:read", "cron:write", "account:read", "memory:read", "prompt:read", "score:read", "ticket:read", "ticket:write", "observability:read"];
+/** @type {Record<GatewayScope, string>} */
+declare const GATEWAY_SCOPE_DESCRIPTIONS: Record<GatewayScope$3, string>;
+type GatewayScope$3 = (typeof GATEWAY_SCOPE_VALUES$1)[number];
+
+/** @typedef {(typeof GATEWAY_SCOPE_VALUES)[number]} GatewayScope */
+declare const GATEWAY_SCOPE_VALUES: readonly ["run:read", "run:write", "run:admin", "approval:submit", "signal:submit", "cron:read", "cron:write", "account:read", "memory:read", "prompt:read", "score:read", "ticket:read", "ticket:write", "observability:read"];
+type GatewayScope$1 = (typeof GATEWAY_SCOPE_VALUES)[number];
+
+/**
+ * Type-only declarations for the stable v1 Gateway RPC contract. The runtime
+ * catalog (schemas, error definitions, lookup helpers) lives in `index.js`,
+ * which re-exports every type here via its `@smithers-type-exports` block.
+ *
+ * This file deliberately does NOT share a basename with `index.js`: a
+ * same-basename `.js`/`.ts` pair both compile to one `.d.ts` and the type-only
+ * twin silently drops every value export from the `.js`.
+ */
+
+type SmithersApiVersion$1 = "v1";
+type JsonSchema$1 = {
+    readonly type?: string | readonly string[];
+    readonly description?: string;
+    readonly enum?: readonly unknown[];
+    readonly const?: unknown;
+    readonly format?: string;
+    readonly minimum?: number;
+    readonly maximum?: number;
+    readonly minLength?: number;
+    readonly maxLength?: number;
+    readonly minItems?: number;
+    readonly maxItems?: number;
+    readonly default?: unknown;
+    readonly nullable?: boolean;
+    readonly items?: JsonSchema$1;
+    readonly properties?: Record<string, JsonSchema$1>;
+    readonly required?: readonly string[];
+    readonly additionalProperties?: boolean | JsonSchema$1;
+    readonly oneOf?: readonly JsonSchema$1[];
+    readonly anyOf?: readonly JsonSchema$1[];
+};
+type GatewayRpcErrorCode$1 = "InvalidRequest" | "InvalidInput" | "Unauthorized" | "Forbidden" | "RunNotFound" | "ScoreNotFound" | "RUN_NOT_ACTIVE" | "CronNotFound" | "TicketNotFound" | "NodeNotFound" | "IterationNotFound" | "NodeHasNoOutput" | "FrameOutOfRange" | "SeqOutOfRange" | "Busy" | "AlreadyDecided" | "RateLimited" | "PayloadTooLarge" | "BackpressureDisconnect" | "UnsupportedSandbox" | "VcsError" | "RewindFailed" | "Internal";
+type GatewayRpcErrorDefinition$1 = {
+    readonly version: SmithersApiVersion$1;
+    readonly code: GatewayRpcErrorCode$1;
+    readonly httpStatus: number;
+    readonly description: string;
+};
+type GatewayRpcDefinition$1 = {
+    readonly version: SmithersApiVersion$1;
+    readonly method: GatewayRpcMethod$1;
+    readonly title: string;
+    readonly description: string;
+    readonly maturity: "stable";
+    readonly transport: "http" | "websocket" | "http+websocket";
+    readonly requiredScope: GatewayScope$1;
+    readonly requestSchema: JsonSchema$1;
+    readonly responseSchema: JsonSchema$1;
+    readonly errors: readonly GatewayRpcErrorCode$1[];
+    readonly exampleRequest: unknown;
+    readonly exampleResponse: unknown;
+};
+type GatewayRpcMethod$1 = "launchRun" | "resumeRun" | "cancelRun" | "pauseRun" | "hijackRun" | "rewindRun" | "submitApproval" | "submitSignal" | "getRun" | "listRuns" | "getSchemaSignature" | "listWorkflows" | "listApprovals" | "listDocs" | "streamRunEvents" | "streamDevTools" | "getDevToolsSnapshot" | "getNodeOutput" | "getNodeDiff" | "whatHappened" | "cronList" | "cronCreate" | "cronDelete" | "cronRun" | "listAccounts" | "listMemoryFacts" | "listPrompts" | "listScores" | "listScoresForRuns" | "getScoreDetail" | "listTickets" | "createTicket" | "updateTicket" | "deleteTicket";
+
+/**
  * @param {string} method
  * @returns {GatewayRpcMethod | undefined}
  */
-declare function canonicalGatewayRpcMethod(method: string): GatewayRpcMethod$1 | undefined;
+declare function canonicalGatewayRpcMethod(method: string): GatewayRpcMethod$2 | undefined;
 /**
  * @param {string} method
  * @returns {GatewayRpcDefinition | undefined}
  */
-declare function getGatewayRpcDefinition(method: string): GatewayRpcDefinition$1 | undefined;
+declare function getGatewayRpcDefinition(method: string): GatewayRpcDefinition$2 | undefined;
 /**
  * @param {string} method
  * @returns {GatewayScope | undefined}
  */
-declare function getRequiredScopeForGatewayMethod(method: string): GatewayScope$1 | undefined;
+declare function getRequiredScopeForGatewayMethod(method: string): GatewayScope$2 | undefined;
 /**
  * @returns {readonly GatewayRpcMethod[]}
  */
-declare function listGatewayRpcMethods(): readonly GatewayRpcMethod$1[];
+declare function listGatewayRpcMethods(): readonly GatewayRpcMethod$2[];
 /**
  * @param {string} method
  * @returns {method is GatewayRpcMethod}
  */
-declare function isGatewayRpcMethod(method: string): method is GatewayRpcMethod$1;
+declare function isGatewayRpcMethod(method: string): method is GatewayRpcMethod$2;
 /**
  * @returns {readonly GatewayScope[]}
  */
-declare function getGatewayScopeValues(): readonly GatewayScope$1[];
-declare const SMITHERS_API_VERSION: SmithersApiVersion$1;
+declare function getGatewayScopeValues(): readonly GatewayScope$2[];
+declare const SMITHERS_API_VERSION: SmithersApiVersion$2;
 declare const GATEWAY_EVENT_WINDOW_DEFAULT: 10000;
 /** @type {JsonSchema} */
-declare const anyJsonSchema: JsonSchema$1;
+declare const anyJsonSchema: JsonSchema$2;
 /** @type {Record<GatewayRpcErrorCode, GatewayRpcErrorDefinition>} */
-declare const GATEWAY_RPC_ERRORS: Record<GatewayRpcErrorCode$1, GatewayRpcErrorDefinition$1>;
+declare const GATEWAY_RPC_ERRORS: Record<GatewayRpcErrorCode$2, GatewayRpcErrorDefinition$2>;
 /** @type {Record<string, GatewayRpcMethod>} */
-declare const GATEWAY_RPC_LEGACY_METHOD_ALIASES: Record<string, GatewayRpcMethod$1>;
+declare const GATEWAY_RPC_LEGACY_METHOD_ALIASES: Record<string, GatewayRpcMethod$2>;
 /** @type {readonly GatewayRpcDefinition[]} */
-declare const GATEWAY_RPC_DEFINITIONS: readonly GatewayRpcDefinition$1[];
-type SmithersApiVersion$1 = SmithersApiVersion$2;
-type JsonSchema$1 = JsonSchema$2;
-type GatewayRpcErrorCode$1 = GatewayRpcErrorCode$2;
-type GatewayRpcErrorDefinition$1 = GatewayRpcErrorDefinition$2;
-type GatewayRpcDefinition$1 = GatewayRpcDefinition$2;
-type GatewayRpcMethod$1 = GatewayRpcMethod$2;
-type GatewayScope$1 = GatewayScope$2;
+declare const GATEWAY_RPC_DEFINITIONS: readonly GatewayRpcDefinition$2[];
+type SmithersApiVersion$2 = SmithersApiVersion$1;
+type JsonSchema$2 = JsonSchema$1;
+type GatewayRpcErrorCode$2 = GatewayRpcErrorCode$1;
+type GatewayRpcErrorDefinition$2 = GatewayRpcErrorDefinition$1;
+type GatewayRpcDefinition$2 = GatewayRpcDefinition$1;
+type GatewayRpcMethod$2 = GatewayRpcMethod$1;
+type GatewayScope$2 = GatewayScope$1;
 
 /**
  * @template {Record<string, unknown>} Row
@@ -523,6 +629,25 @@ declare function serializeRunEventRow<Row extends Record<string, unknown>>(row: 
  */
 declare function serializeRunRow<Row extends Record<string, unknown>>(row: Row): Row;
 
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayComparisonScoreRow} GatewayComparisonScoreRow */
+/**
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayComparisonScoreRow}
+ */
+declare function serializeComparisonScoreRow(row: Record<string, unknown>): GatewayComparisonScoreRow$1;
+type GatewayComparisonScoreRow$1 = GatewayComparisonScoreRow$2;
+
+/** @typedef {import("../rpc/gatewayRpcTypes.ts").GatewayScoreDetail} GatewayScoreDetail */
+/**
+ * Serialize an already-decoded score detail row. JSON parsing deliberately
+ * stays in the server so malformed persistence can fail explicitly instead of
+ * being hidden by a wire serializer.
+ * @param {Record<string, unknown>} row
+ * @returns {GatewayScoreDetail}
+ */
+declare function serializeScoreDetailRow(row: Record<string, unknown>): GatewayScoreDetail$1;
+type GatewayScoreDetail$1 = GatewayScoreDetail$2;
+
 /**
  * @template {Record<string, unknown>} Row
  * @param {Row} row
@@ -544,13 +669,13 @@ declare function serializeTicketRow<Row extends Record<string, unknown>>(row: Ro
  */
 declare function serializeWorkflowRow<Row extends Record<string, unknown>>(row: Row): Row;
 
-type GatewayScope = GatewayScope$2;
-type SmithersApiVersion = SmithersApiVersion$2;
-type JsonSchema = JsonSchema$2;
-type GatewayRpcErrorCode = GatewayRpcErrorCode$2;
-type GatewayRpcErrorDefinition = GatewayRpcErrorDefinition$2;
-type GatewayRpcDefinition = GatewayRpcDefinition$2;
-type GatewayRpcMethod = GatewayRpcMethod$2;
+type GatewayScope = GatewayScope$3;
+type SmithersApiVersion = SmithersApiVersion$3;
+type JsonSchema = JsonSchema$3;
+type GatewayRpcErrorCode = GatewayRpcErrorCode$3;
+type GatewayRpcErrorDefinition = GatewayRpcErrorDefinition$3;
+type GatewayRpcDefinition = GatewayRpcDefinition$3;
+type GatewayRpcMethod = GatewayRpcMethod$3;
 type LaunchRunRequest = LaunchRunRequest$1;
 type LaunchRunResponse = LaunchRunResponse$1;
 type ResumeRunRequest = ResumeRunRequest$1;
@@ -600,6 +725,12 @@ type ListPromptsResponse = ListPromptsResponse$1;
 type GatewayScoreRow = GatewayScoreRow$1;
 type ListScoresRequest = ListScoresRequest$1;
 type ListScoresResponse = ListScoresResponse$1;
+type GatewayComparisonScoreRow = GatewayComparisonScoreRow$2;
+type ListScoresForRunsRequest = ListScoresForRunsRequest$1;
+type ListScoresForRunsResponse = ListScoresForRunsResponse$1;
+type GetScoreDetailRequest = GetScoreDetailRequest$1;
+type GatewayScoreDetail = GatewayScoreDetail$2;
+type GetScoreDetailResponse = GetScoreDetailResponse$1;
 type GatewayDocKind = GatewayDocKind$1;
 type GatewayTicketRow = GatewayTicketRow$1;
 type ListTicketsRequest = ListTicketsRequest$1;
@@ -608,4 +739,4 @@ type CreateTicketRequest = CreateTicketRequest$1;
 type UpdateTicketRequest = UpdateTicketRequest$1;
 type DeleteTicketRequest = DeleteTicketRequest$1;
 
-export { type CancelRunRequest, type CancelRunResponse, type CreateTicketRequest, type CronCreateRequest, type CronDeleteRequest, type CronListRequest, type CronRunRequest, type DeleteTicketRequest, GATEWAY_EVENT_WINDOW_DEFAULT, GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, GATEWAY_RPC_LEGACY_METHOD_ALIASES, GATEWAY_SCOPE_DESCRIPTIONS, GATEWAY_SCOPE_VALUES, type GatewayAccount, type GatewayApprovalSummary, type GatewayDocKind, type GatewayDocRow, type GatewayMemoryFact, type GatewayPrompt, type GatewayRpcDefinition, type GatewayRpcErrorCode, type GatewayRpcErrorDefinition, type GatewayRpcMethod, type GatewayScope, type GatewayScoreRow, type GatewayTicketRow, type GatewayWorkflowSummary, type GetDevToolsSnapshotRequest, type GetDevToolsSnapshotResponse, type GetRunRequest, type GetSchemaSignatureRequest, type GetSchemaSignatureResponse, type HijackRunRequest, type HijackRunResponse, type JsonSchema, type LaunchRunRequest, type LaunchRunResponse, type ListAccountsRequest, type ListAccountsResponse, type ListApprovalsRequest, type ListApprovalsResponse, type ListDocsRequest, type ListDocsResponse, type ListMemoryFactsRequest, type ListMemoryFactsResponse, type ListPromptsRequest, type ListPromptsResponse, type ListRunsRequest, type ListScoresRequest, type ListScoresResponse, type ListTicketsRequest, type ListTicketsResponse, type ListWorkflowsRequest, type ListWorkflowsResponse, type NodeRequest, type PauseRunRequest, type PauseRunResponse, type ResumeRunRequest, type ResumeRunResponse, type RewindRunRequest, SMITHERS_API_VERSION, type SmithersApiVersion, type StreamDevToolsRequest, type StreamRunEventsRequest, type StreamRunEventsResponse, type SubmitApprovalRequest, type SubmitApprovalResponse, type SubmitSignalRequest, type UpdateTicketRequest, anyJsonSchema, apiCollectionNames, canonicalGatewayRpcMethod, getGatewayRpcDefinition, getGatewayScopeValues, getRequiredScopeForGatewayMethod, hasGatewayScope, isGatewayRpcMethod, isGatewayScope, listGatewayRpcMethods, serializeAccountRow, serializeApprovalRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow };
+export { type CancelRunRequest, type CancelRunResponse, type CreateTicketRequest, type CronCreateRequest, type CronDeleteRequest, type CronListRequest, type CronRunRequest, type DeleteTicketRequest, GATEWAY_EVENT_WINDOW_DEFAULT, GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, GATEWAY_RPC_LEGACY_METHOD_ALIASES, GATEWAY_SCOPE_DESCRIPTIONS, GATEWAY_SCOPE_VALUES$1 as GATEWAY_SCOPE_VALUES, type GatewayAccount, type GatewayApprovalSummary, type GatewayComparisonScoreRow, type GatewayDocKind, type GatewayDocRow, type GatewayMemoryFact, type GatewayPrompt, type GatewayRpcDefinition, type GatewayRpcErrorCode, type GatewayRpcErrorDefinition, type GatewayRpcMethod, type GatewayScope, type GatewayScoreDetail, type GatewayScoreRow, type GatewayTicketRow, type GatewayWorkflowSummary, type GetDevToolsSnapshotRequest, type GetDevToolsSnapshotResponse, type GetRunRequest, type GetSchemaSignatureRequest, type GetSchemaSignatureResponse, type GetScoreDetailRequest, type GetScoreDetailResponse, type HijackRunRequest, type HijackRunResponse, type JsonSchema, type LaunchRunRequest, type LaunchRunResponse, type ListAccountsRequest, type ListAccountsResponse, type ListApprovalsRequest, type ListApprovalsResponse, type ListDocsRequest, type ListDocsResponse, type ListMemoryFactsRequest, type ListMemoryFactsResponse, type ListPromptsRequest, type ListPromptsResponse, type ListRunsRequest, type ListScoresForRunsRequest, type ListScoresForRunsResponse, type ListScoresRequest, type ListScoresResponse, type ListTicketsRequest, type ListTicketsResponse, type ListWorkflowsRequest, type ListWorkflowsResponse, type NodeRequest, type PauseRunRequest, type PauseRunResponse, type ResumeRunRequest, type ResumeRunResponse, type RewindRunRequest, SMITHERS_API_VERSION, type SmithersApiVersion, type StreamDevToolsRequest, type StreamRunEventsRequest, type StreamRunEventsResponse, type SubmitApprovalRequest, type SubmitApprovalResponse, type SubmitSignalRequest, type UpdateTicketRequest, anyJsonSchema, apiCollectionNames, canonicalGatewayRpcMethod, getGatewayRpcDefinition, getGatewayScopeValues, getRequiredScopeForGatewayMethod, hasGatewayScope, isGatewayRpcMethod, isGatewayScope, listGatewayRpcMethods, serializeAccountRow, serializeApprovalRow, serializeComparisonScoreRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreDetailRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow };

--- a/packages/gateway/src/index.js
+++ b/packages/gateway/src/index.js
@@ -55,6 +55,12 @@
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").GatewayScoreRow} GatewayScoreRow */
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").ListScoresRequest} ListScoresRequest */
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").ListScoresResponse} ListScoresResponse */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").GatewayComparisonScoreRow} GatewayComparisonScoreRow */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").ListScoresForRunsRequest} ListScoresForRunsRequest */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").ListScoresForRunsResponse} ListScoresForRunsResponse */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").GetScoreDetailRequest} GetScoreDetailRequest */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").GatewayScoreDetail} GatewayScoreDetail */
+/** @typedef {import("./rpc/gatewayRpcTypes.ts").GetScoreDetailResponse} GetScoreDetailResponse */
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").GatewayDocKind} GatewayDocKind */
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").GatewayTicketRow} GatewayTicketRow */
 /** @typedef {import("./rpc/gatewayRpcTypes.ts").ListTicketsRequest} ListTicketsRequest */
@@ -88,6 +94,8 @@ export {
   serializePromptRow,
   serializeRunEventRow,
   serializeRunRow,
+  serializeComparisonScoreRow,
+  serializeScoreDetailRow,
   serializeScoreRow,
   serializeTicketRow,
   serializeWorkflowRow,

--- a/packages/gateway/src/rpc/gatewayRpcTypes.ts
+++ b/packages/gateway/src/rpc/gatewayRpcTypes.ts
@@ -19,6 +19,10 @@ export type JsonSchema = {
   readonly format?: string;
   readonly minimum?: number;
   readonly maximum?: number;
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minItems?: number;
+  readonly maxItems?: number;
   readonly default?: unknown;
   readonly nullable?: boolean;
   readonly items?: JsonSchema;
@@ -35,6 +39,7 @@ export type GatewayRpcErrorCode =
   | "Unauthorized"
   | "Forbidden"
   | "RunNotFound"
+  | "ScoreNotFound"
   | "RUN_NOT_ACTIVE"
   | "CronNotFound"
   | "TicketNotFound"
@@ -104,6 +109,8 @@ export type GatewayRpcMethod =
   | "listMemoryFacts"
   | "listPrompts"
   | "listScores"
+  | "listScoresForRuns"
+  | "getScoreDetail"
   | "listTickets"
   | "createTicket"
   | "updateTicket"
@@ -468,6 +475,51 @@ export type ListScoresRequest = {
 };
 
 export type ListScoresResponse = GatewayScoreRow[];
+
+/** One cross-run score row, including the exact persisted score identity. */
+export type GatewayComparisonScoreRow = GatewayScoreRow & {
+  scoreId: string;
+};
+
+/**
+ * Batch score rows for explicit run ids. Callers must already know the scorer-
+ * producing run ids: this does not expand an eval wrapper run into child case
+ * runs or provide experiment/case alignment.
+ */
+export type ListScoresForRunsRequest = {
+  runIds: string[];
+  nodeId?: string;
+  scorerId?: string;
+  scorerName?: string;
+  source?: "live" | "batch";
+  order?: "scoredAtAsc" | "scoredAtDesc";
+  offset?: number;
+  limit?: number;
+};
+
+export type ListScoresForRunsResponse = {
+  rows: GatewayComparisonScoreRow[];
+  total: number;
+};
+
+export type GetScoreDetailRequest = {
+  runId: string;
+  scoreId: string;
+};
+
+/**
+ * One exact persisted score with its JSON detail columns decoded. Every detail
+ * field is present; a SQL NULL (or stored JSON `null`) is returned as JSON null.
+ */
+export type GatewayScoreDetail = GatewayComparisonScoreRow & {
+  meta: unknown;
+  input: unknown;
+  output: unknown;
+  groundTruth: unknown;
+  context: unknown;
+};
+
+export type GetScoreDetailResponse = GatewayScoreDetail;
 
 /**
  * A doc kind stored in `_smithers_docs`; the tickets surface uses `ticket`. The

--- a/packages/gateway/src/rpc/index.d.ts
+++ b/packages/gateway/src/rpc/index.d.ts
@@ -21,6 +21,10 @@ type JsonSchema$1 = {
     readonly format?: string;
     readonly minimum?: number;
     readonly maximum?: number;
+    readonly minLength?: number;
+    readonly maxLength?: number;
+    readonly minItems?: number;
+    readonly maxItems?: number;
     readonly default?: unknown;
     readonly nullable?: boolean;
     readonly items?: JsonSchema$1;
@@ -30,7 +34,7 @@ type JsonSchema$1 = {
     readonly oneOf?: readonly JsonSchema$1[];
     readonly anyOf?: readonly JsonSchema$1[];
 };
-type GatewayRpcErrorCode$1 = "InvalidRequest" | "InvalidInput" | "Unauthorized" | "Forbidden" | "RunNotFound" | "RUN_NOT_ACTIVE" | "CronNotFound" | "TicketNotFound" | "NodeNotFound" | "IterationNotFound" | "NodeHasNoOutput" | "FrameOutOfRange" | "SeqOutOfRange" | "Busy" | "AlreadyDecided" | "RateLimited" | "PayloadTooLarge" | "BackpressureDisconnect" | "UnsupportedSandbox" | "VcsError" | "RewindFailed" | "Internal";
+type GatewayRpcErrorCode$1 = "InvalidRequest" | "InvalidInput" | "Unauthorized" | "Forbidden" | "RunNotFound" | "ScoreNotFound" | "RUN_NOT_ACTIVE" | "CronNotFound" | "TicketNotFound" | "NodeNotFound" | "IterationNotFound" | "NodeHasNoOutput" | "FrameOutOfRange" | "SeqOutOfRange" | "Busy" | "AlreadyDecided" | "RateLimited" | "PayloadTooLarge" | "BackpressureDisconnect" | "UnsupportedSandbox" | "VcsError" | "RewindFailed" | "Internal";
 type GatewayRpcErrorDefinition$1 = {
     readonly version: SmithersApiVersion$1;
     readonly code: GatewayRpcErrorCode$1;
@@ -51,7 +55,7 @@ type GatewayRpcDefinition$1 = {
     readonly exampleRequest: unknown;
     readonly exampleResponse: unknown;
 };
-type GatewayRpcMethod$1 = "launchRun" | "resumeRun" | "cancelRun" | "pauseRun" | "hijackRun" | "rewindRun" | "submitApproval" | "submitSignal" | "getRun" | "listRuns" | "getSchemaSignature" | "listWorkflows" | "listApprovals" | "listDocs" | "streamRunEvents" | "streamDevTools" | "getDevToolsSnapshot" | "getNodeOutput" | "getNodeDiff" | "whatHappened" | "cronList" | "cronCreate" | "cronDelete" | "cronRun" | "listAccounts" | "listMemoryFacts" | "listPrompts" | "listScores" | "listTickets" | "createTicket" | "updateTicket" | "deleteTicket";
+type GatewayRpcMethod$1 = "launchRun" | "resumeRun" | "cancelRun" | "pauseRun" | "hijackRun" | "rewindRun" | "submitApproval" | "submitSignal" | "getRun" | "listRuns" | "getSchemaSignature" | "listWorkflows" | "listApprovals" | "listDocs" | "streamRunEvents" | "streamDevTools" | "getDevToolsSnapshot" | "getNodeOutput" | "getNodeDiff" | "whatHappened" | "cronList" | "cronCreate" | "cronDelete" | "cronRun" | "listAccounts" | "listMemoryFacts" | "listPrompts" | "listScores" | "listScoresForRuns" | "getScoreDetail" | "listTickets" | "createTicket" | "updateTicket" | "deleteTicket";
 type LaunchRunRequest$1 = {
     workflow: string;
     input?: Record<string, unknown>;
@@ -361,6 +365,45 @@ type ListScoresRequest$1 = {
     nodeId?: string;
 };
 type ListScoresResponse$1 = GatewayScoreRow$1[];
+/** One cross-run score row, including the exact persisted score identity. */
+type GatewayComparisonScoreRow$1 = GatewayScoreRow$1 & {
+    scoreId: string;
+};
+/**
+ * Batch score rows for explicit run ids. Callers must already know the scorer-
+ * producing run ids: this does not expand an eval wrapper run into child case
+ * runs or provide experiment/case alignment.
+ */
+type ListScoresForRunsRequest$1 = {
+    runIds: string[];
+    nodeId?: string;
+    scorerId?: string;
+    scorerName?: string;
+    source?: "live" | "batch";
+    order?: "scoredAtAsc" | "scoredAtDesc";
+    offset?: number;
+    limit?: number;
+};
+type ListScoresForRunsResponse$1 = {
+    rows: GatewayComparisonScoreRow$1[];
+    total: number;
+};
+type GetScoreDetailRequest$1 = {
+    runId: string;
+    scoreId: string;
+};
+/**
+ * One exact persisted score with its JSON detail columns decoded. Every detail
+ * field is present; a SQL NULL (or stored JSON `null`) is returned as JSON null.
+ */
+type GatewayScoreDetail$1 = GatewayComparisonScoreRow$1 & {
+    meta: unknown;
+    input: unknown;
+    output: unknown;
+    groundTruth: unknown;
+    context: unknown;
+};
+type GetScoreDetailResponse$1 = GatewayScoreDetail$1;
 /**
  * A doc kind stored in `_smithers_docs`; the tickets surface uses `ticket`. The
  * runtime `DOC_KINDS` tuple in `index.js` (which feeds every ticket-RPC schema
@@ -497,6 +540,12 @@ type ListPromptsResponse = ListPromptsResponse$1;
 type GatewayScoreRow = GatewayScoreRow$1;
 type ListScoresRequest = ListScoresRequest$1;
 type ListScoresResponse = ListScoresResponse$1;
+type GatewayComparisonScoreRow = GatewayComparisonScoreRow$1;
+type ListScoresForRunsRequest = ListScoresForRunsRequest$1;
+type ListScoresForRunsResponse = ListScoresForRunsResponse$1;
+type GetScoreDetailRequest = GetScoreDetailRequest$1;
+type GatewayScoreDetail = GatewayScoreDetail$1;
+type GetScoreDetailResponse = GetScoreDetailResponse$1;
 type GatewayDocKind = GatewayDocKind$1;
 type GatewayTicketRow = GatewayTicketRow$1;
 type ListTicketsRequest = ListTicketsRequest$1;
@@ -506,4 +555,4 @@ type UpdateTicketRequest = UpdateTicketRequest$1;
 type DeleteTicketRequest = DeleteTicketRequest$1;
 type GatewayScope = GatewayScope$1;
 
-export { type CancelRunRequest, type CancelRunResponse, type CreateTicketRequest, type CronCreateRequest, type CronDeleteRequest, type CronListRequest, type CronRunRequest, type DeleteTicketRequest, GATEWAY_EVENT_WINDOW_DEFAULT, GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, GATEWAY_RPC_LEGACY_METHOD_ALIASES, type GatewayAccount, type GatewayApprovalSummary, type GatewayDocKind, type GatewayDocRow, type GatewayMemoryFact, type GatewayPrompt, type GatewayRpcDefinition, type GatewayRpcErrorCode, type GatewayRpcErrorDefinition, type GatewayRpcMethod, type GatewayScope, type GatewayScoreRow, type GatewayTicketRow, type GatewayWorkflowSummary, type GetDevToolsSnapshotRequest, type GetDevToolsSnapshotResponse, type GetRunRequest, type GetSchemaSignatureRequest, type GetSchemaSignatureResponse, type HijackRunRequest, type HijackRunResponse, type JsonSchema, type LaunchRunRequest, type LaunchRunResponse, type ListAccountsRequest, type ListAccountsResponse, type ListApprovalsRequest, type ListApprovalsResponse, type ListDocsRequest, type ListDocsResponse, type ListMemoryFactsRequest, type ListMemoryFactsResponse, type ListPromptsRequest, type ListPromptsResponse, type ListRunsRequest, type ListScoresRequest, type ListScoresResponse, type ListTicketsRequest, type ListTicketsResponse, type ListWorkflowsRequest, type ListWorkflowsResponse, type NodeRequest, type PauseRunRequest, type PauseRunResponse, type ResumeRunRequest, type ResumeRunResponse, type RewindRunRequest, SMITHERS_API_VERSION, type SmithersApiVersion, type StreamDevToolsRequest, type StreamRunEventsRequest, type StreamRunEventsResponse, type SubmitApprovalRequest, type SubmitApprovalResponse, type SubmitSignalRequest, type UpdateTicketRequest, type WhatHappenedRequest, type WhatHappenedResponse, anyJsonSchema, canonicalGatewayRpcMethod, getGatewayRpcDefinition, getGatewayScopeValues, getRequiredScopeForGatewayMethod, isGatewayRpcMethod, listGatewayRpcMethods };
+export { type CancelRunRequest, type CancelRunResponse, type CreateTicketRequest, type CronCreateRequest, type CronDeleteRequest, type CronListRequest, type CronRunRequest, type DeleteTicketRequest, GATEWAY_EVENT_WINDOW_DEFAULT, GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, GATEWAY_RPC_LEGACY_METHOD_ALIASES, type GatewayAccount, type GatewayApprovalSummary, type GatewayComparisonScoreRow, type GatewayDocKind, type GatewayDocRow, type GatewayMemoryFact, type GatewayPrompt, type GatewayRpcDefinition, type GatewayRpcErrorCode, type GatewayRpcErrorDefinition, type GatewayRpcMethod, type GatewayScope, type GatewayScoreDetail, type GatewayScoreRow, type GatewayTicketRow, type GatewayWorkflowSummary, type GetDevToolsSnapshotRequest, type GetDevToolsSnapshotResponse, type GetRunRequest, type GetSchemaSignatureRequest, type GetSchemaSignatureResponse, type GetScoreDetailRequest, type GetScoreDetailResponse, type HijackRunRequest, type HijackRunResponse, type JsonSchema, type LaunchRunRequest, type LaunchRunResponse, type ListAccountsRequest, type ListAccountsResponse, type ListApprovalsRequest, type ListApprovalsResponse, type ListDocsRequest, type ListDocsResponse, type ListMemoryFactsRequest, type ListMemoryFactsResponse, type ListPromptsRequest, type ListPromptsResponse, type ListRunsRequest, type ListScoresForRunsRequest, type ListScoresForRunsResponse, type ListScoresRequest, type ListScoresResponse, type ListTicketsRequest, type ListTicketsResponse, type ListWorkflowsRequest, type ListWorkflowsResponse, type NodeRequest, type PauseRunRequest, type PauseRunResponse, type ResumeRunRequest, type ResumeRunResponse, type RewindRunRequest, SMITHERS_API_VERSION, type SmithersApiVersion, type StreamDevToolsRequest, type StreamRunEventsRequest, type StreamRunEventsResponse, type SubmitApprovalRequest, type SubmitApprovalResponse, type SubmitSignalRequest, type UpdateTicketRequest, type WhatHappenedRequest, type WhatHappenedResponse, anyJsonSchema, canonicalGatewayRpcMethod, getGatewayRpcDefinition, getGatewayScopeValues, getRequiredScopeForGatewayMethod, isGatewayRpcMethod, listGatewayRpcMethods };

--- a/packages/gateway/src/rpc/index.js
+++ b/packages/gateway/src/rpc/index.js
@@ -56,6 +56,12 @@
 /** @typedef {import("./gatewayRpcTypes.ts").GatewayScoreRow} GatewayScoreRow */
 /** @typedef {import("./gatewayRpcTypes.ts").ListScoresRequest} ListScoresRequest */
 /** @typedef {import("./gatewayRpcTypes.ts").ListScoresResponse} ListScoresResponse */
+/** @typedef {import("./gatewayRpcTypes.ts").GatewayComparisonScoreRow} GatewayComparisonScoreRow */
+/** @typedef {import("./gatewayRpcTypes.ts").ListScoresForRunsRequest} ListScoresForRunsRequest */
+/** @typedef {import("./gatewayRpcTypes.ts").ListScoresForRunsResponse} ListScoresForRunsResponse */
+/** @typedef {import("./gatewayRpcTypes.ts").GetScoreDetailRequest} GetScoreDetailRequest */
+/** @typedef {import("./gatewayRpcTypes.ts").GatewayScoreDetail} GatewayScoreDetail */
+/** @typedef {import("./gatewayRpcTypes.ts").GetScoreDetailResponse} GetScoreDetailResponse */
 /** @typedef {import("./gatewayRpcTypes.ts").GatewayDocKind} GatewayDocKind */
 /** @typedef {import("./gatewayRpcTypes.ts").GatewayTicketRow} GatewayTicketRow */
 /** @typedef {import("./gatewayRpcTypes.ts").ListTicketsRequest} ListTicketsRequest */
@@ -204,6 +210,7 @@ export const GATEWAY_RPC_ERRORS = {
   Unauthorized: { version: SMITHERS_API_VERSION, code: "Unauthorized", httpStatus: 401, description: "Authentication failed or the token expired." },
   Forbidden: { version: SMITHERS_API_VERSION, code: "Forbidden", httpStatus: 403, description: "The token is missing the required scope." },
   RunNotFound: { version: SMITHERS_API_VERSION, code: "RunNotFound", httpStatus: 404, description: "The run does not exist." },
+  ScoreNotFound: { version: SMITHERS_API_VERSION, code: "ScoreNotFound", httpStatus: 404, description: "The score does not exist on the requested run." },
   RUN_NOT_ACTIVE: { version: SMITHERS_API_VERSION, code: "RUN_NOT_ACTIVE", httpStatus: 409, description: "The run is not currently active and cannot be cancelled." },
   CronNotFound: { version: SMITHERS_API_VERSION, code: "CronNotFound", httpStatus: 404, description: "The cron schedule does not exist." },
   TicketNotFound: { version: SMITHERS_API_VERSION, code: "TicketNotFound", httpStatus: 404, description: "The ticket/work doc does not exist." },
@@ -770,7 +777,7 @@ export const GATEWAY_RPC_DEFINITIONS = [
       attempt: integerSchema("Node attempt the score belongs to.", 0),
       scorerId: stringSchema("Stable scorer id."),
       scorerName: stringSchema("Human scorer name."),
-      source: stringSchema("Where the score came from (e.g. 'scorer', 'eval')."),
+      source: stringSchema("Persisted score provenance (`live` or `batch` for production scorer rows)."),
       score: { type: "number", description: "The scorer's numeric verdict." },
       reason: { type: ["string", "null"], description: "Optional human reason for the score." },
       scoredAtMs: integerSchema("Unix epoch milliseconds when the score was recorded.", 0),
@@ -779,7 +786,107 @@ export const GATEWAY_RPC_DEFINITIONS = [
     }, ["runId", "nodeId", "iteration", "attempt", "scorerId", "scorerName", "source", "score", "scoredAtMs"]), "Scorer results."),
     errors: ["InvalidRequest", "Unauthorized", "Forbidden", "RunNotFound", "Internal"],
     exampleRequest: { runId: "run_01", nodeId: "review" },
-    exampleResponse: [{ runId: "run_01", nodeId: "review", iteration: 0, attempt: 0, scorerId: "correctness", scorerName: "correctness", source: "scorer", score: 0.92, scoredAtMs: 1710000000000 }],
+    exampleResponse: [{ runId: "run_01", nodeId: "review", iteration: 0, attempt: 0, scorerId: "correctness", scorerName: "correctness", source: "live", score: 0.92, scoredAtMs: 1710000000000 }],
+  },
+  {
+    version: SMITHERS_API_VERSION,
+    method: "listScoresForRuns",
+    title: "List Scores For Runs",
+    description: "List and globally page persisted scorer rows across up to 30 explicit run ids. The caller must supply the scorer-producing run ids; this does not expand an eval wrapper into child case runs or provide experiment/case alignment.",
+    maturity: "stable",
+    transport: "http+websocket",
+    requiredScope: "score:read",
+    requestSchema: objectSchema({
+      runIds: {
+        type: "array",
+        description: "Up to 30 run-id entries to compare. The server trims values and deduplicates them in first-seen order.",
+        items: { type: "string", minLength: 1, maxLength: 256 },
+        maxItems: 30,
+      },
+      nodeId: stringSchema("Optional exact, case-sensitive node id filter."),
+      scorerId: stringSchema("Optional exact, case-sensitive scorer id filter."),
+      scorerName: stringSchema("Optional exact, case-sensitive scorer name filter."),
+      source: { type: "string", enum: ["live", "batch"], description: "Optional exact production score provenance filter." },
+      order: { type: "string", enum: ["scoredAtAsc", "scoredAtDesc"], default: "scoredAtAsc", description: "Primary score timestamp order." },
+      offset: { type: "integer", minimum: 0, maximum: 9_999, default: 0, description: "Global result offset after merging distinct stores. The offset plus limit may not exceed the 10,000-row comparison window." },
+      limit: { type: "integer", minimum: 1, maximum: 500, default: 500, description: "Maximum globally merged rows to return. The offset plus limit may not exceed the 10,000-row comparison window." },
+    }, ["runIds"]),
+    responseSchema: objectSchema({
+      rows: arraySchema(objectSchema({
+        scoreId: stringSchema("Exact persisted score id."),
+        runId: stringSchema("Run id the score belongs to."),
+        nodeId: stringSchema("Node id the score was produced for."),
+        iteration: integerSchema("Node iteration the score belongs to.", 0),
+        attempt: integerSchema("Node attempt the score belongs to.", 0),
+        scorerId: stringSchema("Stable scorer id."),
+        scorerName: stringSchema("Human scorer name."),
+        source: stringSchema("Persisted score source."),
+        score: { type: "number", description: "The scorer's numeric verdict." },
+        reason: { type: ["string", "null"], description: "Optional human reason for the score." },
+        scoredAtMs: integerSchema("Unix epoch milliseconds when the score was recorded.", 0),
+        latencyMs: { type: ["number", "null"], description: "Optional scorer latency in milliseconds." },
+        durationMs: { type: ["number", "null"], description: "Optional node duration in milliseconds." },
+      }, ["scoreId", "runId", "nodeId", "iteration", "attempt", "scorerId", "scorerName", "source", "score", "scoredAtMs"]), "Globally ordered persisted scorer rows."),
+      total: integerSchema("Total filtered row count before global pagination.", 0),
+    }, ["rows", "total"]),
+    errors: ["InvalidRequest", "Unauthorized", "Forbidden", "RunNotFound", "Internal"],
+    exampleRequest: { runIds: ["run_01", "run_02"], order: "scoredAtDesc", offset: 0, limit: 500 },
+    exampleResponse: {
+      rows: [{ scoreId: "run_01:review:correctness", runId: "run_01", nodeId: "review", iteration: 0, attempt: 0, scorerId: "correctness", scorerName: "correctness", source: "live", score: 0.92, scoredAtMs: 1710000000000 }],
+      total: 1,
+    },
+  },
+  {
+    version: SMITHERS_API_VERSION,
+    method: "getScoreDetail",
+    title: "Get Score Detail",
+    description: "Read one exact persisted score row with its JSON detail columns decoded.",
+    maturity: "stable",
+    transport: "http+websocket",
+    requiredScope: "score:read",
+    requestSchema: objectSchema({
+      runId: { type: "string", minLength: 1, maxLength: 256, description: "Owning run id (trimmed by the server)." },
+      scoreId: { type: "string", minLength: 1, maxLength: 256, description: "Exact persisted score id (trimmed by the server)." },
+    }, ["runId", "scoreId"]),
+    responseSchema: objectSchema({
+      scoreId: stringSchema("Exact persisted score id."),
+      runId: stringSchema("Run id the score belongs to."),
+      nodeId: stringSchema("Node id the score was produced for."),
+      iteration: integerSchema("Node iteration the score belongs to.", 0),
+      attempt: integerSchema("Node attempt the score belongs to.", 0),
+      scorerId: stringSchema("Stable scorer id."),
+      scorerName: stringSchema("Human scorer name."),
+      source: stringSchema("Persisted score source."),
+      score: { type: "number", description: "The scorer's numeric verdict." },
+      reason: { type: ["string", "null"], description: "Optional human reason for the score." },
+      scoredAtMs: integerSchema("Unix epoch milliseconds when the score was recorded.", 0),
+      latencyMs: { type: ["number", "null"], description: "Optional scorer latency in milliseconds." },
+      durationMs: { type: ["number", "null"], description: "Optional node duration in milliseconds." },
+      meta: anyJsonSchema,
+      input: anyJsonSchema,
+      output: anyJsonSchema,
+      groundTruth: anyJsonSchema,
+      context: anyJsonSchema,
+    }, ["scoreId", "runId", "nodeId", "iteration", "attempt", "scorerId", "scorerName", "source", "score", "scoredAtMs", "meta", "input", "output", "groundTruth", "context"]),
+    errors: ["InvalidRequest", "Unauthorized", "Forbidden", "RunNotFound", "ScoreNotFound", "Internal"],
+    exampleRequest: { runId: "run_01", scoreId: "run_01:review:correctness" },
+    exampleResponse: {
+      scoreId: "run_01:review:correctness",
+      runId: "run_01",
+      nodeId: "review",
+      iteration: 0,
+      attempt: 0,
+      scorerId: "correctness",
+      scorerName: "correctness",
+      source: "live",
+      score: 0.92,
+      scoredAtMs: 1710000000000,
+      meta: { rubric: "correctness" },
+      input: { prompt: "Review this." },
+      output: { verdict: "pass" },
+      groundTruth: null,
+      context: null,
+    },
   },
   {
     version: SMITHERS_API_VERSION,

--- a/packages/gateway/tests/generate-openapi.test.ts
+++ b/packages/gateway/tests/generate-openapi.test.ts
@@ -12,7 +12,7 @@ import {
   successSchema,
   requestFrameSchema,
 } from "../scripts/generate-openapi.ts";
-import { GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, SMITHERS_API_VERSION } from "../src/rpc/index.js";
+import { GATEWAY_RPC_DEFINITIONS, GATEWAY_RPC_ERRORS, SMITHERS_API_VERSION, getGatewayRpcDefinition } from "../src/rpc/index.js";
 import { GATEWAY_SCOPE_VALUES } from "../src/auth/scopes.js";
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -92,8 +92,70 @@ describe("generate-openapi helpers", () => {
       expect(doc.paths[`/v1/rpc/${def.method}`]).toBeDefined();
     }
     expect(doc.paths["/v1/api/runs"]).toBeDefined();
+    expect(doc.paths["/v1/api/scores/compare"]).toBeDefined();
+    expect(doc.paths["/v1/api/scores/{runId}/{scoreId}"]).toBeDefined();
+    expect((doc.paths["/v1/api/scores/compare"] as any).get["x-smithers-rpc-method"]).toBe("listScoresForRuns");
+    expect((doc.paths["/v1/api/scores/{runId}/{scoreId}"] as any).get["x-smithers-rpc-method"]).toBe("getScoreDetail");
     expect(doc.paths["/v1/api/stream"]).toBeDefined();
     expect(Object.keys(doc.paths).length).toBeGreaterThan(GATEWAY_RPC_DEFINITIONS.length);
+  });
+
+  test("score REST aliases publish exact parameters and RPC response schemas", () => {
+    const doc = buildOpenApiDocument();
+    const compare = (doc.paths["/v1/api/scores/compare"] as any).get;
+    const compareParameters = Object.fromEntries(
+      compare.parameters.map((parameter: any) => [parameter.name, parameter]),
+    );
+    expect(Object.keys(compareParameters)).toEqual([
+      "runId",
+      "nodeId",
+      "scorerId",
+      "scorerName",
+      "source",
+      "order",
+      "offset",
+      "limit",
+    ]);
+    expect(compareParameters.runId).toMatchObject({
+      in: "query",
+      required: false,
+      style: "form",
+      explode: true,
+      schema: {
+        type: "array",
+        maxItems: 30,
+        items: { type: "string", minLength: 1, maxLength: 256 },
+      },
+    });
+    expect(compareParameters.source.schema.enum).toEqual(["live", "batch"]);
+    expect(compareParameters.order.schema).toMatchObject({
+      enum: ["scoredAtAsc", "scoredAtDesc"],
+      default: "scoredAtAsc",
+    });
+    expect(compareParameters.offset.schema).toMatchObject({ minimum: 0, maximum: 9_999, default: 0 });
+    expect(compareParameters.limit.schema).toMatchObject({ minimum: 1, maximum: 500, default: 500 });
+    expect(compare.responses["200"].content["application/json"].schema.properties.data)
+      .toBe(getGatewayRpcDefinition("listScoresForRuns")?.responseSchema);
+
+    const detail = (doc.paths["/v1/api/scores/{runId}/{scoreId}"] as any).get;
+    expect(detail.parameters).toEqual([
+      {
+        name: "runId",
+        in: "path",
+        description: "Owning run id.",
+        required: true,
+        schema: getGatewayRpcDefinition("getScoreDetail")?.requestSchema.properties?.runId,
+      },
+      {
+        name: "scoreId",
+        in: "path",
+        description: "Exact persisted score id.",
+        required: true,
+        schema: getGatewayRpcDefinition("getScoreDetail")?.requestSchema.properties?.scoreId,
+      },
+    ]);
+    expect(detail.responses["200"].content["application/json"].schema.properties.data)
+      .toBe(getGatewayRpcDefinition("getScoreDetail")?.responseSchema);
   });
 });
 

--- a/packages/gateway/tests/rpc-contract.test.ts
+++ b/packages/gateway/tests/rpc-contract.test.ts
@@ -48,6 +48,10 @@ import {
   type ListMemoryFactsRequest,
   type ListPromptsRequest,
   type ListScoresRequest,
+  type ListScoresForRunsRequest,
+  type ListScoresForRunsResponse,
+  type GetScoreDetailRequest,
+  type GetScoreDetailResponse,
   type ListTicketsRequest,
   type CreateTicketRequest,
   type UpdateTicketRequest,
@@ -113,6 +117,18 @@ function validateAgainstSchema(value: unknown, schema: JsonSchema, path = "$"): 
 
   if (typeof value === "number" && schema.minimum !== undefined && value < schema.minimum) {
     errors.push(`${path}: ${value} is below minimum ${schema.minimum}`);
+  }
+  if (typeof value === "number" && schema.maximum !== undefined && value > schema.maximum) {
+    errors.push(`${path}: ${value} is above maximum ${schema.maximum}`);
+  }
+  if (typeof value === "string" && schema.minLength !== undefined && value.length < schema.minLength) {
+    errors.push(`${path}: string is shorter than minLength ${schema.minLength}`);
+  }
+  if (typeof value === "string" && schema.maxLength !== undefined && value.length > schema.maxLength) {
+    errors.push(`${path}: string is longer than maxLength ${schema.maxLength}`);
+  }
+  if (Array.isArray(value) && schema.maxItems !== undefined && value.length > schema.maxItems) {
+    errors.push(`${path}: array exceeds maxItems ${schema.maxItems}`);
   }
 
   if (types.includes("object") || (schema.properties && jsonType(value) === "object")) {
@@ -187,6 +203,8 @@ describe("Gateway RPC contract", () => {
       "listMemoryFacts",
       "listPrompts",
       "listScores",
+      "listScoresForRuns",
+      "getScoreDetail",
       "listTickets",
       "createTicket",
       "updateTicket",
@@ -226,6 +244,32 @@ describe("Gateway RPC contract", () => {
     expect(getGatewayScopeValues()).toEqual(GATEWAY_SCOPE_VALUES);
   });
 
+  test("publishes the exact cross-run score and detail contract", () => {
+    const list = getGatewayRpcDefinition("listScoresForRuns")!;
+    expect(list.transport).toBe("http+websocket");
+    expect(list.requiredScope).toBe("score:read");
+    expect(list.requestSchema.properties?.order?.default).toBe("scoredAtAsc");
+    expect(list.requestSchema.properties?.offset?.maximum).toBe(9_999);
+    expect(list.requestSchema.properties?.limit?.maximum).toBe(500);
+    expect(list.requestSchema.properties?.runIds?.items?.maxLength).toBe(256);
+    expect(list.requestSchema.properties?.runIds?.maxItems).toBe(30);
+    expect(list.requestSchema.properties?.source?.enum).toEqual(["live", "batch"]);
+    const row = list.responseSchema.properties?.rows?.items;
+    expect(row?.required).toContain("scoreId");
+    expect(row?.properties).not.toHaveProperty("meta");
+    expect(row?.properties).not.toHaveProperty("input");
+
+    const detail = getGatewayRpcDefinition("getScoreDetail")!;
+    expect(detail.transport).toBe("http+websocket");
+    expect(detail.requiredScope).toBe("score:read");
+    for (const field of ["meta", "input", "output", "groundTruth", "context"]) {
+      expect(detail.responseSchema.required).toContain(field);
+    }
+    expect(detail.errors).toContain("ScoreNotFound");
+    expect(GATEWAY_RPC_ERRORS.ScoreNotFound.httpStatus).toBe(404);
+    expect(isGatewayRpcMethod("compareExperiments")).toBe(false);
+  });
+
   test("pins exact required scopes for every stable RPC method", () => {
     const expectedScopes: Record<string, GatewayScope> = {
       launchRun: "run:write",
@@ -256,6 +300,8 @@ describe("Gateway RPC contract", () => {
       listMemoryFacts: "memory:read",
       listPrompts: "prompt:read",
       listScores: "score:read",
+      listScoresForRuns: "score:read",
+      getScoreDetail: "score:read",
       listTickets: "ticket:read",
       createTicket: "ticket:write",
       updateTicket: "ticket:write",
@@ -658,6 +704,35 @@ describe("Gateway RPC contract", () => {
         method: "listScores",
         request: { runId: "r1", nodeId: "n1" } satisfies ListScoresRequest,
         response: [],
+      },
+      {
+        method: "listScoresForRuns",
+        request: { runIds: ["r1", "r2"], scorerName: "quality", source: "batch", order: "scoredAtDesc", offset: 2, limit: 50 } satisfies ListScoresForRunsRequest,
+        response: {
+          rows: [{ scoreId: "score-1", runId: "r1", nodeId: "n1", iteration: 0, attempt: 1, scorerId: "quality", scorerName: "quality", source: "batch", score: 0.9, scoredAtMs: 1 }],
+          total: 1,
+        } satisfies ListScoresForRunsResponse,
+      },
+      {
+        method: "getScoreDetail",
+        request: { runId: "r1", scoreId: "score-1" } satisfies GetScoreDetailRequest,
+        response: {
+          scoreId: "score-1",
+          runId: "r1",
+          nodeId: "n1",
+          iteration: 0,
+          attempt: 1,
+          scorerId: "quality",
+          scorerName: "quality",
+          source: "batch",
+          score: 0.9,
+          scoredAtMs: 1,
+          meta: { rubric: "quality" },
+          input: null,
+          output: { verdict: "pass" },
+          groundTruth: null,
+          context: ["nightly"],
+        } satisfies GetScoreDetailResponse,
       },
       {
         method: "listTickets",

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -14,7 +14,7 @@ import { dirname, extname, join, relative, resolve, sep } from "node:path";
 import { CronExpressionParser } from "cron-parser";
 import { Effect, Metric } from "effect";
 import { WebSocketServer } from "ws";
-import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { DB_RUN_ID_MAX_LENGTH, SmithersDb } from "@smithers-orchestrator/db/adapter";
 import { captureTxid, createTxidCapture, isRealPostgresAdapter, runWithTxidCapture } from "@smithers-orchestrator/db/captureTxid";
 import { getSmithersSchemaSignature } from "@smithers-orchestrator/db/getSmithersSchemaSignature";
 import { computeRunStateFromRow } from "@smithers-orchestrator/db/runState";
@@ -44,7 +44,7 @@ import { writeRewindAuditRow } from "@smithers-orchestrator/time-travel/writeRew
 import { recoverInProgressRewindAudits } from "@smithers-orchestrator/time-travel/recoverInProgressRewindAudits";
 import { GATEWAY_EVENT_WINDOW_DEFAULT, SMITHERS_API_VERSION, getRequiredScopeForGatewayMethod, } from "@smithers-orchestrator/gateway/rpc";
 import { hasGatewayScope } from "@smithers-orchestrator/gateway/auth/scopes";
-import { apiCollectionNames, serializeAccountRow, serializeApprovalRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow, } from "@smithers-orchestrator/gateway/api";
+import { apiCollectionNames, serializeAccountRow, serializeApprovalRow, serializeComparisonScoreRow, serializeCronRow, serializeDocRow, serializeMemoryFactRow, serializePromptRow, serializeRunEventRow, serializeRunRow, serializeScoreDetailRow, serializeScoreRow, serializeTicketRow, serializeWorkflowRow, } from "@smithers-orchestrator/gateway/api";
 import { listAccounts } from "@smithers-orchestrator/accounts/listAccounts";
 import { EXTENSION_BACKPRESSURE_DISCONNECT_CODE, EXTENSION_METHOD_NOT_FOUND_CODE, EXTENSION_PAYLOAD_MAX_BYTES, EXTENSION_STREAM_OUTBOUND_QUEUE_LIMIT, EXTENSION_WS_BUFFERED_HIGH_WATER_BYTES, GatewayExtensions, isExtensionMethod, } from "./GatewayExtensions.js";
 import { workflowUiThemeCss } from "@smithers-orchestrator/ui-styleguide";
@@ -1335,6 +1335,7 @@ export function statusForRpcError(code) {
         case "SeqOutOfRange":
             return 400;
         case "RunNotFound":
+        case "ScoreNotFound":
         case "NodeNotFound":
         case "AttemptNotFound":
         case "IterationNotFound":
@@ -1849,6 +1850,150 @@ function asOptionalNonNegativeInt(value, field) {
     }
     return number;
 }
+const SCORE_COMPARE_MAX_RUNS = 30;
+const SCORE_ID_MAX_LENGTH = 256;
+const SCORE_COMPARE_MAX_WINDOW = 10_000;
+const SCORE_COMPARE_MAX_OFFSET = SCORE_COMPARE_MAX_WINDOW - 1;
+const SCORE_COMPARE_DEFAULT_LIMIT = 500;
+const SCORE_COMPARE_MAX_LIMIT = 500;
+/**
+ * Normalize the cross-run score identities once, before any persistence read.
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function normalizeScoreRunIds(value) {
+    if (!Array.isArray(value)) {
+        throw new SmithersError("INVALID_REQUEST", "runIds must be an array of strings");
+    }
+    if (value.length > SCORE_COMPARE_MAX_RUNS) {
+        throw new SmithersError("INVALID_REQUEST", `runIds may contain at most ${SCORE_COMPARE_MAX_RUNS} entries`);
+    }
+    const seen = new Set();
+    const runIds = [];
+    for (const valueRunId of value) {
+        if (typeof valueRunId !== "string") {
+            throw new SmithersError("INVALID_REQUEST", "runIds must contain only strings");
+        }
+        const runId = valueRunId.trim();
+        if (!runId) {
+            throw new SmithersError("INVALID_REQUEST", "runIds must not contain blank ids");
+        }
+        if (runId.length > DB_RUN_ID_MAX_LENGTH) {
+            throw new SmithersError("INVALID_REQUEST", `runIds must be at most ${DB_RUN_ID_MAX_LENGTH} characters after trimming`);
+        }
+        if (!seen.has(runId)) {
+            seen.add(runId);
+            runIds.push(runId);
+        }
+    }
+    return runIds;
+}
+/**
+ * @param {unknown} value
+ * @param {string} field
+ * @returns {string | undefined}
+ */
+function optionalScoreFilter(value, field) {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value !== "string") {
+        throw new SmithersError("INVALID_REQUEST", `${field} must be a string`);
+    }
+    return value;
+}
+/** @param {unknown} value @returns {"live" | "batch" | undefined} */
+function optionalScoreSource(value) {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value !== "live" && value !== "batch") {
+        throw new SmithersError("INVALID_REQUEST", "source must be live or batch");
+    }
+    return value;
+}
+/**
+ * @param {unknown} value
+ * @param {string} field
+ * @param {number} fallback
+ * @param {number} minimum
+ * @param {number} maximum
+ */
+function boundedScorePageInteger(value, field, fallback, minimum, maximum) {
+    if (value === undefined) {
+        return fallback;
+    }
+    if (typeof value !== "number" || !Number.isInteger(value) || value < minimum || value > maximum) {
+        throw new SmithersError("INVALID_REQUEST", `${field} must be an integer from ${minimum} to ${maximum}`);
+    }
+    return value;
+}
+/**
+ * @param {unknown} value
+ * @returns {"scoredAtAsc" | "scoredAtDesc"}
+ */
+function scoreResultOrder(value) {
+    if (value === undefined) {
+        return "scoredAtAsc";
+    }
+    if (value !== "scoredAtAsc" && value !== "scoredAtDesc") {
+        throw new SmithersError("INVALID_REQUEST", "order must be scoredAtAsc or scoredAtDesc");
+    }
+    return value;
+}
+/** @param {unknown} left @param {unknown} right */
+function compareAscending(left, right) {
+    return left < right ? -1 : left > right ? 1 : 0;
+}
+/**
+ * @param {Record<string, unknown>} left
+ * @param {Record<string, unknown>} right
+ * @param {"scoredAtAsc" | "scoredAtDesc"} order
+ */
+function compareScoreRows(left, right, order) {
+    const leftScoredAt = Number(left.scoredAtMs ?? 0);
+    const rightScoredAt = Number(right.scoredAtMs ?? 0);
+    if (leftScoredAt !== rightScoredAt) {
+        return order === "scoredAtAsc" ? leftScoredAt - rightScoredAt : rightScoredAt - leftScoredAt;
+    }
+    for (const key of ["runId", "nodeId"]) {
+        const compared = compareAscending(String(left[key] ?? ""), String(right[key] ?? ""));
+        if (compared !== 0)
+            return compared;
+    }
+    for (const key of ["iteration", "attempt"]) {
+        const compared = Number(left[key] ?? 0) - Number(right[key] ?? 0);
+        if (compared !== 0)
+            return compared;
+    }
+    for (const key of ["scorerId", "scoreId"]) {
+        const compared = compareAscending(String(left[key] ?? ""), String(right[key] ?? ""));
+        if (compared !== 0)
+            return compared;
+    }
+    return 0;
+}
+/**
+ * Decode one persisted JSON detail column. SQL NULL is an honest JSON null;
+ * malformed or non-text persistence is an explicit internal failure.
+ * @param {unknown} value
+ * @param {string} scoreId
+ * @param {string} field
+ */
+function decodeScoreDetailJson(value, scoreId, field) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+    if (typeof value !== "string") {
+        throw new SmithersError("Internal", `Persisted score ${scoreId} has non-text ${field} JSON`);
+    }
+    try {
+        return JSON.parse(value);
+    }
+    catch (cause) {
+        throw new SmithersError("Internal", `Persisted score ${scoreId} has malformed ${field} JSON`, undefined, { cause });
+    }
+}
 /**
  * @param {URLSearchParams} searchParams
  * @param {string} name
@@ -1918,6 +2063,15 @@ function serializeGatewayApiPayload(method, payload) {
             return serializeRowOrRows(payload, serializeMemoryFactRow);
         case "listScores":
             return serializeRowOrRows(payload, serializeScoreRow);
+        case "listScoresForRuns": {
+            const response = asObject(payload) ?? {};
+            const rows = Array.isArray(response.rows)
+                ? response.rows.map((row) => serializeComparisonScoreRow(asObject(row) ?? {}))
+                : [];
+            return { rows, total: response.total ?? 0 };
+        }
+        case "getScoreDetail":
+            return serializeRowOrRows(payload, serializeScoreDetailRow);
         case "listTickets":
         case "createTicket":
         case "updateTicket":
@@ -3672,6 +3826,33 @@ a { color: var(--brand); }</style>
         }
         if (httpMethod === "POST" && pathname === "/v1/api/crons/run") {
             return { method: "cronRun", params: body, mutation: true };
+        }
+        // Keep the fixed comparison path ahead of the parameterized score
+        // detail route so `compare` can never be interpreted as a run id.
+        if (httpMethod === "GET" && pathname === "/v1/api/scores/compare") {
+            return {
+                method: "listScoresForRuns",
+                params: {
+                    runIds: url.searchParams.getAll("runId"),
+                    nodeId: queryString(url.searchParams, "nodeId"),
+                    scorerId: queryString(url.searchParams, "scorerId"),
+                    scorerName: queryString(url.searchParams, "scorerName"),
+                    source: queryString(url.searchParams, "source"),
+                    order: queryString(url.searchParams, "order"),
+                    offset: queryNonNegativeInt(url.searchParams, "offset"),
+                    limit: queryNonNegativeInt(url.searchParams, "limit"),
+                },
+            };
+        }
+        const scoreDetail = pathname.match(/^\/v1\/api\/scores\/([^/]+)\/([^/]+)$/);
+        if (httpMethod === "GET" && scoreDetail) {
+            return {
+                method: "getScoreDetail",
+                params: {
+                    runId: decodeURIComponent(scoreDetail[1]),
+                    scoreId: decodeURIComponent(scoreDetail[2]),
+                },
+            };
         }
         if (httpMethod === "POST" && pathname === "/v1/api/tickets") {
             return { method: "createTicket", params: body, mutation: true };
@@ -6474,6 +6655,93 @@ a { color: var(--brand); }</style>
             durationMs: row.durationMs ?? null,
         }));
     }
+    /**
+   * Query persisted scorer rows across runs that may live in distinct stores.
+   * All run ownership is resolved before the first score-table query so an
+   * unknown id fails atomically. Each store contributes its filtered count and
+   * its first `offset + limit` candidates; pagination happens after the global
+   * deterministic merge.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   *   order: "scoredAtAsc" | "scoredAtDesc";
+   *   offset: number;
+   *   limit: number;
+   * }} query
+   * @returns {Promise<{ missingRunId: string } | { rows: Array<Record<string, unknown>>, total: number }>}
+   */
+    async listScoresForRunsAcrossStores(query) {
+        /** @type {Map<SmithersDb, string[]>} */
+        const runIdsByAdapter = new Map();
+        // Deliberately finish this complete ownership pass before score queries.
+        for (const runId of query.runIds) {
+            const resolved = await this.resolveRun(runId);
+            if (!resolved) {
+                return { missingRunId: runId };
+            }
+            const runIds = runIdsByAdapter.get(resolved.adapter) ?? [];
+            runIds.push(runId);
+            runIdsByAdapter.set(resolved.adapter, runIds);
+        }
+        const candidateLimit = query.offset + query.limit;
+        const storeResults = await Promise.all([...runIdsByAdapter.entries()].map(async ([adapter, runIds]) => {
+            const storeQuery = {
+                runIds,
+                nodeId: query.nodeId,
+                scorerId: query.scorerId,
+                scorerName: query.scorerName,
+                source: query.source,
+            };
+            const [total, rows] = await Promise.all([
+                adapter.countScorerResultsForRuns(storeQuery),
+                adapter.listScorerResultsForRuns({
+                    ...storeQuery,
+                    order: query.order,
+                    offset: 0,
+                    limit: candidateLimit,
+                }),
+            ]);
+            return { total, rows };
+        }));
+        const candidates = storeResults.flatMap((result) => result.rows.map((row) => serializeComparisonScoreRow(row)));
+        candidates.sort((left, right) => compareScoreRows(left, right, query.order));
+        return {
+            rows: candidates.slice(query.offset, query.offset + query.limit),
+            total: storeResults.reduce((sum, result) => sum + result.total, 0),
+        };
+    }
+    /**
+   * Read and decode one exact persisted score row. Missing runs and missing
+   * score ids remain distinct so the typed RPC errors stay precise; malformed
+   * JSON throws `Internal`.
+   * @param {string} runId
+   * @param {string} scoreId
+   * @returns {Promise<{ missing: "run" | "score" } | { detail: Record<string, unknown> }>}
+   */
+    async getScoreDetailForRun(runId, scoreId) {
+        const resolved = await this.resolveRun(runId);
+        if (!resolved) {
+            return { missing: "run" };
+        }
+        const row = await resolved.adapter.getScorerResult(runId, scoreId);
+        if (!row) {
+            return { missing: "score" };
+        }
+        return {
+            detail: serializeScoreDetailRow({
+                ...row,
+                scoreId: row.id,
+                meta: decodeScoreDetailJson(row.metaJson, scoreId, "meta"),
+                input: decodeScoreDetailJson(row.inputJson, scoreId, "input"),
+                output: decodeScoreDetailJson(row.outputJson, scoreId, "output"),
+                groundTruth: decodeScoreDetailJson(row.groundTruthJson, scoreId, "groundTruth"),
+                context: decodeScoreDetailJson(row.contextJson, scoreId, "context"),
+            }),
+        };
+    }
     // ---------------------------------------------------------------------------
     // Tickets / work docs (`_smithers_docs`) — listTickets/createTicket/
     // updateTicket/deleteTicket RPCs + the file-watcher durability seam.
@@ -8091,6 +8359,75 @@ a { color: var(--brand); }</style>
                     return responseError(frame.id, "NOT_FOUND", `Run not found: ${runId}`);
                 }
                 return responseOk(frame.id, scores);
+            }
+            case "listScoresForRuns": {
+                const allowed = new Set(["runIds", "nodeId", "scorerId", "scorerName", "source", "order", "offset", "limit"]);
+                const unexpected = Object.keys(params).find((key) => !allowed.has(key));
+                if (unexpected) {
+                    return responseError(frame.id, "INVALID_REQUEST", `Unexpected listScoresForRuns parameter: ${unexpected}`);
+                }
+                let runIds;
+                let nodeId;
+                let scorerId;
+                let scorerName;
+                let source;
+                let order;
+                let offset;
+                let limit;
+                try {
+                    runIds = normalizeScoreRunIds(params.runIds);
+                    nodeId = optionalScoreFilter(params.nodeId, "nodeId");
+                    scorerId = optionalScoreFilter(params.scorerId, "scorerId");
+                    scorerName = optionalScoreFilter(params.scorerName, "scorerName");
+                    source = optionalScoreSource(params.source);
+                    order = scoreResultOrder(params.order);
+                    offset = boundedScorePageInteger(params.offset, "offset", 0, 0, SCORE_COMPARE_MAX_OFFSET);
+                    limit = boundedScorePageInteger(params.limit, "limit", SCORE_COMPARE_DEFAULT_LIMIT, 1, SCORE_COMPARE_MAX_LIMIT);
+                    if (offset + limit > SCORE_COMPARE_MAX_WINDOW) {
+                        throw new SmithersError("INVALID_REQUEST", `offset + limit must not exceed ${SCORE_COMPARE_MAX_WINDOW}`);
+                    }
+                }
+                catch (error) {
+                    if (isSmithersError(error)) {
+                        return responseError(frame.id, error.code, error.summary);
+                    }
+                    throw error;
+                }
+                if (runIds.length === 0) {
+                    return responseOk(frame.id, { rows: [], total: 0 });
+                }
+                const result = await this.listScoresForRunsAcrossStores({ runIds, nodeId, scorerId, scorerName, source, order, offset, limit });
+                if ("missingRunId" in result) {
+                    return responseError(frame.id, "RunNotFound", `Run not found: ${result.missingRunId}`);
+                }
+                return responseOk(frame.id, result);
+            }
+            case "getScoreDetail": {
+                const unexpected = Object.keys(params).find((key) => key !== "runId" && key !== "scoreId");
+                if (unexpected) {
+                    return responseError(frame.id, "INVALID_REQUEST", `Unexpected getScoreDetail parameter: ${unexpected}`);
+                }
+                if (typeof params.runId !== "string" || typeof params.scoreId !== "string") {
+                    return responseError(frame.id, "INVALID_REQUEST", "runId and scoreId must be strings");
+                }
+                const runId = params.runId.trim();
+                const scoreId = params.scoreId.trim();
+                if (!runId || !scoreId) {
+                    return responseError(frame.id, "INVALID_REQUEST", "runId and scoreId must not be blank");
+                }
+                if (runId.length > DB_RUN_ID_MAX_LENGTH) {
+                    return responseError(frame.id, "INVALID_REQUEST", `runId must be at most ${DB_RUN_ID_MAX_LENGTH} characters after trimming`);
+                }
+                if (scoreId.length > SCORE_ID_MAX_LENGTH) {
+                    return responseError(frame.id, "INVALID_REQUEST", `scoreId must be at most ${SCORE_ID_MAX_LENGTH} characters after trimming`);
+                }
+                const result = await this.getScoreDetailForRun(runId, scoreId);
+                if ("missing" in result) {
+                    return result.missing === "run"
+                        ? responseError(frame.id, "RunNotFound", `Run not found: ${runId}`)
+                        : responseError(frame.id, "ScoreNotFound", `Score not found on run ${runId}: ${scoreId}`);
+                }
+                return responseOk(frame.id, result.detail);
             }
             case "listTickets": {
                 const kind = asString(params.kind);

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -1543,6 +1543,52 @@ declare class Gateway {
    */
     listScoresForRun(runId: string, nodeId?: string | null): Promise<Array<Record<string, unknown>> | null>;
     /**
+   * Query persisted scorer rows across runs that may live in distinct stores.
+   * All run ownership is resolved before the first score-table query so an
+   * unknown id fails atomically. Each store contributes its filtered count and
+   * its first `offset + limit` candidates; pagination happens after the global
+   * deterministic merge.
+   * @param {{
+   *   runIds: string[];
+   *   nodeId?: string;
+   *   scorerId?: string;
+   *   scorerName?: string;
+   *   source?: string;
+   *   order: "scoredAtAsc" | "scoredAtDesc";
+   *   offset: number;
+   *   limit: number;
+   * }} query
+   * @returns {Promise<{ missingRunId: string } | { rows: Array<Record<string, unknown>>, total: number }>}
+   */
+    listScoresForRunsAcrossStores(query: {
+        runIds: string[];
+        nodeId?: string;
+        scorerId?: string;
+        scorerName?: string;
+        source?: string;
+        order: "scoredAtAsc" | "scoredAtDesc";
+        offset: number;
+        limit: number;
+    }): Promise<{
+        missingRunId: string;
+    } | {
+        rows: Array<Record<string, unknown>>;
+        total: number;
+    }>;
+    /**
+   * Read and decode one exact persisted score row. Missing runs and missing
+   * score ids remain distinct so the typed RPC errors stay precise; malformed
+   * JSON throws `Internal`.
+   * @param {string} runId
+   * @param {string} scoreId
+   * @returns {Promise<{ missing: "run" | "score" } | { detail: Record<string, unknown> }>}
+   */
+    getScoreDetailForRun(runId: string, scoreId: string): Promise<{
+        missing: "run" | "score";
+    } | {
+        detail: Record<string, unknown>;
+    }>;
+    /**
    * The ONE adapter that backs the ticket WRITE RPCs (create/update/delete) and
    * the file-watcher. `_smithers_docs` is a SINGLE global table (not per-run,
    * not per-workflow), so writes must land in one deterministic DB — the first
@@ -1777,7 +1823,6 @@ type ConnectRequest = ConnectRequest$1;
 type RunEventStreamState = {
     streamId: string;
     runId: string;
-    heartbeat: unknown;
     outboundQueue: Record<string, unknown>[];
     flushPending: boolean;
     backpressureDisconnected: boolean;

--- a/packages/server/tests/gateway-score-rpcs.test.jsx
+++ b/packages/server/tests/gateway-score-rpcs.test.jsx
@@ -1,0 +1,310 @@
+/** @jsxImportSource smithers-orchestrator */
+import { afterEach, describe, expect, test } from "bun:test";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WebSocket } from "ws";
+import { z } from "zod";
+import { createSmithers } from "smithers-orchestrator";
+import { SmithersDb } from "@smithers-orchestrator/db/adapter";
+import { ensureSmithersTables } from "@smithers-orchestrator/db/ensure";
+import { Gateway } from "../src/gateway.js";
+import { sleep } from "../../smithers/tests/helpers.js";
+
+const cleanups = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    try { await cleanup(); } catch {}
+  }
+});
+
+function dbPath(name) {
+  return join(tmpdir(), `smithers-score-rpc-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function createWorkflow(path, name) {
+  const api = createSmithers({ result: z.object({ value: z.number() }) }, { dbPath: path });
+  const workflow = api.smithers(() => (
+    <api.Workflow name={name}>
+      <api.Task id="task" output={api.outputs.result}>{{ value: 1 }}</api.Task>
+    </api.Workflow>
+  ));
+  return { api, workflow };
+}
+
+async function seedScore(adapter, row) {
+  await adapter.insertScorerResult({
+    iteration: 0,
+    attempt: 1,
+    reason: null,
+    latencyMs: null,
+    durationMs: null,
+    metaJson: null,
+    inputJson: null,
+    outputJson: null,
+    groundTruthJson: null,
+    contextJson: null,
+    ...row,
+  });
+}
+
+async function boot() {
+  const pathA = dbPath("a");
+  const pathB = dbPath("b");
+  const a = createWorkflow(pathA, "wf-a");
+  const aShared = a.api.smithers(() => (
+    <a.api.Workflow name="wf-a-shared">
+      <a.api.Task id="task" output={a.api.outputs.result}>{{ value: 1 }}</a.api.Task>
+    </a.api.Workflow>
+  ));
+  const b = createWorkflow(pathB, "wf-b");
+  ensureSmithersTables(a.workflow.db);
+  ensureSmithersTables(b.workflow.db);
+  const adapterA = new SmithersDb(a.workflow.db);
+  const adapterB = new SmithersDb(b.workflow.db);
+  await adapterA.insertRun({ runId: "run-a", workflowName: "wf-a", status: "finished", createdAtMs: 1 });
+  await adapterB.insertRun({ runId: "run-b", workflowName: "wf-b", status: "finished", createdAtMs: 2 });
+
+  await seedScore(adapterA, {
+    id: "score-a-early", runId: "run-a", nodeId: "alpha", scorerId: "judge", scorerName: "Quality",
+    source: "live", score: 0.91, reason: "good", scoredAtMs: 100, latencyMs: 12, durationMs: 34,
+    metaJson: '{"rubric":"quality"}', inputJson: '["prompt"]', outputJson: '"pass"', groundTruthJson: "null",
+  });
+  await seedScore(adapterA, {
+    id: "score-a-tie", runId: "run-a", nodeId: "beta", scorerId: "judge", scorerName: "Quality",
+    source: "live", score: 0.8, scoredAtMs: 200,
+  });
+  await seedScore(adapterA, {
+    id: "score-malformed", runId: "run-a", nodeId: "gamma", scorerId: "judge", scorerName: "Quality",
+    source: "batch", score: 0.1, scoredAtMs: 250, metaJson: "{not-json",
+  });
+  await seedScore(adapterB, {
+    id: "score-b-middle", runId: "run-b", nodeId: "alpha", scorerId: "judge", scorerName: "quality",
+    source: "batch", score: 0.7, scoredAtMs: 150,
+  });
+  await seedScore(adapterB, {
+    id: "score-b-tie", runId: "run-b", nodeId: "alpha", scorerId: "judge", scorerName: "Quality",
+    source: "live", score: 0.85, scoredAtMs: 200,
+  });
+
+  const gateway = new Gateway({
+    auth: {
+      mode: "token",
+      tokens: {
+        "score-token": { role: "viewer", scopes: ["score:read"] },
+        "run-token": { role: "viewer", scopes: ["run:read"] },
+      },
+    },
+  });
+  gateway.register("wf-a", a.workflow);
+  // A second workflow on the same physical store exercises adapter/store dedupe.
+  gateway.register("wf-a-shared", aShared);
+  gateway.register("wf-b", b.workflow);
+  const server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("gateway has no port");
+  cleanups.push(() => {
+    a.workflow.db.$client?.close?.();
+    b.workflow.db.$client?.close?.();
+    for (const path of [pathA, pathB]) {
+      rmSync(path, { force: true });
+      rmSync(`${path}-shm`, { force: true });
+      rmSync(`${path}-wal`, { force: true });
+    }
+  });
+  cleanups.push(() => gateway.close());
+  return { baseUrl: `http://127.0.0.1:${address.port}`, port: address.port };
+}
+
+async function rpc(baseUrl, method, params, token = "score-token") {
+  const response = await fetch(`${baseUrl}/v1/rpc/${method}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  return { status: response.status, json: await response.json() };
+}
+
+async function rest(baseUrl, path, token = "score-token") {
+  const response = await fetch(`${baseUrl}${path}`, { headers: { authorization: `Bearer ${token}` } });
+  return { status: response.status, json: await response.json() };
+}
+
+class WsClient {
+  messages = [];
+  constructor(ws) {
+    this.ws = ws;
+    ws.on("message", (raw) => this.messages.push(JSON.parse(String(raw))));
+  }
+  async waitFor(predicate) {
+    for (let i = 0; i < 500; i += 1) {
+      const index = this.messages.findIndex(predicate);
+      if (index >= 0) return this.messages.splice(index, 1)[0];
+      await sleep(10);
+    }
+    throw new Error(`timed out waiting for WS message: ${JSON.stringify(this.messages)}`);
+  }
+  async request(method, params) {
+    const id = `${method}-${Math.random()}`;
+    this.ws.send(JSON.stringify({ type: "req", id, method, params }));
+    return this.waitFor((message) => message.type === "res" && message.id === id);
+  }
+  async close() {
+    if (this.ws.readyState === this.ws.CLOSED) return;
+    await new Promise((resolve) => {
+      this.ws.once("close", resolve);
+      this.ws.close();
+    });
+  }
+}
+
+async function wsClient(port) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  await new Promise((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  const client = new WsClient(ws);
+  await client.waitFor((message) => message.type === "event" && message.event === "connect.challenge");
+  const hello = await client.request("connect", {
+    minProtocol: 1,
+    maxProtocol: 1,
+    client: { id: "score-rpc-test", version: "1", platform: "bun" },
+    auth: { token: "score-token" },
+  });
+  expect(hello.ok).toBe(true);
+  cleanups.push(() => client.close());
+  return client;
+}
+
+describe("Gateway cross-run score RPCs", () => {
+  test("globally orders/pages real rows across distinct and shared SQLite stores", async () => {
+    const { baseUrl, port } = await boot();
+    const compared = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: [" run-b ", "run-a", "run-b"],
+    });
+    expect(compared.status).toBe(200);
+    expect(compared.json.payload.total).toBe(5);
+    expect(compared.json.payload.rows.map((row) => row.scoreId)).toEqual([
+      "score-a-early", "score-b-middle", "score-a-tie", "score-b-tie", "score-malformed",
+    ]);
+    expect(compared.json.payload.rows[0]).not.toHaveProperty("meta");
+    expect(compared.json.payload.rows[0]).not.toHaveProperty("metaJson");
+    expect(compared.json.payload.rows[0]).not.toHaveProperty("input");
+
+    const page = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: ["run-a", "run-b"], offset: 1, limit: 2,
+    });
+    expect(page.json.payload.total).toBe(5);
+    expect(page.json.payload.rows.map((row) => row.scoreId)).toEqual(["score-b-middle", "score-a-tie"]);
+
+    const descending = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: ["run-a", "run-b"], order: "scoredAtDesc", offset: 1, limit: 3,
+    });
+    // Timestamp direction flips, but ties remain ascending by runId and fields.
+    expect(descending.json.payload.rows.map((row) => row.scoreId)).toEqual(["score-a-tie", "score-b-tie", "score-b-middle"]);
+
+    const filtered = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: ["run-a", "run-b"], nodeId: "alpha", scorerId: "judge", scorerName: "Quality", source: "live",
+    });
+    expect(filtered.json.payload.rows.map((row) => row.scoreId)).toEqual(["score-a-early", "score-b-tie"]);
+    const caseSensitive = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: ["run-a", "run-b"], scorerName: "quality", source: "batch",
+    });
+    expect(caseSensitive.json.payload.rows.map((row) => row.scoreId)).toEqual(["score-b-middle"]);
+
+    const empty = await rpc(baseUrl, "listScoresForRuns", { runIds: [] });
+    expect(empty.json.payload).toEqual({ rows: [], total: 0 });
+
+    const detail = await rpc(baseUrl, "getScoreDetail", { runId: " run-a ", scoreId: " score-a-early " });
+    expect(detail.json.payload).toMatchObject({
+      scoreId: "score-a-early", runId: "run-a", meta: { rubric: "quality" }, input: ["prompt"], output: "pass",
+      groundTruth: null, context: null,
+    });
+    const nullDetail = await rpc(baseUrl, "getScoreDetail", { runId: "run-a", scoreId: "score-a-tie" });
+    expect(nullDetail.json.payload).toMatchObject({ meta: null, input: null, output: null, groundTruth: null, context: null });
+
+    // listScores remains the legacy per-run array and does not gain identity/detail fields.
+    const legacy = await rpc(baseUrl, "listScores", { runId: "run-a" });
+    expect(legacy.json.payload.map((row) => row.scoredAtMs)).toEqual([100, 200, 250]);
+    expect(legacy.json.payload[0]).not.toHaveProperty("scoreId");
+    expect(legacy.json.payload[0]).not.toHaveProperty("meta");
+
+    const restCompare = await rest(baseUrl, "/v1/api/scores/compare?runId=run-b&runId=run-a&offset=1&limit=2");
+    expect(restCompare.status).toBe(200);
+    expect(restCompare.json.data).toEqual(page.json.payload);
+    const restDetail = await rest(baseUrl, "/v1/api/scores/run-a/score-a-early");
+    expect(restDetail.json.data).toEqual(detail.json.payload);
+
+    const ws = await wsClient(port);
+    const wsCompared = await ws.request("listScoresForRuns", { runIds: ["run-a", "run-b"], limit: 1 });
+    expect(wsCompared.ok).toBe(true);
+    expect(wsCompared.payload).toMatchObject({ total: 5, rows: [{ scoreId: "score-a-early" }] });
+    const wsDetail = await ws.request("getScoreDetail", { runId: "run-a", scoreId: "score-a-early" });
+    expect(wsDetail.ok).toBe(true);
+    expect(wsDetail.payload.meta).toEqual({ rubric: "quality" });
+  });
+
+  test("rejects invalid/auth requests and returns typed atomic not-found/internal errors", async () => {
+    const { baseUrl } = await boot();
+    const forbidden = await rpc(baseUrl, "listScoresForRuns", { runIds: ["run-a"] }, "run-token");
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.json.error.code).toBe("FORBIDDEN");
+    const restForbidden = await rest(baseUrl, "/v1/api/scores/compare?runId=run-a", "run-token");
+    expect(restForbidden.status).toBe(403);
+
+    for (const params of [
+      {},
+      { runIds: "run-a" },
+      { runIds: [1] },
+      { runIds: [" "] },
+      { runIds: ["run-a"], source: "eval" },
+      { runIds: ["run-a"], order: "newest" },
+      { runIds: ["run-a"], offset: -1 },
+      { runIds: ["run-a"], offset: 10_000 },
+      { runIds: ["run-a"], limit: 0 },
+      { runIds: ["run-a"], limit: 501 },
+      { runIds: ["run-a"], limit: 1.5 },
+      { runIds: ["run-a"], offset: 9_999, limit: 2 },
+      { runIds: [], limit: 0 },
+      { runIds: ["run-a"], extra: true },
+      { runIds: ["x".repeat(257)] },
+    ]) {
+      const invalid = await rpc(baseUrl, "listScoresForRuns", params);
+      expect(invalid.status, JSON.stringify(params)).toBe(400);
+    }
+    const tooMany = await rpc(baseUrl, "listScoresForRuns", {
+      runIds: Array.from({ length: 31 }, (_, index) => `run-${index}`),
+    });
+    expect(tooMany.status).toBe(400);
+    // Thirty repeated entries normalize to one first-seen id and remain valid.
+    const duplicates = await rpc(baseUrl, "listScoresForRuns", { runIds: Array(30).fill(" run-a "), limit: 1 });
+    expect(duplicates.status).toBe(200);
+
+    const unknown = await rpc(baseUrl, "listScoresForRuns", { runIds: ["run-a", "missing"] });
+    expect(unknown.status).toBe(404);
+    expect(unknown.json.error.code).toBe("RunNotFound");
+    const missingRun = await rpc(baseUrl, "getScoreDetail", { runId: "missing", scoreId: "score-a-early" });
+    expect(missingRun.json.error.code).toBe("RunNotFound");
+    const missingScore = await rpc(baseUrl, "getScoreDetail", { runId: "run-b", scoreId: "score-a-early" });
+    expect(missingScore.json.error.code).toBe("ScoreNotFound");
+    const blankDetail = await rpc(baseUrl, "getScoreDetail", { runId: " ", scoreId: " " });
+    expect(blankDetail.status).toBe(400);
+    const longDetail = await rpc(baseUrl, "getScoreDetail", { runId: "run-a", scoreId: "x".repeat(257) });
+    expect(longDetail.status).toBe(400);
+
+    const malformed = await rpc(baseUrl, "getScoreDetail", { runId: "run-a", scoreId: "score-malformed" });
+    expect(malformed.status).toBe(500);
+    expect(malformed.json.error.code).toBe("Internal");
+
+    // REST uses strict integer parsing too; it never floors a decimal limit.
+    const decimalRest = await rest(baseUrl, "/v1/api/scores/compare?runId=run-a&limit=1.5");
+    expect(decimalRest.status).toBe(400);
+    const invalidEmptyRest = await rest(baseUrl, "/v1/api/scores/compare?limit=0");
+    expect(invalidEmptyRest.status).toBe(400);
+    const precedence = await rest(baseUrl, "/v1/api/scores/compare");
+    expect(precedence.status).toBe(200);
+    expect(precedence.json.data).toEqual({ rows: [], total: 0 });
+  });
+});

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -12109,12 +12109,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404

--- a/packages/smithers/tests/migrateSmithersStore.test.js
+++ b/packages/smithers/tests/migrateSmithersStore.test.js
@@ -280,7 +280,7 @@ describe("migrateSmithersStore", () => {
     expect(result.backend).toBe("pglite");
     expect(result.dbPath).toBe(dbPath);
     expect(result.runCount).toBe(1);
-    expect(result.schemaVersion).toBe("0025");
+    expect(result.schemaVersion).toBe("0026");
     expect(existsSync(result.markerPath)).toBe(true);
     expect(existsSync(dbPath)).toBe(true);
     expect(progress.some((event) => event.type === "table-copied" && event.table === "result")).toBe(true);
@@ -929,7 +929,7 @@ describe("migrateSmithersStore", () => {
     }
 
     const result = await migrateSmithersStore({ cwd, from: "sqlite", to: "pglite" });
-    expect(result.schemaVersion).toBe("0025");
+    expect(result.schemaVersion).toBe("0026");
 
     // The migration itself upgraded the source schema before copying.
     sqlite = new Database(dbPath, { readonly: true });
@@ -1130,7 +1130,7 @@ describe("migrateSmithersStore real postgres", () => {
       expect(result.source.backend).toBe("sqlite");
       expect(result.target).toMatchObject({ backend: "postgres", url: "set" });
       expect(result.runCount).toBe(1);
-      expect(result.schemaVersion).toBe("0025");
+      expect(result.schemaVersion).toBe("0026");
       expect(existsSync(result.markerPath)).toBe(true);
 
       const api = await openSmithersBackend({}, { cwd, backend: "postgres", connectionString: url, env: {} });

--- a/packages/time-travel/src/ReplayParams.ts
+++ b/packages/time-travel/src/ReplayParams.ts
@@ -9,4 +9,15 @@ export type ReplayParams = {
   branchLabel?: string;
   restoreVcs?: boolean;
   cwd?: string;
+  /**
+   * Re-bless the forked run's durable workflow metadata to the workflow being
+   * replayed. Without these, the fork inherits the PARENT's hashes and the
+   * resume guard (assertResumeDurabilityMetadata) rejects a replay whose
+   * workflow source was edited — defeating the "carry the edit forward" purpose
+   * of replay. The CLI computes these from the resolved workflow file (mirrors
+   * the `fork` command); omit them to keep the parent's metadata unchanged.
+   */
+  workflowPath?: string;
+  workflowHash?: string | null;
+  entryWorkflowHash?: string | null;
 };

--- a/packages/time-travel/src/replayFromCheckpointEffect.js
+++ b/packages/time-travel/src/replayFromCheckpointEffect.js
@@ -17,8 +17,11 @@ import { replaysStarted } from "./replaysStarted.js";
  */
 export function replayFromCheckpoint(adapter, params) {
     return Effect.gen(function* () {
-        const { parentRunId, frameNo, inputOverrides, resetNodes, branchLabel, restoreVcs, cwd, } = params;
-        // 1. Fork the run
+        const { parentRunId, frameNo, inputOverrides, resetNodes, branchLabel, restoreVcs, cwd, workflowPath, workflowHash, entryWorkflowHash, } = params;
+        // 1. Fork the run. Thread through the workflow identity so a replay that
+        //    carries an edited workflow re-blesses the child's durable metadata;
+        //    otherwise the child inherits the parent's hashes and the resume
+        //    guard rejects the very edit replay exists to carry forward.
         const { runId, branch, snapshot } = yield* forkRunEffect(adapter, {
             parentRunId,
             frameNo,
@@ -26,6 +29,9 @@ export function replayFromCheckpoint(adapter, params) {
             resetNodes,
             branchLabel,
             forkDescription: `Replay from ${parentRunId}:${frameNo}`,
+            ...(workflowPath !== undefined ? { workflowPath } : {}),
+            ...(workflowHash !== undefined ? { workflowHash } : {}),
+            ...(entryWorkflowHash !== undefined ? { entryWorkflowHash } : {}),
         });
         // 2. Optionally restore VCS state
         let vcsRestored = false;

--- a/packages/time-travel/tests/time-travel-replay.test.js
+++ b/packages/time-travel/tests/time-travel-replay.test.js
@@ -61,6 +61,90 @@ describe("replayFromCheckpoint", () => {
         expect(result.vcsPointer).toBeNull();
         expect(result.vcsError).toBeUndefined();
     });
+    test("re-blesses workflow hashes so a replayed edit resumes (regression: replay ignored the new source)", async () => {
+        const { adapter } = createTestDb();
+        // Parent ran an OLD workflow source; replaying carries a NEW (edited) source.
+        await adapter.insertRun({
+            runId: "parent-run",
+            parentRunId: null,
+            workflowName: "time-travel-parent",
+            workflowPath: "/tmp/old-workflow.tsx",
+            workflowHash: "old-workflow-hash",
+            status: "failed",
+            createdAtMs: 1_000,
+            startedAtMs: 1_100,
+            finishedAtMs: 1_200,
+            heartbeatAtMs: null,
+            runtimeOwnerId: null,
+            cancelRequestedAtMs: null,
+            hijackRequestedAtMs: null,
+            hijackTarget: null,
+            vcsType: null,
+            vcsRoot: null,
+            vcsRevision: null,
+            errorJson: null,
+            configJson: JSON.stringify({
+                keep: "value",
+                __smithersDurability: { version: 2, entryWorkflowHash: "old-entry-hash" },
+            }),
+        });
+        await captureSnapshot(adapter, "parent-run", 0, sampleData({ workflowHash: "old-workflow-hash" }));
+
+        const result = await replayFromCheckpoint(adapter, {
+            parentRunId: "parent-run",
+            frameNo: 0,
+            workflowPath: "/tmp/new-workflow.tsx",
+            workflowHash: "new-workflow-hash",
+            entryWorkflowHash: "new-entry-hash",
+        });
+
+        // The forked child must carry the NEW source's identity; otherwise the
+        // resume guard rejects the replay with RESUME_METADATA_MISMATCH.
+        const childRun = await adapter.getRun(result.runId);
+        expect(childRun).toMatchObject({
+            workflowPath: "/tmp/new-workflow.tsx",
+            workflowHash: "new-workflow-hash",
+        });
+        expect(JSON.parse(childRun?.configJson ?? "{}")).toEqual({
+            keep: "value",
+            __smithersDurability: { version: 2, entryWorkflowHash: "new-entry-hash" },
+        });
+        expect(result.snapshot.workflowHash).toBe("new-workflow-hash");
+    });
+    test("leaves parent workflow hashes untouched when replay passes no source identity", async () => {
+        const { adapter } = createTestDb();
+        await adapter.insertRun({
+            runId: "parent-run",
+            parentRunId: null,
+            workflowName: "time-travel-parent",
+            workflowPath: "/tmp/old-workflow.tsx",
+            workflowHash: "old-workflow-hash",
+            status: "failed",
+            createdAtMs: 1_000,
+            startedAtMs: 1_100,
+            finishedAtMs: 1_200,
+            heartbeatAtMs: null,
+            runtimeOwnerId: null,
+            cancelRequestedAtMs: null,
+            hijackRequestedAtMs: null,
+            hijackTarget: null,
+            vcsType: null,
+            vcsRoot: null,
+            vcsRevision: null,
+            errorJson: null,
+            configJson: JSON.stringify({ __smithersDurability: { version: 2, entryWorkflowHash: "old-entry-hash" } }),
+        });
+        await captureSnapshot(adapter, "parent-run", 0, sampleData({ workflowHash: "old-workflow-hash" }));
+
+        const result = await replayFromCheckpoint(adapter, { parentRunId: "parent-run", frameNo: 0 });
+
+        const childRun = await adapter.getRun(result.runId);
+        expect(childRun).toMatchObject({
+            workflowPath: "/tmp/old-workflow.tsx",
+            workflowHash: "old-workflow-hash",
+        });
+        expect(result.snapshot.workflowHash).toBe("old-workflow-hash");
+    });
     test("sets branch description to indicate replay", async () => {
         const { adapter } = createTestDb();
         await captureSnapshot(adapter, "parent-run", 2, sampleData());

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1003,8 +1003,8 @@ function checkGatewayRpcReferenceDocsMatchRegistry() {
   const extraDocs = actualDocs.filter((name) => !expectedDocs.includes(name));
   const problems = [];
 
-  if (definitions.length !== 32) {
-    problems.push(`expected 32 Gateway RPC definitions, found ${definitions.length}`);
+  if (definitions.length !== 34) {
+    problems.push(`expected 34 Gateway RPC definitions, found ${definitions.length}`);
   }
   for (const name of missingDocs) problems.push(`missing docs/rpc/${name}`);
   for (const name of extraDocs) problems.push(`unexpected docs/rpc/${name}`);

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -12109,12 +12109,13 @@ type OutputSchemaDescriptor = {
 Gateway v1 RPC errors use stable code strings and HTTP status mappings:
 
 ```toon
-errors[22]{code,http}:
+errors[23]{code,http}:
   InvalidRequest,400
   InvalidInput,400
   Unauthorized,401
   Forbidden,403
   RunNotFound,404
+  ScoreNotFound,404
   RUN_NOT_ACTIVE,409
   CronNotFound,404
   TicketNotFound,404


### PR DESCRIPTION
Unblocks the multi-side Smithers Cloud evals epic (smithersai/multi#5), which needs to compare eval scores **across runs** — today the gateway's score surface is per-run only (`listScores` takes one `runId`).

## What this adds
- **RPC `listScoresForRuns`** (scope `score:read`): query persisted scorer rows across up to 30 runs at once, with filters (`nodeId`, `scorerId`, `scorerName`, `source`), ordering, and pagination inside a bounded 10k-row comparison window. Returns `{rows, total}` where each row carries `scoreId/runId/nodeId/iteration/attempt/scorerId/scorerName/source/score/reason/scoredAtMs/latencyMs/durationMs`.
- **RPC `getScoreDetail`**: one row plus its decoded JSON detail columns.
- **REST `GET /v1/api/scores/compare`** mapping to `listScoresForRuns` (strict integer parsing; empty query → `200 {rows: [], total: 0}`). Existing `GET /v1/api/scores` is unchanged.
- **DB adapter** cross-store queries: run ownership resolved before the first score-table query so an unknown id fails atomically; each store contributes a filtered count + candidates, with pagination after a global deterministic merge.
- **gateway-client** types (`GatewayComparisonScoreRow`, `GatewayScoreDetail`) wired into `GatewayRpcTypeMap` / `SmithersApi` / `createSmithersDataClient`, plus OpenAPI regeneration.

## Verification
`bun test packages/db/tests/scorer-cross-run.test.js packages/server/tests/gateway-score-rpcs.test.jsx packages/gateway/tests packages/gateway-client/tests` → **209 pass / 0 fail** (26 files), rebased on current `main`.

Implemented by codex gpt-5.6-sol; rebased, re-verified, and landed by the orchestration run.