### PR TITLE
fix(monitor): make event stream accessible

### DIFF
--- a/apps/cli/src/monitor-ui/monitor.tsx
+++ b/apps/cli/src/monitor-ui/monitor.tsx
@@ -2807,14 +2807,20 @@ const FOLLOW_THRESHOLD_PX = 80;
 
 type EventView = "notable" | "activity" | "all";
 
+const EVENT_VIEW_LABELS: Record<EventView, string> = {
+  notable: "Notable",
+  activity: "Activity",
+  all: "All",
+};
+
 /** The shared run-event subscription, lifted to RunDetail so the log reads one
  * buffer. Token-usage totals come from useGatewayRunTokenUsage (full durable
  * scan), not this ring. */
 type RunEventsState = ReturnType<typeof useGatewayRunEvents>;
 
-function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEventsState }) {
+export function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEventsState }) {
   const { events: allEvents, lastHeartbeat, streaming, error, loading } = eventsState;
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLOListElement | null>(null);
   const [following, setFollowing] = useState(true);
   // Default to Activity: lifecycle transitions plus the agent's visible work
   // (tool calls, chat output, frames, token usage). Heartbeats and session
@@ -2847,9 +2853,10 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
     if (!following) return;
     const el = containerRef.current;
     if (!el) return;
-    requestAnimationFrame(() => {
+    const frame = requestAnimationFrame(() => {
       el.scrollTop = el.scrollHeight;
     });
+    return () => cancelAnimationFrame(frame);
   }, [events.length, following, runId]);
 
   const onScroll = () => {
@@ -2858,6 +2865,8 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
     const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < FOLLOW_THRESHOLD_PX;
     setFollowing(nearBottom);
   };
+  const eventListId = `monitor-events-${runId}`;
+  const followStatusId = `${eventListId}-follow-status`;
 
   return (
     <section className="mon-panel mon-events-panel">
@@ -2877,6 +2886,9 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
         ) : null}
         <Chip
           on={view === "notable"}
+          aria-controls={eventListId}
+          aria-label="Show notable events"
+          data-testid="monitor-events-filter-notable"
           onClick={() => setView("notable")}
           title="Node/run lifecycle, approvals, human requests"
         >
@@ -2884,6 +2896,9 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
         </Chip>
         <Chip
           on={view === "activity"}
+          aria-controls={eventListId}
+          aria-label="Show activity events"
+          data-testid="monitor-events-filter-activity"
           onClick={() => setView("activity")}
           title="Notable plus tool calls, agent output, frames, and token usage"
         >
@@ -2891,6 +2906,9 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
         </Chip>
         <Chip
           on={view === "all"}
+          aria-controls={eventListId}
+          aria-label="Show all events"
+          data-testid="monitor-events-filter-all"
           onClick={() => setView("all")}
           title="Every event except heartbeats (collapsed to one liveness row)"
         >
@@ -2898,6 +2916,9 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
         </Chip>
         <Chip
           on={following}
+          aria-controls={eventListId}
+          aria-label={following ? "Following new events" : "Resume following new events"}
+          data-testid="monitor-events-follow"
           onClick={() => {
             setFollowing(true);
             const el = containerRef.current;
@@ -2905,13 +2926,35 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
           }}
           title="Auto-scroll to new events"
         >
-          {streaming ? "● " : ""}Follow
+          {following ? `${streaming ? "● " : ""}Following` : "Resume follow"}
         </Chip>
+        <span
+          id={followStatusId}
+          className="sui-sr-only"
+          role="status"
+          aria-live="polite"
+          data-testid="monitor-events-follow-status"
+        >
+          {following ? "Following new events." : "Event stream paused."}
+        </span>
       </header>
       {error ? <div className="mon-banner tone-failed">{error.message}</div> : null}
-      <div className="mon-events" ref={containerRef} onScroll={onScroll} data-testid="monitor-events">
+      <ol
+        id={eventListId}
+        className="mon-events"
+        ref={containerRef}
+        onScroll={onScroll}
+        data-testid="monitor-events"
+        tabIndex={0}
+        aria-label={`${EVENT_VIEW_LABELS[view]} event stream`}
+        aria-describedby={followStatusId}
+        aria-live={following ? "polite" : "off"}
+        aria-relevant="additions text"
+        aria-atomic={false}
+        aria-busy={loading}
+      >
         {events.length === 0 ? (
-          <div className="mon-empty">
+          <li className="mon-empty">
             {loading
               ? "Loading events…"
               : allEvents.length === 0
@@ -2919,31 +2962,31 @@ function EventLog({ runId, eventsState }: { runId: string; eventsState: RunEvent
                 : view === "notable"
                   ? "No notable events yet."
                   : "No activity yet."}
-          </div>
+          </li>
         ) : null}
         {events.map((frame) => {
           if (frame.event === "__heartbeats__") {
             const count = isRecord(frame.payload) ? (asNumber(frame.payload.count) ?? 0) : 0;
             return (
-              <div className="mon-event mon-event-heartbeats" key={`${runId}:heartbeats`}>
+              <li className="mon-event mon-event-heartbeats" key={`${runId}:heartbeats`}>
                 <span className="mon-mono mon-dim">#{frame.seq}</span>
                 <span className="mon-event-name mon-dim">TaskHeartbeat</span>
                 <span className="mon-event-detail mon-dim">×{count} — collapsed; the engine is alive</span>
                 <EventWhen ms={frame.timestampMs} />
-              </div>
+              </li>
             );
           }
           const line = formatEventLine(frame);
           return (
-            <div className="mon-event" key={`${runId}:${line.seq}`}>
+            <li className="mon-event" key={`${runId}:${line.seq}`}>
               <span className="mon-mono mon-dim">#{line.seq}</span>
               <span className="mon-event-name">{line.name}</span>
               <span className="mon-event-detail mon-dim">{line.detail}</span>
               <EventWhen ms={frame.timestampMs} />
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ol>
     </section>
   );
 }
@@ -4799,7 +4842,7 @@ code { font-family: var(--font-mono); font-size: var(--fs-2); background: var(--
 .mon-runs-table-panel { display: flex; flex-direction: column; height: 100%; min-height: 0; margin: 0; }
 .mon-runs-table-panel .mon-panel-head { margin-bottom: var(--sp-2); }
 .mon-runs-scroll { flex: 1; min-height: 0; overflow: auto; border: 1px solid var(--border); border-radius: var(--r-2); }
-.mon-runs-scroll:focus-visible, .mon-tree:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--ring-border); }
+.mon-runs-scroll:focus-visible, .mon-tree:focus-visible, .mon-events:focus-visible { outline: none; box-shadow: inset 0 0 0 2px var(--ring-border); }
 /* The shared Table wraps itself in an overflow-x container; inside the
    monitor's scrollports that inner scroller would defeat the sticky header,
    so let the outer .mon-*-scroll own all scrolling. */
@@ -4931,7 +4974,7 @@ code { font-family: var(--font-mono); font-size: var(--fs-2); background: var(--
 .mon-scrub-loading { font-size: var(--fs-1); white-space: nowrap; animation: mon-pulse 1.2s ease-in-out infinite; }
 
 .mon-events-panel { display: flex; flex-direction: column; }
-.mon-events { max-height: 300px; overflow-y: auto; font-size: var(--fs-1); }
+.mon-events { max-height: 300px; overflow-y: auto; margin: 0; padding: 0; list-style: none; font-size: var(--fs-1); }
 .mon-event { display: flex; gap: var(--sp-2); padding: var(--sp-1) 0; border-bottom: 1px solid var(--border); align-items: baseline; }
 .mon-event:last-child { border-bottom: 0; }
 .mon-event-name { font-weight: 600; white-space: nowrap; }

--- a/apps/cli/tests/monitor-shell-controls.test.tsx
+++ b/apps/cli/tests/monitor-shell-controls.test.tsx
@@ -33,6 +33,7 @@ const { Chip, MonitorToolbar, RunLifecycleActions, RunLifecycleControls, RunRail
   await import("../src/monitor-ui/monitorShell.tsx");
 const {
   createMonitorKeydownHandler,
+  EventLog,
   ExecutionTree,
   monitorCss,
   RunProgressCell,
@@ -501,6 +502,96 @@ describe("migrated monitor surfaces", () => {
   });
 });
 
+describe("event log accessibility", () => {
+  const eventsState = (
+    overrides: Partial<Parameters<typeof EventLog>[0]["eventsState"]> = {},
+  ): Parameters<typeof EventLog>[0]["eventsState"] => ({
+    events: [
+      {
+        type: "event",
+        event: "NodeStarted",
+        payload: { nodeId: "task-1" },
+        seq: 1,
+        stateVersion: 1,
+        timestampMs: Date.now() - 2_000,
+      },
+      {
+        type: "event",
+        event: "AgentEvent",
+        payload: { text: "working" },
+        seq: 2,
+        stateVersion: 2,
+        timestampMs: Date.now() - 1_000,
+      },
+    ],
+    lastHeartbeat: undefined,
+    error: undefined,
+    streaming: true,
+    loading: false,
+    ...overrides,
+  });
+
+  test("exposes a focusable live list, row semantics, and selected filter state", async () => {
+    await render(<EventLog runId="run-events" eventsState={eventsState()} />);
+
+    const list = byTestId("monitor-events");
+    expect(list.tagName).toBe("OL");
+    expect(list.tabIndex).toBe(0);
+    expect(list.getAttribute("aria-label")).toBe("Activity event stream");
+    expect(list.getAttribute("aria-live")).toBe("polite");
+    expect(list.getAttribute("aria-relevant")).toBe("additions text");
+    expect(list.getAttribute("aria-busy")).toBe("false");
+    await act(async () => list.focus());
+    expect(document.activeElement).toBe(list);
+
+    const rows = [...list.querySelectorAll(".mon-event")];
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.tagName === "LI")).toBe(true);
+
+    const activity = byTestId("monitor-events-filter-activity");
+    const notable = byTestId("monitor-events-filter-notable");
+    expect(activity.getAttribute("aria-pressed")).toBe("true");
+    expect(notable.getAttribute("aria-pressed")).toBe("false");
+    expect(activity.getAttribute("aria-controls")).toBe(list.id);
+
+    await act(async () => notable.focus());
+    expect(document.activeElement).toBe(notable);
+    await click(notable);
+    expect(notable.getAttribute("aria-pressed")).toBe("true");
+    expect(activity.getAttribute("aria-pressed")).toBe("false");
+    expect(list.getAttribute("aria-label")).toBe("Notable event stream");
+    expect(list.querySelectorAll(".mon-event")).toHaveLength(1);
+  });
+
+  test("announces paused following and provides a keyboard-focusable resume control", async () => {
+    await render(<EventLog runId="run-follow" eventsState={eventsState()} />);
+
+    const list = byTestId("monitor-events");
+    Object.defineProperty(list, "scrollHeight", { configurable: true, value: 1_000 });
+    Object.defineProperty(list, "clientHeight", { configurable: true, value: 100 });
+    list.scrollTop = 100;
+    await act(async () => list.dispatchEvent(new Event("scroll", { bubbles: true })));
+
+    const follow = byTestId("monitor-events-follow");
+    const status = byTestId("monitor-events-follow-status");
+    expect(follow.getAttribute("aria-pressed")).toBe("false");
+    expect(follow.getAttribute("aria-label")).toBe("Resume following new events");
+    expect(follow.textContent).toContain("Resume follow");
+    expect(status.textContent).toContain("paused");
+    expect(list.getAttribute("aria-live")).toBe("off");
+
+    await act(async () => follow.focus());
+    expect(document.activeElement).toBe(follow);
+    await click(follow);
+    expect(follow.getAttribute("aria-pressed")).toBe("true");
+    expect(follow.getAttribute("aria-label")).toBe("Following new events");
+    expect(follow.textContent).toContain("Following");
+    expect(status.textContent).toContain("Following new events");
+    expect(list.getAttribute("aria-live")).toBe("polite");
+    expect(list.scrollTop).toBe(1_000);
+  });
+});
+
 describe("execution tree unavailable states", () => {
   const historicalRoot = {
     key: "workflow#0",
@@ -661,6 +752,7 @@ describe("monitor theme contract", () => {
     for (const selector of [
       ".mon-tree-chevron:focus-visible",
       ".mon-tree-main:focus-visible",
+      ".mon-events:focus-visible",
       ".mon-timeline-row:focus-visible",
       ".mon-approval-main:focus-visible",
       ".mon-diff-summary:focus-visible",


### PR DESCRIPTION
## Summary
- turn the event viewport into a focusable, labeled native event list
- expose filter selection, live-update behavior, and paused/follow status to assistive technology
- keep resume-follow keyboard accessible and add a visible focus ring
- add DOM coverage for list rows, filter state, live announcements, pause, and resume

## Root cause
The event viewport was a non-focusable div with no list semantics or live-region contract, and follow state was only conveyed by a visual chip accent.

## Impact
Keyboard and screen-reader users can navigate the event stream, identify the active filter, hear new events while following, and understand when scrolling has paused updates.

## Checks
- `pnpm -C apps/cli exec bun test --timeout=120000 --max-concurrency=1 tests/monitor-shell-controls.test.tsx` (40 pass)
- `pnpm -C apps/cli typecheck`
- `pnpm typecheck`
- `pnpm lint` (existing warnings only)

Closes #1134