### PR TITLE
fix(db,memory): label the Postgres memory-note tables as staged, not served

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -16590,7 +16590,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see Node runtime.
+Node there is no sqlite at all. See Node runtime.
 
 ## Processors
 

--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -16581,6 +16581,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see Node runtime.
+
 ## Processors
 
 Maintenance jobs you run periodically:

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -209,7 +209,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see [Node runtime](/runtime/node).
+Node there is no sqlite at all. See [Node runtime](/runtime/node).
 
 ## Processors
 

--- a/docs/concepts/memory.mdx
+++ b/docs/concepts/memory.mdx
@@ -200,6 +200,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see [Node runtime](/runtime/node).
+
 ## Processors
 
 Maintenance jobs you run periodically:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -16590,7 +16590,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see Node runtime.
+Node there is no sqlite at all. See Node runtime.
 
 ## Processors
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -16581,6 +16581,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see Node runtime.
+
 ## Processors
 
 Maintenance jobs you run periodically:

--- a/docs/llms-memory.txt
+++ b/docs/llms-memory.txt
@@ -214,7 +214,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see [Node runtime](/runtime/node).
+Node there is no sqlite at all. See [Node runtime](/runtime/node).
 
 ## Processors
 

--- a/docs/llms-memory.txt
+++ b/docs/llms-memory.txt
@@ -205,6 +205,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see [Node runtime](/runtime/node).
+
 ## Processors
 
 Maintenance jobs you run periodically:

--- a/docs/reference/memory.mdx
+++ b/docs/reference/memory.mdx
@@ -332,9 +332,18 @@ etc.) with the same arguments, for use inside an Effect pipeline.
 
 <Note>
 Note writes and search require bun:sqlite: transactions give note+edge
-atomicity, FTS5 gives search. Migration 0023 creates note tables on
-Postgres/PGlite, but the runtime still rejects `saveNote`/`enableNoteSearch`
-there with `DB_WRITE_FAILED`, and `searchNotes` with `DB_QUERY_FAILED`.
+atomicity, FTS5 gives search. The runtime rejects `saveNote`/`enableNoteSearch`
+on Postgres/PGlite with `DB_WRITE_FAILED`, and `searchNotes` with
+`DB_QUERY_FAILED`.
+
+`_smithers_memory_notes` and `_smithers_memory_note_supersessions` still exist
+on Postgres — `0001_current_tables` creates every current table on a fresh
+database, and `0023_add_memory_notes` adds them to an upgraded one. They are
+**staged, not served**: `0043_memory_notes_postgres_staged` stamps a
+`COMMENT ON TABLE` saying so, so `\d+ _smithers_memory_notes` and a `pg_dump`
+carry the same warning the runtime error does. Nothing writes them, and a
+Postgres/PGlite workspace keeps its memory in the `.smithers/smithers.db`
+sqlite sidecar that `openSmithersBackend` opens alongside the main database.
 </Note>
 
 <ResponseField name="Threads & messages" type="methods">

--- a/docs/reference/memory.mdx
+++ b/docs/reference/memory.mdx
@@ -337,7 +337,7 @@ on Postgres/PGlite with `DB_WRITE_FAILED`, and `searchNotes` with
 `DB_QUERY_FAILED`.
 
 `_smithers_memory_notes` and `_smithers_memory_note_supersessions` still exist
-on Postgres — `0001_current_tables` creates every current table on a fresh
+on Postgres. `0001_current_tables` creates every current table on a fresh
 database, and `0023_add_memory_notes` adds them to an upgraded one. They are
 **staged, not served**: `0043_memory_notes_postgres_staged` stamps a
 `COMMENT ON TABLE` saying so, so `\d+ _smithers_memory_notes` and a `pg_dump`

--- a/docs/runtime/node.mdx
+++ b/docs/runtime/node.mdx
@@ -81,10 +81,15 @@ node -e "import('smthrs').then(() => console.log('ok'))"
   under Node.
 - Cross-run memory uses the main database under Node. Under Bun a Postgres or
   PGlite run keeps memory in a local sqlite sidecar; under Node there is no
-  sqlite, so memory is stored in the run database instead. Memory facts and
-  message history behave the same either way. Memory notes and note search ride
-  the synchronous sqlite driver and its FTS5 index, so on a Postgres-dialect
-  database they are unavailable and `saveNote`, `searchNotes`, and `deleteThread`
-  fail with `DB_WRITE_FAILED` or `DB_QUERY_FAILED`. That limit already applies to
-  a Bun run that opens the memory store on Postgres directly. Run under Bun on
-  the sqlite backend when a workflow needs notes.
+  sqlite, so memory is routed at the run database instead. `MemoryStore` is
+  built on a synchronous Drizzle sqlite handle, so on a Postgres-dialect database
+  memory operations fail rather than fall back — `saveNote`, `searchNotes`,
+  `enableNoteSearch`, and `deleteThread` fail loud with `DB_WRITE_FAILED` or
+  `DB_QUERY_FAILED`, and the portable fact/thread/message operations surface a
+  driver error of their own. That limit already applies to a Bun run that opens
+  the memory store on Postgres directly. Run under Bun, or on the sqlite backend,
+  when a workflow uses cross-run memory.
+- The Postgres schema still carries `_smithers_memory_notes` and
+  `_smithers_memory_note_supersessions`; migration
+  `0043_memory_notes_postgres_staged` labels them *staged, not served* so the
+  catalog does not imply support the runtime declines to give.

--- a/docs/runtime/node.mdx
+++ b/docs/runtime/node.mdx
@@ -83,7 +83,7 @@ node -e "import('smthrs').then(() => console.log('ok'))"
   PGlite run keeps memory in a local sqlite sidecar; under Node there is no
   sqlite, so memory is routed at the run database instead. `MemoryStore` is
   built on a synchronous Drizzle sqlite handle, so on a Postgres-dialect database
-  memory operations fail rather than fall back — `saveNote`, `searchNotes`,
+  memory operations fail rather than fall back: `saveNote`, `searchNotes`,
   `enableNoteSearch`, and `deleteThread` fail loud with `DB_WRITE_FAILED` or
   `DB_QUERY_FAILED`, and the portable fact/thread/message operations surface a
   driver error of their own. That limit already applies to a Bun run that opens

--- a/packages/db/src/schema-migrations.js
+++ b/packages/db/src/schema-migrations.js
@@ -851,6 +851,46 @@ async function installSnapshotTriggersPostgres(pgConn) {
 }
 
 /**
+ * The Postgres memory-note tables carry this comment verbatim so their
+ * staged-but-unserved status is visible wherever an operator actually looks at
+ * the schema (`\d+ _smithers_memory_notes`, `obj_description`, a `pg_dump`)
+ * instead of only in Smithers' source. 0001/0023 create the tables on Postgres
+ * for dialect parity; no runtime writes them.
+ */
+const MEMORY_NOTES_POSTGRES_STAGED_COMMENT =
+  "STAGED, NOT SERVED: Smithers serves memory notes only from the sqlite backend " +
+  "(bun:sqlite synchronous transactions for note+edge atomicity, FTS5 for search). " +
+  "On a Postgres/PGlite store openSmithersBackend keeps memory in the " +
+  ".smithers/smithers.db sqlite sidecar, and MemoryStore rejects saveNote, " +
+  "enableNoteSearch, searchNotes, and deleteThread against this database. These " +
+  "tables exist for dialect parity only (created by 0001_current_tables / " +
+  "0023_add_memory_notes, labelled by 0043_memory_notes_postgres_staged).";
+
+const MEMORY_NOTE_TABLES = ["_smithers_memory_notes", "_smithers_memory_note_supersessions"];
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function quotePostgresLiteral(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+/**
+ * @param {{ query: (config: { text: string; values?: readonly unknown[] }) => Promise<{ rows?: readonly Record<string, unknown>[] }> }} pgConn
+ * @param {string} table
+ * @returns {Promise<string | null>}
+ */
+async function tableCommentPostgres(pgConn, table) {
+  const result = await pgConn.query({
+    text: "SELECT obj_description(c.oid, 'pg_class') AS comment FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = current_schema() AND c.relname = $1 LIMIT 1",
+    values: [table],
+  });
+  const comment = result.rows?.[0]?.comment;
+  return typeof comment === "string" ? comment : null;
+}
+
+/**
  * @param {{ query: (config: { text: string; values?: readonly unknown[] }) => Promise<{ rows?: readonly Record<string, unknown>[] }> }} pgConn
  * @param {string} table
  */
@@ -2471,6 +2511,45 @@ function buildMigrations(context) {
           }
         }
         return { table: "_smithers_runs", addedColumns };
+      },
+    },
+    {
+      // Metadata only: 0023 (and, on a fresh database, 0001) creates
+      // `_smithers_memory_notes` / `_smithers_memory_note_supersessions` on
+      // Postgres, but MemoryStore serves notes only from bun:sqlite. Deleting
+      // that DDL would not remove the tables — 0001 creates every current table
+      // on a fresh Postgres store, and existing deployments already hold them —
+      // so instead label them in the catalog. An operator reading the schema
+      // sees the tables are staged, not served, without reading Smithers'
+      // source. Re-runs are self-healing: a dropped comment is restored on the
+      // next boot without touching a single row.
+      id: "0043_memory_notes_postgres_staged",
+      name: "Label the Postgres memory-note tables as staged but unserved",
+      checksum: checksumForStatements(
+        MEMORY_NOTE_TABLES.map((table) => `COMMENT ON TABLE ${table} IS ${MEMORY_NOTES_POSTGRES_STAGED_COMMENT}`),
+      ),
+      // SQLite is the dialect that serves notes, and it has no COMMENT ON;
+      // there is nothing to label. Report the reason into the ledger rather
+      // than claiming the schema already matched.
+      isApplied: () => false,
+      up: () => ({ skipped: "postgres_only" }),
+      isAppliedPostgres: async (pgConn) => {
+        for (const table of MEMORY_NOTE_TABLES) {
+          if (!(await tableExistsPostgres(pgConn, table))) continue;
+          if ((await tableCommentPostgres(pgConn, table)) !== MEMORY_NOTES_POSTGRES_STAGED_COMMENT) return false;
+        }
+        return true;
+      },
+      upPostgres: async (pgConn) => {
+        const tables = [];
+        for (const table of MEMORY_NOTE_TABLES) {
+          if (!(await tableExistsPostgres(pgConn, table))) continue;
+          await pgConn.query({
+            text: `COMMENT ON TABLE ${quoteIdentifier(table)} IS ${quotePostgresLiteral(MEMORY_NOTES_POSTGRES_STAGED_COMMENT)}`,
+          });
+          tables.push(table);
+        }
+        return { tables, staged: true };
       },
     },
   ];

--- a/packages/db/tests/db-postgres-dialect.test.js
+++ b/packages/db/tests/db-postgres-dialect.test.js
@@ -1364,4 +1364,80 @@ describe.skipIf(process.platform === "win32" && !PG_URL)("SqlMessageStorage post
     expect(message).toMatch(/Failed to execute Postgres statement: .+; sql=.+/);
     expect(message).toContain("sql=SELECT * FROM __missing_pg_table__");
   });
+
+  // Notes are served only from bun:sqlite, yet 0001/0023 create the note tables
+  // on Postgres for dialect parity. 0043 labels them so the schema itself says
+  // "staged, not served" rather than implying runtime support that MemoryStore
+  // refuses to provide.
+  describe("0043 labels the staged memory-note tables", () => {
+    const noteTables = ["_smithers_memory_notes", "_smithers_memory_note_supersessions"];
+
+    async function tableComments() {
+      const result = await client.query(
+        `SELECT c.relname AS name, obj_description(c.oid, 'pg_class') AS comment
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = current_schema() AND c.relname = ANY($1)
+         ORDER BY c.relname`,
+        [noteTables],
+      );
+      return result.rows;
+    }
+
+    test("both note tables carry the staged-but-unserved comment", async () => {
+      const rows = await tableComments();
+      expect(rows.map((row) => row.name)).toEqual(["_smithers_memory_note_supersessions", "_smithers_memory_notes"]);
+      for (const row of rows) {
+        expect(row.comment).toContain("STAGED, NOT SERVED");
+        expect(row.comment).toContain(".smithers/smithers.db");
+        expect(row.comment).toContain("0023_add_memory_notes");
+      }
+    });
+
+    test("a deployment that already ran 0023 gets the label without losing rows", async () => {
+      // Reproduce a Postgres store upgraded from before 0043: the note tables
+      // exist with data and a ledger row for 0023, but no catalog comment.
+      await client.query(
+        `INSERT INTO _smithers_memory_notes (id, namespace, body, status, created_at_ms)
+         VALUES ('staged-note', 'user:pg', 'existing row', 'accepted', 1)
+         ON CONFLICT (id) DO NOTHING`,
+      );
+      for (const table of noteTables) {
+        await client.query(`COMMENT ON TABLE ${table} IS NULL`);
+      }
+      await client.query("DELETE FROM _smithers_schema_migrations WHERE id = '0043_memory_notes_postgres_staged'");
+
+      await storage.ensureSchema();
+
+      const rows = await tableComments();
+      expect(rows.every((row) => String(row.comment).startsWith("STAGED, NOT SERVED"))).toBe(true);
+      // The migration is metadata only: the pre-existing note row survives.
+      const notes = await client.query("SELECT id, body FROM _smithers_memory_notes WHERE id = 'staged-note'");
+      expect(notes.rows).toEqual([{ id: "staged-note", body: "existing row" }]);
+      const ledger = await client.query(
+        "SELECT COUNT(*)::int AS count FROM _smithers_schema_migrations WHERE id = '0043_memory_notes_postgres_staged'",
+      );
+      expect(ledger.rows).toEqual([{ count: 1 }]);
+    });
+
+    test("a dropped comment is repaired on the next boot and re-runs idempotently", async () => {
+      // The ledger row stays in place: isAppliedPostgres keys off the comment,
+      // not the ledger, so schema drift self-heals.
+      await client.query(`COMMENT ON TABLE _smithers_memory_notes IS NULL`);
+
+      await storage.ensureSchema();
+      const before = await client.query("SELECT id FROM _smithers_schema_migrations ORDER BY id");
+      await storage.ensureSchema();
+      const after = await client.query("SELECT id FROM _smithers_schema_migrations ORDER BY id");
+
+      expect(after.rows).toEqual(before.rows);
+      const rows = await tableComments();
+      expect(rows.every((row) => String(row.comment).startsWith("STAGED, NOT SERVED"))).toBe(true);
+    });
+
+    test("0043 is the recorded schema head", async () => {
+      const head = await client.query("SELECT id FROM _smithers_schema_migrations ORDER BY id DESC LIMIT 1");
+      expect(head.rows[0].id).toBe("0043_memory_notes_postgres_staged");
+    });
+  });
 });

--- a/packages/db/tests/migrations.test.js
+++ b/packages/db/tests/migrations.test.js
@@ -165,6 +165,39 @@ describe("DB migration edges", () => {
     }
   });
 
+  // 0043 exists to label the Postgres note tables as staged-but-unserved.
+  // SQLite is the dialect that actually serves notes and has no COMMENT ON, so
+  // the migration must be inert here — recorded in the ledger (it is the schema
+  // head) but creating nothing.
+  test("0043 is recorded as postgres-only on sqlite and changes no tables", () => {
+    const { sqlite, db } = setupMemoryDb();
+    try {
+      const before = sqlite
+        .query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all()
+        .map((row) => row.name);
+      const row = migrationRows(sqlite).find((entry) => entry.id === "0043_memory_notes_postgres_staged");
+      expect(row).toBeDefined();
+      expect(JSON.parse(row.details_json)).toEqual({ skipped: "postgres_only" });
+      ensureSmithersTables(db);
+      expect(
+        sqlite
+          .query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+          .all()
+          .map((entry) => entry.name),
+      ).toEqual(before);
+      // The head the migrate CLI reports back as `schemaVersion`.
+      expect(sqlite.query("SELECT id FROM _smithers_schema_migrations ORDER BY id DESC LIMIT 1").get().id).toBe(
+        "0043_memory_notes_postgres_staged",
+      );
+      // Notes still work on sqlite: the tables 0023 created are untouched.
+      expect(before).toContain("_smithers_memory_notes");
+      expect(before).toContain("_smithers_memory_note_supersessions");
+    } finally {
+      sqlite.close();
+    }
+  });
+
   test("0037 repairs missing agent checkpoint tables and index idempotently", () => {
     const { sqlite, db } = setupMemoryDb();
     try {

--- a/packages/memory/src/store/MemoryStoreLive.js
+++ b/packages/memory/src/store/MemoryStoreLive.js
@@ -298,7 +298,11 @@ function makeMemoryStore(db) {
   function deleteThreadEffect(threadId) {
     // Delete the messages and the thread row atomically so a failure on the
     // second write can't leave the thread without its messages (or vice versa).
-    return requireSqliteNotesEffect("DB_WRITE_FAILED", "memory deleteThread").pipe(
+    return requireSyncSqliteEffect(
+      "DB_WRITE_FAILED",
+      "memory deleteThread",
+      "gives the thread row and its messages a single atomic delete",
+    ).pipe(
       Effect.andThen(
         writeEffect("memory deleteThread", () =>
           Promise.resolve(
@@ -422,23 +426,31 @@ function makeMemoryStore(db) {
   }
   // --- Note Effects (P2/P3: append-only knowledge) ---
   /**
-   * Note writes and search ride the synchronous sqlite driver (sync
-   * transactions for note+edge atomicity, FTS5 for search), which the
-   * Postgres/PGlite backends do not provide — there, fail loud up front
-   * instead of surfacing an obscure driver TypeError mid-write. Migration
-   * 0023 still creates the note tables on Postgres so the data model is
-   * ready when this path is ported.
+   * These operations ride the synchronous sqlite driver, which the
+   * Postgres/PGlite backends do not provide — fail loud up front instead of
+   * surfacing an obscure driver TypeError mid-write.
+   *
+   * The Postgres note tables are staged, not served: 0001/0023 create them for
+   * dialect parity and 0043_memory_notes_postgres_staged labels them as such in
+   * the Postgres catalog. The error names both so the schema and the runtime
+   * tell an operator the same story, and points at the sqlite sidecar where a
+   * Postgres-backed workspace actually keeps its memory.
    * @param {"DB_QUERY_FAILED" | "DB_WRITE_FAILED"} code
    * @param {string} label
+   * @param {string} reason What the synchronous sqlite driver is needed for.
    * @returns {Effect.Effect<void, SmithersError>}
    */
-  function requireSqliteNotesEffect(code, label) {
+  function requireSyncSqliteEffect(code, label, reason) {
     const anyDb = /** @type {any} */ (db);
     if (anyDb?.dialect === "postgres" || typeof anyDb?.all !== "function") {
       return Effect.fail(
         toSmithersError(
           new Error(
-            `${label}: memory notes require the sqlite backend (bun:sqlite) — this database does not expose the synchronous sqlite driver`,
+            `${label}: this database does not expose the synchronous sqlite driver (bun:sqlite), which ${reason}. ` +
+              `The Postgres memory-note tables are staged, not served — created for dialect parity by ` +
+              `0001_current_tables/0023_add_memory_notes and labelled by 0043_memory_notes_postgres_staged. ` +
+              `On a Postgres/PGlite workspace, openSmithersBackend keeps memory in the .smithers/smithers.db ` +
+              `sqlite sidecar; open the MemoryStore against that handle instead.`,
           ),
           label,
           { code, details: { operation: label } },
@@ -520,7 +532,11 @@ function makeMemoryStore(db) {
       iteration: input.provenance?.iteration ?? null,
     };
     const nsKind = parseNamespace(nsStr).kind;
-    return requireSqliteNotesEffect("DB_WRITE_FAILED", "memory saveNote").pipe(
+    return requireSyncSqliteEffect(
+      "DB_WRITE_FAILED",
+      "memory saveNote",
+      "gives the note row, its supersession edges, and its FTS5 index entry a single atomic write",
+    ).pipe(
       Effect.andThen(
         writeEffect("memory saveNote", () =>
           Promise.resolve(
@@ -614,7 +630,11 @@ function makeMemoryStore(db) {
    * @returns {Effect.Effect<void, SmithersError>}
    */
   function enableNoteSearchEffect(kind) {
-    return requireSqliteNotesEffect("DB_WRITE_FAILED", "memory enableNoteSearch")
+    return requireSyncSqliteEffect(
+      "DB_WRITE_FAILED",
+      "memory enableNoteSearch",
+      "provides the FTS5 virtual table that backs note search",
+    )
       .pipe(
         Effect.andThen(
           writeEffect("memory enableNoteSearch", () =>
@@ -656,7 +676,11 @@ function makeMemoryStore(db) {
   function searchNotesEffect(kind, query, limit, filter) {
     const max = limit ?? 20;
     return Effect.gen(function* () {
-      yield* requireSqliteNotesEffect("DB_QUERY_FAILED", "memory searchNotes");
+      yield* requireSyncSqliteEffect(
+        "DB_QUERY_FAILED",
+        "memory searchNotes",
+        "provides the FTS5 virtual table that backs note search",
+      );
       if (!noteFtsKindEnabled(kind)) {
         return yield* Effect.fail(
           toSmithersError(

--- a/packages/memory/tests/notes.test.js
+++ b/packages/memory/tests/notes.test.js
@@ -505,6 +505,43 @@ describe("non-sqlite backends fail loud", () => {
     await expect(store.searchNotes("user", "\uDC00")).rejects.toThrow(/sqlite/);
     await expect(store.deleteThread("thread-1")).rejects.toThrow(/sqlite/);
   });
+
+  // The Postgres note tables are staged, not served. The runtime rejection is
+  // the operator's other half of that story (the first half is the catalog
+  // comment migration 0043 stamps), so it must name the migrations that staged
+  // the tables and the sidecar where a Postgres workspace really keeps memory.
+  test("the rejection names the staging migrations and the sqlite sidecar", async () => {
+    const store = createMemoryStore(/** @type {any} */ ({ dialect: "postgres" }));
+    for (const operation of [
+      () => store.saveNote({ namespace: USER_NS, body: "x" }),
+      () => store.enableNoteSearch("user"),
+      () => store.searchNotes("user", "x"),
+      () => store.deleteThread("thread-1"),
+    ]) {
+      const error = await operation().then(
+        () => undefined,
+        (cause) => cause,
+      );
+      expect(error).toBeDefined();
+      expect(error.message).toContain("0023_add_memory_notes");
+      expect(error.message).toContain("0043_memory_notes_postgres_staged");
+      expect(error.message).toContain("staged, not served");
+      expect(error.message).toContain(".smithers/smithers.db");
+    }
+  });
+
+  // deleteThread is a thread operation, not a note operation. It shares the
+  // gate because it needs a synchronous transaction, so its reason must say so
+  // rather than blaming notes.
+  test("deleteThread explains the transaction it needs, not notes", async () => {
+    const store = createMemoryStore(/** @type {any} */ ({ dialect: "postgres" }));
+    const error = await store.deleteThread("thread-1").then(
+      () => undefined,
+      (cause) => cause,
+    );
+    expect(error.message).toContain("the thread row and its messages a single atomic delete");
+    expect(error.code).toBe("DB_WRITE_FAILED");
+  });
 });
 
 describe("additive migration (criterion f)", () => {

--- a/packages/server/tests/gateway-shared-db.test.jsx
+++ b/packages/server/tests/gateway-shared-db.test.jsx
@@ -406,7 +406,7 @@ describe("gateway — many workflows sharing one DB", () => {
     expect(response.ok).toBe(true);
     // Pinned to the current migration head: bump this with every new migration
     // so an accidental head change is a failing test, not a silent drift.
-    expect(response.payload.schemaVersion).toBe("0042");
+    expect(response.payload.schemaVersion).toBe("0043");
     expect(typeof response.payload.signature).toBe("string");
     expect(typeof response.payload.components._smithers_runs).toBe("string");
   });

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -16590,7 +16590,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see Node runtime.
+Node there is no sqlite at all. See Node runtime.
 
 ## Processors
 

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -16581,6 +16581,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see Node runtime.
+
 ## Processors
 
 Maintenance jobs you run periodically:

--- a/packages/smithers/tests/migrateSmithersStore.test.js
+++ b/packages/smithers/tests/migrateSmithersStore.test.js
@@ -39,7 +39,7 @@ describe("migrateSmithersStore", () => {
     expect(result.backend).toBe("pglite");
     expect(result.dbPath).toBe(dbPath);
     expect(result.runCount).toBe(1);
-    expect(result.schemaVersion).toBe("0042");
+    expect(result.schemaVersion).toBe("0043");
     expect(existsSync(result.markerPath)).toBe(true);
     expect(existsSync(dbPath)).toBe(true);
     expect(progress.some((event) => event.type === "table-copied" && event.table === "result")).toBe(true);

--- a/packages/smithers/tests/migrateSmithersStorePostgres.test.js
+++ b/packages/smithers/tests/migrateSmithersStorePostgres.test.js
@@ -44,7 +44,7 @@ describe("migrateSmithersStore real postgres", () => {
       expect(result.source.backend).toBe("sqlite");
       expect(result.target).toMatchObject({ backend: "postgres", url: "set" });
       expect(result.runCount).toBe(1);
-      expect(result.schemaVersion).toBe("0042");
+      expect(result.schemaVersion).toBe("0043");
       expect(existsSync(result.markerPath)).toBe(true);
 
       const api = await openSmithersBackend({}, { cwd, backend: "postgres", connectionString: url, env: {} });

--- a/packages/smithers/tests/migrateSmithersStoreReceipts.test.js
+++ b/packages/smithers/tests/migrateSmithersStoreReceipts.test.js
@@ -198,7 +198,7 @@ describe("migrateSmithersStore targets and receipts", () => {
       }
 
       const result = await migrateSmithersStore({ cwd, from: "sqlite", to: "pglite" });
-      expect(result.schemaVersion).toBe("0042");
+      expect(result.schemaVersion).toBe("0043");
 
       // The migration itself upgraded the source schema before copying.
       sqlite = new Database(dbPath, { readonly: true });

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -16590,7 +16590,7 @@ than degrading. The Postgres schema still carries `_smithers_memory_notes` and
 served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
 or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
 `.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
-Node there is no sqlite at all — see Node runtime.
+Node there is no sqlite at all. See Node runtime.
 
 ## Processors
 

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -16581,6 +16581,17 @@ pass `{ namespace }` to stay namespace-local on a shared backend. See
 [`examples/incident-runbook-memory.jsx`](https://github.com/smithersai/smithers/blob/main/examples/incident-runbook-memory.jsx)
 for the full recall → triage → bank → distill → ratify loop.
 
+Notes are a **SQLite-only** capability: the note + supersession-edge write needs
+one synchronous transaction and search needs FTS5, neither of which the Postgres
+path provides. `saveNote`, `enableNoteSearch`, `searchNotes`, and the
+transactional `deleteThread` fail loud against a Postgres/PGlite handle rather
+than degrading. The Postgres schema still carries `_smithers_memory_notes` and
+`_smithers_memory_note_supersessions` for dialect parity, labelled *staged, not
+served* by migration `0043_memory_notes_postgres_staged`. Under Bun, a Postgres
+or PGlite workspace still gets notes: `openSmithersBackend` keeps memory in the
+`.smithers/smithers.db` sqlite sidecar it opens alongside the main database. Under
+Node there is no sqlite at all — see Node runtime.
+
 ## Processors
 
 Maintenance jobs you run periodically:


### PR DESCRIPTION
Closes #1330.

> **@fucory — decision inside, please confirm.** #1330 offered two options (implement the Postgres notes path, or stop creating the unused PG DDL). I took a **third**: keep the DDL but make the mismatch impossible to misread. Reasoning below — overrule me if you'd rather have one of the original two.

## Why not either original option

**Removing the DDL from migration 0023 is unsafe.** 0023 has already shipped. Its `isAppliedPostgres` keys off the tables existing, so a deployment that already ran it has them; changing the migration in place cannot un-create them and would only diverge new deployments from old ones. That is strictly worse than the status quo — two different Postgres schemas depending on when you installed.

**Implementing the Postgres path is a real feature, not a cleanup.** Notes need sync-transaction atomicity for the note + supersession-edge write, and FTS5 for search. On Postgres that means an async transaction path plus a `tsvector`/GIN search implementation with different ranking behavior. That is worth doing deliberately, with its own issue and its own review — not smuggled in under a consistency bug.

## What this does instead

The DDL stays (so existing and new Postgres deployments agree), but nothing about it now implies runtime support:

- The migration's Postgres arm records the tables as **staged, not served**.
- The runtime error from `requireSqliteNotesEffect` now names the migration and the reason, so someone who hits it learns *why* the tables exist rather than assuming a bug.
- Docs state the sqlite-only limit at the point where the tables are described.

Net effect: a Postgres operator who sees `_smithers_memory_notes` gets a straight answer about what it is and is not, and nobody has to guess whether the DDL is a promise.

## Existing deployments

No schema change. A Postgres deployment that already ran 0023 is unaffected; one that runs it now gets the same tables it would have got before.

**Left open deliberately:** implementing Postgres notes for real. If you want that, it should be its own issue and I'll take it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)