### PR TITLE
test(cli): lock retry-task workflow ID resolution

### DIFF
--- a/apps/cli/tests/retry-task-workflow-id.e2e.test.js
+++ b/apps/cli/tests/retry-task-workflow-id.e2e.test.js
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+
+import { createTempRepo, runSmithers, writeTestWorkflow } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+test("retry-task resolves a discovered workflow ID before looking up the node", () => {
+  const repo = createTempRepo();
+  writeTestWorkflow(repo, ".smithers/workflows/retryable.tsx");
+
+  const result = runSmithers(["retry-task", "retryable", "--run-id", "missing-run", "--node-id", "missing-node"], {
+    cwd: repo.dir,
+    format: "json",
+    env: { SMITHERS_NO_SKILL_REFRESH: "1" },
+  });
+
+  expect(result.exitCode).toBe(1);
+  expect(result.json).toMatchObject({
+    success: false,
+    error: "Node not found: missing-run/missing-node/0",
+  });
+  expect(`${result.stdout}\n${result.stderr}`).not.toContain("Cannot find module");
+}, 30_000);


### PR DESCRIPTION
## Summary

- exercise `retry-task` with a workflow discovered by bare ID through the real CLI
- prove workflow resolution reaches node lookup instead of treating the ID as a module path
- lock the behavior that fixed #1490 against regression

## Root cause

The original failure passed the raw positional argument directly to `loadWorkflowDb`. Commit `8375863cba` later switched `retry-task` to `resolveWorkflowArg` while fixing #1481, incidentally resolving #1490, but it added no bare-ID regression and left this issue open.

## Impact

`retry-task <workflow-id>` now has an explicit end-to-end contract matching `graph` and `up`; a future return to path-only module loading will fail the CLI suite.

## Validation

- `pnpm -C apps/cli test` (254/254 batches passed)
- `pnpm -C apps/cli typecheck`
- `pnpm exec oxlint apps/cli/tests/retry-task-workflow-id.e2e.test.js`
- `pnpm exec oxfmt --check apps/cli/tests/retry-task-workflow-id.e2e.test.js`

Closes #1490
