### PR TITLE
test(cli): lock subdirectory workspace resolution

### DIFF
--- a/apps/cli/tests/workspace-subdirectory.e2e.test.js
+++ b/apps/cli/tests/workspace-subdirectory.e2e.test.js
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test";
+import { homedir } from "node:os";
+import {
+  createTempRepo,
+  pinSqliteBackend,
+  runSmithers,
+  writeTestWorkflow,
+} from "../../../packages/smithers/tests/e2e-helpers.js";
+
+const QUIET_ENV = {
+  SMITHERS_NO_SKILL_REFRESH: "1",
+  SMITHERS_NO_UPDATE_CHECK: "1",
+};
+
+test("ps and status resolve the parent workspace from a nested package directory", () => {
+  // Project anchors are deliberately restricted to directories below the
+  // user's home, so stage this walk-up fixture there instead of the OS tmpdir.
+  const repo = createTempRepo({ parentDir: homedir() });
+  writeTestWorkflow(repo, ".smithers/workflows/workspace-subdirectory.tsx");
+  pinSqliteBackend(repo.dir);
+  repo.write("packages/tooling/package.json", '{"name":"tooling","private":true}\n');
+
+  const runId = "workspace-subdirectory";
+  const launched = runSmithers(["workflow", "run", "workspace-subdirectory", "--run-id", runId], {
+    cwd: repo.dir,
+    env: QUIET_ENV,
+    format: "json",
+    timeoutMs: 120_000,
+  });
+  expect(launched.exitCode, `${launched.stdout}\n${launched.stderr}`).toBe(0);
+  expect(launched.json.status).toBe("finished");
+
+  const rootPs = runSmithers(["ps"], {
+    cwd: repo.dir,
+    env: QUIET_ENV,
+    format: "json",
+    timeoutMs: 120_000,
+  });
+  expect(rootPs.exitCode, `${rootPs.stdout}\n${rootPs.stderr}`).toBe(0);
+  expect(
+    rootPs.json.runs.some((run) => run.id === runId),
+    JSON.stringify(rootPs.json),
+  ).toBe(true);
+
+  const nestedCwd = repo.path("packages", "tooling");
+  const ps = runSmithers(["ps"], {
+    cwd: nestedCwd,
+    env: QUIET_ENV,
+    format: "json",
+    timeoutMs: 120_000,
+  });
+  expect(ps.exitCode, `${ps.stdout}\n${ps.stderr}`).toBe(0);
+  expect(
+    ps.json.runs.some((run) => run.id === runId),
+    JSON.stringify(ps.json),
+  ).toBe(true);
+
+  const status = runSmithers(["status", runId], {
+    cwd: nestedCwd,
+    env: QUIET_ENV,
+    format: "json",
+    timeoutMs: 120_000,
+  });
+  expect(status.exitCode, `${status.stdout}\n${status.stderr}`).toBe(0);
+  expect(status.json.runId).toBe(runId);
+}, 300_000);

--- a/packages/smithers/tests/e2e-helpers.js
+++ b/packages/smithers/tests/e2e-helpers.js
@@ -145,10 +145,11 @@ function linkRepoRuntimeDeps(repoDir) {
   symlinkIfMissing(resolve(ROOT_NODE_MODULES, "typescript", "bin", "tsc"), join(binDir, "tsc"), "file");
 }
 /**
+ * @param {{ parentDir?: string }} [options]
  * @returns {TempRepo}
  */
-export function createTempRepo() {
-  const dir = realpathSync(mkdtempSync(join(tmpdir(), "smithers-e2e-")));
+export function createTempRepo(options = {}) {
+  const dir = realpathSync(mkdtempSync(join(options.parentDir ?? tmpdir(), ".smithers-e2e-")));
   tempDirs.add(dir);
   onTestFinished(() => {
     cleanupTempDir(dir);


### PR DESCRIPTION
## Summary

- add a real-CLI regression that creates a run at a workspace root
- verify root `ps`, nested-package `ps`, and nested-package `status` all resolve the same store
- let E2E fixtures opt into a parent directory so walk-up tests can run below the real user home boundary

## Root cause

The affected release resolved read-command storage from the exact current directory. Current source centralizes reads through the upward workspace-anchor resolver, but lacked an end-to-end contract for the reported `ps` and `status` paths. That gap allowed the published behavior to drift without a regression failure.

## Impact

Agents and operators can run read commands after `cd`-ing into a monorepo package without seeing a false empty store or `RUN_NOT_FOUND` for a run owned by the parent workspace.

## Validation

- `bun test --timeout=300000 --max-concurrency=1 tests/workspace-subdirectory.e2e.test.js`
- `pnpm exec oxfmt --check apps/cli/tests/workspace-subdirectory.e2e.test.js packages/smithers/tests/e2e-helpers.js`
- `pnpm exec oxlint apps/cli/tests/workspace-subdirectory.e2e.test.js packages/smithers/tests/e2e-helpers.js`
- `pnpm -C apps/cli typecheck`
- `pnpm -C apps/cli test` (254/254 batches passed)

Closes #1497
