### PR TITLE
test(cli): register agents reauth in the subcommand surface

### DIFF
--- a/apps/cli/tests/cli-subcommands-surface-unit.test.js
+++ b/apps/cli/tests/cli-subcommands-surface-unit.test.js
@@ -91,7 +91,7 @@ describe("CLI_SUBCOMMANDS command registry", () => {
     expect(groupCommands("cron")).toEqual(["add", "list", "rm", "start"]);
     expect(groupCommands("memory")).toEqual(["get", "list", "rm", "set"]);
     expect(groupCommands("openapi")).toEqual(["generate", "list"]);
-    expect(groupCommands("agents")).toEqual(["add", "capabilities", "doctor", "list", "remove", "test"]);
+    expect(groupCommands("agents")).toEqual(["add", "capabilities", "doctor", "list", "reauth", "remove", "test"]);
     expect(groupCommands("token")).toEqual(["exec", "issue", "revoke"]);
     expect(groupCommands("claude")).toEqual(["monitor", "node-wait", "subscribe", "tick", "unsubscribe"]);
   });


### PR DESCRIPTION
## Summary
- #1571 added the `agents reauth` subcommand (docs bundles included) but did not update `cli-subcommands-surface-unit.test.js`, so `test (ubuntu-latest, 1, 3)` and `test (windows-latest, 1, 4)` fail on every main run since.

## Checks
- `bun test apps/cli/tests/cli-subcommands-surface-unit.test.js` (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)