### PR TITLE
test(vcs): skip bash fake-jj stale recovery on windows

### DIFF
--- a/packages/vcs/tests/jj-workspace-stale-recovery.test.js
+++ b/packages/vcs/tests/jj-workspace-stale-recovery.test.js
@@ -35,7 +35,9 @@ async function withFakeJj(script, fn) {
   }
 }
 
-describe("workspaceAdd stale working-copy recovery", () => {
+// The fake jj is a bash-shebang script; Windows cannot execute it, matching
+// the platform skips in the real-jj suites.
+describe.skipIf(process.platform === "win32")("workspaceAdd stale working-copy recovery", () => {
   test("runs `workspace update-stale` and retries when add reports a stale working copy", async () => {
     // The fake jj rejects `workspace add` with jj's stale-working-copy error
     // until `workspace update-stale` has run, then accepts it. A state file


### PR DESCRIPTION
## Summary
- #1576's stale working-copy recovery tests drive a fake jj written as a bash-shebang script. Windows cannot execute it, so `test (windows-latest, 1, 4)` fails on every main run since. Skip on win32 like the sibling real-jj suites.

## Checks
- `bun test packages/vcs/tests/jj-workspace-stale-recovery.test.js` (2/2 on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)