### PR TITLE
fix(cli): stop sampling the detached log cap mid-run

### DIFF
--- a/apps/cli/tests/detached-run-logs.test.js
+++ b/apps/cli/tests/detached-run-logs.test.js
@@ -45,6 +45,28 @@ async function waitForRunConfig(repo, runId) {
   throw new Error(`Detached run did not finish: ${runId}`);
 }
 
+/**
+ * Wait for a detached child to actually exit. The run row flips to a terminal
+ * status from inside the child, so a terminal status only means the child is
+ * on its way out. Rotation caps the inherited log periodically and once more
+ * on `exit`, so the size cap holds for a settled log, not for a log sampled
+ * mid-run between sweeps.
+ *
+ * @param {number | undefined} pid
+ */
+async function waitForProcessExit(pid) {
+  if (typeof pid !== "number") throw new Error("Detached launch did not report a pid");
+  for (let attempt = 0; attempt < 240; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    await Bun.sleep(50);
+  }
+  throw new Error(`Detached child did not exit: ${pid}`);
+}
+
 describe("detached run log paths", () => {
   test(
     "defaults to the workspace .smithers/logs directory and records the exact path",
@@ -128,6 +150,7 @@ describe("detached run log paths", () => {
         },
       });
       await waitForRunConfig(repo, runId);
+      await waitForProcessExit(result.json?.pid);
 
       const logFile = repo.path(".smithers", "logs", `${runId}.log`);
       const contents = readFileSync(logFile, "utf8");


### PR DESCRIPTION
`detached run log paths > caps a live detached child's inherited log and leaves a truncation notice` fails on `test (ubuntu-latest, 1, 3)` in roughly half of recent `main` CI runs (three of the last eight), reporting 1382 bytes against a 1024-byte cap. It is the second independent cause of `main` being red, alongside #1577.

**Root cause (test race, not a product defect).** `startDetachedRunLogRotation` caps the inherited stdout descriptor on an interval and once more from the child's `exit` handler, so the byte cap is an at-rest property: between sweeps the file legitimately holds up to one interval's worth of extra output. The test asserted the size as soon as the run row left `running` — a status the child writes from inside itself while it is still running and still producing output — so on a loaded runner it sampled the log mid-sweep.

**Fix.** Wait for the detached child process to exit before asserting. The exit-time sweep has then run, and the settled log respects the cap. The assertions themselves are unchanged.

Verified with `bun test tests/detached-run-logs.test.js` (12 pass), `pnpm lint`, `pnpm format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)