### PR TITLE
fix(cli): preserve Node loader across every re-entry

### DIFF
--- a/apps/cli/src/ask.js
+++ b/apps/cli/src/ask.js
@@ -13,6 +13,7 @@ import { PiAgent } from "@smthrs/agents/PiAgent";
 import { SmithersError } from "@smthrs/errors";
 import { createSmithersAgentContract, renderSmithersAgentPromptGuidance } from "@smthrs/agents/agent-contract";
 import { describeUnavailableAgent, detectAvailableAgents, formatNoUsableAgentsMessage } from "./agent-detection.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 /**
  * @typedef {typeof ASK_AGENT_IDS[number]} AskAgentId
  */
@@ -122,10 +123,12 @@ function bootstrapRank(mode) {
  * @returns {{ command: string; args: string[] }}
  */
 function buildSmithersMcpLaunchSpec(toolSurface = "semantic") {
-  return {
-    command: process.execPath,
-    args: ["run", resolve(dirname(fileURLToPath(import.meta.url)), "index.js"), "--mcp", "--surface", toolSurface],
-  };
+  return smithersRuntimeReentry([
+    resolve(dirname(fileURLToPath(import.meta.url)), "index.js"),
+    "--mcp",
+    "--surface",
+    toolSurface,
+  ]);
 }
 /**
  * @param {SmithersToolSurface} toolSurface

--- a/apps/cli/src/herdr.js
+++ b/apps/cli/src/herdr.js
@@ -14,6 +14,7 @@ import { computeRunStateFromRow } from "@smthrs/db/runState";
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { deriveTailStatus, isTailActiveState } from "./tail.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 
 /**
  * CLI wiring for the optional herdr mirror plane (`smithers up --herdr`,
@@ -277,8 +278,9 @@ export function buildTailCommand(cliPath, opts = {}) {
   const dbPath = typeof opts.dbPath === "string" && opts.dbPath.endsWith("smithers.db") ? opts.dbPath : undefined;
   if (existsSync(thinEntry)) {
     return (ctx) => {
+      const runtime = smithersRuntimeReentry([thinEntry, ctx.runId, "--node", ctx.nodeId, "--linger"]);
       /** @type {string[]} */
-      const argv = [process.execPath, thinEntry, ctx.runId, "--node", ctx.nodeId, "--linger"];
+      const argv = [runtime.command, ...runtime.args];
       // Pin the store the supervisor is reading so mid-run opens cannot
       // resolve a different/empty smithers.db via cwd walk.
       if (dbPath) argv.push("--db", dbPath);
@@ -288,7 +290,10 @@ export function buildTailCommand(cliPath, opts = {}) {
 
   // Fallback: full CLI tail + HUD dock (s steer · h hijack · q).
   // Note: `smithers tail` has no `--db` flag — relies on cwd discovery.
-  return (ctx) => [process.execPath, cliPath, "tail", ctx.runId, "--node", ctx.nodeId, "--hud", "--linger"];
+  return (ctx) => {
+    const runtime = smithersRuntimeReentry([cliPath, "tail", ctx.runId, "--node", ctx.nodeId, "--hud", "--linger"]);
+    return [runtime.command, ...runtime.args];
+  };
 }
 
 /**
@@ -304,7 +309,10 @@ export function buildTailCommand(cliPath, opts = {}) {
  * @returns {(ctx: { runId: string, nodeId: string }) => string[]}
  */
 export function buildGateCommand(cliPath) {
-  return (ctx) => [process.execPath, cliPath, "approve", ctx.runId, "--watch", "--node", ctx.nodeId];
+  return (ctx) => {
+    const runtime = smithersRuntimeReentry([cliPath, "approve", ctx.runId, "--watch", "--node", ctx.nodeId]);
+    return [runtime.command, ...runtime.args];
+  };
 }
 
 /**
@@ -318,8 +326,9 @@ export function buildGateCommand(cliPath) {
  * @returns {(ctx: { runId: string }) => string[]}
  */
 export function buildOverviewCommand(cliPath, opts = {}) {
+  const runtime = smithersRuntimeReentry([cliPath, "supervisor"]);
   /** @type {string[]} */
-  const argv = [process.execPath, cliPath, "supervisor"];
+  const argv = [runtime.command, ...runtime.args];
   if (typeof opts.dbPath === "string" && opts.dbPath !== "") {
     argv.push("--db", opts.dbPath);
   }

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -26,7 +26,7 @@ import { isRunHeartbeatFresh, runWorkflow, renderFrame, resolveSchema } from "@s
 import { __engineInternals } from "@smthrs/engine/engine";
 import { readWorkflowEntryHash, readWorkflowGraphHash } from "@smthrs/engine/workflow-hash";
 import { mdxPlugin } from "./mdx-plugin.js";
-import { smithersRuntimeSpawn } from "./node-loader/smithersRuntimeSpawn.js";
+import { smithersRuntimeReentry, smithersRuntimeSpawn } from "./node-loader/smithersRuntimeSpawn.js";
 import { approveNode, denyNode } from "@smthrs/engine/approvals";
 import { isPidAlive, parseRuntimeOwnerPid } from "@smthrs/engine/runtime-owner";
 import { signalRun } from "@smthrs/engine/signals";
@@ -4952,29 +4952,26 @@ async function ensureWorkspaceGateway(workspace, preferredPort, opts = {}) {
     const autostartIdleMs = process.env.SMITHERS_GATEWAY_IDLE_MS
       ? String(Math.max(0, Math.floor(Number(process.env.SMITHERS_GATEWAY_IDLE_MS) || 0)))
       : "300000";
-    child = spawn(
-      process.argv[0],
-      [
-        process.argv[1],
-        "gateway",
-        "--host",
-        host,
-        "--port",
-        String(preferredPort),
-        "--idle-timeout",
-        autostartIdleMs,
-        // The gateway refuses an unauthenticated non-loopback bind (it would
-        // be a full-control open control plane), so autostart on a remote-
-        // reachable host always mints a token; the state file hands it to
-        // this client, which passes it through the browser session handoff.
-        ...(GATEWAY_LOOPBACK_HOSTS.has(host) ? [] : ["--mint-token"]),
-      ],
-      {
-        stdio: ["ignore", stderrFd, stderrFd],
-        detached: true,
-        cwd: workspace,
-      },
-    );
+    const gatewaySpawn = smithersRuntimeReentry([
+      process.argv[1],
+      "gateway",
+      "--host",
+      host,
+      "--port",
+      String(preferredPort),
+      "--idle-timeout",
+      autostartIdleMs,
+      // The gateway refuses an unauthenticated non-loopback bind (it would
+      // be a full-control open control plane), so autostart on a remote-
+      // reachable host always mints a token; the state file hands it to
+      // this client, which passes it through the browser session handoff.
+      ...(GATEWAY_LOOPBACK_HOSTS.has(host) ? [] : ["--mint-token"]),
+    ]);
+    child = spawn(gatewaySpawn.command, gatewaySpawn.args, {
+      stdio: ["ignore", stderrFd, stderrFd],
+      detached: true,
+      cwd: workspace,
+    });
     child.unref();
   } catch (error) {
     if (stderrFd !== undefined) {
@@ -5689,11 +5686,14 @@ async function runGatewayCommand(options) {
     // finished runs reopen the recorded agent session for a post-mortem.
     const cliEntry = fileURLToPath(new URL("./index.js", import.meta.url));
     /** @type {(params: { runId: string; nodeId?: string }) => { command: string[]; cwd?: string; env?: Record<string, string | undefined> }} */
-    const hijackPty = ({ runId, nodeId }) => ({
-      command: [process.execPath, cliEntry, "hijack", runId, ...(nodeId ? ["--target", nodeId] : [])],
-      cwd: workspace,
-      env: { ...process.env, FORCE_COLOR: process.env.FORCE_COLOR ?? "1" },
-    });
+    const hijackPty = ({ runId, nodeId }) => {
+      const runtime = smithersRuntimeReentry([cliEntry, "hijack", runId, ...(nodeId ? ["--target", nodeId] : [])]);
+      return {
+        command: [runtime.command, ...runtime.args],
+        cwd: workspace,
+        env: { ...process.env, FORCE_COLOR: process.env.FORCE_COLOR ?? "1" },
+      };
+    };
     const oneshotMonitor = createOneshotMonitorControl({
       cliEntry,
       cancelRun: (adapter, runId) => cascadeCancelRun(adapter, runId),
@@ -13314,10 +13314,12 @@ async function relaunchForConflictedWorkspaceManifest() {
   // the conflicted cwd while it waits for a child.
   if (typeof process.execve === "function") {
     process.chdir(cliPackageDir);
-    process.execve(process.execPath, [process.execPath, cliEntry, ...process.argv.slice(2)], childEnv);
+    const runtime = smithersRuntimeReentry([cliEntry, ...process.argv.slice(2)]);
+    process.execve(runtime.command, [runtime.command, ...runtime.args], childEnv);
   }
   process.chdir(cliPackageDir);
-  const child = spawn(process.execPath, [cliEntry, ...process.argv.slice(2)], {
+  const runtime = smithersRuntimeReentry([cliEntry, ...process.argv.slice(2)]);
+  const child = spawn(runtime.command, runtime.args, {
     env: childEnv,
     stdio: "inherit",
   });

--- a/apps/cli/src/launchPostFailureAutopsy.js
+++ b/apps/cli/src/launchPostFailureAutopsy.js
@@ -6,6 +6,7 @@ import { DETACHED_RUN_LOG_FILE_ENV } from "./detachedRunLogEnv.js";
 import { workflowIdFromPath } from "./monitoring-suggestion.js";
 import { resolveDetachedRunLogFile } from "./resolveDetachedRunLogFile.js";
 import { resolveWorkflow } from "./workflows.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 
 /**
  * Workflows that must never trigger an autopsy of themselves: the autopsy
@@ -76,7 +77,8 @@ export function launchPostFailureAutopsy({
   try {
     mkdirSync(dirname(logFile), { recursive: true });
     const fd = openSync(logFile, "a");
-    const child = spawnFn(process.execPath, [cliPath, "up", entryFile, "--run-id", autopsyRunId, "--input", input], {
+    const runtime = smithersRuntimeReentry([cliPath, "up", entryFile, "--run-id", autopsyRunId, "--input", input]);
+    const child = spawnFn(runtime.command, runtime.args, {
       cwd,
       detached: true,
       stdio: ["ignore", fd, fd],

--- a/apps/cli/src/node-loader/smithersRuntimeSpawn.js
+++ b/apps/cli/src/node-loader/smithersRuntimeSpawn.js
@@ -20,3 +20,16 @@ export function smithersRuntimeSpawn(args) {
   const register = fileURLToPath(new URL("./register.js", import.meta.url));
   return { command: process.execPath, args: ["--import", register, ...args] };
 }
+
+/**
+ * Re-enter a CLI file while preserving the absolute Bun executable used by
+ * call sites that already relied on `process.execPath`. Node still needs the
+ * loader hook installed in the child process.
+ *
+ * @param {string[]} args arguments after the executable, starting with the entry file
+ * @returns {{ command: string; args: string[] }}
+ */
+export function smithersRuntimeReentry(args) {
+  if (typeof Bun !== "undefined") return { command: process.execPath, args };
+  return smithersRuntimeSpawn(args);
+}

--- a/apps/cli/src/oneshot/monitor-control.js
+++ b/apps/cli/src/oneshot/monitor-control.js
@@ -5,6 +5,7 @@ import { terminateRunOwner } from "../cancel-cascade.js";
 import { BUILTIN_RESUME_CONFIG_KEY, buildBuiltinRelaunch } from "../resume-target.js";
 import { buildHijackEnvironment, resolveHijackCandidate, waitForHijackCandidate } from "../hijack.js";
 import { startOneshotStatusUpdater } from "./startOneshotStatusUpdater.js";
+import { smithersRuntimeReentry } from "../node-loader/smithersRuntimeSpawn.js";
 
 const ATTACH_LEASE_MS = 35_000;
 const RESTART_RELEASE_TIMEOUT_MS = 15_000;
@@ -249,7 +250,8 @@ export function createOneshotMonitorControl(options) {
 
   const launchBuiltin = async (config, runId, resume) => {
     const launch = buildBuiltinRelaunch(config, { runId, resume });
-    const child = spawnImpl(process.execPath, [options.cliEntry, ...launch.args], {
+    const runtime = smithersRuntimeReentry([options.cliEntry, ...launch.args]);
+    const child = spawnImpl(runtime.command, runtime.args, {
       cwd: launch.cwd,
       detached: true,
       stdio: "ignore",

--- a/apps/cli/src/scheduler.js
+++ b/apps/cli/src/scheduler.js
@@ -5,6 +5,7 @@ import { Effect, Schedule } from "effect";
 import { toSmithersError } from "@smthrs/errors/toSmithersError";
 import { runPromise } from "./smithersRuntime.js";
 import { findAndOpenDb } from "./find-db.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 const CLI_ENTRYPOINT = fileURLToPath(new URL("./index.js", import.meta.url));
 /** @typedef {import("@smthrs/db/adapter").SmithersDb} SmithersDb */
 /**
@@ -46,7 +47,8 @@ function acquireSchedulerDbEffect() {
  * @param {typeof spawn} [spawnProcess]
  */
 export function launchCronWorkflow(job, spawnProcess = spawn) {
-  const proc = spawnProcess(process.execPath, [CLI_ENTRYPOINT, "up", job.workflowPath, "-d"], {
+  const runtime = smithersRuntimeReentry([CLI_ENTRYPOINT, "up", job.workflowPath, "-d"]);
+  const proc = spawnProcess(runtime.command, runtime.args, {
     cwd: process.cwd(),
     detached: true,
     stdio: "ignore",

--- a/apps/cli/src/syncSkillsAfterUpgrade.js
+++ b/apps/cli/src/syncSkillsAfterUpgrade.js
@@ -1,6 +1,7 @@
 import { spawn as nodeSpawn } from "node:child_process";
 
 import { formatSkillsAddSummary, syncCuratedSkill } from "./curatedSkillSync.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 
 /**
  * Post-upgrade skill sync for `smithers update`.
@@ -80,12 +81,14 @@ function syncCuratedSkillNow(opts) {
  */
 function runUpgradedSkillsAdd(opts) {
   const spawn = opts.spawn ?? nodeSpawn;
-  const execPath = opts.execPath ?? process.execPath;
   const entry = opts.entry ?? process.argv[1];
   if (!entry) return Promise.resolve({ via: "cli", ok: false, notice: null, error: "no CLI entry path" });
+  const runtime = opts.execPath
+    ? { command: opts.execPath, args: [entry, "skills", "add"] }
+    : smithersRuntimeReentry([entry, "skills", "add"]);
   return new Promise((resolve) => {
     try {
-      const child = spawn(execPath, [entry, "skills", "add"], { stdio: "inherit" });
+      const child = spawn(runtime.command, runtime.args, { stdio: "inherit" });
       child.on("error", (err) => resolve({ via: "cli", ok: false, notice: null, error: err.message }));
       child.on("close", (code) =>
         code === 0

--- a/apps/cli/src/tail.js
+++ b/apps/cli/src/tail.js
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { computeRunStateFromRow } from "@smthrs/db/runState";
 import { formatEventLine } from "./format.js";
+import { smithersRuntimeReentry } from "./node-loader/smithersRuntimeSpawn.js";
 
 /**
  * The subtle one-line control hint shown at the start of a steerable LIVE tail:
@@ -175,8 +176,10 @@ export function formatTailFinalStatusLine(runId, status) {
  */
 export function spawnSteer(options) {
   const spawnFn = options.spawnFn ?? spawn;
-  const execPath = options.execPath ?? process.execPath;
-  const argv = [execPath, options.cliEntry, "steer", options.runId];
+  const runtime = options.execPath
+    ? { command: options.execPath, args: [options.cliEntry, "steer", options.runId] }
+    : smithersRuntimeReentry([options.cliEntry, "steer", options.runId]);
+  const argv = [runtime.command, ...runtime.args];
   if (typeof options.nodeId === "string" && options.nodeId !== "") {
     argv.push("--node", options.nodeId);
   }

--- a/apps/cli/tests/node-loader.test.js
+++ b/apps/cli/tests/node-loader.test.js
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveJsxImportSource } from "../src/node-loader/resolveJsxImportSource.js";
-import { smithersRuntimeSpawn } from "../src/node-loader/smithersRuntimeSpawn.js";
+import { smithersRuntimeReentry, smithersRuntimeSpawn } from "../src/node-loader/smithersRuntimeSpawn.js";
 
 const scratch = mkdtempSync(join(tmpdir(), "smithers-node-loader-"));
 
@@ -62,6 +62,26 @@ describe("smithersRuntimeSpawn", () => {
     const output = runUnderNode(`
       const { smithersRuntimeSpawn } = await import(${JSON.stringify(url)});
       const spawned = smithersRuntimeSpawn(["/entry.js", "up"]);
+      console.log(JSON.stringify({ isNode: spawned.command === process.execPath, args: spawned.args }));
+    `);
+    const spawned = JSON.parse(output);
+    expect(spawned.isNode).toBe(true);
+    expect(spawned.args[0]).toBe("--import");
+    expect(spawned.args[1]).toContain("node-loader/register.js");
+    expect(spawned.args.slice(2)).toEqual(["/entry.js", "up"]);
+  });
+
+  test("preserves Bun's absolute executable for existing re-entry paths", () => {
+    const spawned = smithersRuntimeReentry(["/entry.js", "up"]);
+    expect(spawned.command).toBe(process.execPath);
+    expect(spawned.args).toEqual(["/entry.js", "up"]);
+  });
+
+  test("re-entry uses the Node executable and loader hook under Node", () => {
+    const url = new URL("../src/node-loader/smithersRuntimeSpawn.js", import.meta.url).href;
+    const output = runUnderNode(`
+      const { smithersRuntimeReentry } = await import(${JSON.stringify(url)});
+      const spawned = smithersRuntimeReentry(["/entry.js", "up"]);
       console.log(JSON.stringify({ isNode: spawned.command === process.execPath, args: spawned.args }));
     `);
     const spawned = JSON.parse(output);

--- a/e2e/runtime/run-node-cli.mjs
+++ b/e2e/runtime/run-node-cli.mjs
@@ -10,7 +10,7 @@
 // Slow (packs ~54 tarballs and runs a real npm install), so it is its own
 // script rather than part of `bun test`.
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,12 +20,18 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const workspace = mkdtempSync(join(tmpdir(), "smithers-node-cli-"));
 const tarballDir = join(workspace, "tarballs");
 const project = join(workspace, "project");
+const fakeBin = join(workspace, "bin");
 
 // Node with no Bun anywhere on PATH. `spawn("bun", ...)` used to be hardcoded
 // in the detached run launcher, and a PATH that still had Bun hid that.
 const nodeBin = dirname(process.execPath);
-const nodeOnlyPath = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", nodeBin].join(":");
-const env = { ...process.env, PATH: nodeOnlyPath, SMITHERS_BACKEND: "pglite" };
+const nodeOnlyPath = [fakeBin, "/usr/bin", "/bin", "/usr/sbin", "/sbin", nodeBin].join(":");
+const env = {
+  ...process.env,
+  PATH: nodeOnlyPath,
+  OPENAI_API_KEY: "sk-node-conformance-placeholder",
+  SMITHERS_BACKEND: "pglite",
+};
 delete env.BUN_INSTALL;
 
 const failures = [];
@@ -70,6 +76,10 @@ function assert(condition, message) {
 }
 
 try {
+  mkdirSync(fakeBin, { recursive: true });
+  const fakeCodex = join(fakeBin, "codex");
+  writeFileSync(fakeCodex, "#!/bin/sh\nexit 0\n");
+  chmodSync(fakeCodex, 0o755);
   console.log("packing workspace tarballs...");
   const tarballs = packWorkspaceTarballs(tarballDir, repoRoot);
   mkdirSync(project, { recursive: true });
@@ -141,7 +151,10 @@ export default smithers((ctx) => (
     const result = smithers(["up", "workflow.tsx", "--backend", "sqlite", "--input", '{"name":"node"}', "-d"]);
     const combined = result.stdout + result.stderr;
     assert(result.status !== 0, "expected a non-zero exit");
-    assert(combined.includes("DB_REQUIRES_BUN_SQLITE"), `expected DB_REQUIRES_BUN_SQLITE, got: ${combined.slice(0, 400)}`);
+    assert(
+      combined.includes("DB_REQUIRES_BUN_SQLITE"),
+      `expected DB_REQUIRES_BUN_SQLITE, got: ${combined.slice(0, 400)}`,
+    );
     assert(combined.includes("SMITHERS_BACKEND=pglite"), "the error must name the pglite fix");
     assert(!combined.includes("ERR_UNSUPPORTED_ESM_URL_SCHEME"), "a loader crash leaked instead of the SmithersError");
   });
@@ -187,6 +200,15 @@ export default smithers((ctx) => (
     assert(/bun/i.test(combined), `expected a missing-Bun message, got: ${combined.slice(0, 300)}`);
   });
 
+  await check("smithers ask probes MCP and prints a Node-valid bootstrap", () => {
+    const result = smithers(["ask", "--agent", "codex", "--print-bootstrap"]);
+    const combined = result.stdout + result.stderr;
+    assert(result.status === 0, `ask bootstrap failed: ${combined.slice(0, 800)}`);
+    assert(combined.includes("bootstrapMode: mcp-config-inline"), `unexpected bootstrap: ${combined.slice(0, 800)}`);
+    assert(combined.includes("--import"), `bootstrap omitted the Node loader: ${combined.slice(0, 800)}`);
+    assert(!combined.includes('"run"'), `bootstrap retained Bun's run subcommand: ${combined.slice(0, 800)}`);
+  });
+
   await check("smithers output returns the task row", () => {
     const output = smithers(["output", runId, "greet"]);
     assert(output.status === 0, `output failed: ${output.stderr.slice(0, 400)}`);
@@ -212,7 +234,16 @@ export default smithers((ctx) => (
       assert(url, `gateway never reported a listening URL: ${log.slice(0, 600)}`);
       const rpc = execFileSync(
         "curl",
-        ["-s", "-X", "POST", `${url}/rpc`, "-H", "content-type: application/json", "-d", '{"method":"listRuns","params":{}}'],
+        [
+          "-s",
+          "-X",
+          "POST",
+          `${url}/rpc`,
+          "-H",
+          "content-type: application/json",
+          "-d",
+          '{"method":"listRuns","params":{}}',
+        ],
         { encoding: "utf8" },
       );
       assert(rpc.includes(runId), `listRuns did not include ${runId}: ${rpc.slice(0, 300)}`);


### PR DESCRIPTION
Post-merge review of #1506 found secondary CLI re-entry paths that still launched source files without reinstalling the Node TypeScript/JSX loader. This fixes MCP bootstrap for smithers ask plus gateway, herdr, cron, autopsy, oneshot restart, steer, upgrade, hijack, and conflicted-manifest child processes. Bun retains its absolute executable for the paths that previously relied on process.execPath.

The packed Bun-free Node conformance now probes the live smithers ask MCP bootstrap and asserts the loader hook is present and Bun's run subcommand is absent.

Verified locally: packed Node CLI conformance (10 checks), complete CLI suite (253/253 shards), server 733 pass, ui-styleguide 53 pass, pnpm typecheck, lint, frozen pnpm and Bun installs, check-dts, check-docs, check-llms, check-ui-architecture, and check-db-access.