### PR TITLE
fix(vcs): recover from stale working copy in workspaceAdd

### DIFF
--- a/packages/vcs/src/jj.js
+++ b/packages/vcs/src/jj.js
@@ -309,6 +309,15 @@ export function isJjRepo(cwd) {
 const LOCK_CONTENTION_PATTERN =
   /could not be obtained|Could not acquire lock|index\.lock|packed-refs\.lock|lock file already exists/i;
 const LOCK_CONTENTION_RETRIES = 8;
+/**
+ * jj refuses to snapshot from a workspace whose working copy is stale — which
+ * happens whenever another workspace (a concurrent agent lane, a sibling
+ * session) commits an operation that moves this workspace's working-copy
+ * commit. The refusal is self-healing: `jj workspace update-stale` brings the
+ * working copy to the latest operation without discarding anything, after
+ * which the original command succeeds.
+ */
+const STALE_WORKING_COPY_PATTERN = /working copy is stale/i;
 
 export function workspaceAdd(name, path, opts = {}) {
   const attempts = [];
@@ -357,12 +366,17 @@ export function workspaceAdd(name, path, opts = {}) {
     // syntax ladder (issue #935: 38 of 50 parallel lanes lost this race).
     for (const args of attempts) {
       let res = yield* runJj(args, { cwd: opts.cwd });
-      for (
-        let retry = 0;
-        res.code !== 0 && LOCK_CONTENTION_PATTERN.test(jjError(res)) && retry < LOCK_CONTENTION_RETRIES;
-        retry += 1
-      ) {
-        yield* Effect.sleep(`${150 + Math.floor(Math.random() * 600)} millis`);
+      for (let retry = 0; res.code !== 0 && retry < LOCK_CONTENTION_RETRIES; retry += 1) {
+        const err = jjError(res);
+        if (STALE_WORKING_COPY_PATTERN.test(err)) {
+          // Recover, then retry the same invocation. update-stale failures
+          // fall through to the retried command, whose error stays canonical.
+          yield* runJj(["workspace", "update-stale"], { cwd: opts.cwd });
+        } else if (LOCK_CONTENTION_PATTERN.test(err)) {
+          yield* Effect.sleep(`${150 + Math.floor(Math.random() * 600)} millis`);
+        } else {
+          break;
+        }
         res = yield* runJj(args, { cwd: opts.cwd });
       }
       if (res.code === 0) {

--- a/packages/vcs/tests/jj-workspace-stale-recovery.test.js
+++ b/packages/vcs/tests/jj-workspace-stale-recovery.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect } from "bun:test";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import { Effect } from "effect";
+import * as BunContext from "@effect/platform-bun/BunServices";
+import * as vcsEffects from "../src/jj.js";
+
+const JJ_ENV = "SMITHERS_JJ_PATH";
+
+/** @param {import("effect").Effect.Effect<any, any, any>} effect */
+function runVcs(effect) {
+  return Effect.runPromise(effect.pipe(Effect.provide(BunContext.layer)));
+}
+
+/**
+ * Run `fn` with SMITHERS_JJ_PATH pointing at a fake jj whose behavior is the
+ * given bash script. The script sees the jj arguments verbatim.
+ *
+ * @param {string} script
+ * @param {(tmp: string) => Promise<void>} fn
+ */
+async function withFakeJj(script, fn) {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "jj-stale-"));
+  const binPath = path.join(tmp, "jj");
+  await fs.writeFile(binPath, `#!/usr/bin/env bash\n${script}`, { mode: 0o755 });
+  const prevJj = process.env[JJ_ENV];
+  process.env[JJ_ENV] = binPath;
+  try {
+    await fn(tmp);
+  } finally {
+    if (prevJj === undefined) delete process.env[JJ_ENV];
+    else process.env[JJ_ENV] = prevJj;
+    await fs.rm(tmp, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+describe("workspaceAdd stale working-copy recovery", () => {
+  test("runs `workspace update-stale` and retries when add reports a stale working copy", async () => {
+    // The fake jj rejects `workspace add` with jj's stale-working-copy error
+    // until `workspace update-stale` has run, then accepts it. A state file
+    // shared between invocations records the recovery.
+    const script = `
+STATE="$(dirname "$0")/state"
+LOG="$(dirname "$0")/log"
+echo "$@" >> "$LOG"
+case "$1 $2" in
+  "workspace list") exit 0 ;;
+  "workspace update-stale") touch "$STATE"; exit 0 ;;
+  "workspace add")
+    if [ -f "$STATE" ]; then mkdir -p "$3" 2>/dev/null; exit 0; fi
+    echo "Error: The working copy is stale (not updated since operation abc123)." >&2
+    echo 'Hint: Run \`jj workspace update-stale\` to update it.' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+`;
+    await withFakeJj(script, async (tmp) => {
+      const workspacePath = path.join(tmp, "lanes", "lane-1");
+      const result = await runVcs(vcsEffects.workspaceAdd("lane-1", workspacePath, { cwd: tmp }));
+      expect(result.success).toBe(true);
+      const log = await fs.readFile(path.join(tmp, "log"), "utf8");
+      expect(log).toContain("workspace update-stale");
+    });
+  }, 30_000);
+
+  test("still fails with the original error when the failure is not staleness", async () => {
+    const script = `
+LOG="$(dirname "$0")/log"
+echo "$@" >> "$LOG"
+case "$1 $2" in
+  "workspace list") exit 0 ;;
+  "workspace add")
+    echo "Error: something unrelated went wrong" >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+`;
+    await withFakeJj(script, async (tmp) => {
+      const workspacePath = path.join(tmp, "lanes", "lane-2");
+      const result = await runVcs(vcsEffects.workspaceAdd("lane-2", workspacePath, { cwd: tmp }));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("something unrelated went wrong");
+      const log = await fs.readFile(path.join(tmp, "log"), "utf8");
+      expect(log).not.toContain("workspace update-stale");
+    });
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem

`jj workspace add` refuses to run when the invoking workspace's working copy is stale — jj's response to any other workspace (a concurrent agent lane, a sibling session sharing the repo) committing an operation that moves this workspace's working-copy commit:

```
Error: The working copy is stale (not updated since operation <op>).
Hint: Run `jj workspace update-stale` to update it.
```

Parallel workflow lanes then fail worktree creation with `WORKTREE_CREATE_FAILED` even though the condition is self-healing. Hit in production: every doc lane of a 10-lane workflow died on this while another live session was operating on the same jj repo.

## Fix

Extend the existing `workspaceAdd` retry loop in `packages/vcs/src/jj.js`: when the error matches jj's stale-working-copy refusal, run `jj workspace update-stale` (which discards nothing — it brings the working copy to the latest operation) and retry the same invocation. This sits alongside the existing lock-contention jittered backoff; any other error still falls through the syntax ladder unchanged.

## Tests

`packages/vcs/tests/jj-workspace-stale-recovery.test.js` fakes the jj binary:
- `workspace add` fails with the stale error until `workspace update-stale` has run, then succeeds → `workspaceAdd` returns success and the log shows the recovery ran.
- A non-stale failure never triggers `update-stale` and surfaces the original error.

Full `packages/vcs/tests` suite: 97-98 pass; the only failures are pre-existing load-flaky `jj-real-repo.test.js` snapshot-op timeouts (different tests fail on consecutive runs on a loaded machine, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)