### PR TITLE
fix(agents): boot the parent-death watchdog outside the agent's cwd

### DIFF
--- a/apps/review/tests/action/actionManifest.test.ts
+++ b/apps/review/tests/action/actionManifest.test.ts
@@ -5,14 +5,19 @@ import { parse } from "yaml";
 type ActionStep = {
   name?: string;
   run?: string;
+  "working-directory"?: string;
 };
+
+function readSteps(): ActionStep[] {
+  const manifest = parse(readFileSync(new URL("../../action/action.yml", import.meta.url), "utf8")) as {
+    runs?: { steps?: ActionStep[] };
+  };
+  return manifest.runs?.steps ?? [];
+}
 
 describe("review action manifest", () => {
   test("pins Codex resolution to the npm-installed CLI ahead of Bun", () => {
-    const manifest = parse(readFileSync(new URL("../../action/action.yml", import.meta.url), "utf8")) as {
-      runs?: { steps?: ActionStep[] };
-    };
-    const steps = manifest.runs?.steps ?? [];
+    const steps = readSteps();
     const installIndex = steps.findIndex((step) => step.name === "Install Codex CLI");
     const reviewIndex = steps.findIndex((step) => step.name === "Authenticate and review");
     const install = steps[installIndex]?.run ?? "";
@@ -23,5 +28,20 @@ describe("review action manifest", () => {
     expect(install).toContain('codex_bin="$(npm prefix -g)/bin"');
     expect(install).toContain('"$codex_bin/codex" --version');
     expect(install).toContain('echo "$codex_bin" >> "$GITHUB_PATH"');
+  });
+
+  // #1546: Bun reads bunfig.toml from its cwd. A `bun` step started inside the
+  // caller's checkout evaluates that repo's `preload`, and because the action
+  // never installs the caller's checkout, Bun auto-installs the preload's
+  // imports out of `~/.bun/install/cache` — the intermittent
+  // `unist-util-visit-parents/do-not-use-color` failure. Every bun step must
+  // therefore stay inside the action's own installed tree.
+  test("runs every bun step inside the action's tree, never the caller's checkout", () => {
+    const bunSteps = readSteps().filter((step) => /(^|\s)bun\s/.test(step.run ?? ""));
+
+    expect(bunSteps.length).toBeGreaterThan(0);
+    for (const step of bunSteps) {
+      expect(step["working-directory"]).toStartWith("${{ github.action_path }}");
+    }
   });
 });

--- a/packages/agents/src/BaseCliAgent/parentDeathCommand.js
+++ b/packages/agents/src/BaseCliAgent/parentDeathCommand.js
@@ -1,24 +1,43 @@
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const WATCHDOG_PATH = fileURLToPath(new URL("./parentDeathWatchdog.js", import.meta.url));
+/**
+ * Where the watchdog process itself runs. Deliberately *not* the agent's cwd:
+ * `process.execPath` is Bun whenever the engine runs under Bun, and Bun reads
+ * `bunfig.toml` from its own cwd. Booting the watchdog inside a checkout that
+ * declares a `preload` makes Bun evaluate that preload — and if the checkout
+ * has no `node_modules` (the review action clones the PR repo without
+ * installing it) Bun falls back to auto-installing the preload's imports out of
+ * `~/.bun/install/cache`, which resolves intermittently and kills the watchdog
+ * before the agent is ever spawned (#1546). The package's own directory carries
+ * no bunfig, so the watchdog boots identically everywhere.
+ */
+const WATCHDOG_CWD = dirname(WATCHDOG_PATH);
 
 /**
  * Route a POSIX agent command through the detached watchdog that owns its
  * process group. Custom spawn implementations are left untouched because
  * they may not create real operating-system processes.
  *
+ * `cwd` is the directory the *agent* must run in; the watchdog forwards it to
+ * the real command and is itself spawned in `invocation.cwd`. It is resolved
+ * here, against the engine's cwd, because the watchdog no longer shares it.
+ *
  * @param {string} command
  * @param {string[]} args
  * @param {boolean} [enabled]
- * @returns {{ command: string; args: string[]; contained: boolean }}
+ * @param {string} [cwd]
+ * @returns {{ command: string; args: string[]; contained: boolean; cwd: string | undefined }}
  */
-export function parentDeathCommand(command, args, enabled = true) {
+export function parentDeathCommand(command, args, enabled = true, cwd = undefined) {
   if (!enabled || process.platform === "win32") {
-    return { command, args, contained: false };
+    return { command, args, contained: false, cwd };
   }
   return {
     command: process.execPath,
-    args: [WATCHDOG_PATH, String(process.pid), command, ...args],
+    args: [WATCHDOG_PATH, String(process.pid), resolve(cwd ?? process.cwd()), command, ...args],
     contained: true,
+    cwd: WATCHDOG_CWD,
   };
 }

--- a/packages/agents/src/BaseCliAgent/parentDeathWatchdog.js
+++ b/packages/agents/src/BaseCliAgent/parentDeathWatchdog.js
@@ -1,9 +1,13 @@
 import { spawn } from "node:child_process";
 
-const [expectedParentPidText, command, ...args] = process.argv.slice(2);
+// argv: <expected parent pid> <agent cwd> <command> [...args]. The agent cwd is
+// passed explicitly rather than inherited: this watchdog is deliberately booted
+// outside the agent's directory so a `bunfig.toml` there cannot preload into the
+// watchdog process (see parentDeathCommand.js).
+const [expectedParentPidText, childCwd, command, ...args] = process.argv.slice(2);
 const expectedParentPid = Number(expectedParentPidText);
 
-if (!Number.isInteger(expectedParentPid) || expectedParentPid <= 0 || !command) {
+if (!Number.isInteger(expectedParentPid) || expectedParentPid <= 0 || !childCwd || !command) {
   process.exit(64);
 }
 
@@ -22,7 +26,7 @@ function parentIsAlive() {
 if (!parentIsAlive()) process.exit(1);
 
 const child = spawn(command, args, {
-  cwd: process.cwd(),
+  cwd: childCwd,
   env: process.env,
   stdio: "inherit",
 });

--- a/packages/agents/src/BaseCliAgent/runCommandEffect.js
+++ b/packages/agents/src/BaseCliAgent/runCommandEffect.js
@@ -28,9 +28,12 @@ export function runCommandEffect(command, args, options) {
     onStderr,
     onProcess,
   } = options;
-  const invocation = parentDeathCommand(command, args);
+  const invocation = parentDeathCommand(command, args, true, cwd);
   return spawnCaptureEffect(invocation.command, invocation.args, {
-    cwd,
+    // The watchdog runs in its own package directory, not the agent's cwd, so a
+    // `bunfig.toml` in the target repo cannot preload into it (#1546). It hands
+    // `cwd` to the agent process itself.
+    cwd: invocation.cwd ?? cwd,
     env,
     input,
     signal,

--- a/packages/agents/src/BaseCliAgent/runRpcCommandEffect.js
+++ b/packages/agents/src/BaseCliAgent/runRpcCommandEffect.js
@@ -121,9 +121,10 @@ export function runRpcCommandEffect(command, args, options) {
     let stderrTruncated = false;
     let terminationStarted = false;
     logDebug("starting agent RPC command", logAnnotations, span);
-    const invocation = parentDeathCommand(command, args, spawnFn === spawn);
+    const invocation = parentDeathCommand(command, args, spawnFn === spawn, cwd);
     const child = spawnFn(invocation.command, invocation.args, {
-      cwd,
+      // See runCommandEffect: the watchdog must not boot inside the agent's cwd.
+      cwd: invocation.cwd ?? cwd,
       env,
       detached: true,
       stdio: ["pipe", "pipe", "pipe"],

--- a/packages/agents/tests/parent-death-watchdog-cwd.test.js
+++ b/packages/agents/tests/parent-death-watchdog-cwd.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parentDeathCommand } from "../src/BaseCliAgent/parentDeathCommand.js";
+
+const WATCHDOG_PATH = fileURLToPath(new URL("../src/BaseCliAgent/parentDeathWatchdog.js", import.meta.url));
+
+/**
+ * Build a checkout that looks like the one the review action hands an agent:
+ * a `bunfig.toml` that preloads a file, and no `node_modules` to resolve it
+ * from. Any Bun process booted here evaluates the preload; in CI that meant
+ * Bun auto-installing the preload's import graph out of `~/.bun/install/cache`
+ * and dying on `unist-util-visit-parents/do-not-use-color` (#1546). The preload
+ * throws outright so the failure is deterministic instead of a cache race.
+ *
+ * @returns {Promise<string>}
+ */
+async function makeHostileCheckout() {
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "smithers-bunfig-")));
+  await writeFile(join(dir, "bunfig.toml"), 'preload = ["./preload.js"]\n', "utf8");
+  await writeFile(join(dir, "preload.js"), 'throw new Error("bunfig preload evaluated");\n', "utf8");
+  return dir;
+}
+
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string} cwd
+ * @returns {Promise<{ code: number | null; stdout: string; stderr: string }>}
+ */
+function run(command, args, cwd) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code) => resolvePromise({ code, stdout, stderr }));
+  });
+}
+
+describe("parentDeathCommand", () => {
+  test.skipIf(process.platform === "win32")("boots the watchdog outside the agent's cwd", () => {
+    const invocation = parentDeathCommand("codex", ["exec"], true, "/some/agent/cwd");
+
+    expect(invocation.contained).toBe(true);
+    expect(invocation.command).toBe(process.execPath);
+    // The watchdog runs beside its own source, which carries no bunfig.toml.
+    expect(invocation.cwd).toBe(dirname(WATCHDOG_PATH));
+    // …and the agent's cwd travels in argv instead of being inherited.
+    expect(invocation.args.slice(0, 2)).toEqual([WATCHDOG_PATH, String(process.pid)]);
+    expect(invocation.args[2]).toBe("/some/agent/cwd");
+    expect(invocation.args.slice(3)).toEqual(["codex", "exec"]);
+  });
+
+  test("resolves a relative agent cwd against the engine, not the watchdog", () => {
+    const invocation = parentDeathCommand("codex", [], true, ".");
+
+    if (invocation.contained) expect(invocation.args[2]).toBe(process.cwd());
+    else expect(invocation.cwd).toBe(".");
+  });
+
+  test("leaves uncontained invocations untouched", () => {
+    const invocation = parentDeathCommand("codex", ["exec"], false, "/some/agent/cwd");
+
+    expect(invocation).toEqual({ command: "codex", args: ["exec"], contained: false, cwd: "/some/agent/cwd" });
+  });
+});
+
+describe("parentDeathWatchdog", () => {
+  test.skipIf(process.platform === "win32")(
+    "survives a bunfig preload in the agent's cwd and still runs the agent there (#1546)",
+    async () => {
+      const checkout = await makeHostileCheckout();
+      try {
+        // Baseline: this is the bug. Booting the watchdog *in* the checkout —
+        // what smithers did before #1546 — dies before the agent is spawned.
+        // Only Bun reads bunfig.toml, so the baseline is asserted only there.
+        if (typeof Bun !== "undefined") {
+          const inCheckout = await run(
+            process.execPath,
+            [WATCHDOG_PATH, String(process.pid), checkout, "pwd"],
+            checkout,
+          );
+          expect(inCheckout.code).not.toBe(0);
+          expect(inCheckout.stderr).toContain("bunfig preload evaluated");
+        }
+
+        // The fix: the same invocation, routed through parentDeathCommand.
+        const invocation = parentDeathCommand("pwd", [], true, checkout);
+        const fixed = await run(invocation.command, invocation.args, /** @type {string} */ (invocation.cwd));
+
+        expect(fixed.stderr).not.toContain("bunfig preload evaluated");
+        expect(fixed.code).toBe(0);
+        // The agent itself still runs in the checkout it was asked for.
+        expect(fixed.stdout.trim()).toBe(checkout);
+      } finally {
+        await rm(checkout, { recursive: true, force: true });
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes #1546.

## Root cause — not the review action's dependencies, and not which codex binary is on PATH

`parentDeathCommand` routes every POSIX agent spawn through `parentDeathWatchdog.js`, launched as `process.execPath` — which is **Bun** whenever the engine runs under Bun (`bun runAction.ts`) — and it **inherited the agent's cwd**.

In the review action that cwd is `GITHUB_WORKSPACE`: the freshly cloned PR checkout (confirmed in the failing job log, `cwd=/home/runner/work/smithers/smithers`). That checkout contains this repo's root `bunfig.toml` with `preload = ["./preload.js"]` — and the action installs only its own tree (`pnpm -C $SMITHERS_ACTION_PATH/../../.. install`), never the caller's checkout. So the preload's import graph (`preload.js` → `@mdx-js/esbuild` → remark/unified → `unist-util-visit-parents`) has no `node_modules` to resolve from, and Bun **auto-installs it into the shared `~/.bun/install/cache`**.

Eight parallel agents (the log shows `maxConcurrency` raised to 8) then race the same cold cache entries. A lost race produces exactly the reported error, from exactly the reported path shape:

```
Cannot find module 'unist-util-visit-parents/do-not-use-color'
from '~/.bun/install/cache/unist-util-visit-parents@6.0.2@@@1/lib/index.js'
```

The watchdog dies **before codex is ever spawned**, so every file review and `narrate` fail in ~0s and the action exits 1.

This explains all three things the issue could not: the intermittency (warm vs cold cache), why #1548's PATH pin changed nothing, and why other PRs in the same batch were green.

## Evidence

1. Job log `95199278032`: the agent cwd is the workspace checkout, and the error arrives on the child's stderr at sequence 0, before any codex output.
2. Reproduced the mechanism locally — booting bun with cwd set to a directory holding that bunfig+preload and no `node_modules` auto-installs the whole graph into the cache in the exact `name@version@@@1` layout from the error string.
3. Verified Bun does **not** walk up for `bunfig.toml`, so booting the watchdog one directory away is sufficient.

**What I could not reproduce:** the resolution failure itself. Eight concurrent cold auto-installs on macOS / bun 1.4.0 all succeeded; the race appears specific to Linux / bun 1.3.13. What is made deterministic here is the *precondition* — the auto-install happening at all — and the fix removes that precondition entirely.

## Fix

The watchdog now boots in its own package directory, which carries no `bunfig.toml`, and receives the agent's cwd as `argv[2]` instead of inheriting it. `runCommandEffect` / `runRpcCommandEffect` pass `invocation.cwd` through to spawn, resolved against the engine's cwd since the watchdog no longer shares it. **The agent process still runs exactly where it was asked to.** No dependency manifests changed, so both lockfiles are untouched.

## Regression coverage

`packages/agents/tests/parent-death-watchdog-cwd.test.js` hands the watchdog a checkout whose bunfig preload throws — the deterministic form of the cache race — and asserts the watchdog still boots and the agent still runs in the requested directory. It runs under `bun test`, i.e. under Bun on Linux in CI's ubuntu shards, which is where the original failure lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)