### PR TITLE
fix(cli): spread each oneshot rung across every registered account

### DIFF
--- a/apps/cli/src/oneshot/selectOneshotAgents.js
+++ b/apps/cli/src/oneshot/selectOneshotAgents.js
@@ -1,5 +1,6 @@
 import { resolveOneshotChain } from "./resolveOneshotChain.js";
 import { listAccounts } from "@smthrs/accounts";
+import { orderAccountsByUsage } from "@smthrs/usage";
 import { registeredAgentId } from "../registered-agent-id.js";
 
 const ACCOUNT_PROVIDERS = {
@@ -54,21 +55,51 @@ async function createAgent(spec, cwd, account) {
 }
 
 /**
+ * Expand one engine/model rung into one agent per registered account for that
+ * engine, least-used account first.
+ *
+ * A rung bound to a single account fails the whole run when that one
+ * subscription is rate-limited, even with other accounts registered and idle —
+ * the same failure `fallbackAgents()` exists to prevent. Ordering reuses
+ * `orderAccountsByUsage`, so a quota-blocked account sinks below usable ones
+ * instead of being tried first.
+ *
+ * Engines with no account concept (opencode, pi) and engines with no registered
+ * account fall back to a single ambient agent.
+ *
+ * @param {{ engine: string; model: string; provider?: string }} spec
+ * @param {string} cwd
+ * @param {import("@smthrs/accounts").Account[]} accounts
+ * @param {NodeJS.ProcessEnv} env
+ */
+async function createAgentsForSpec(spec, cwd, accounts, env) {
+  const providers = ACCOUNT_PROVIDERS[spec.engine];
+  const matching = providers ? accounts.filter((account) => providers.has(account.provider)) : [];
+  if (matching.length === 0) return [await createAgent(spec, cwd, undefined)];
+  const ordered = orderAccountsByUsage(matching, { env, modelFor: () => spec.model });
+  return Promise.all(ordered.map((account) => createAgent(spec, cwd, account)));
+}
+
+/**
  * @param {import("../AgentAvailability.ts").AgentAvailability[]} detections
  * @param {{ cwd: string; model?: string; agent?: string; goal?: string; env?: NodeJS.ProcessEnv }} options
  */
 export async function selectOneshotAgents(detections, options) {
+  const env = options.env ?? process.env;
   const specs = resolveOneshotChain(detections, options);
-  const accounts = listAccounts(options.env ?? process.env);
-  const accountFor = (engine) => {
+  const accounts = listAccounts(env);
+  const accountsFor = (engine) => {
     const labels = detections.find((detection) => detection.id === engine)?.registeredAccountLabels ?? [];
-    const providers = ACCOUNT_PROVIDERS[engine];
-    return accounts.find((account) => labels.includes(account.label) && providers?.has(account.provider));
+    return accounts.filter((account) => labels.includes(account.label));
   };
-  const agents = await Promise.all(specs.map((spec) => createAgent(spec, options.cwd, accountFor(spec.engine))));
+  const expand = async (list) => {
+    const groups = await Promise.all(
+      list.map((spec) => createAgentsForSpec(spec, options.cwd, accountsFor(spec.engine), env)),
+    );
+    return groups.flat();
+  };
+  const agents = await expand(specs);
   const reviewSpecs = specs.length > 1 ? [...specs.slice(1), specs[0]] : specs;
-  const reviewAgents = await Promise.all(
-    reviewSpecs.map((spec) => createAgent(spec, options.cwd, accountFor(spec.engine))),
-  );
+  const reviewAgents = await expand(reviewSpecs);
   return { agents, reviewAgents, chain: specs };
 }

--- a/apps/cli/tests/oneshot.test.js
+++ b/apps/cli/tests/oneshot.test.js
@@ -350,6 +350,71 @@ test("oneshot accepts a registered Claude account and uses its config directory"
   ).toBe(configDir);
 }, 60_000);
 
+test("oneshot spreads a Claude rung across every registered account, least used first", async () => {
+  const home = temp("smithers-oneshot-claude-pool-");
+  const binDir = createExecutableDir();
+  writeExecutable(binDir, "claude", `#!${process.execPath}\nprocess.exit(1);\n`);
+  const smithersHome = join(home, ".smithers");
+  const labels = ["claude-1", "claude-2", "claude-3"];
+  const configDirs = {};
+  for (const label of labels) {
+    const configDir = join(smithersHome, "accounts", label);
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: `oauth-${label}`, expiresAt: Date.now() + 60_000 } }) + "\n",
+    );
+    configDirs[label] = configDir;
+  }
+  writeFileSync(
+    join(smithersHome, "accounts.json"),
+    JSON.stringify({
+      version: 1,
+      accounts: labels.map((label) => ({ label, provider: "claude-code", configDir: configDirs[label] })),
+    }) + "\n",
+  );
+  // claude-1 is registered first but its weekly window is spent: the pool must
+  // not pin the rung to it while claude-2 and claude-3 sit idle.
+  writeFileSync(
+    join(smithersHome, "usage-cache.json"),
+    JSON.stringify({
+      version: 1,
+      entries: {
+        "claude-1": {
+          report: {
+            source: "oauth",
+            windows: [{ id: "weekly", usedPercent: 100, resetsAt: new Date(Date.now() + 3_600_000).toISOString() }],
+          },
+        },
+        "claude-2": { report: { source: "oauth", windows: [{ id: "weekly", usedPercent: 10 }] } },
+        "claude-3": { report: { source: "oauth", windows: [{ id: "weekly", usedPercent: 60 }] } },
+      },
+    }) + "\n",
+  );
+  const env = {
+    ...process.env,
+    HOME: home,
+    SMITHERS_HOME: smithersHome,
+    PATH: `${binDir}${delimiter}${process.env.PATH}`,
+  };
+
+  const detections = detectAvailableAgents(env, { cwd: home });
+  const selected = await selectOneshotAgents(detections, { cwd: home, agent: "claude", env });
+  const claudeIds = selected.agents
+    .filter((agent) => typeof agent.id === "string" && agent.id.startsWith("smithers-account:"))
+    .map((agent) => agent.id);
+
+  // Every registered account is a rung, not just the first one on file.
+  for (const label of labels) {
+    expect(claudeIds).toContain(`smithers-account:${label}`);
+  }
+  // The quota-blocked account sinks below the usable ones.
+  expect(claudeIds.indexOf("smithers-account:claude-2")).toBeLessThan(claudeIds.indexOf("smithers-account:claude-1"));
+  expect(claudeIds.indexOf("smithers-account:claude-3")).toBeLessThan(claudeIds.indexOf("smithers-account:claude-1"));
+  // Least-used usable account leads.
+  expect(claudeIds[0]).toBe("smithers-account:claude-2");
+}, 60_000);
+
 describe("oneshot status updater", () => {
   test("pins every default narrator to the cheap model tier", () => {
     expect(ONESHOT_NARRATOR_MODELS).toEqual({


### PR DESCRIPTION
## Problem

`smithers oneshot` builds its failover chain in `selectOneshotAgents`, which bound each engine rung to `accounts.find(...)` — the **first** registered account for that provider. With several Claude subscriptions registered, the Claude rung was pinned to whichever account happened to be first in `accounts.json`.

When that one account is rate-limited, the entire rung fails and the run drops to the next *engine* while every other registered account sits idle. Hit in practice: `claude-1` was seven-day-limited, six healthy Claude accounts were registered, and the run fell through to Codex (also limited) and then Kimi before failing outright.

This is the exact failure `fallbackAgents()` exists to prevent, and `fallbackAgents()` has been quota-aware since #1571 — `oneshot`, the most-used command, just never used that pooling.

## Fix

Expand each rung into one agent per registered account for that engine, ordered with `orderAccountsByUsage` (from `@smthrs/usage`, already an `apps/cli` dependency), so the least-used account leads and a quota-blocked account sinks below the usable ones.

Behavior is unchanged for a single-account install, and engines with no account concept (`opencode`, `pi`) or no registered account keep their single ambient agent.

## Tests

New `apps/cli/tests/oneshot.test.js` case registers three Claude accounts with a seeded usage cache marking the first one spent, and asserts all three become rungs with the least-used first. Verified red before the fix (`Expected to contain: "smithers-account:claude-2"` / `Received: [ "smithers-account:claude-1" ]`) and green after.

Gates: `bun test tests/oneshot.test.js` (48 pass), `pnpm lint`, `pnpm format:check`, `pnpm -C apps/cli typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)