### PR TITLE
fix(engine): fall back to PATH after Bun.which miss

### DIFF
--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -197,7 +197,10 @@ function acquireWorktreeCreationSlot(root) {
 function resolveBinary(cmd) {
   const bunRuntime = typeof Bun !== "undefined" ? Bun : null;
   if (typeof bunRuntime?.which === "function") {
-    return bunRuntime.which(cmd);
+    const resolved = bunRuntime.which(cmd);
+    if (resolved) {
+      return resolved;
+    }
   }
   const pathEnv = typeof process !== "undefined" ? process.env.PATH : undefined;
   if (!pathEnv) {
@@ -10952,6 +10955,7 @@ export const __engineInternals = {
   cloneRalphStateMap,
   buildCarriedInputRow,
   continueRunAsNew,
+  resolveBinary,
   resolveRootDir,
   resolveLogDir,
   getWorkflowImportScanLoader,

--- a/packages/engine/tests/engine-internals.test.js
+++ b/packages/engine/tests/engine-internals.test.js
@@ -82,6 +82,29 @@ async function insertRun(adapter, runId, overrides = {}) {
 }
 
 describe("engine internals: errors, heartbeat and continuation helpers", () => {
+  test("resolveBinary falls back to PATH when Bun.which cannot resolve", () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-resolve-binary-"));
+    const command = process.platform === "win32" ? "fallback-tool.exe" : "fallback-tool";
+    const candidate = join(dir, command);
+    const originalPath = process.env.PATH;
+    const originalWhich = Bun.which;
+    writeFileSync(candidate, "");
+
+    try {
+      process.env.PATH = dir;
+      Bun.which = () => null;
+      expect(I.resolveBinary(command)).toBe(candidate);
+    } finally {
+      Bun.which = originalWhich;
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("cancellation resolves pending approvals and human requests", async () => {
     const { adapter, sqlite } = makeContinueDb();
     try {


### PR DESCRIPTION
## Summary

- continue to the existing PATH scanner when `Bun.which` cannot resolve a command
- add regression coverage for function-typed `Bun.which` implementations returning `null`

## Root cause

`resolveBinary` returned `Bun.which(cmd)` immediately whenever `Bun.which` was a function. Embedders that supply a function-typed polyfill but cannot resolve the command returned `null`, preventing the existing PATH fallback from running.

## Impact

Binary discovery remains Bun-native when successful and now works for embedders whose `Bun.which` shim misses a command that is present on PATH.

## Validation

- `bun test packages/engine/tests/engine-internals.test.js -t "resolveBinary falls back"`
- `pnpm -C packages/engine test` (1,224 passed, 3 skipped)
- `pnpm -C packages/engine typecheck`
- `pnpm exec oxlint packages/engine/src/engine.js packages/engine/tests/engine-internals.test.js`
- `pnpm exec oxfmt --check packages/engine/src/engine.js packages/engine/tests/engine-internals.test.js`

Closes #1425
