### PR TITLE
test(cli): make agents-add regen test hermetic on CI

### DIFF
--- a/apps/cli/tests/agents-account-cli.e2e.test.js
+++ b/apps/cli/tests/agents-account-cli.e2e.test.js
@@ -200,12 +200,23 @@ test("agents remove deletes by label and is idempotent under --silent", () => {
 test("agents add regenerates .smithers/agents.ts when one already exists", () => {
   const repo = createTempRepo();
   const home = newSmithersHome();
+  // Make the claude CLI detectable so tier lines list providers.claude as
+  // active; CI runners have no real claude binary on PATH.
+  const binDir = createExecutableDir();
+  writeFakeClaudeBinary(binDir);
+  repo.write(".claude/.credentials.json", "{}\n");
   // Pre-populate a generated agents.ts so the regen helper rewrites it.
   repo.write(".smithers/agents.ts", "// smithers-source: generated\n// (placeholder)\n");
   runSmithers(["agents", "add", "--provider", "claude-code", "--label", "claude-work", "--skip-login"], {
     cwd: repo.dir,
     format: "json",
-    env: { SMITHERS_HOME: home },
+    env: {
+      HOME: repo.dir,
+      PATH: [binDir, process.env.PATH ?? ""].filter(Boolean).join(delimiter),
+      SMITHERS_HOME: home,
+      ANTHROPIC_API_KEY: "sk-ant-test",
+      OPENAI_API_KEY: "",
+    },
   });
   const regenerated = repo.read(".smithers/agents.ts");
   // The new account shows up as a provider…


### PR DESCRIPTION
## Summary
- The `agents add regenerates .smithers/agents.ts` test asserted pool lines that only render when the claude CLI is detected as usable. CI runners have no claude binary, so every main run since #1571 fails `test (ubuntu-latest, 1, 3)` and `test (windows-latest, 1, 4)`.
- Reuse the sibling test's hermetic setup: fake claude binary on PATH, stub credentials, and a scoped HOME.

## Checks
- `bun test apps/cli/tests/agents-account-cli.e2e.test.js` (11/11 locally; the target test passes with the fake binary, which is the CI condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)