### PR TITLE
feat(agents): default omp streaming runs to a persistent RPC session

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -18125,11 +18125,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+`<Task>`, or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 

--- a/docs/integrations/cli-agents.mdx
+++ b/docs/integrations/cli-agents.mdx
@@ -101,11 +101,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+[`<Task>`](/components/task), or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -18125,11 +18125,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+`<Task>`, or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 

--- a/docs/llms-integrations.txt
+++ b/docs/llms-integrations.txt
@@ -186,11 +186,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+[`<Task>`](/components/task), or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 

--- a/docs/reference/agents.mdx
+++ b/docs/reference/agents.mdx
@@ -318,6 +318,11 @@ Wraps the Pi CLI and adds extension UI hook support. Key additions: `provider`,
 ### OmpAgent
 
 Wraps the Oh My Pi (OMP) harness in headless text, JSON print, or RPC mode.
+With `mode` omitted, streaming runs default to `rpc` (a persistent session, so the
+multi-turn tool loop runs) and everything else defaults to `text`; set
+`mode: "json"` for a one-shot execution, which streaming runs also fall back to
+when file arguments are passed. See
+[CLI agents → Mode defaults](/integrations/cli-agents#mode-defaults).
 Adds `provider`, `mode` (`"text" | "json" | "rpc"`), `thinking` (`"off"` through
 `"max"`, or `"auto"`), `skills` (plural, comma-separated), `hooks`, `maxTime`,
 `autoApprove`, `approvalMode`, and session controls (`resume`, `continueSession`,

--- a/packages/agents/src/BaseCliAgent/runRpcCommandEffect.js
+++ b/packages/agents/src/BaseCliAgent/runRpcCommandEffect.js
@@ -7,6 +7,7 @@ import { toSmithersError } from "@smithers-orchestrator/errors/toSmithersError";
 import { logDebug, logWarning } from "@smithers-orchestrator/observability/logging";
 import { toolOutputTruncatedTotal } from "@smithers-orchestrator/observability/metrics";
 import { extractTextFromJsonValue } from "./extractTextFromJsonValue.js";
+import { normalizeTokenUsage } from "./normalizeTokenUsage.js";
 import { truncateToBytes } from "./truncateToBytes.js";
 import { sanitizeCliArgs, sanitizeCliErrorCause } from "./sanitizeCliArgs.js";
 /** @typedef {import("./PiExtensionUiResponse.ts").PiExtensionUiResponse} PiExtensionUiResponse */
@@ -55,6 +56,30 @@ function createInactivityTimer(timeoutMs, onTimeout) {
     return { reset, clear };
 }
 /**
+ * Normalize CLI usage into the AI SDK shape consumed by Smithers telemetry.
+ * @param {unknown} value
+ * @returns {import("ai").LanguageModelUsage | undefined}
+ */
+function toLanguageModelUsage(value) {
+    const usage = normalizeTokenUsage(value);
+    if (!usage)
+        return undefined;
+    return {
+        inputTokens: usage.inputTokens,
+        inputTokenDetails: {
+            noCacheTokens: undefined,
+            cacheReadTokens: usage.cacheReadTokens,
+            cacheWriteTokens: usage.cacheWriteTokens,
+        },
+        outputTokens: usage.outputTokens,
+        outputTokenDetails: {
+            textTokens: undefined,
+            reasoningTokens: usage.reasoningTokens,
+        },
+        totalTokens: usage.totalTokens ?? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0) || undefined),
+    };
+}
+/**
  * @param {string} command
  * @param {string[]} args
  * @param {RunRpcCommandOptions} options
@@ -82,6 +107,7 @@ export function runRpcCommandEffect(command, args, options) {
         let promptResponseError = null;
         let extractedUsage = undefined;
         let stderrTruncated = false;
+        let terminationStarted = false;
         logDebug("starting agent RPC command", logAnnotations, span);
         const child = spawnFn(command, args, {
             cwd,
@@ -125,6 +151,9 @@ export function runRpcCommandEffect(command, args, options) {
             if (signal) {
                 signal.removeEventListener("abort", onAbort);
             }
+            if (!processExited) {
+                terminateChild();
+            }
             notifyProcessExited();
             logWarning(message, {
                 ...logAnnotations,
@@ -164,7 +193,7 @@ export function runRpcCommandEffect(command, args, options) {
             catch {
                 // ignore
             }
-            resume(Effect.succeed({ text, output, stderr, exitCode: child.exitCode, usage: extractedUsage }));
+            resume(Effect.succeed({ text, output, stderr, exitCode: child.exitCode, usage: toLanguageModelUsage(extractedUsage) }));
         };
         /**
     * @param {NodeJS.Signals} signal
@@ -172,16 +201,27 @@ export function runRpcCommandEffect(command, args, options) {
         const killProcessGroup = (signal) => {
             if (!child.pid)
                 return;
+            if (process.platform !== "win32") {
+                try {
+                    process.kill(-child.pid, signal);
+                    return;
+                }
+                catch {
+                    // Fall through to the direct child when the detached group
+                    // is not observable yet.
+                }
+            }
             try {
-                process.kill(-child.pid, signal);
+                child.kill(signal);
             }
             catch {
-                // process group already exited
+                // process already exited
             }
         };
         const terminateChild = () => {
-            if (!child.pid)
+            if (!child.pid || terminationStarted)
                 return;
+            terminationStarted = true;
             killProcessGroup("SIGTERM");
             const killTimer = setTimeout(() => {
                 killProcessGroup("SIGKILL");

--- a/packages/agents/src/OmpAgent.js
+++ b/packages/agents/src/OmpAgent.js
@@ -30,8 +30,12 @@ export class OmpAgent extends BaseCliAgent {
     this.opts = opts;
     this.capabilities = createOmpCapabilityRegistry(opts);
   }
-  /** @param {{ onEvent?: unknown } | undefined} options @returns {"text" | "json" | "rpc"} */
-  resolveMode(options) { return this.opts.mode ?? (options?.onEvent ? "json" : "text"); }
+  /** @param {{ onEvent?: unknown, files?: unknown[] } | undefined} options @returns {"text" | "json" | "rpc"} */
+  resolveMode(options) {
+    if (this.opts.mode) return this.opts.mode;           // explicit opt-out/opt-in wins
+    if (!options?.onEvent) return "text";                // non-streaming unchanged
+    return options?.files?.length ? "json" : "rpc";      // stream: RPC unless file args
+  }
   resolveCredentialEnv() {
     if (!this.opts.apiKey) return undefined;
     const envName = resolveOmpProviderEnv(this.opts.provider, this.opts.model ?? this.model);

--- a/packages/agents/src/OmpAgent.js
+++ b/packages/agents/src/OmpAgent.js
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { BaseCliAgent, asString, extractPrompt, extractTextFromJsonValue, pushFlag, resolveTimeouts, runAgentPromise, runRpcCommandEffect, buildGenerateResult, toolKindFromName } from "./BaseCliAgent/index.js";
+import { taskContextEnv } from "./BaseCliAgent/taskContextEnv.js";
 import { normalizeCapabilityStringList } from "./capability-registry/index.js";
 import { resolveOmpProviderEnv } from "./ompProviderEnv.js";
 
@@ -113,12 +114,22 @@ export class OmpAgent extends BaseCliAgent {
     const env = this.resolveCredentialEnv();
     return { command: "omp", args: this.buildArgs({ prompt, cwd, options, mode }), ...(env ? { env } : {}), outputFormat: mode };
   }
+  /**
+   * Environment for a persistent RPC session. Mirrors the env BaseCliAgent builds for
+   * the one-shot path: `inheritEnv: false` is honored, and the task's `SMITHERS_*`
+   * identifiers are forwarded. Streaming defaults to RPC, so an RPC session that
+   * dropped those would silently break `smithers ask-human` from inside an omp agent.
+   * @param {{ taskContext?: unknown } | undefined} options @returns {Record<string, string>}
+   */
+  resolveRpcEnv(options) {
+    return { ...(this.inheritEnv ? process.env : {}), ...this.env, ...taskContextEnv(options?.taskContext), ...this.resolveCredentialEnv() };
+  }
   async generate(options = {}) {
     if (this.resolveMode(options) !== "rpc") return super.generate(options);
     if (options.files?.length) throw new Error("OMP RPC mode does not support file arguments");
     const { prompt } = extractPrompt(options);
     const cwd = this.cwd ?? options.rootDir ?? process.cwd();
-    const env = { ...process.env, ...this.env, ...this.resolveCredentialEnv() };
+    const env = this.resolveRpcEnv(options);
     const timeouts = resolveTimeouts(options.timeout, { totalMs: this.timeoutMs, idleMs: this.idleTimeoutMs });
     const interpreter = this.createOutputInterpreter();
     const program = Effect.gen(this, function* () {

--- a/packages/agents/src/OmpAgent.js
+++ b/packages/agents/src/OmpAgent.js
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { BaseCliAgent, asString, extractPrompt, extractTextFromJsonValue, pushFlag, resolveTimeouts, runAgentPromise, runRpcCommandEffect, buildGenerateResult, toolKindFromName } from "./BaseCliAgent/index.js";
+import { BaseCliAgent, asString, extractPrompt, extractTextFromJsonValue, pushFlag, resolveTimeouts, runAgentPromise, runRpcCommandEffect, buildGenerateResult, toolKindFromName, tryParseJson } from "./BaseCliAgent/index.js";
 import { taskContextEnv } from "./BaseCliAgent/taskContextEnv.js";
 import { normalizeCapabilityStringList } from "./capability-registry/index.js";
 import { resolveOmpProviderEnv } from "./ompProviderEnv.js";
@@ -135,7 +135,9 @@ export class OmpAgent extends BaseCliAgent {
     const program = Effect.gen(this, function* () {
       const result = yield* runRpcCommandEffect("omp", this.buildArgs({ prompt, cwd, options, mode: "rpc" }), { cwd, env, prompt, timeoutMs: timeouts.totalMs, idleTimeoutMs: timeouts.idleMs, signal: options.abortSignal, maxOutputBytes: this.maxOutputBytes ?? options.maxOutputBytes, onStdout: options.onStdout, onStderr: options.onStderr, onProcess: options.onProcess, onJsonEvent: (event) => { for (const value of interpreter.onStdoutLine?.(JSON.stringify(event)) ?? []) void Promise.resolve(options.onEvent?.(value)).catch(() => undefined); } });
       for (const value of interpreter.onExit?.({ stdout: result.text, stderr: result.stderr, exitCode: result.exitCode }) ?? []) void Promise.resolve(options.onEvent?.(value)).catch(() => undefined);
-      return buildGenerateResult(result.text, result.output, this.opts.model ?? "omp", result.usage);
+      // Match the one-shot path: expose parsed JSON as structured output and
+      // leave non-JSON answers unset so the engine can recover fenced JSON from text.
+      return buildGenerateResult(result.text, tryParseJson(result.text), this.opts.model ?? "omp", result.usage);
     }.bind(this));
     return runAgentPromise(program);
   }

--- a/packages/agents/src/index.d.ts
+++ b/packages/agents/src/index.d.ts
@@ -1617,9 +1617,10 @@ declare class OmpAgent extends BaseCliAgent {
     /** @type {AgentCapabilityRegistry} */ capabilities: AgentCapabilityRegistry$1;
     cliEngine: string;
     issuedSessionId: any;
-    /** @param {{ onEvent?: unknown } | undefined} options @returns {"text" | "json" | "rpc"} */
+    /** @param {{ onEvent?: unknown, files?: unknown[] } | undefined} options @returns {"text" | "json" | "rpc"} */
     resolveMode(options: {
         onEvent?: unknown;
+        files?: unknown[];
     } | undefined): "text" | "json" | "rpc";
     resolveCredentialEnv(): {
         [x: string]: string;
@@ -1701,6 +1702,16 @@ declare class OmpAgent extends BaseCliAgent {
         env?: Record<string, string>;
         outputFormat: "text" | "json" | "rpc";
     }>;
+    /**
+     * Environment for a persistent RPC session. Mirrors the env BaseCliAgent builds for
+     * the one-shot path: `inheritEnv: false` is honored, and the task's `SMITHERS_*`
+     * identifiers are forwarded. Streaming defaults to RPC, so an RPC session that
+     * dropped those would silently break `smithers ask-human` from inside an omp agent.
+     * @param {{ taskContext?: unknown } | undefined} options @returns {Record<string, string>}
+     */
+    resolveRpcEnv(options: {
+        taskContext?: unknown;
+    } | undefined): Record<string, string>;
     generate(options?: {}): Promise<any>;
     diagnosticHints(): {
         provider: string | undefined;

--- a/packages/agents/tests/coverage-run-rpc-command.test.js
+++ b/packages/agents/tests/coverage-run-rpc-command.test.js
@@ -26,10 +26,16 @@ const tick = (ms = 20) => new Promise((r) => setTimeout(r, ms));
 describe("runRpcCommandEffect branches", () => {
   /** @type {(...args: any[]) => any} */
   let realKill;
+  /** @type {Array<[number, NodeJS.Signals]>} */
+  let killCalls;
   beforeEach(() => {
     // Never let a fake pid signal a real process group.
     realKill = process.kill;
-    process.kill = /** @type {any} */ (() => true);
+    killCalls = [];
+    process.kill = /** @type {any} */ ((pid, signal) => {
+      killCalls.push([pid, signal]);
+      return true;
+    });
   });
   afterEach(() => {
     process.kill = realKill;
@@ -52,6 +58,8 @@ describe("runRpcCommandEffect branches", () => {
 
   test("finalizes a successful turn, tracking usage and terminating the group", async () => {
     const child = makeFakeChild({ pid: 4242 });
+    const childKillSignals = [];
+    child.kill = (signal) => { childKillSignals.push(signal); return true; };
     const controller = new AbortController();
     /** @type {string[]} */
     const streamed = [];
@@ -86,8 +94,10 @@ describe("runRpcCommandEffect branches", () => {
     child.emit("close", 0);
     const result = await promise;
     expect(result.text).toBe("final answer");
-    expect(result.usage).toEqual({ output_tokens: 7 });
+    expect(result.usage).toMatchObject({ outputTokens: 7, totalTokens: 7 });
     expect(streamed.join("")).toBe("final answer");
+    if (process.platform === "win32") expect(childKillSignals).toContain("SIGTERM");
+    else expect(killCalls).toContainEqual([-4242, "SIGTERM"]);
     expect(lifecycle).toHaveLength(2);
     expect(lifecycle[0]).toMatchObject({ phase: "started", pid: 4242 });
     expect(lifecycle[1]).toMatchObject({ phase: "exited", pid: 4242 });
@@ -135,7 +145,9 @@ describe("runRpcCommandEffect branches", () => {
   });
 
   test("surfaces an assistant error stop reason from turn_end", async () => {
-    const child = makeFakeChild();
+    const child = makeFakeChild({ pid: 4343 });
+    const childKillSignals = [];
+    child.kill = (signal) => { childKillSignals.push(signal); return true; };
     const promise = start(child);
     await tick();
     child.stdout.write(
@@ -151,6 +163,8 @@ describe("runRpcCommandEffect branches", () => {
       }) + "\n",
     );
     await expect(promise).rejects.toThrow(/turn boom/);
+    if (process.platform === "win32") expect(childKillSignals).toContain("SIGTERM");
+    else expect(killCalls).toContainEqual([-4343, "SIGTERM"]);
   });
 
   test("truncates over-long stderr and finalizes via a clean close", async () => {
@@ -315,10 +329,16 @@ describe("runRpcCommandEffect branches", () => {
 
   test("fires the delayed SIGKILL when no close clears the terminate timer", async () => {
     const child = makeFakeChild({ pid: 7777 });
+    const childKillSignals = [];
+    child.kill = (signal) => { childKillSignals.push(signal); return true; };
     const promise = start(child, { idleTimeoutMs: 30 });
     await expect(promise).rejects.toThrow(/idle timed out/);
+    if (process.platform === "win32") expect(childKillSignals).toContain("SIGTERM");
+    else expect(killCalls).toContainEqual([-7777, "SIGTERM"]);
     // The idle kill scheduled a 250ms SIGKILL fallback; with no close event it
     // fires here (process.kill is stubbed for the whole describe block).
     await tick(300);
+    if (process.platform === "win32") expect(childKillSignals).toContain("SIGKILL");
+    else expect(killCalls).toContainEqual([-7777, "SIGKILL"]);
   });
 });

--- a/packages/agents/tests/omp-support.test.js
+++ b/packages/agents/tests/omp-support.test.js
@@ -244,4 +244,14 @@ describe("OmpAgent", () => {
     expect(spec.outputFormat).toBe("json");
     expect(spec.args).toContain("--print");
   });
+
+  test("forwards task context and honors inheritEnv in the default RPC session", () => {
+    const taskContext = { runId: "run-1", nodeId: "node-1", iteration: 2, attempt: 3 };
+    const sealed = new OmpAgent({ model: "m", inheritEnv: false, env: { CUSTOM: "1" } }).resolveRpcEnv({ taskContext });
+    // Same SMITHERS_* contract the one-shot path gets, so `smithers ask-human` still resolves its run.
+    expect(sealed).toEqual({ CUSTOM: "1", SMITHERS_RUN_ID: "run-1", SMITHERS_NODE_ID: "node-1", SMITHERS_ITERATION: "2", SMITHERS_ATTEMPT: "3" });
+    const inherited = new OmpAgent({ model: "m" }).resolveRpcEnv({ taskContext });
+    expect(inherited.PATH).toBe(process.env.PATH);
+    expect(inherited.SMITHERS_RUN_ID).toBe("run-1");
+  });
 });

--- a/packages/agents/tests/omp-support.test.js
+++ b/packages/agents/tests/omp-support.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import { Effect } from "effect";
 import { OmpAgent } from "../src/OmpAgent.js";
@@ -253,5 +256,43 @@ describe("OmpAgent", () => {
     const inherited = new OmpAgent({ model: "m" }).resolveRpcEnv({ taskContext });
     expect(inherited.PATH).toBe(process.env.PATH);
     expect(inherited.SMITHERS_RUN_ID).toBe("run-1");
+  });
+
+  test("keeps RPC tool events, usage, and structured output at JSON-mode parity", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "smithers-omp-rpc-"));
+    const bin = join(dir, "omp");
+    await writeFile(bin, `#!/usr/bin/env node
+const readline = require("node:readline");
+const rl = readline.createInterface({ input: process.stdin });
+process.stdout.write(JSON.stringify({ type: "ready" }) + "\\n");
+rl.on("line", (line) => {
+  const command = JSON.parse(line);
+  if (command.type === "get_state") {
+    process.stdout.write(JSON.stringify({ type: "response", command: "get_state", success: true, data: { sessionId: "rpc-1" } }) + "\\n");
+  }
+  if (command.type === "prompt") {
+    process.stdout.write(JSON.stringify({ type: "tool_execution_start", toolName: "read", toolCallId: "tool-1", args: { path: "README.md" } }) + "\\n");
+    process.stdout.write(JSON.stringify({ type: "agent_end", messages: [{ role: "assistant", content: "{\\"value\\":42}", stopReason: "stop", usage: { input_tokens: 11, output_tokens: 4, total_tokens: 15 } }] }) + "\\n");
+  }
+});
+`, "utf8");
+    await chmod(bin, 0o755);
+    try {
+      const events = [];
+      const result = await new OmpAgent({ model: "m", env: { PATH: `${dir}:${process.env.PATH ?? ""}` } }).generate({
+        prompt: "return json",
+        onEvent: (event) => events.push(event),
+      });
+      const rpcAction = events.find((event) => event.type === "action" && event.action.id === "tool-1");
+      const jsonAction = new OmpAgent({ mode: "json" }).createOutputInterpreter()
+        .onStdoutLine(JSON.stringify({ type: "tool_execution_start", toolName: "read", toolCallId: "tool-1", args: { path: "README.md" } }))
+        .find((event) => event.type === "action");
+      expect(rpcAction).toEqual(jsonAction);
+      expect(result.output).toEqual({ value: 42 });
+      expect(result.usage).toMatchObject({ inputTokens: 11, outputTokens: 4, totalTokens: 15 });
+    }
+    finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agents/tests/omp-support.test.js
+++ b/packages/agents/tests/omp-support.test.js
@@ -224,4 +224,24 @@ describe("OmpAgent", () => {
     await expect(pending).rejects.toThrow("CLI aborted");
     expect(commands.at(-1)?.type).toBe("abort");
   });
+
+  test("defaults a streaming run to a persistent RPC session", async () => {
+    const spec = await new OmpAgent({ model: "m" }).buildCommand({ prompt: "hi", cwd: "/repo", options: { onEvent() {} } });
+    expect(spec.outputFormat).toBe("rpc");
+    expect(spec.args).toContain("--mode");
+    expect(spec.args).toContain("rpc");
+    expect(spec.args).not.toContain("--print");
+  });
+
+  test("falls back to one-shot json when the caller passes file arguments", async () => {
+    const spec = await new OmpAgent({ model: "m" }).buildCommand({ prompt: "hi", cwd: "/repo", options: { onEvent() {}, files: ["/repo/a.txt"] } });
+    expect(spec.outputFormat).toBe("json");
+    expect(spec.args).toContain("--print");
+  });
+
+  test("honors an explicit mode:json opt-out for cheap single-shot work", async () => {
+    const spec = await new OmpAgent({ model: "m", mode: "json" }).buildCommand({ prompt: "hi", cwd: "/repo", options: { onEvent() {} } });
+    expect(spec.outputFormat).toBe("json");
+    expect(spec.args).toContain("--print");
+  });
 });

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -18125,11 +18125,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+`<Task>`, or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -18125,11 +18125,30 @@ import { OmpAgent } from "smithers-orchestrator";
 const omp = new OmpAgent({
   provider: "openai",
   model: "gpt-5.6-terra",
-  mode: "json",
   cwd: process.cwd(),
   autoApprove: true,
 });
 ```
+
+### Mode defaults
+
+When `mode` is omitted, Smithers picks it from the call. A streaming run (any
+`<Task>`, or a `generate()` that passes `onEvent`) defaults to
+`rpc`: a persistent session, the same protocol the interactive OMP TUI speaks, so
+the agent runs its full multi-turn tool loop instead of answering once and exiting.
+Everything else defaults to `text`.
+
+Set `mode: "json"` to opt back into a one-shot `--print --mode json` execution. That
+is the cheaper choice for genuinely single-turn work such as classification or
+extraction, where a persistent session only costs extra tokens and latency. A
+streaming run that passes file arguments falls back to one-shot `json`
+automatically, because RPC mode rejects files.
+
+| `mode` | Streaming run | Non-streaming run |
+| --- | --- | --- |
+| omitted (default) | `rpc`, or `json` when file arguments are passed | `text` |
+| `"json"` | one-shot `--print --mode json` | one-shot `--print --mode json` |
+| `"rpc"` | persistent session; file arguments are rejected | persistent session |
 
 Smithers emits only flags verified by `omp --help`: `--print`, `--mode`, model/provider and system-prompt options, `--cwd`, session controls, tools, extensions, plural comma-separated `--skills`, thinking (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or `auto`), hooks, `--max-time`, and approval controls. Credentials are delivered through the provider's documented environment variable (for example `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`), never as `--api-key`; an explicit key fails closed when no safe provider/model mapping is known. A valued `--resume` takes precedence over `continueSession`; `--continue` selects OMP's recent session. In RPC mode, prompts are sent over stdin and file arguments are rejected.
 


### PR DESCRIPTION
Refs #1372

## Summary

Flip the native `OmpAgent` streaming default from a one-shot `--print --mode json`
to a persistent `--mode rpc` session (the protocol the omp TUI uses), so spawned
omp coding agents actually run their multi-turn tool loop instead of answering
once and exiting.

- `resolveMode`: streaming (`options.onEvent`) now defaults to `"rpc"`.
- Falls back to `"json"` when file arguments are present (`buildArgs` rejects
  `rpc` + files), so that path is unchanged.
- Explicit `mode: "json"` remains the one-shot opt-out for cheap single-turn work.
- `generate()` already routes to the RPC path for `mode === "rpc"`, so no other
  wiring changes.

## Evidence

Real multi-step task: one-shot = single-shot / ~0 tool calls / ~9s; RPC = 62
turns / 8 tool calls / ~50s (persistent session, like the TUI).

## Tests

Adds cases in `packages/agents/tests/omp-support.test.js`: streaming defaults to
RPC; streaming + file args falls back to json; explicit `mode:"json"` opt-out
stays one-shot. Full `packages/agents` suite passes.

## Note

Opened as **draft** — this changes a default and its blast radius (cost/latency
for single-shot Task nodes) is a maintainer call. Marking ready once reviewed.
