### PR TITLE
📝 docs: rewrite README microsandbox-style, relocate marketing content

### DIFF
--- a/scripts/readme-contract.test.mjs
+++ b/scripts/readme-contract.test.mjs
@@ -7,16 +7,18 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const readme = readFileSync(join(root, "README.md"), "utf8");
 
 describe("README public examples", () => {
-  test("hero alt text avoids out-of-scope Studio wording", () => {
+  test("hero image keeps the time-travel fork visual and avoids Studio wording", () => {
     expect(readme).toContain(
-      "![Live workflow runs: some succeeded, some running, some paused on an approval gate, every run resumable and rewindable.]",
+      '<img src="./docs/images/why/task-fork.gif" alt="Forking a Smithers run from an earlier frame to branch an alternate timeline"',
     );
     expect(readme).not.toContain("![Live runs in Smithers Studio:");
   });
 
   test("component primer promotes Loop instead of deprecated Ralph", () => {
     expect(readme).toContain("| `<Loop>`     | Repeat tasks until a condition is met  |");
-    expect(readme).toContain('<Loop until={ctx.latest("validate")?.approved} maxIterations={5}>');
+    expect(readme).toContain(
+      '<Loop until={ctx.latest(outputs.review, "validate")?.approved} maxIterations={5}>',
+    );
     expect(readme).toContain("</Loop>");
     expect(readme).not.toContain("| `<Ralph>`    | Loop until a condition is met  |");
     expect(readme).not.toContain("<Ralph until=");


### PR DESCRIPTION
Restructures the README along the lines of microsandbox's (lean, visual, command-first) while keeping everything load-bearing: both product GIFs, the Monitor screenshot, the workflow code example, the mental-model loop, and the CLI cheat sheet.

## README

- Opens with the existing light/dark logo wordmarks as a banner, a centered tagline, and a centered badge row.
- Six-bullet feature list, then a command-first Get started with a Requirements callout (Bun 1.3+).
- Removed marketing-page content: the "When to use Smithers" table, the "Why not just let my agent orchestrate itself?" section, and the 100+ patterns marketing card. The docs landing page already carries the self-orchestration comparison nearly verbatim.
- Fixed defects: the orphaned one-row `<Loop>` primitive table, the triple "former starters" repetition (one mention remains, in Examples), and the quickstart command that required a manual copy step first.
- All commands stay in the canonical `bunx smithers-orchestrator` form (normalize-bunx gates this; bare `smithers` is a different npm package).

## Docs

- The "When to use Smithers" decision table moves to `docs/guide/what-is-smithers.mdx` (not in the llms manifest, so no bundle regen).

## Gates

- `scripts/check-docs.mjs`: the README needle set required the exact orphaned table row; it now requires the `<Loop until=...>` code example instead, still forbidding Ralph/Studio strings.
- `scripts/readme-contract.test.mjs`: was stale (expected an image alt and a Loop form the README no longer had); realigned with the current content. Passes under `bun test`.
- New `CONTRIBUTING.md` linked from the README: setup, CI gates, and the repo invariants.

`pnpm check:docs` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)