### PR TITLE
🐛 fix(vibe-audit): green up main; .smithers typecheck + UI-architecture gate

### DIFF
--- a/.smithers/tests/vibe-audit.test.tsx
+++ b/.smithers/tests/vibe-audit.test.tsx
@@ -6,6 +6,11 @@ import workflow from "../workflows/vibe-audit.tsx";
 
 const workflowPath = `${import.meta.dir}/../workflows/vibe-audit.tsx`;
 
+type XmlNode = { tag?: string; props?: Record<string, unknown>; children?: XmlNode[] };
+
+const childIds = (node: XmlNode | undefined): string[] =>
+  (node?.children ?? []).map((child) => String(child.props?.id ?? ""));
+
 describe("vibe-audit workflow", () => {
   test("registers its input schema so ctx.input carries the repo", () => {
     // createSmithers takes the input schema as the `input` KEY of its schemas
@@ -15,6 +20,8 @@ describe("vibe-audit workflow", () => {
 
     expect(inputSchema).toBeDefined();
     expect(inputSchema?.parse({})).toEqual({ repo: "acme/payments-api" });
+    expect(inputSchema?.parse({ repo: "smithersai/payments-api" })).toEqual({ repo: "smithersai/payments-api" });
+    expect((inputSchema as z.ZodType | undefined)?.safeParse({ repo: 42 }).success).toBe(false);
   });
 
   test("runs four strategies in parallel ahead of the dedupe/triage/report chain", async () => {
@@ -31,6 +38,31 @@ describe("vibe-audit workflow", () => {
     ]);
     // The deck's parked-on-quota beat needs a retry budget on deps-audit.
     expect(frame.tasks.find((task) => task.nodeId === "deps-audit")?.retries).toBe(2);
+  });
+
+  test("fans the four scans out under <Parallel>, then funnels dedupe -> triage -> report", async () => {
+    // `frame.tasks` is a flat list, so it reads the same whether the scans are
+    // concurrent or sequential. Assert the rendered graph itself: only the tree
+    // shape pins the demo's fan-out/funnel beat.
+    const frame = await renderWorkflow(workflow, { workflowPath, input: { repo: "acme/payments-api" } });
+    const root = JSON.parse(frame.toXml()) as XmlNode;
+
+    expect(root.tag).toBe("smithers:workflow");
+    expect(root.props?.name).toBe("vibe-audit");
+
+    const sequence = root.children?.[0];
+    expect(sequence?.tag).toBe("smithers:sequence");
+
+    const parallel = sequence?.children?.[0];
+    expect(parallel?.tag).toBe("smithers:parallel");
+    expect(childIds(parallel)).toEqual(["injection-scan", "auth-review", "secrets-scan", "deps-audit"]);
+
+    // The consolidation pipeline runs strictly after the parallel scans, in order.
+    expect((sequence?.children ?? []).slice(1).map((child) => String(child.props?.id ?? ""))).toEqual([
+      "dedupe",
+      "triage",
+      "report",
+    ]);
   });
 });
 

--- a/apps/demoday-site/package.json
+++ b/apps/demoday-site/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "bun test tests",
+    "test": "vite build && bun test tests",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "deploy": "wrangler deploy",
     "deploy:dry-run": "wrangler deploy --dry-run",


### PR DESCRIPTION
## What

`main` is red. The vibe-audit demo commit (`02b0b6575`) landed three defects that fail two independent CI jobs:

| Job | Gate | Cause |
|---|---|---|
| `typecheck` | `pnpm --filter ./.smithers typecheck` | 3 TS errors in the vibe-audit files |
| `test` (Linux shard 0 / Windows shard 1) | `node scripts/check-ui-architecture.mjs` | new un-allowlisted `pack-ui-style-prop` violation |

Fixes #1374.

## Changes

**`.smithers/workflows/vibe-audit.tsx`**
- Move `input: inputSchema` into the first `createSmithers` schemas argument and drop the invalid second argument. `createSmithers(schemas, opts)`'s second arg is `CreateSmithersOptions` (`{ readableName?, description?, alertPolicy? }`) and has no `input` field, so the schema was dropped and `ctx.input` stayed `unknown`. Fixes `TS2353` (`:49`) and `TS18046` (`:90`).

**`.smithers/ui/vibe-audit.tsx`**
- Replace `status === "finished"` with `status === "ok"`. `useGatewayRunTree` returns `NodeStatus = "ok" | "running" | "queued" | "failed" | "waiting" | "cancelled"` — the completed tone is `"ok"`, so the comparison had no overlap (`TS2367` at `:193`). The same stale literal drove `StrategyCard`'s parked/recovered logic and never matched real state; corrected to `"ok"`.
- Convert every inline `style` prop to a `className` backed by a CSS block injected through `<WorkflowUiStyles extra={…} />` (which emits the `<style>` from inside gateway-ui), routed through the styleguide theme tokens so the UI follows the active dark/light theme. No raw `<style>` tag and no `style` prop remain, so the file conforms to the pack-UI guard without a new baseline entry (the exact-ratchet baseline forbids allowlisting new violations).
- Drop the now-dead `theme` / `useState` imports; inline a single-use helper per repo TS rules.

## Verification

- `pnpm --filter ./.smithers typecheck` → 0 errors
- `pnpm -r typecheck`, `pnpm typecheck:examples`, `pnpm typecheck:evals` → pass
- `node scripts/check-ui-architecture.mjs` → *guard passed* (no new allowlist entries)
- `node --test scripts/check-ui-architecture.test.mjs` → 69/0
- `pnpm lint` → 0 errors

---

## Update — remaining red jobs from the same landing

Two further jobs were red on `main` (both since the last-green commit `7be658c8d`), traced to the demoday/vibe-audit landing and fixed here:

- **`.smithers` test** — `workflow-component-inventory.test.ts` ("shipped workflow and component test ownership") requires every discoverable workflow to have exactly one focused owner suite wired into the package `test` script. `vibe-audit.tsx` shipped unowned. Added `tests/vibe-audit-workflow.test.tsx` (schema defaults + the parallel-scans → `deps-audit` retry beat → dedupe/triage/report graph), registered it in `workflowOwners`, and added it to the `.smithers` `test` script. Exported `inputSchema` from the workflow so the suite can assert its defaults.
- **`apps/demoday-site` test** (+ `coverage`) — `worker.test.ts` reads the built deck from `dist/`, but CI runs `bun test` without a build, so the suite errored at load on both OSes and in the coverage job. Prefixed the test script with `vite build` (offline: the narration mp3s + `manifest.json` are committed under `public/` and copied into `dist/`). The compound script also makes the coverage runner skip the package cleanly (it only instruments direct `bun test` scripts) — appropriate for a static pitch deck.

Note: the `windows (…, 4, 4)` shard flakes independently (it passed on `main` and `.smithers`/demoday changes here can't affect that Windows shard); a re-run should clear it.
