### PR TITLE
fix(db): one refcounted sqlite connection per file per process (does NOT fix #1577)

### DIFF
--- a/apps/cli/src/openInlineWorkflowStore.js
+++ b/apps/cli/src/openInlineWorkflowStore.js
@@ -3,15 +3,21 @@ import { SmithersError } from "@smthrs/errors";
 
 /** @param {string} cwd @param {Record<string, import("zod").ZodTypeAny>} schemas */
 export async function openInlineWorkflowStore(cwd, schemas) {
-  const [{ Database }, { drizzle }, { sqliteTable, text }, { zodToTable }, { syncZodTableSchema }, { camelToSnake }] =
-    await Promise.all([
-      import("bun:sqlite"),
-      import("drizzle-orm/bun-sqlite"),
-      import("drizzle-orm/sqlite-core"),
-      import("@smthrs/db/zodToTable"),
-      import("@smthrs/db/zodToCreateTableSQL"),
-      import("@smthrs/db/utils/camelToSnake"),
-    ]);
+  const [
+    { acquireSqliteConnection },
+    { drizzle },
+    { sqliteTable, text },
+    { zodToTable },
+    { syncZodTableSchema },
+    { camelToSnake },
+  ] = await Promise.all([
+    import("@smthrs/db/sqliteConnectionRegistry"),
+    import("drizzle-orm/bun-sqlite"),
+    import("drizzle-orm/sqlite-core"),
+    import("@smthrs/db/zodToTable"),
+    import("@smthrs/db/zodToCreateTableSQL"),
+    import("@smthrs/db/utils/camelToSnake"),
+  ]);
   const { findSmithersAnchorDir } = await import("smthrs/findSmithersAnchorDir");
   const { resolveSmithersBackendPreference } = await import("smthrs/resolveSmithersBackendChoice");
   const anchorDir = findSmithersAnchorDir(cwd);
@@ -28,12 +34,19 @@ export async function openInlineWorkflowStore(cwd, schemas) {
         `Pin sqlite for this workspace to run inline workflows such as \`smithers oneshot\`: set SMITHERS_BACKEND=sqlite, ` +
         `add \`backend: "sqlite"\` to .smithers/smithers.config.ts, or write {"backend":"sqlite"} to .smithers/backend.json.`,
     );
-  const sqlite = new Database(resolve(anchorDir ?? cwd, "smithers.db"));
-  sqlite.run("PRAGMA journal_mode = WAL");
-  sqlite.run("PRAGMA busy_timeout = 30000");
-  sqlite.run("PRAGMA synchronous = NORMAL");
-  sqlite.run("PRAGMA locking_mode = NORMAL");
-  sqlite.run("PRAGMA foreign_keys = ON");
+  // One connection per database file per process; see `acquireSqliteConnection`.
+  // An inline workflow runs inside a CLI process that may already hold this
+  // store open (`smithers up`, the gateway), and a second synchronous handle
+  // would block the event loop for the whole busy_timeout on first contention.
+  const sqlite = acquireSqliteConnection(resolve(anchorDir ?? cwd, "smithers.db"), {
+    configure: (connection) => {
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run("PRAGMA journal_mode = WAL");
+      connection.run("PRAGMA synchronous = NORMAL");
+      connection.run("PRAGMA locking_mode = NORMAL");
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
   sqlite.exec(`CREATE TABLE IF NOT EXISTS "input" (run_id TEXT PRIMARY KEY, payload TEXT)`);
   const inputTable = sqliteTable("input", {
     runId: text("run_id").primaryKey(),

--- a/apps/cli/tests/db-encapsulation-boundary.test.js
+++ b/apps/cli/tests/db-encapsulation-boundary.test.js
@@ -4,9 +4,13 @@ import { describe, expect, test } from "bun:test";
 
 const repoRoot = resolve(import.meta.dir, "../../..");
 const cliSrcRoot = resolve(repoRoot, "apps/cli/src");
-// buildInlineChatWorkflow carved the inline auto-hijacked chat/tutorial
-// workflow (and its workspace sqlite open) out of index.js.
-const allowedDirectDatabaseOpeners = new Set(["apps/cli/src/openInlineWorkflowStore.js"]);
+// Empty since #1577: `openInlineWorkflowStore` — the last direct opener, carved
+// out of index.js with the inline auto-hijacked chat/tutorial workflow — now
+// acquires through `@smthrs/db/sqliteConnectionRegistry` like every other
+// in-process open, so the CLI holds no `new Database(` of its own. Keep the set
+// so a future entry point has somewhere to be declared, and keep it empty until
+// one genuinely needs to bypass the registry.
+const allowedDirectDatabaseOpeners = new Set([]);
 
 function repoRelative(path) {
   return relative(repoRoot, path).split(sep).join("/");

--- a/packages/db/src/openDurableSqliteDatabase.js
+++ b/packages/db/src/openDurableSqliteDatabase.js
@@ -1,9 +1,15 @@
-import { loadBunSqliteDatabase, loadBunSqliteDrizzle } from "./bunSqliteRuntime.js";
+import { loadBunSqliteDrizzle } from "./bunSqliteRuntime.js";
+import { acquireSqliteConnection } from "./sqliteConnectionRegistry.js";
 
 /**
  * Open the standard durable local SQLite connection used by Smithers sidecars.
  * Keeping the raw constructor in the DB package preserves the repository's
  * storage ownership boundary.
+ *
+ * Routed through {@link acquireSqliteConnection} so a process that already has
+ * this file open reuses that connection instead of adding a second one; a
+ * second synchronous `bun:sqlite` handle on one file wedges the event loop for
+ * the whole `busy_timeout` as soon as the two contend.
  *
  * Requires Bun. Callers that must also run on Node route around this: see
  * `attachMemoryBackend` in `smthrs/src/openSmithersBackend.js`.
@@ -11,18 +17,25 @@ import { loadBunSqliteDatabase, loadBunSqliteDrizzle } from "./bunSqliteRuntime.
  * @param {string} path
  */
 export function openDurableSqliteDatabase(path) {
-  const Database = loadBunSqliteDatabase();
   const drizzle = loadBunSqliteDrizzle();
-  const sqlite = new Database(path);
-  // busy_timeout must precede the journal_mode change: switching journal modes
-  // takes locks, and with no busy_timeout a contended open fails SQLITE_BUSY.
-  sqlite.run("PRAGMA busy_timeout = 30000");
-  sqlite.run("PRAGMA journal_mode = WAL");
-  sqlite.run("PRAGMA synchronous = NORMAL");
-  sqlite.run("PRAGMA locking_mode = NORMAL");
-  sqlite.run("PRAGMA foreign_keys = ON");
+  const sqlite = acquireSqliteConnection(path, {
+    configure: (connection) => {
+      // busy_timeout must precede the journal_mode change: switching journal modes
+      // takes locks, and with no busy_timeout a contended open fails SQLITE_BUSY.
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run("PRAGMA journal_mode = WAL");
+      connection.run("PRAGMA synchronous = NORMAL");
+      connection.run("PRAGMA locking_mode = NORMAL");
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
+  let released = false;
   return {
     db: drizzle(sqlite),
-    close: () => sqlite.close(),
+    close: () => {
+      if (released) return;
+      released = true;
+      sqlite.close();
+    },
   };
 }

--- a/packages/db/src/sqliteConnectionRegistry.js
+++ b/packages/db/src/sqliteConnectionRegistry.js
@@ -1,0 +1,191 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { loadBunSqliteDatabase } from "./bunSqliteRuntime.js";
+
+/**
+ * Process-wide, refcounted `bun:sqlite` connections keyed by resolved absolute
+ * path, so one process holds exactly ONE connection per database file.
+ *
+ * Why this has to exist: `bun:sqlite` is synchronous. When two connections in
+ * the same process point at one file and the first holds the WAL write lock
+ * across an `await`, the second one's write blocks the whole event loop inside
+ * `sqlite3_step` for the entire `busy_timeout` (30s here). Nothing else can run
+ * — including the very continuation that would commit and release the first
+ * transaction — so the lock cannot clear and the wait always runs to timeout,
+ * surfacing as SQLITE_BUSY / SQLITE_PROTOCOL ("locking protocol"). Lease
+ * heartbeats, timers, and HTTP handlers all die for the duration. Two
+ * connections to the same file in one process are never worth the risk: SQLite
+ * serializes statements on a shared connection instead, and the adapter's
+ * per-client transaction coordination (see `sqliteTransactionStateByClient` in
+ * `adapter.js`) already queues concurrent fibers behind an open transaction.
+ *
+ * Refcounted so existing close semantics keep working: every acquirer still
+ * calls `close()` exactly as before (including `Gateway.close()` using it as an
+ * I/O barrier); the underlying `sqlite3_close()` happens when the last acquirer
+ * releases.
+ */
+
+/** @typedef {import("bun:sqlite").Database} Database */
+/** @typedef {{ sqlite: Database; refs: number; realClose: (...args: unknown[]) => unknown }} RegistryEntry */
+
+// pnpm workspaces plus Bun's module graph can evaluate this module more than
+// once in a single process (a different resolved specifier for `@smthrs/db`
+// yields a separate module instance). A module-scoped Map would then hand out
+// one connection per copy and reintroduce exactly the wedge above, so anchor
+// the table on a well-known global symbol instead.
+const REGISTRY_SYMBOL = Symbol.for("@smthrs/db/sqliteConnectionRegistry");
+
+/** @returns {Map<string, RegistryEntry>} */
+function getRegistry() {
+  const host = /** @type {Record<symbol, unknown>} */ (globalThis);
+  let registry = /** @type {Map<string, RegistryEntry> | undefined} */ (host[REGISTRY_SYMBOL]);
+  if (!registry) {
+    registry = new Map();
+    Object.defineProperty(host, REGISTRY_SYMBOL, {
+      configurable: true,
+      enumerable: false,
+      writable: false,
+      value: registry,
+    });
+  }
+  return registry;
+}
+
+/**
+ * The registry key for a filename, or `null` when the database must NOT be
+ * shared. In-memory databases are private per connection — `:memory:` opened
+ * twice is two unrelated databases, and sharing them would silently merge
+ * unrelated state. A `file:` URI can request the same thing through query
+ * parameters, so those are left unshared rather than parsed.
+ *
+ * @param {unknown} filename
+ * @returns {string | null}
+ */
+export function sqliteShareKey(filename) {
+  if (typeof filename !== "string") return null;
+  const trimmed = filename.trim();
+  if (trimmed === "" || trimmed === ":memory:") return null;
+  if (trimmed.startsWith("file:")) return null;
+  return resolve(trimmed);
+}
+
+/**
+ * Whether a registry entry may still be handed to a new acquirer for `key`.
+ * Two ways it goes stale in a long-lived process:
+ *
+ *  - the file was deleted and a caller now wants a *new* database at the same
+ *    path (test suites delete their temp db between cases). Handing back the
+ *    connection to the deleted inode would silently write to a ghost file.
+ *  - the handle was closed out from under the registry (`Database.prototype.close`
+ *    called directly, bypassing the refcounted override).
+ *
+ * Either way the entry is evicted; the existing owner keeps its handle and its
+ * own release path, so eviction never closes a connection someone still holds.
+ *
+ * @param {string} key
+ * @param {RegistryEntry} entry
+ * @returns {boolean}
+ */
+function isEntryReusable(key, entry) {
+  if (!existsSync(key)) return false;
+  try {
+    entry.sqlite.run("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Acquire the process's connection for `filename`, opening it if this is the
+ * first acquirer. The returned handle is a normal `bun:sqlite` Database whose
+ * `close()` releases one reference; the real close runs at zero. Each acquire
+ * must therefore be paired with exactly ONE close — every wrapper around this
+ * function makes its own `close()`/`cleanup()` idempotent so a caller that
+ * closes twice cannot drop a reference it does not own.
+ *
+ * `configure` runs ONLY when this call actually opens the connection, for two
+ * reasons. Re-applying a later acquirer's pragmas would silently reconfigure a
+ * connection an earlier owner is already using (a read path's
+ * `wal_autocheckpoint = 0`, a probe's deliberately short `busy_timeout`), and
+ * `journal_mode` cannot be set at all while any holder has a transaction open.
+ * Callers therefore keep their pragma set narrow enough to be a safe baseline
+ * for whoever comes second.
+ *
+ * @param {string} filename
+ * @param {{ configure?: (sqlite: Database) => void }} [opts]
+ * @returns {Database}
+ */
+export function acquireSqliteConnection(filename, opts = {}) {
+  const Database = loadBunSqliteDatabase();
+  const key = sqliteShareKey(filename);
+  if (key === null) {
+    const sqlite = new Database(filename);
+    opts.configure?.(sqlite);
+    return sqlite;
+  }
+
+  const registry = getRegistry();
+  const existing = registry.get(key);
+  if (existing) {
+    if (isEntryReusable(key, existing)) {
+      existing.refs += 1;
+      return existing.sqlite;
+    }
+    registry.delete(key);
+  }
+
+  const sqlite = new Database(filename);
+  /** @type {RegistryEntry} */
+  const entry = {
+    sqlite,
+    refs: 1,
+    realClose: (...args) => Database.prototype.close.apply(sqlite, /** @type {[]} */ (args)),
+  };
+  Object.defineProperty(sqlite, "close", {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: (...args) => releaseEntry(key, entry, args),
+  });
+  registry.set(key, entry);
+  try {
+    opts.configure?.(sqlite);
+  } catch (error) {
+    entry.refs = 1;
+    sqlite.close();
+    throw error;
+  }
+  return sqlite;
+}
+
+/**
+ * @param {string} key
+ * @param {RegistryEntry} entry
+ * @param {unknown[]} args
+ */
+function releaseEntry(key, entry, args) {
+  // A holder that closes twice must not release someone else's reference, and
+  // must not re-close an already-closed handle. Callers pair one acquire with
+  // one release; anything past zero is a no-op.
+  if (entry.refs <= 0) return undefined;
+  entry.refs -= 1;
+  if (entry.refs > 0) return undefined;
+  entry.refs = 0;
+  const registry = getRegistry();
+  if (registry.get(key) === entry) registry.delete(key);
+  return entry.realClose(...args);
+}
+
+/**
+ * Live reference count for a database file. Diagnostics and regression tests
+ * only — production code should acquire and release instead.
+ *
+ * @param {string} filename
+ * @returns {number}
+ */
+export function sqliteConnectionRefCount(filename) {
+  const key = sqliteShareKey(filename);
+  if (key === null) return 0;
+  return getRegistry().get(key)?.refs ?? 0;
+}

--- a/packages/db/tests/sqlite-connection-registry.test.js
+++ b/packages/db/tests/sqlite-connection-registry.test.js
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openDurableSqliteDatabase } from "@smthrs/db/openDurableSqliteDatabase";
+import { acquireSqliteConnection, sqliteConnectionRefCount, sqliteShareKey } from "@smthrs/db/sqliteConnectionRegistry";
+
+/** @type {(() => void)[]} */
+const cleanups = [];
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    try {
+      cleanup();
+    } catch {
+      // best-effort teardown
+    }
+  }
+});
+
+function makeDbPath(name) {
+  const dir = mkdtempSync(join(tmpdir(), `smithers-registry-${name}-`));
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return join(dir, "smithers.db");
+}
+
+describe("sqlite connection registry", () => {
+  test("a second in-process open of the same file reuses one connection", () => {
+    const dbPath = makeDbPath("share");
+    const first = openDurableSqliteDatabase(dbPath);
+    cleanups.push(first.close);
+    const second = openDurableSqliteDatabase(dbPath);
+    cleanups.push(second.close);
+
+    expect(second.db.$client).toBe(first.db.$client);
+    expect(sqliteConnectionRefCount(dbPath)).toBe(2);
+  });
+
+  test("a write from a second opener does not wedge on the first opener's transaction", async () => {
+    // Regression test for issue #1577. `bun:sqlite` is synchronous: with two
+    // connections on one file, a write issued while the other connection holds
+    // the WAL write lock blocks the whole event loop inside sqlite3_step for the
+    // entire 30s busy_timeout. Nothing can run during that block -- including
+    // the continuation that would COMMIT and release the lock -- so the wait
+    // always runs to timeout and fails with SQLITE_BUSY / SQLITE_PROTOCOL,
+    // taking every timer, lease heartbeat and HTTP handler down with it.
+    const dbPath = makeDbPath("wedge");
+    const writer = openDurableSqliteDatabase(dbPath);
+    cleanups.push(writer.close);
+    const writerClient = writer.db.$client;
+    writerClient.run(`CREATE TABLE IF NOT EXISTS t (k TEXT PRIMARY KEY, v TEXT)`);
+
+    // A second component opens the same store while the first holds a write
+    // transaction open across an await, exactly as the gateway's detached
+    // recovery/poller jobs do against a running workflow's database.
+    writerClient.run("BEGIN IMMEDIATE");
+    writerClient.run(`INSERT OR REPLACE INTO t VALUES ('held', '1')`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const second = openDurableSqliteDatabase(dbPath);
+    cleanups.push(second.close);
+    const startedAt = Date.now();
+    second.db.$client.run(`INSERT OR REPLACE INTO t VALUES ('other', '2')`);
+    const elapsedMs = Date.now() - startedAt;
+    writerClient.run("COMMIT");
+
+    // With two connections this took the full busy_timeout (30_000ms) and then
+    // threw; with one shared connection the write simply joins the open turn.
+    expect(elapsedMs).toBeLessThan(1_000);
+    expect(writerClient.query(`SELECT v FROM t WHERE k = 'other'`).get()?.v).toBe("2");
+  });
+
+  test("close is refcounted: the file closes only when the last holder releases", () => {
+    const dbPath = makeDbPath("refcount");
+    const first = openDurableSqliteDatabase(dbPath);
+    const second = openDurableSqliteDatabase(dbPath);
+    const client = first.db.$client;
+    client.run(`CREATE TABLE IF NOT EXISTS t (k TEXT PRIMARY KEY)`);
+
+    first.close();
+    expect(sqliteConnectionRefCount(dbPath)).toBe(1);
+    // Still usable: the underlying sqlite3 handle must not have been closed.
+    expect(() => client.run(`INSERT OR REPLACE INTO t VALUES ('a')`)).not.toThrow();
+
+    second.close();
+    expect(sqliteConnectionRefCount(dbPath)).toBe(0);
+    expect(() => client.run(`SELECT 1`)).toThrow();
+  });
+
+  test("a repeated close from one holder cannot close the file under another", () => {
+    const dbPath = makeDbPath("double-close");
+    const first = openDurableSqliteDatabase(dbPath);
+    const second = openDurableSqliteDatabase(dbPath);
+    cleanups.push(second.close);
+
+    // Each acquire pairs with exactly one release; every wrapper around the
+    // registry makes its own `close()` idempotent, so a caller that closes
+    // twice cannot drop a reference it does not own.
+    first.close();
+    first.close();
+    expect(sqliteConnectionRefCount(dbPath)).toBe(1);
+    expect(() => second.db.$client.run(`SELECT 1`)).not.toThrow();
+  });
+
+  test("in-memory databases are never shared", () => {
+    expect(sqliteShareKey(":memory:")).toBeNull();
+    expect(sqliteShareKey("")).toBeNull();
+    expect(sqliteShareKey("file:x?mode=memory")).toBeNull();
+    expect(sqliteShareKey("relative.db")).toBe(join(process.cwd(), "relative.db"));
+
+    const first = acquireSqliteConnection(":memory:");
+    const second = acquireSqliteConnection(":memory:");
+    cleanups.push(() => first.close());
+    cleanups.push(() => second.close());
+    expect(second).not.toBe(first);
+  });
+
+  test("a database file deleted under the registry is not handed to the next opener", () => {
+    const dbPath = makeDbPath("deleted");
+    const first = openDurableSqliteDatabase(dbPath);
+    cleanups.push(first.close);
+    first.db.$client.run(`CREATE TABLE IF NOT EXISTS t (k TEXT PRIMARY KEY)`);
+
+    for (const suffix of ["", "-wal", "-shm"]) rmSync(`${dbPath}${suffix}`, { force: true });
+    expect(existsSync(dbPath)).toBe(false);
+
+    const second = openDurableSqliteDatabase(dbPath);
+    cleanups.push(second.close);
+    expect(second.db.$client).not.toBe(first.db.$client);
+    // The evicted holder keeps a working handle; eviction must not close it.
+    expect(() => first.db.$client.run(`SELECT 1`)).not.toThrow();
+  });
+});

--- a/packages/engine/src/effect/builder.js
+++ b/packages/engine/src/effect/builder.js
@@ -1,16 +1,11 @@
 import { createRequire } from "node:module";
 
-// bun:sqlite is Bun-only, and createBuilderDb (the only user) runs only on the
+// drizzle-orm/bun-sqlite is Bun-only, and createBuilderDb (the only user) runs only on the
 // Bun sqlite path. Load it lazily via createRequire (which stays synchronous, so
 // createBuilderDb keeps its sync signature) so this module -- and therefore the
 // engine that transitively imports it -- IMPORTS on Node / V8 isolates, where
 // createBuilderDb is never called. Fixes engine load under a Node serverless host.
 const requireBun = createRequire(import.meta.url);
-/** @type {typeof import("bun:sqlite").Database | undefined} */
-let BunDatabase;
-function loadBunDatabase() {
-  return (BunDatabase ??= requireBun("bun:sqlite").Database);
-}
 /** @type {typeof import("drizzle-orm/bun-sqlite").drizzle | undefined} */
 let bunDrizzle;
 function loadBunDrizzle() {
@@ -21,6 +16,7 @@ import { Context, Duration, Effect, Layer, Result, Schedule, Schema, SchemaParse
 import { integer, primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import React from "react";
 import { SmithersDb } from "@smthrs/db/adapter";
+import { acquireSqliteConnection } from "@smthrs/db/sqliteConnectionRegistry";
 import { runWorkflow } from "../engine.js";
 import { ignoreSyncError } from "@smthrs/driver/interop";
 import { requireTaskRuntime } from "@smthrs/driver/task-runtime";
@@ -700,19 +696,26 @@ function createInputTable() {
  * @param {BuilderStepHandle[]} handles
  */
 function createBuilderDb(filename, handles) {
-  const Database = loadBunDatabase();
-  const sqlite = new Database(filename);
-  sqlite.run("PRAGMA journal_mode = WAL");
-  // 30s timeout: concurrent worktrees each spawn agent processes that all write
-  // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
-  // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
-  sqlite.run("PRAGMA busy_timeout = 30000");
-  // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
-  // stalls that contribute to WAL checkpoint contention across processes.
-  sqlite.run("PRAGMA synchronous = NORMAL");
-  // Ensure no exclusive lock is held, allowing multiple readers/writers.
-  sqlite.run("PRAGMA locking_mode = NORMAL");
-  sqlite.run("PRAGMA foreign_keys = ON");
+  // One connection per database file per process; see `acquireSqliteConnection`.
+  // A builder run inside a host that already holds this store open would
+  // otherwise add a second synchronous handle and block the event loop for the
+  // full busy_timeout the first time the two contend.
+  const sqlite = acquireSqliteConnection(filename, {
+    configure: (connection) => {
+      // 30s timeout: concurrent worktrees each spawn agent processes that all write
+      // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
+      // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
+      // Must precede the journal_mode change: switching journal modes takes locks.
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run("PRAGMA journal_mode = WAL");
+      // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
+      // stalls that contribute to WAL checkpoint contention across processes.
+      connection.run("PRAGMA synchronous = NORMAL");
+      // Ensure no exclusive lock is held, allowing multiple readers/writers.
+      connection.run("PRAGMA locking_mode = NORMAL");
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
   sqlite.run(`CREATE TABLE IF NOT EXISTS "input" (run_id TEXT PRIMARY KEY, payload TEXT)`);
   for (const handle of handles) {
     sqlite.run(

--- a/packages/smithers/src/create.js
+++ b/packages/smithers/src/create.js
@@ -5,7 +5,8 @@
  */
 // @smithers-type-exports-end
 
-import { loadBunSqliteDatabase, loadBunSqliteDrizzle } from "@smthrs/db/bunSqliteRuntime";
+import { loadBunSqliteDrizzle } from "@smthrs/db/bunSqliteRuntime";
+import { acquireSqliteConnection } from "@smthrs/db/sqliteConnectionRegistry";
 import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import React from "react";
 import { createSmithersContext, SmithersContext as GlobalSmithersContext } from "@smthrs/react-reconciler/context";
@@ -436,22 +437,28 @@ export function createSmithers(schemas, opts) {
   // 1. Generate Drizzle tables + schema metadata from Zod schemas.
   const { tables, drizzleSchema, schemaRegistry, outputs, zodToKeyName, ambiguousZodSchemas } =
     prepareSmithersTables(schemas);
-  // 2. Create SQLite db
-  const Database = loadBunSqliteDatabase();
-  const sqlite = new Database(dbPath);
-  // 30s timeout: concurrent worktrees each spawn agent processes that all write
-  // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
-  // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
-  // Must be set before the journal_mode change: switching journal modes takes
-  // locks, and with no busy_timeout a contended open fails with SQLITE_BUSY.
-  sqlite.run("PRAGMA busy_timeout = 30000");
-  sqlite.run(`PRAGMA journal_mode = ${opts?.journalMode ?? "WAL"}`);
-  // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
-  // stalls that contribute to WAL checkpoint contention across processes.
-  sqlite.run("PRAGMA synchronous = NORMAL");
-  // Ensure no exclusive lock is held, allowing multiple readers/writers.
-  sqlite.run("PRAGMA locking_mode = NORMAL");
-  sqlite.run("PRAGMA foreign_keys = ON");
+  // 2. Create SQLite db. `acquireSqliteConnection` keeps this process to ONE
+  // connection per database file: `bun:sqlite` is synchronous, so a second
+  // handle on the same file blocks the event loop inside sqlite3_step for the
+  // full busy_timeout the moment the two contend, and the blocked loop is what
+  // would have committed and released the first transaction.
+  const sqlite = acquireSqliteConnection(dbPath, {
+    configure: (connection) => {
+      // 30s timeout: concurrent worktrees each spawn agent processes that all write
+      // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
+      // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
+      // Must be set before the journal_mode change: switching journal modes takes
+      // locks, and with no busy_timeout a contended open fails with SQLITE_BUSY.
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run(`PRAGMA journal_mode = ${opts?.journalMode ?? "WAL"}`);
+      // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
+      // stalls that contribute to WAL checkpoint contention across processes.
+      connection.run("PRAGMA synchronous = NORMAL");
+      // Ensure no exclusive lock is held, allowing multiple readers/writers.
+      connection.run("PRAGMA locking_mode = NORMAL");
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
   // Register a process-exit hook to explicitly close the Database.
   // bun:sqlite's GC finalizer calls sqlite3_close() which fatally aborts if
   // Drizzle's cached prepared statements haven't been finalized first.

--- a/packages/smithers/src/external/create-external-smithers.js
+++ b/packages/smithers/src/external/create-external-smithers.js
@@ -8,7 +8,8 @@
 // @smithers-type-exports-end
 
 import React from "react";
-import { loadBunSqliteDatabase, loadBunSqliteDrizzle } from "@smthrs/db/bunSqliteRuntime";
+import { loadBunSqliteDrizzle } from "@smthrs/db/bunSqliteRuntime";
+import { acquireSqliteConnection } from "@smthrs/db/sqliteConnectionRegistry";
 import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { zodToTable } from "@smthrs/db/zodToTable";
 import { syncZodTableSchema } from "@smthrs/db/zodToCreateTableSQL";
@@ -82,19 +83,23 @@ export function createExternalSmithers(config) {
   const dbPath = config.dbPath
     ? resolve(config.dbPath)
     : join(mkdtempSync(join(tmpdir(), "smithers-ext-")), "smithers.db");
-  const Database = loadBunSqliteDatabase();
-  const sqlite = new Database(dbPath);
-  sqlite.run("PRAGMA journal_mode = WAL");
-  // 30s timeout: concurrent worktrees each spawn agent processes that all write
-  // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
-  // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
-  sqlite.run("PRAGMA busy_timeout = 30000");
-  // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
-  // stalls that contribute to WAL checkpoint contention across processes.
-  sqlite.run("PRAGMA synchronous = NORMAL");
-  // Ensure no exclusive lock is held, allowing multiple readers/writers.
-  sqlite.run("PRAGMA locking_mode = NORMAL");
-  sqlite.run("PRAGMA foreign_keys = ON");
+  // One connection per database file per process; see `acquireSqliteConnection`.
+  const sqlite = acquireSqliteConnection(dbPath, {
+    configure: (connection) => {
+      // 30s timeout: concurrent worktrees each spawn agent processes that all write
+      // to smithers.db simultaneously. 5s is too short and causes SQLITE_IOERR_VNODE
+      // on macOS when the VFS can't acquire the WAL shared-memory lock in time.
+      // Must precede the journal_mode change: switching journal modes takes locks.
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run("PRAGMA journal_mode = WAL");
+      // NORMAL is safe in WAL mode (no data loss on crash) and reduces fsync
+      // stalls that contribute to WAL checkpoint contention across processes.
+      connection.run("PRAGMA synchronous = NORMAL");
+      // Ensure no exclusive lock is held, allowing multiple readers/writers.
+      connection.run("PRAGMA locking_mode = NORMAL");
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
   let dbClosed = false;
   const closeDb = () => {
     if (dbClosed) return;

--- a/packages/smithers/src/openSmithersStore.js
+++ b/packages/smithers/src/openSmithersStore.js
@@ -15,35 +15,50 @@ const RUNS_TABLE_PROBE_BUSY_TIMEOUT_MS = 500;
 const RUNS_TABLE_PROBE_MAX_ATTEMPTS = 3;
 
 async function openSqliteStore(dbPath, opts = {}) {
-  const { Database } = await import("bun:sqlite");
+  const { acquireSqliteConnection } = await import("@smthrs/db/sqliteConnectionRegistry");
   const { drizzle } = await import("drizzle-orm/bun-sqlite");
-  const sqlite = new Database(dbPath);
+  // Read mode executes NO DDL: a `smithers ps` must not mutate the store
+  // (spec: singleton-gateway.md decision 9). A store written by an older
+  // smithers that lacks a newer table fails loud on the query instead of
+  // being silently upgraded by a passing reader; any write path (or
+  // `smithers migrate`) brings the schema forward.
+  //
+  // Transient CLI readers (inspect/ps/tui/logs) must NOT disturb the WAL that a
+  // concurrent `smithers up` writer depends on. They can't use {readonly:true}
+  // (SQLite can't read a WAL db read-only — it needs write access to the -shm
+  // wal-index to register as a reader, so a read-only handle would miss all
+  // un-checkpointed WAL data). Instead, disable THIS connection's auto- and
+  // close-time checkpointing so it never truncates the shared WAL/-shm out from
+  // under the live writer (the writer owns checkpointing). This is what curbs
+  // the SQLITE_IOERR_VNODE churn on macOS without breaking WAL visibility.
+  // busy_timeout lets a brief writer lock clear instead of erroring immediately.
+  //
+  // Both pragmas are connection-scoped, so they only apply when this call is
+  // what opens the connection. When the process ALREADY holds this store open
+  // (a gateway answering an in-process read), the reader shares that single
+  // connection: no second synchronous handle, so no event-loop-blocking busy
+  // wait, and no separate WAL reader to keep out of the writer's way either.
+  const sqlite = acquireSqliteConnection(dbPath, {
+    configure: (connection) => {
+      if (!opts.read) return;
+      connection.run("PRAGMA busy_timeout = 30000");
+      connection.run("PRAGMA wal_autocheckpoint = 0");
+      // Match the write path's connection baseline so a writer that later
+      // shares this connection still gets foreign-key enforcement.
+      connection.run("PRAGMA foreign_keys = ON");
+    },
+  });
   const db = drizzle(sqlite);
-  if (opts.read) {
-    // Read mode executes NO DDL: a `smithers ps` must not mutate the store
-    // (spec: singleton-gateway.md decision 9). A store written by an older
-    // smithers that lacks a newer table fails loud on the query instead of
-    // being silently upgraded by a passing reader; any write path (or
-    // `smithers migrate`) brings the schema forward.
-    //
-    // Transient CLI readers (inspect/ps/tui/logs) must NOT disturb the WAL that a
-    // concurrent `smithers up` writer depends on. They can't use {readonly:true}
-    // (SQLite can't read a WAL db read-only — it needs write access to the -shm
-    // wal-index to register as a reader, so a read-only handle would miss all
-    // un-checkpointed WAL data). Instead, disable THIS connection's auto- and
-    // close-time checkpointing so it never truncates the shared WAL/-shm out from
-    // under the live writer (the writer owns checkpointing). This is what curbs
-    // the SQLITE_IOERR_VNODE churn on macOS without breaking WAL visibility.
-    // busy_timeout lets a brief writer lock clear instead of erroring immediately.
-    sqlite.run("PRAGMA busy_timeout = 30000");
-    sqlite.run("PRAGMA wal_autocheckpoint = 0");
-  } else {
+  if (!opts.read) {
     ensureSmithersTables(db);
   }
+  let released = false;
   return {
     adapter: new SmithersDb(db),
     db,
     cleanup: () => {
+      if (released) return;
+      released = true;
       try {
         sqlite.close();
       } catch {
@@ -80,12 +95,15 @@ async function sqliteHasRunsTable(dbPath) {
   if (!existsSync(dbPath)) {
     return false;
   }
-  const { Database } = await import("bun:sqlite");
+  const { acquireSqliteConnection } = await import("@smthrs/db/sqliteConnectionRegistry");
   for (let attempt = 1; ; attempt += 1) {
     let sqlite;
     try {
-      sqlite = new Database(dbPath);
-      sqlite.run(`PRAGMA busy_timeout = ${RUNS_TABLE_PROBE_BUSY_TIMEOUT_MS}`);
+      // Reuses the process's existing handle when there is one, so the probe
+      // can never contend with (or block) a writer living in this same process.
+      sqlite = acquireSqliteConnection(dbPath, {
+        configure: (connection) => connection.run(`PRAGMA busy_timeout = ${RUNS_TABLE_PROBE_BUSY_TIMEOUT_MS}`),
+      });
       const row = sqlite.query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = '_smithers_runs'").get();
       return Boolean(row);
     } catch (error) {

--- a/scripts/check-no-direct-db-access.mjs
+++ b/scripts/check-no-direct-db-access.mjs
@@ -16,14 +16,16 @@ const sanctionedSourceRoots = new Set(["packages/db/src", "packages/gateway/src"
 const directDbPattern =
   /new Database\(|new \(loadBunSqliteDatabase\(\)\)\(|new pg\.Client\(|new pg\.Pool\(|PGlite\.create\(/g;
 
+// The bun:sqlite entries here dropped when every in-process sqlite open moved
+// behind `@smthrs/db/sqliteConnectionRegistry` (issue #1577): one refcounted
+// connection per database file per process. What remains in these files is the
+// Postgres/PGlite constructors, which the registry does not cover.
 const allowedDirectDbAccess = new Map([
-  ["packages/engine/src/effect/builder.js", 3],
-  ["packages/smithers/src/openSmithersStore.js", 4],
+  ["packages/engine/src/effect/builder.js", 2],
+  ["packages/smithers/src/openSmithersStore.js", 2],
   ["packages/smithers/src/migrateSmithersStore.js", 7],
   ["packages/smithers/src/resolveSmithersBackendChoice.js", 3],
-  ["packages/smithers/src/create.js", 3],
-  ["packages/smithers/src/external/create-external-smithers.js", 1],
-  ["apps/cli/src/openInlineWorkflowStore.js", 1],
+  ["packages/smithers/src/create.js", 2],
 ]);
 
 /** @param {string} path */


### PR DESCRIPTION
> **Read this first: this PR does _not_ fix #1577.** It is left open for a decision — see "Negative result" below. The `Closes #1577` claim in the original description was wrong and has been removed.

## Negative result

CI shard 3 on this branch still fails the exact same four tests, with the same 30-second-stall signature, with the fix in place:

- `gateway devtools serializer warnings and audit recovery` (both tests)
- `Gateway webhook ingestion > rejects invalid webhook signatures and records rejection metrics`
- `jumpToFrame auth > pause path fails with RewindFailed when task does not terminate within 10s`

So the "two in-process connections to one file" hypothesis in #1577 is **not** the cause, or not the whole cause.

The local Linux-container evidence that pointed the other way does not hold up: running the full `packages/server` suite in an ubuntu container, the unfixed baseline failed the webhook test and the fixed build passed it — but both runs also carried environmental failures (no Chromium in the image) and ran under heavy host load, so that single flip was almost certainly noise rather than signal. I am recording it as a false positive.

## What this branch still contains, on its own merits

A process-wide, refcounted `bun:sqlite` connection registry keyed by resolved absolute path (`@smthrs/db/sqliteConnectionRegistry`), anchored on a `Symbol.for` global so a duplicated module instance cannot hand out a second connection. Every in-process open routes through it: `createSmithers`, `openDurableSqliteDatabase`, `createBuilderDb`, `openSmithersStore`, `create-external-smithers`, `openInlineWorkflowStore`.

`close()` releases one reference and the real `sqlite3_close` runs at zero, so existing close semantics — including `Gateway.close()` as an I/O barrier — keep working; repeated closes from one holder are no-ops. `:memory:` and `file:` URIs are never shared. An entry whose file was deleted, or whose handle was closed behind the registry's back, is evicted rather than reused. Pragmas apply only on the open that actually creates the connection. `scripts/check-no-direct-db-access.mjs` and the CLI boundary test both ratchet down accordingly.

Whether that invariant is worth having independently of #1577 is the maintainer's call. It is a real tightening (one connection per file per process is a defensible rule on its own), but it touches every SQLite open path, so it should not land just because it is written.

## Gates

`packages/db` 817 pass · `packages/smithers` 333 pass · `packages/engine` pass · `packages/server` `server.test.js` + `gateway-pty-hijack.test.jsx` 58 pass · new `packages/db/tests/sqlite-connection-registry.test.js` 6 pass · `check-no-direct-db-access` · `pnpm lint` · `pnpm format:check` · per-package typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)