### PR TITLE
fix(server): drain gateway database jobs on close

### DIFF
--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -2584,6 +2584,13 @@ export class Gateway {
   /** @type {Map<string, Promise<void>>} */
   workflowRegistryRefreshes = new Map();
   /**
+   * Register-time rewind recovery touches the workflow database after
+   * `register()` returns. Track those jobs so `close()` is a real I/O barrier:
+   * callers may safely close or remove their backend once it resolves.
+   * @type {Set<Promise<void>>}
+   */
+  startupRecoveryJobs = new Set();
+  /**
    * Background <UI>/<TUI> discovery. register() never renders a workflow
    * synchronously: renders are queued and drained one per macrotask so a slow
    * or throwing workflow can neither block startup nor starve /health.
@@ -2625,6 +2632,8 @@ export class Gateway {
    */
   inflightResumes = new Map();
   devtoolsSubscribers = new Map();
+  /** @type {Set<Promise<void>>} */
+  devtoolsStreamJobs = new Set();
   runEventWindows = new Map();
   runEventSubscriberCounts = new Map();
   runEventSubscriberTotal = 0;
@@ -5216,17 +5225,22 @@ a { color: var(--brand); }</style>
     // `needs_attention`. Runs asynchronously; failures are logged and
     // never block registration.
     const adapter = new SmithersDb(workflow.db);
-    recoverInProgressRewindAudits(adapter).catch((error) => {
-      emitGatewayLog(
-        "warning",
-        "rewind audit recovery failed",
-        {
-          workflow: key,
-          ...gatewayErrorAnnotations(error),
-        },
-        "gateway:startup-recovery",
-      );
-    });
+    const recoveryJob = recoverInProgressRewindAudits(adapter)
+      .catch((error) => {
+        emitGatewayLog(
+          "warning",
+          "rewind audit recovery failed",
+          {
+            workflow: key,
+            ...gatewayErrorAnnotations(error),
+          },
+          "gateway:startup-recovery",
+        );
+      })
+      .finally(() => {
+        this.startupRecoveryJobs.delete(recoveryJob);
+      });
+    this.startupRecoveryJobs.add(recoveryJob);
     return this;
   }
   /**
@@ -5835,9 +5849,36 @@ a { color: var(--brand); }</style>
     for (const activeRun of activeRuns) {
       activeRun.abort.abort();
     }
+    // Approval decisions can start a detached resume while the original run
+    // is still settling. Drain that gate before taking the final active/inflight
+    // snapshots so a resume cannot begin using its database after close.
+    const inflightResumes = [...this.inflightResumes.values()];
+    if (inflightResumes.length > 0) {
+      await Promise.allSettled(inflightResumes);
+    }
+    // A resume that had already entered startRun before gatewayClosing was set
+    // may have registered while we awaited it. Abort that raced run too.
+    for (const activeRun of this.activeRuns.values()) {
+      activeRun.abort.abort();
+    }
     const inflightRuns = [...this.inflightRuns.values()];
     if (inflightRuns.length > 0) {
       await Promise.allSettled(inflightRuns);
+    }
+    const startupRecoveryJobs = [...this.startupRecoveryJobs];
+    if (startupRecoveryJobs.length > 0) {
+      await Promise.allSettled(startupRecoveryJobs);
+    }
+    // streamDevTools workers poll workflow databases independently of the
+    // websocket. Abort every registered worker (including direct route users
+    // that are not in `connections`) and wait for its generator finalizer
+    // before callers tear down the backend.
+    for (const subscriber of this.devtoolsSubscribers.values()) {
+      subscriber.abort.abort();
+    }
+    const devtoolsStreamJobs = [...this.devtoolsStreamJobs];
+    if (devtoolsStreamJobs.length > 0) {
+      await Promise.allSettled(devtoolsStreamJobs);
     }
     for (const connection of this.connections) {
       // Fence any subscribe handler still awaiting resolveRun(), then
@@ -6653,6 +6694,9 @@ a { color: var(--brand); }</style>
    * @param {RunStartAuthContext} auth
    */
   async resumeRunIfNeeded(runId, workflowKey, adapter, auth) {
+    if (this.gatewayClosing) {
+      return;
+    }
     const existingResume = this.inflightResumes.get(runId);
     if (existingResume) {
       await existingResume;
@@ -6660,11 +6704,17 @@ a { color: var(--brand); }</style>
     }
     const resumePromise = (async () => {
       for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (this.gatewayClosing) {
+          return;
+        }
         if (this.activeRuns.has(runId)) {
           await delay(25);
           continue;
         }
         const run = await adapter.getRun(runId);
+        if (this.gatewayClosing) {
+          return;
+        }
         if (!run) {
           return;
         }
@@ -9723,9 +9773,9 @@ a { color: var(--brand); }</style>
               );
             }
           }
-          if (connection.closed) {
+          if (this.gatewayClosing || connection.closed) {
             // The WS closed while resolveRun()/getLastFrame() were in
-            // flight; its close path already ran
+            // flight, or the gateway began closing; teardown already ran
             // cleanupDevToolsSubscribers for this connection.
             // Registering now would leak a subscriber that stays in
             // devtoolsSubscribers with a never-aborted signal (#553).
@@ -9795,7 +9845,7 @@ a { color: var(--brand); }</style>
             outboundQueue.push(payload);
             drainOutboundQueue();
           };
-          void (async () => {
+          const streamJob = (async () => {
             let eventsDelivered = 0;
             try {
               for await (const event of streamDevToolsRoute({
@@ -9889,6 +9939,12 @@ a { color: var(--brand); }</style>
               });
             }
           })();
+          this.devtoolsStreamJobs.add(streamJob);
+          void streamJob
+            .finally(() => {
+              this.devtoolsStreamJobs.delete(streamJob);
+            })
+            .catch(() => {});
           return responseOk(frame.id, {
             streamId,
             runId,

--- a/packages/server/src/gatewayRoutes/streamDevTools.js
+++ b/packages/server/src/gatewayRoutes/streamDevTools.js
@@ -19,10 +19,22 @@ export const DEVTOOLS_POLL_INTERVAL_MS = 25;
 
 /**
  * @param {number} timeMs
+ * @param {AbortSignal} [signal]
  * @returns {Promise<void>}
  */
-function delay(timeMs) {
-  return new Promise((resolve) => setTimeout(resolve, timeMs));
+function delay(timeMs, signal) {
+  if (signal?.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, timeMs);
+    signal?.addEventListener("abort", finish, { once: true });
+  });
 }
 
 /**
@@ -224,6 +236,13 @@ export async function* streamDevToolsRoute(input) {
   let producerErrorCode = undefined;
   const queue = new AsyncEventQueue(maxBufferedEvents);
   let cancelled = false;
+  const pollAbort = new AbortController();
+  const abortPolling = () => pollAbort.abort();
+  if (input.signal?.aborted) {
+    pollAbort.abort();
+  } else {
+    input.signal?.addEventListener("abort", abortPolling, { once: true });
+  }
   input.onLog?.("info", "devtools stream subscribed", {
     runId,
     fromSeq: input.fromSeq ?? null,
@@ -462,7 +481,7 @@ export async function* streamDevToolsRoute(input) {
           if (shouldStop()) {
             break;
           }
-          await delay(pollIntervalMs);
+          await delay(pollIntervalMs, pollAbort.signal);
         }
       } catch (error) {
         producerErrorCode = error?.code ?? undefined;
@@ -487,10 +506,11 @@ export async function* streamDevToolsRoute(input) {
     }
   } finally {
     cancelled = true;
+    pollAbort.abort();
+    input.signal?.removeEventListener("abort", abortPolling);
     queue.close();
-    const closeWaitMs = Math.max(25, pollIntervalMs * 4);
     try {
-      await Promise.race([producer, delay(closeWaitMs)]);
+      await producer;
     } catch {}
     if (!producerErrorCode && queue.error?.code) {
       producerErrorCode = queue.error.code;

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -991,6 +991,13 @@ declare class Gateway {
     /** @type {Map<string, Promise<void>>} */
     workflowRegistryRefreshes: Map<string, Promise<void>>;
     /**
+     * Register-time rewind recovery touches the workflow database after
+     * `register()` returns. Track those jobs so `close()` is a real I/O barrier:
+     * callers may safely close or remove their backend once it resolves.
+     * @type {Set<Promise<void>>}
+     */
+    startupRecoveryJobs: Set<Promise<void>>;
+    /**
      * Background <UI>/<TUI> discovery. register() never renders a workflow
      * synchronously: renders are queued and drained one per macrotask so a slow
      * or throwing workflow can neither block startup nor starve /health.
@@ -1043,6 +1050,8 @@ declare class Gateway {
      */
     inflightResumes: Map<string, Promise<void>>;
     devtoolsSubscribers: Map<any, any>;
+    /** @type {Set<Promise<void>>} */
+    devtoolsStreamJobs: Set<Promise<void>>;
     runEventWindows: Map<any, any>;
     runEventSubscriberCounts: Map<any, any>;
     runEventSubscriberTotal: number;

--- a/packages/server/tests/gateway-devtools-warning-coverage.test.jsx
+++ b/packages/server/tests/gateway-devtools-warning-coverage.test.jsx
@@ -106,6 +106,45 @@ function makeDbPath(name) {
 }
 
 describe("gateway devtools serializer warnings and audit recovery", () => {
+  test("close waits for register-time rewind recovery to release the backend", async () => {
+    let markRecoveryStarted;
+    const recoveryStarted = new Promise((resolve) => {
+      markRecoveryStarted = resolve;
+    });
+    let releaseRecovery;
+    const recoveryBlocked = new Promise((resolve) => {
+      releaseRecovery = resolve;
+    });
+    const workflow = {
+      db: {
+        dialect: "postgres",
+        connection: {
+          async query() {
+            markRecoveryStarted();
+            await recoveryBlocked;
+            return { rows: [] };
+          },
+        },
+      },
+      build: () => null,
+      opts: {},
+    };
+    const gateway = new Gateway({});
+    gateway.register("blocked-recovery", workflow);
+    await recoveryStarted;
+
+    let closeSettled = false;
+    const closing = gateway.close().then(() => {
+      closeSettled = true;
+    });
+    await sleep(10);
+    expect(closeSettled).toBe(false);
+
+    releaseRecovery();
+    await closing;
+    expect(closeSettled).toBe(true);
+  });
+
   test("a too-deep snapshot tree drives the serializer onWarning on both routes", async () => {
     const dbPath = makeDbPath("deep");
     const { workflow, db } = makeWorkflow(dbPath);
@@ -146,6 +185,9 @@ describe("gateway devtools serializer warnings and audit recovery", () => {
     expect(streamRes.ok).toBe(true);
     await sleep(120);
     expect(streamConn.sent.some((e) => e.event === "devtools.event")).toBe(true);
+    expect(gateway.getDevToolsSubscriberCount(runId)).toBe(1);
+    await gateway.close();
+    expect(gateway.getDevToolsSubscriberCount(runId)).toBe(0);
   }, 20000);
 
   test("register swallows a rewind-audit recovery failure and still registers", async () => {

--- a/packages/server/tests/gateway-run-idempotency.test.jsx
+++ b/packages/server/tests/gateway-run-idempotency.test.jsx
@@ -7,6 +7,7 @@ import { createSmithers } from "smthrs";
 import { retryTask } from "@smthrs/time-travel/retry-task";
 import { z } from "zod";
 import { Gateway } from "../src/gateway.js";
+import { sleep } from "../../smithers/tests/helpers.js";
 
 /**
  * Run-id ownership regressions. A new launch must not overwrite an active run,
@@ -217,6 +218,38 @@ describe("gateway run-id ownership", () => {
     await gateway.resumeRunIfNeeded("retryable-resume", "idem", adapter, AUTH);
     expect(lookupCalls).toBe(2);
     expect(gateway.inflightResumes.has("retryable-resume")).toBe(false);
+  });
+
+  test("close drains an in-flight resume lookup without starting another run", async () => {
+    gateway = new Gateway({ heartbeatMs: 1000 });
+    const lookupStarted = deferred();
+    const releaseLookup = deferred();
+    const adapter = {
+      async getRun() {
+        lookupStarted.resolve();
+        await releaseLookup.promise;
+        return { status: "running" };
+      },
+    };
+    let startCalls = 0;
+    gateway.startRun = async () => {
+      startCalls += 1;
+      return { runId: "closing-resume", workflow: "idem", system: false };
+    };
+
+    const resuming = gateway.resumeRunIfNeeded("closing-resume", "idem", adapter, AUTH);
+    await lookupStarted.promise;
+    let closeSettled = false;
+    const closing = gateway.close().then(() => {
+      closeSettled = true;
+    });
+    await sleep(10);
+    expect(closeSettled).toBe(false);
+
+    releaseLookup.resolve();
+    await Promise.all([resuming, closing]);
+    expect(startCalls).toBe(0);
+    expect(gateway.inflightResumes.has("closing-resume")).toBe(false);
   });
 
   test("an older settling invocation preserves newer same-run tracking", async () => {

--- a/packages/server/tests/streamDevTools.test.tsx
+++ b/packages/server/tests/streamDevTools.test.tsx
@@ -716,6 +716,34 @@ describe("streamDevToolsRoute concurrency + performance", () => {
     sqlite.close();
   });
 
+  test("cancellation wakes a sleeping poller immediately", async () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+    ensureSmithersTables(db);
+    const adapter = new SmithersDb(db);
+    await seedFrames(adapter, "run-cancel-poll", 1);
+    const controller = new AbortController();
+    const stream = streamDevToolsRoute({
+      adapter,
+      runId: "run-cancel-poll",
+      signal: controller.signal,
+      pollIntervalMs: 60_000,
+    })[Symbol.asyncIterator]();
+    const first = await stream.next();
+    expect(first.done).toBe(false);
+    await sleep(10);
+
+    controller.abort();
+    const next = await Promise.race([
+      stream.next(),
+      sleep(250).then(() => {
+        throw new Error("sleeping DevTools poller did not observe cancellation");
+      }),
+    ]);
+    expect(next.done).toBe(true);
+    sqlite.close();
+  });
+
   test("reconnect storm: 100 subscribers complete without error", async () => {
     const sqlite = new Database(":memory:");
     const db = drizzle(sqlite);


### PR DESCRIPTION
## Summary

- make Gateway.close() drain register-time rewind recovery, approval resume gates/runs, and DevTools stream workers
- make DevTools polling cancellation wake immediately and fully join the producer before teardown
- add regressions for all three detached database-work paths

## Root cause

Gateway.close() could resolve while detached recovery, resume, or DevTools polling work still held the workflow database. Tests then closed and removed SQLite files while those jobs were reading them, producing disk I/O errors and poisoning Bun SQLite lock state for later fresh databases.

## Impact

Gateway shutdown is now a deterministic database I/O barrier. Test and application teardown can safely close or remove workflow backends after close() resolves without leaking pollers or racing a late resume.

## Checks

- pnpm -C packages/server test (752 pass, 1 skip)
- affected CI sequence repeated 10x on Linux x86_64 with Bun 1.3.13
- pnpm -C packages/server typecheck
- pnpm -C packages/server build
- pnpm typecheck
- pnpm lint
- pnpm check:local-smithers
- pnpm check:dts confirms server declarations are current; the root check still reports pre-existing packages/agents declaration drift

## Closes

Closes #1549
