### PR TITLE
feat(cli): complete the monitor's loading, empty, and error states

### DIFF
--- a/apps/cli/src/monitor-ui/monitor.tsx
+++ b/apps/cli/src/monitor-ui/monitor.tsx
@@ -87,7 +87,9 @@ import {
   diagnoseRun,
   diffPatchesOf,
   diffSummaryOf,
+  eventLogViewState,
   eventViewFor,
+  executionTreeViewState,
   filterRuns,
   formatDiffSummary,
   formatDurationMs,
@@ -115,6 +117,7 @@ import {
   nodeAttemptHistoryRowsOf,
   nodeAttemptHistoryView,
   nodeErrorOf,
+  nodeOutputViewState,
   nodeStateRowsOf,
   nodeSummaryEligible,
   nodeTimingsOf,
@@ -130,7 +133,6 @@ import {
   runProgress,
   runsLandingState,
   runUsageChipOf,
-  runsViewState,
   RUNS_PAGE_SIZE,
   scoreRowsOf,
   scoresForNode,
@@ -158,7 +160,9 @@ import {
   type PromScrape,
   type RunRow,
   type MonitorConnectionStatus,
+  type RunsLandingState,
   type RunsTableSort,
+  type RunsViewState,
   type ScoreRow,
   type Tone,
   type TreeNodeLike,
@@ -683,6 +687,17 @@ function RunListRow({
   );
 }
 
+/**
+ * The runs-list zero states the surfaces share: the ordinary
+ * loading/error/filtered/empty classification plus "connecting", the transport
+ * state that must never be reported as "no runs yet" — nothing has arrived, so
+ * emptiness is a claim the client cannot back.
+ */
+type RunsZeroStateKind = Exclude<RunsViewState, "ready"> | "connecting";
+
+/** Landing states the rail answers with a zero state rather than a banner. */
+const RAIL_ZERO_STATES = new Set<RunsLandingState>(["loading", "error", "empty", "filtered", "connecting"]);
+
 function RunsZeroState({
   state,
   testId,
@@ -692,7 +707,7 @@ function RunsZeroState({
   onResetFilters,
   onRetry,
 }: {
-  state: Exclude<ReturnType<typeof runsViewState>, "ready">;
+  state: RunsZeroStateKind;
   testId: string;
   hero?: boolean;
   totalCount: number;
@@ -711,6 +726,20 @@ function RunsZeroState({
           </Button>
         ) : null}
       </Alert>
+    );
+  }
+  if (state === "connecting") {
+    return (
+      <EmptyState
+        className={hero ? "mon-empty-hero" : undefined}
+        data-testid={testId}
+        data-state={state}
+        role="status"
+        title="Connecting to the Smithers gateway…"
+        description="Runs will appear after the first successful response."
+      >
+        <Skeleton className="mon-state-skeleton" />
+      </EmptyState>
     );
   }
   if (state === "loading") {
@@ -788,12 +817,20 @@ export function RunsRail({
   const banner = connection.banner;
   const lastKnown = connStatus === "offline" && runs.length > 0;
   const blocked = connStatus === "unauthorized";
-  const zeroState = runsViewState({
+  // Transport-aware: a rail deep-linked into a run must not answer "No runs
+  // yet" while the socket is still opening (runsLandingState's contract).
+  const landingState = runsLandingState({
     visibleCount: runs.length,
     totalCount,
     loading,
     queryError: queryError !== undefined,
+    connectionStatus: connStatus,
   });
+  // Offline and unauthorized states already render `banner`, which owns the
+  // surface; everything else that is not "ready" earns a zero state.
+  const zeroState: RunsZeroStateKind | null = RAIL_ZERO_STATES.has(landingState)
+    ? (landingState as RunsZeroStateKind)
+    : null;
   return (
     <nav className="mon-rail-runs" data-testid="monitor-runs">
       {banner ? (
@@ -804,7 +841,7 @@ export function RunsRail({
           <AlertDescription>{lastKnown && connection.hint ? connection.hint : banner.detail}</AlertDescription>
         </Alert>
       ) : null}
-      {!banner && zeroState !== "ready" ? (
+      {!banner && zeroState ? (
         <RunsZeroState
           state={zeroState}
           testId="monitor-empty"
@@ -814,7 +851,7 @@ export function RunsRail({
           onRetry={onRetry}
         />
       ) : null}
-      {queryError && zeroState === "ready" && !banner ? (
+      {queryError && !zeroState && !banner ? (
         <Alert variant="destructive" data-testid="monitor-runs-query-error">
           <AlertTitle>Couldn&apos;t refresh runs.</AlertTitle>
           <AlertDescription>{queryError.message}</AlertDescription>
@@ -1613,20 +1650,6 @@ export function RunsTable({
     connectionStatus: connStatus,
     hasCachedData,
   });
-  if (landingState === "connecting") {
-    return (
-      <EmptyState
-        className="mon-empty-hero"
-        data-testid="monitor-empty-detail"
-        data-state={landingState}
-        role="status"
-        title="Connecting to the Smithers gateway…"
-        description="Runs will appear after the first successful response."
-      >
-        <Skeleton className="mon-state-skeleton" />
-      </EmptyState>
-    );
-  }
   if (landingState === "offline-without-cache") {
     return (
       <Alert
@@ -2418,11 +2441,19 @@ export function ExecutionTree({
     event.preventDefault();
     if (nextKey) setFocusedKey(nextKey);
   };
-  if (!isStatic && error) {
+  const treeState = executionTreeViewState({
+    hasRoot: root !== null && root !== undefined,
+    loading: isLoading,
+    queryError: error !== undefined,
+    isStatic,
+    frameLoading,
+    frameError: frameError !== undefined,
+  });
+  if (treeState === "error") {
     return (
       <Alert variant="destructive" data-testid="monitor-tree-error">
         <AlertTitle>Failed to load the execution tree.</AlertTitle>
-        <AlertDescription>{error.message}</AlertDescription>
+        <AlertDescription>{error?.message ?? "The execution tree query failed."}</AlertDescription>
         {onRetry ? (
           <div className="mon-empty-actions">
             <Chip data-testid="monitor-tree-retry" onClick={onRetry}>
@@ -2433,46 +2464,72 @@ export function ExecutionTree({
       </Alert>
     );
   }
-  if (!isStatic && isLoading) {
+  if (treeState === "loading") {
     return (
-      <EmptyState data-testid="monitor-tree-loading" role="status" title="Loading execution tree…">
+      <EmptyState
+        data-testid="monitor-tree-loading"
+        data-state={treeState}
+        role="status"
+        title="Loading execution tree…"
+        description="Reading this run's nodes from the gateway."
+      >
         <Skeleton className="mon-state-skeleton" />
       </EmptyState>
     );
   }
-  if (!root) {
-    if (frameLoading) {
-      return (
-        <EmptyState data-testid="monitor-frame-loading" role="status" title="Loading frame…">
-          <Skeleton className="mon-state-skeleton" />
-        </EmptyState>
-      );
-    }
-    if (frameError) {
-      return (
-        <Alert variant="destructive" data-testid="monitor-frame-unavailable">
-          <AlertTitle>Frame unavailable.</AlertTitle>
-          <AlertDescription>{frameError.message}</AlertDescription>
-          <div className="mon-empty-actions">
-            {frameOverride?.onRetry ? (
-              <Chip data-testid="monitor-frame-retry" onClick={frameOverride.onRetry}>
-                Retry
-              </Chip>
-            ) : null}
-            {frameOverride?.onReturnToLive ? (
-              <Chip data-testid="monitor-frame-live" onClick={frameOverride.onReturnToLive}>
-                Return to live
-              </Chip>
-            ) : null}
-          </div>
-        </Alert>
-      );
-    }
+  if (treeState === "frame-loading") {
     return (
       <EmptyState
-        data-testid={isStatic ? "monitor-frame-empty" : "monitor-tree-empty"}
-        data-state="empty"
-        title={isStatic ? "No nodes in this frame." : "No nodes recorded yet."}
+        data-testid="monitor-frame-loading"
+        data-state={treeState}
+        role="status"
+        title="Loading frame…"
+        description="Rebuilding the execution tree at this point in the run's history."
+      >
+        <Skeleton className="mon-state-skeleton" />
+      </EmptyState>
+    );
+  }
+  if (treeState === "frame-error") {
+    return (
+      <Alert variant="destructive" data-testid="monitor-frame-unavailable" data-state={treeState}>
+        <AlertTitle>Frame unavailable.</AlertTitle>
+        <AlertDescription>{frameError?.message ?? "This frame could not be rebuilt."}</AlertDescription>
+        <div className="mon-empty-actions">
+          {frameOverride?.onRetry ? (
+            <Chip data-testid="monitor-frame-retry" onClick={frameOverride.onRetry}>
+              Retry
+            </Chip>
+          ) : null}
+          {frameOverride?.onReturnToLive ? (
+            <Chip data-testid="monitor-frame-live" onClick={frameOverride.onReturnToLive}>
+              Return to live
+            </Chip>
+          ) : null}
+        </div>
+      </Alert>
+    );
+  }
+  // Every other rootless state returned above, so this is settled emptiness.
+  if (!root) {
+    const frame = treeState === "frame-empty";
+    return (
+      <EmptyState
+        data-testid={frame ? "monitor-frame-empty" : "monitor-tree-empty"}
+        data-state={treeState}
+        title={frame ? "No nodes in this frame." : "No nodes recorded yet."}
+        description={
+          frame
+            ? "This point in the run's history is before its first node was scheduled."
+            : "Nodes appear here as the engine schedules this run's work."
+        }
+        action={
+          frame && frameOverride?.onReturnToLive ? (
+            <Chip data-testid="monitor-frame-live" onClick={frameOverride.onReturnToLive}>
+              Return to live
+            </Chip>
+          ) : undefined
+        }
       />
     );
   }
@@ -3289,6 +3346,15 @@ export function EventLog({ runId, eventsState }: { runId: string; eventsState: R
   };
 
   const hasLastKnownEvents = allEvents.length > 0;
+  // One classification for the list: a pending or failed query is never
+  // reported as emptiness, and a buffer hidden by the view chips reads as
+  // "filtered" (with a way back to All) rather than "no events".
+  const listState = eventLogViewState({
+    visibleCount: events.length,
+    totalCount: allEvents.length,
+    loading,
+    queryError: error !== undefined,
+  });
   const errorState =
     connectionStatus === "unauthorized"
       ? "unauthorized"
@@ -3419,23 +3485,39 @@ export function EventLog({ runId, eventsState }: { runId: string; eventsState: R
           aria-atomic={false}
           aria-busy={loading}
         >
-          {events.length === 0 && !error ? (
+          {listState !== "ready" && listState !== "error" ? (
             <li>
               <EmptyState
                 data-testid="monitor-events-state"
-                data-state={loading ? "loading" : allEvents.length === 0 ? "empty" : `filtered-${view}`}
-                role={loading ? "status" : undefined}
+                data-state={listState === "filtered" ? `filtered-${view}` : listState}
+                role={listState === "loading" ? "status" : undefined}
                 title={
-                  loading
+                  listState === "loading"
                     ? "Loading events…"
-                    : allEvents.length === 0
+                    : listState === "empty"
                       ? "No events recorded for this run yet."
                       : view === "notable"
-                        ? "No notable events in this buffer. Switch to Activity or All to inspect other events."
-                        : "No activity events in this buffer. Switch to All to inspect session and heartbeat events."
+                        ? "No notable events in this buffer."
+                        : "No activity events in this buffer."
+                }
+                description={
+                  listState === "loading"
+                    ? "Reading this run's event history from the gateway."
+                    : listState === "empty"
+                      ? "Events stream in here as the engine schedules and runs tasks."
+                      : view === "notable"
+                        ? `Switch to Activity or All to inspect the ${allEvents.length} buffered ${allEvents.length === 1 ? "event" : "events"}.`
+                        : `Switch to All to inspect the ${allEvents.length} buffered session and heartbeat ${allEvents.length === 1 ? "event" : "events"}.`
+                }
+                action={
+                  listState === "filtered" ? (
+                    <Button variant="outline" data-testid="monitor-events-show-all" onClick={() => setView("all")}>
+                      Show all events
+                    </Button>
+                  ) : undefined
                 }
               >
-                {loading ? <Skeleton className="mon-state-skeleton" /> : null}
+                {listState === "loading" ? <Skeleton className="mon-state-skeleton" /> : null}
               </EmptyState>
             </li>
           ) : null}
@@ -4117,6 +4199,14 @@ export function NodeOutputState({
     </Alert>
   ) : null;
 
+  const state = nodeOutputViewState({
+    hasRow: row !== null,
+    loading,
+    queryError: error !== undefined,
+    failed: failure !== null && failure !== undefined,
+    live,
+  });
+  // "ready" is exactly `row !== null`; test the row so it narrows.
   if (row) {
     return (
       <>
@@ -4125,35 +4215,50 @@ export function NodeOutputState({
       </>
     );
   }
-  if (loading) {
+  if (state === "loading") {
     return (
-      <EmptyState data-testid="monitor-output-loading" role="status" title="Loading output…">
+      <EmptyState
+        data-testid="monitor-output-loading"
+        data-state={state}
+        role="status"
+        title="Loading output…"
+        description="Reading this node's structured output from the gateway."
+      >
         <Skeleton className="mon-state-skeleton" />
       </EmptyState>
     );
   }
-  if (errorAlert) return errorAlert;
-  if (failure) {
+  if (state === "error") return errorAlert;
+  if (state === "failed") {
     return (
       <EmptyState
         data-testid="monitor-output-failed"
-        title="The node failed before producing structured output. Failure details are shown above."
+        data-state={state}
+        title="The node failed before producing structured output."
+        description="Failure details are shown above."
       />
     );
   }
-  if (live) {
+  if (state === "live") {
     return (
       <EmptyState
         data-testid="monitor-output-live"
+        data-state={state}
         role="status"
-        title="running — structured output lands here when the node finishes"
+        title="Still running…"
+        description="Structured output lands here when the node finishes."
       >
         <Skeleton className="mon-state-skeleton" />
       </EmptyState>
     );
   }
   return (
-    <EmptyState data-testid="monitor-output-empty" title="This node completed without recording structured output." />
+    <EmptyState
+      data-testid="monitor-output-empty"
+      data-state={state}
+      title="No structured output."
+      description="This node completed without recording structured output."
+    />
   );
 }
 
@@ -5509,7 +5614,7 @@ function App() {
             totalCount={allRuns.length}
             showMetrics={showMetrics}
             onToggleMetrics={() => setShowMetrics((value) => !value)}
-            onRefresh={() => void runsQuery.refetch()}
+            onRefresh={runsQuery.refetch}
           />
         </header>
       ) : null}

--- a/apps/cli/src/monitor-ui/monitorModel.ts
+++ b/apps/cli/src/monitor-ui/monitorModel.ts
@@ -2413,3 +2413,92 @@ export function runsLandingState(input: {
     queryError: input.queryError === true,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Run-detail panel states: event log, execution tree, node output. Each panel
+// classifies the same way the runs list does — an in-flight or failed query is
+// never reported as emptiness — so the view only has to pick copy, never
+// re-derive which state it is in.
+// ---------------------------------------------------------------------------
+
+export type EventLogViewState = "ready" | "loading" | "error" | "empty" | "filtered";
+
+/**
+ * Classify the event list. "filtered" means the buffer holds events the active
+ * Notable/Activity view hides — the panel owes a way back to All rather than a
+ * bare "no events". A failed query outranks loading here (unlike the runs list)
+ * because the panel's error alert already owns the surface and reporting
+ * emptiness underneath it would be a second, contradictory claim.
+ */
+export function eventLogViewState(options: {
+  visibleCount: number;
+  totalCount: number;
+  loading: boolean;
+  queryError: boolean;
+}): EventLogViewState {
+  if (options.visibleCount > 0) return "ready";
+  if (options.queryError) return "error";
+  if (options.loading) return "loading";
+  if (options.totalCount > 0) return "filtered";
+  return "empty";
+}
+
+export type ExecutionTreeViewState =
+  | "ready"
+  | "loading"
+  | "error"
+  | "empty"
+  | "frame-loading"
+  | "frame-error"
+  | "frame-empty"
+  | "stale-frame-loading"
+  | "stale-frame-error";
+
+/**
+ * Classify the execution tree, live or scrubbed to a historical frame.
+ *
+ * The frame scrubber overrides the live query, so a live error or live loading
+ * only speaks for the live tree. A frame that is still in flight (or that
+ * failed) keeps the previous frame on screen when there is one — the `stale-*`
+ * states, rendered as a notice above real rows — and owns the panel when there
+ * is nothing to keep. Only a settled query with no root is emptiness, and the
+ * static/live split decides whether that reads as "this frame" or "yet".
+ */
+export function executionTreeViewState(input: {
+  hasRoot: boolean;
+  loading: boolean;
+  queryError: boolean;
+  isStatic: boolean;
+  frameLoading: boolean;
+  frameError: boolean;
+}): ExecutionTreeViewState {
+  if (!input.isStatic && input.queryError) return "error";
+  if (!input.isStatic && input.loading) return "loading";
+  if (input.frameLoading) return input.hasRoot ? "stale-frame-loading" : "frame-loading";
+  if (input.frameError) return input.hasRoot ? "stale-frame-error" : "frame-error";
+  if (!input.hasRoot) return input.isStatic ? "frame-empty" : "empty";
+  return "ready";
+}
+
+export type NodeOutputViewState = "ready" | "loading" | "error" | "failed" | "live" | "empty";
+
+/**
+ * Classify a node's structured output. A row that already arrived wins — a
+ * refetch failure is reported as a banner over real data, never as an empty
+ * panel. "empty" — the node finished and simply recorded nothing — is the last
+ * resort, claimed only once no other state explains the missing row.
+ */
+export function nodeOutputViewState(options: {
+  hasRow: boolean;
+  loading: boolean;
+  queryError: boolean;
+  failed: boolean;
+  live: boolean;
+}): NodeOutputViewState {
+  if (options.hasRow) return "ready";
+  if (options.loading) return "loading";
+  if (options.queryError) return "error";
+  if (options.failed) return "failed";
+  if (options.live) return "live";
+  return "empty";
+}

--- a/apps/cli/src/monitor-ui/monitorShell.tsx
+++ b/apps/cli/src/monitor-ui/monitorShell.tsx
@@ -101,8 +101,20 @@ export function MonitorToolbar({
   totalCount: number;
   showMetrics: boolean;
   onToggleMetrics: () => void;
-  onRefresh: () => void;
+  onRefresh: () => void | Promise<void>;
 }) {
+  // A refetch never flips the runs query back to `loading` (it keeps the rows
+  // it already has), so the only honest place to report one in flight is the
+  // control that started it.
+  const [refreshing, setRefreshing] = useState(false);
+  const refresh = () => {
+    const result = onRefresh();
+    if (!(result instanceof Promise)) return;
+    setRefreshing(true);
+    // A rejected refetch is already reported by the query's own error state;
+    // swallow it here so it cannot surface as an unhandled rejection.
+    void result.finally(() => setRefreshing(false)).catch(() => {});
+  };
   return (
     <div className="mon-toolbar">
       <Input
@@ -140,8 +152,14 @@ export function MonitorToolbar({
       >
         Metrics
       </Chip>
-      <Button variant="outline" onClick={onRefresh}>
-        Refresh
+      <Button
+        variant="outline"
+        data-testid="monitor-refresh"
+        aria-busy={refreshing}
+        disabled={refreshing}
+        onClick={refresh}
+      >
+        {refreshing ? "Refreshing…" : "Refresh"}
       </Button>
     </div>
   );

--- a/apps/cli/tests/monitor-shell-controls.test.tsx
+++ b/apps/cli/tests/monitor-shell-controls.test.tsx
@@ -237,6 +237,45 @@ describe("node inspector output states", () => {
     expect(byTestId("monitor-output-empty").getAttribute("data-slot")).toBe("empty-state");
   });
 
+  test("every missing-output state labels itself and explains what is happening", async () => {
+    // Issue #855: a label alone leaves the operator guessing whether output is
+    // coming, gone, or never existed.
+    await render(nodeOutputState({ loading: true }));
+    expect(byTestId("monitor-output-loading").getAttribute("data-state")).toBe("loading");
+    expect(byTestId("monitor-output-loading").querySelector(".sui-empty-title")?.textContent).toBe("Loading output…");
+    expect(byTestId("monitor-output-loading").querySelector(".sui-empty-description")?.textContent).toContain(
+      "from the gateway",
+    );
+
+    await rerender(nodeOutputState({ live: true }));
+    expect(byTestId("monitor-output-live").getAttribute("data-state")).toBe("live");
+    expect(byTestId("monitor-output-live").querySelector(".sui-empty-title")?.textContent).toBe("Still running…");
+    expect(byTestId("monitor-output-live").querySelector(".sui-empty-description")?.textContent).toContain(
+      "lands here when the node finishes",
+    );
+
+    await rerender(nodeOutputState({ failure: { message: "agent failed" } }));
+    expect(byTestId("monitor-output-failed").getAttribute("data-state")).toBe("failed");
+    expect(byTestId("monitor-output-failed").querySelector(".sui-empty-title")?.textContent).toContain(
+      "failed before producing structured output",
+    );
+    expect(byTestId("monitor-output-failed").querySelector(".sui-empty-description")?.textContent).toBe(
+      "Failure details are shown above.",
+    );
+
+    await rerender(nodeOutputState());
+    expect(byTestId("monitor-output-empty").getAttribute("data-state")).toBe("empty");
+    expect(byTestId("monitor-output-empty").querySelector(".sui-empty-title")?.textContent).toBe(
+      "No structured output.",
+    );
+    expect(byTestId("monitor-output-empty").querySelector(".sui-empty-description")?.textContent).toContain(
+      "completed without recording structured output",
+    );
+    // A settled empty node is not a spinner: no skeleton, no live region.
+    expect(byTestId("monitor-output-empty").querySelector('[data-slot="skeleton"]')).toBeNull();
+    expect(byTestId("monitor-output-empty").getAttribute("role")).toBeNull();
+  });
+
   test("makes output query failures actionable", async () => {
     let retries = 0;
     await render(
@@ -791,11 +830,19 @@ describe("migrated monitor surfaces", () => {
     expect(byTestId("monitor-run-row").getAttribute("data-active")).toBe("true");
     expect(byTestId("monitor-run-row").textContent).toContain("rendered-coverage");
 
+    // A socket that has not opened yet outranks the query's own loading flag:
+    // the rail must not claim emptiness it cannot back (issue #855).
     await rerender(
       <RunsRail runs={[]} loading connStatus="connecting" selectedRunId={undefined} onSelect={() => {}} />,
     );
-    expect(byTestId("monitor-runs").textContent).toContain("Loading runs");
+    expect(byTestId("monitor-runs").textContent).toContain("Connecting to the Smithers gateway");
+    expect(byTestId("monitor-empty").getAttribute("data-state")).toBe("connecting");
     expect(byTestId("monitor-empty").getAttribute("data-slot")).toBe("empty-state");
+    expect(byTestId("monitor-empty").querySelector('[data-slot="skeleton"]')).not.toBeNull();
+
+    await rerender(<RunsRail runs={[]} loading connStatus="online" selectedRunId={undefined} onSelect={() => {}} />);
+    expect(byTestId("monitor-runs").textContent).toContain("Loading runs");
+    expect(byTestId("monitor-empty").getAttribute("data-state")).toBe("loading");
     expect(byTestId("monitor-empty").querySelector('[data-slot="skeleton"]')).not.toBeNull();
     await rerender(
       <RunsRail runs={[]} loading={false} connStatus="online" selectedRunId={undefined} onSelect={() => {}} />,
@@ -1072,6 +1119,37 @@ describe("monitor event states", () => {
     await click(buttonNamed("All"));
     expect(document.querySelectorAll(".mon-event").length).toBe(1);
     expect(document.querySelector('[data-testid="monitor-events-state"]')).toBeNull();
+  });
+
+  test("a buffer hidden by the view chips offers a one-click way back to All", async () => {
+    // Issue #855: a filtered-empty log must carry the control, not just prose.
+    const chatter = eventLogState({
+      events: [
+        { event: "AgentSessionEvent", seq: 1, stateVersion: 0, payload: {} },
+        { event: "AgentSessionEvent", seq: 2, stateVersion: 0, payload: {} },
+      ],
+    });
+    await render(<EventLog runId="run-events" eventsState={chatter} />);
+    expect(byTestId("monitor-events-state").getAttribute("data-state")).toBe("filtered-activity");
+    expect(byTestId("monitor-events-state").querySelector(".sui-empty-title")?.textContent).toBe(
+      "No activity events in this buffer.",
+    );
+    expect(byTestId("monitor-events-state").querySelector(".sui-empty-description")?.textContent).toContain(
+      "Switch to All to inspect the 2 buffered",
+    );
+
+    await click(byTestId("monitor-events-show-all"));
+    expect(document.querySelector('[data-testid="monitor-events-state"]')).toBeNull();
+    expect(document.querySelectorAll(".mon-event").length).toBe(2);
+
+    // The durable-empty state has nothing to clear, so it offers no action.
+    await rerender(<EventLog runId="run-events" eventsState={eventLogState()} />);
+    expect(byTestId("monitor-events-state").getAttribute("data-state")).toBe("empty");
+    expect(byTestId("monitor-events-state").querySelector(".sui-empty-description")?.textContent).toContain(
+      "Events stream in here",
+    );
+    expect(document.querySelector('[data-testid="monitor-events-show-all"]')).toBeNull();
+    expect(byTestId("monitor-events-state").querySelector('[data-slot="skeleton"]')).toBeNull();
   });
 
   test("surfaces an empty query failure with guidance and a retry action", async () => {
@@ -1569,6 +1647,44 @@ describe("execution tree unavailable states", () => {
     expect(byTestId("monitor-frame-unavailable").getAttribute("data-slot")).toBe("alert");
     expect(byTestId("monitor-tree").textContent).toContain("Previous valid frame");
   });
+
+  test("empty trees explain themselves and an empty frame offers the way back to live", async () => {
+    // Issue #855: "No nodes recorded yet." alone reads like a broken panel.
+    let returnsToLive = 0;
+    await render(executionTree({ isLoading: true }));
+    expect(byTestId("monitor-tree-loading").getAttribute("data-state")).toBe("loading");
+    expect(byTestId("monitor-tree-loading").querySelector(".sui-empty-description")?.textContent).toContain(
+      "from the gateway",
+    );
+
+    await rerender(executionTree());
+    expect(byTestId("monitor-tree-empty").getAttribute("data-state")).toBe("empty");
+    expect(byTestId("monitor-tree-empty").querySelector(".sui-empty-title")?.textContent).toBe(
+      "No nodes recorded yet.",
+    );
+    expect(byTestId("monitor-tree-empty").querySelector(".sui-empty-description")?.textContent).toContain(
+      "as the engine schedules this run's work",
+    );
+    // A settled empty tree is not a spinner and has no run to return to.
+    expect(byTestId("monitor-tree-empty").querySelector('[data-slot="skeleton"]')).toBeNull();
+    expect(document.querySelector('[data-testid="monitor-frame-live"]')).toBeNull();
+
+    await rerender(
+      <ExecutionTree
+        runId="run-tree-states"
+        treeQuery={{ root: null, nodes: [], status: "queued", isLoading: false, error: undefined }}
+        selectedNodeKey={undefined}
+        onSelectNode={() => {}}
+        frameOverride={{ root: null, loading: false, onReturnToLive: () => returnsToLive++ }}
+      />,
+    );
+    expect(byTestId("monitor-frame-empty").getAttribute("data-state")).toBe("frame-empty");
+    expect(byTestId("monitor-frame-empty").querySelector(".sui-empty-description")?.textContent).toContain(
+      "before its first node was scheduled",
+    );
+    await click(byTestId("monitor-frame-live"));
+    expect(returnsToLive).toBe(1);
+  });
 });
 
 describe("monitor theme contract", () => {
@@ -1747,6 +1863,33 @@ describe("MonitorToolbar", () => {
     await keydown(document.activeElement ?? trigger, "Escape");
     expect(document.querySelector('[data-slot="select-content"]')).toBeNull();
     expect(calls.workflow).toEqual([]);
+  });
+
+  test("reports an in-flight refetch on the control that started it", async () => {
+    // Issue #855: a refetch never flips the runs query back to `loading` (the
+    // rows stay), so Refresh is the only honest place to say it is in flight.
+    let settle: (() => void) | undefined;
+    const { element } = toolbarHarness({
+      onRefresh: () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+    });
+    await render(element);
+    const refresh = byTestId("monitor-refresh");
+    expect(refresh.textContent).toBe("Refresh");
+    expect(refresh.getAttribute("aria-busy")).toBe("false");
+
+    await click(refresh);
+    expect(byTestId("monitor-refresh").textContent).toBe("Refreshing…");
+    expect(byTestId("monitor-refresh").getAttribute("aria-busy")).toBe("true");
+    expect((byTestId("monitor-refresh") as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      settle?.();
+    });
+    expect(byTestId("monitor-refresh").textContent).toBe("Refresh");
+    expect((byTestId("monitor-refresh") as HTMLButtonElement).disabled).toBe(false);
   });
 
   test("active: the Metrics chip carries aria-pressed and the is-on accent only when on", async () => {

--- a/apps/cli/tests/monitor-states.e2e.test.js
+++ b/apps/cli/tests/monitor-states.e2e.test.js
@@ -1,0 +1,163 @@
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import { resolve } from "node:path";
+import { createTempRepo, writeTestWorkflow } from "../../../packages/smithers/tests/e2e-helpers.js";
+
+/**
+ * Real-browser coverage for the monitor's non-happy-path states (issue #855):
+ * a workspace with no runs, a filter that hides every run, and a run id that
+ * does not exist. Each must carry a label, an explanation, and the action that
+ * recovers from it — against a real gateway over a real workspace, with no
+ * transport or collection behavior mocked.
+ *
+ * The states are also checked in both themes. They are built from the shared
+ * smthrs/ui primitives, so their colors come from theme tokens and must move
+ * when `data-theme` flips. Chromium is deliberately optional here, matching
+ * the other monitor browser suites: CI does not install browsers.
+ */
+const require = createRequire(import.meta.url);
+const CLI_ENTRY = resolve(import.meta.dir, "..", "src", "index.js");
+const WORKFLOW = "fixture-workflow";
+const RUN_ID = "monitor-states-run";
+const MISSING_RUN = "monitor-states-missing";
+
+function resolveChromium() {
+  try {
+    const chromium = require("playwright").chromium;
+    const executablePath = chromium?.executablePath?.();
+    if (typeof executablePath === "string" && existsSync(executablePath)) return chromium;
+  } catch {}
+  return null;
+}
+
+const CHROMIUM = resolveChromium();
+const browserTest = CHROMIUM ? test : test.skip;
+
+async function findOpenPort() {
+  const server = createServer();
+  await new Promise((resolvePort, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolvePort);
+  });
+  const address = server.address();
+  await new Promise((resolveClose) => server.close(resolveClose));
+  if (!address || typeof address === "string") throw new Error("Could not allocate an open port");
+  return address.port;
+}
+
+async function waitForHealth(base, timeoutMs = 60_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      if ((await fetch(`${base}/health`)).ok) return;
+    } catch {}
+    await new Promise((resolveWait) => setTimeout(resolveWait, 100));
+  }
+  throw new Error(`Gateway did not become healthy at ${base}`);
+}
+
+async function rpc(base, method, params) {
+  const response = await fetch(`${base}/v1/rpc/${method}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  const body = await response.json();
+  expect(response.status, JSON.stringify(body)).toBe(200);
+  expect(body.ok).toBe(true);
+  return body.payload;
+}
+
+/** The rendered color of a state's explanation line under one theme. */
+async function descriptionColor(page, testId, theme) {
+  await page.evaluate((value) => {
+    document.documentElement.setAttribute("data-theme", value);
+  }, theme);
+  return page
+    .locator(`[data-testid="${testId}"] .sui-empty-description`)
+    .first()
+    .evaluate((node) => getComputedStyle(node).color);
+}
+
+browserTest(
+  "monitor answers no runs, filtered-out runs, and an unavailable run with a label, a reason, and a way out",
+  async () => {
+    const repo = createTempRepo();
+    writeTestWorkflow(repo, `.smithers/workflows/${WORKFLOW}.tsx`);
+    const port = await findOpenPort();
+    const base = `http://127.0.0.1:${port}`;
+    const gateway = spawn(
+      process.execPath,
+      ["run", CLI_ENTRY, "gateway", "--host", "127.0.0.1", "--port", String(port)],
+      {
+        cwd: repo.dir,
+        env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0" },
+        stdio: "ignore",
+      },
+    );
+
+    let browser;
+    try {
+      await waitForHealth(base);
+      expect(await rpc(base, "listRuns", { filter: { limit: 1000 } })).toHaveLength(0);
+
+      browser = await CHROMIUM.launch({ headless: true });
+      const page = await browser.newPage();
+      await page.goto(`${base}/monitor`, { waitUntil: "domcontentloaded" });
+      await page.waitForSelector('[data-testid="monitor-root"]', { timeout: 30_000 });
+
+      // 1. No runs in the workspace at all. The claim is only made once the
+      //    gateway actually answered, and it names the command that fixes it.
+      await page.waitForSelector('[data-testid="monitor-empty-detail"][data-state="empty"]', { timeout: 30_000 });
+      const emptyText = await page.getByTestId("monitor-empty-detail").textContent();
+      expect(emptyText).toContain("No runs yet.");
+      expect(emptyText).toContain("smithers up");
+
+      // Light and dark are both real: the shared empty state reads its color
+      // from theme tokens, so flipping data-theme must move it.
+      const lightColor = await descriptionColor(page, "monitor-empty-detail", "light");
+      const darkColor = await descriptionColor(page, "monitor-empty-detail", "dark");
+      expect(lightColor).not.toBe("");
+      expect(lightColor).not.toBe(darkColor);
+      await page.evaluate(() => document.documentElement.removeAttribute("data-theme"));
+
+      // 2. Runs exist but the filter matches none: a different claim, with a
+      //    clear-filters control instead of the "launch one" copy.
+      const launched = await rpc(base, "launchRun", { workflow: WORKFLOW, input: {}, runId: RUN_ID });
+      expect(launched.runId).toBe(RUN_ID);
+      await page.waitForSelector(`[data-run-id="${RUN_ID}"]`, { timeout: 30_000 });
+
+      await page.getByTestId("monitor-filter").fill("no-such-run-anywhere");
+      await page.waitForSelector('[data-testid="monitor-empty-detail"][data-state="filtered"]', { timeout: 30_000 });
+      const filteredText = await page.getByTestId("monitor-empty-detail").textContent();
+      expect(filteredText).toContain("No runs match your filters.");
+      expect(filteredText).not.toContain("No runs yet.");
+      await page.getByTestId("monitor-empty-detail-reset").click();
+      await page.waitForSelector(`[data-run-id="${RUN_ID}"]`, { timeout: 30_000 });
+      expect(await page.getByTestId("monitor-filter").inputValue()).toBe("");
+
+      // 3. A requested run that does not exist: an honest unavailable state
+      //    with both recovery actions, never a blank detail pane.
+      await page.goto(`${base}/monitor?runId=${MISSING_RUN}`, { waitUntil: "domcontentloaded" });
+      await page.waitForSelector('[data-testid="monitor-run-unavailable"]', { timeout: 30_000 });
+      const unavailableText = await page.getByTestId("monitor-run-unavailable").textContent();
+      expect(unavailableText).toContain("Run unavailable.");
+      expect(unavailableText).toContain(MISSING_RUN);
+      expect(await page.getByTestId("monitor-run-refresh").count()).toBe(1);
+      await page.getByTestId("monitor-run-return").click();
+      await page.waitForSelector('[data-testid="monitor-runs-table"]', { timeout: 30_000 });
+      expect(await page.locator(`[data-run-id="${RUN_ID}"]`).count()).toBe(1);
+    } finally {
+      try {
+        await browser?.close();
+      } catch {}
+      try {
+        gateway.kill("SIGTERM");
+      } catch {}
+    }
+  },
+  180_000,
+);

--- a/apps/cli/tests/monitor-ui-model.test.ts
+++ b/apps/cli/tests/monitor-ui-model.test.ts
@@ -38,7 +38,9 @@ import {
   diffPatchesOf,
   diffSummaryOf,
   embedModeFromSearch,
+  eventLogViewState,
   eventViewFor,
+  executionTreeViewState,
   filterRuns,
   formatDiffSummary,
   formatDurationMs,
@@ -57,6 +59,7 @@ import {
   labelForStatus,
   looksLikeUnifiedDiff,
   middleTruncate,
+  nodeOutputViewState,
   nodeStateRowsOf,
   nodeSummaryEligible,
   paginateRuns,
@@ -64,6 +67,7 @@ import {
   rowOf,
   runErrorOf,
   runProgress,
+  runsLandingState,
   runsViewState,
   RUNS_PAGE_SIZE,
   shortRunId,
@@ -532,6 +536,77 @@ describe("filtering", () => {
     expect(runsViewState({ ...base, totalCount: 3 })).toBe("filtered");
     expect(runsViewState({ ...base, totalCount: 3, queryError: true })).toBe("error");
     expect(runsViewState({ ...base, visibleCount: 1, totalCount: 3 })).toBe("ready");
+  });
+
+  test("the transport outranks emptiness on every runs surface", () => {
+    const base = { visibleCount: 0, totalCount: 0, loading: false, queryError: false };
+    // A socket that has not opened yet can't back "no runs yet" (issue #855).
+    expect(runsLandingState({ ...base, connectionStatus: "connecting" })).toBe("connecting");
+    expect(runsLandingState({ ...base, connectionStatus: "idle" })).toBe("connecting");
+    expect(runsLandingState({ ...base, loading: true, connectionStatus: "connecting" })).toBe("connecting");
+    expect(runsLandingState({ ...base, connectionStatus: "unauthorized", totalCount: 3, visibleCount: 3 })).toBe(
+      "unauthorized",
+    );
+    expect(runsLandingState({ ...base, connectionStatus: "offline" })).toBe("offline-without-cache");
+    expect(runsLandingState({ ...base, connectionStatus: "offline", hasCachedData: true })).toBe("offline-with-cache");
+    expect(runsLandingState({ ...base, connectionStatus: "online", loading: true })).toBe("loading");
+    expect(runsLandingState({ ...base, connectionStatus: "online", queryError: true })).toBe("error");
+    expect(runsLandingState({ ...base, connectionStatus: "online", totalCount: 3 })).toBe("filtered");
+    expect(runsLandingState({ ...base, connectionStatus: "online" })).toBe("empty");
+  });
+});
+
+describe("run-detail panel states", () => {
+  test("the event log separates loading, failure, durable emptiness, and a hidden buffer", () => {
+    const base = { visibleCount: 0, totalCount: 0, loading: false, queryError: false };
+    expect(eventLogViewState({ ...base, visibleCount: 2, totalCount: 9 })).toBe("ready");
+    // The panel's error alert owns the surface, so a failure outranks loading;
+    // reporting emptiness underneath it would be a contradictory claim.
+    expect(eventLogViewState({ ...base, loading: true, queryError: true })).toBe("error");
+    expect(eventLogViewState({ ...base, loading: true })).toBe("loading");
+    // Buffered events hidden by the Notable/Activity chips are "filtered", not
+    // "empty" — the panel owes a way back to All.
+    expect(eventLogViewState({ ...base, totalCount: 4 })).toBe("filtered");
+    expect(eventLogViewState(base)).toBe("empty");
+    // Rows on screen beat every degraded flag: a failed refetch is a banner.
+    expect(eventLogViewState({ visibleCount: 1, totalCount: 1, loading: true, queryError: true })).toBe("ready");
+  });
+
+  test("the execution tree separates the live query from the scrubbed frame", () => {
+    const base = {
+      hasRoot: false,
+      loading: false,
+      queryError: false,
+      isStatic: false,
+      frameLoading: false,
+      frameError: false,
+    };
+    expect(executionTreeViewState({ ...base, hasRoot: true })).toBe("ready");
+    expect(executionTreeViewState({ ...base, loading: true })).toBe("loading");
+    expect(executionTreeViewState({ ...base, queryError: true, loading: true })).toBe("error");
+    expect(executionTreeViewState(base)).toBe("empty");
+    // The scrubber overrides the live query, so live loading/error is muted.
+    const stat = { ...base, isStatic: true };
+    expect(executionTreeViewState({ ...stat, queryError: true, loading: true })).toBe("frame-empty");
+    expect(executionTreeViewState({ ...stat, frameLoading: true })).toBe("frame-loading");
+    expect(executionTreeViewState({ ...stat, frameError: true })).toBe("frame-error");
+    // A previous valid frame stays on screen behind a notice.
+    expect(executionTreeViewState({ ...stat, hasRoot: true, frameLoading: true })).toBe("stale-frame-loading");
+    expect(executionTreeViewState({ ...stat, hasRoot: true, frameError: true })).toBe("stale-frame-error");
+    // Loading wins over a stale error: the newer request is still in flight.
+    expect(executionTreeViewState({ ...stat, frameLoading: true, frameError: true })).toBe("frame-loading");
+    expect(executionTreeViewState({ ...stat, hasRoot: true })).toBe("ready");
+  });
+
+  test("node output never reports a pending or failed query as missing output", () => {
+    const base = { hasRow: false, loading: false, queryError: false, failed: false, live: false };
+    expect(nodeOutputViewState({ ...base, hasRow: true, queryError: true })).toBe("ready");
+    expect(nodeOutputViewState({ ...base, loading: true, queryError: true })).toBe("loading");
+    expect(nodeOutputViewState({ ...base, queryError: true, failed: true })).toBe("error");
+    expect(nodeOutputViewState({ ...base, failed: true, live: true })).toBe("failed");
+    expect(nodeOutputViewState({ ...base, live: true })).toBe("live");
+    // "empty" is the one honest claim that the node finished recording nothing.
+    expect(nodeOutputViewState(base)).toBe("empty");
   });
 });
 


### PR DESCRIPTION
Closes #855.

Completes every non-happy-path state in `smithers monitor`, composed entirely from shipped `smthrs/ui` primitives (`EmptyState`, `Alert`, `Button`, `Skeleton`, `Chip`), with the state derivation moved into `monitorModel.ts` rather than computed ad hoc in the view. No new CSS.

**Scope discipline:** this deliberately changes no layout, colour, or information hierarchy. The monitor redesign work is tracked separately in #850 / #991 / #992 and is gated on your approval; none of it is touched here.

## The nine states

| State | Now renders |
|---|---|
| No runs at all | `EmptyState` with the `smithers up` / `workflow run` command to start one |
| Filter matches none | Named count + a real **Clear filters** button |
| Run unavailable | Run id + cause, with **Refresh** / **Return to runs**; a non-404 gives a destructive `Alert` + **Retry** |
| Loading (initial) | Per-surface skeletons with `role="status"` for rail, table, tree, events, output, run |
| Loading (refetch) | The runs query never returns to `loading` once it holds rows, so **Refresh** itself reports "Refreshing…", `aria-busy`, disabled while in flight |
| Query failed | Destructive `Alert` carrying the real message plus **Retry**, on every surface including over live rows |
| Gateway disconnected | The rail was the gap — it used `runsViewState` and claimed "No runs yet" while the socket was still opening. Now uses `runsLandingState` and shares the `connecting` state; offline keeps its last-known banner, unauthorized keeps its credentials copy |
| Empty event log | Distinguishes genuinely empty from filtered-empty, the latter with a **Show all events** button (previously prose crammed into a title with no control) |
| Empty tree / no output | "No nodes recorded yet"; a scrubbed frame that maps to nothing reads as a frame-specific empty rather than a generic one |

## Tests

New `apps/cli/tests/monitor-states.e2e.test.js`, plus additions to `monitor-shell-controls.test.tsx` and `monitor-ui-model.test.ts`.

## Gates — one incomplete, reported honestly

`pnpm lint`, `pnpm format:check`, `pnpm -r typecheck` all pass.

`pnpm -C apps/cli test` **did not complete locally**. This machine is shared and was at load ~180 during the run. Every failure was reproduced as unrelated: `agents-ts-codegen` (state leaked from the agents e2e scheduled before it — fails identically on pristine `origin/main`), two 60–180s timeouts, and `monitor-command.test.js`, whose "no Gateway is reachable" assertions cannot hold because another session's gateway is listening on this host — also byte-identical on pristine `origin/main`.

Monitor coverage run cleanly: `monitor-shell-controls` 69/69, `monitor-ui-model` + `monitor-model-no-react` 158/158, `monitor-states.e2e` 1/1, `monitor-reduced-motion` / `monitor-live-update` / `monitor-node-inspector` 1/1 each.

CI on a clean runner is the real gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)