### PR TITLE
fix(gateway): require a trusted-proxy peer boundary before honouring identity headers

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -10519,6 +10519,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"
@@ -11334,6 +11335,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See Gateway auth. |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |
@@ -13578,6 +13580,8 @@ The proxy usually has two Gateway-auth branches:
 The Gateway auth mode determines which branch preserves per-user identity. In `mode: "trusted-proxy"`, the Gateway reads role, scopes, user id, and token id from the trusted headers the proxy set. In `mode: "token"` or `mode: "jwt"`, the Gateway reads the bearer credential and ignores trusted-proxy identity headers; use the service-token branch only when service identity is acceptable. The browser never sees a Gateway credential; the iframe's RPC calls and WebSocket upgrades flow through the proxy.
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
+
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See Gateway auth.
 
 ## Local dev quick reference
 
@@ -17821,6 +17825,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -17828,7 +17833,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 

--- a/docs/deployment/production-hardening.mdx
+++ b/docs/deployment/production-hardening.mdx
@@ -57,6 +57,8 @@ Recommended scopes by client type:
 
 Rotate token grants regularly; revoke them once a user, CI job, or integration no longer needs access.
 
+If you terminate user sessions at a reverse proxy and run the Gateway in `mode: "trusted-proxy"`, you must also declare the transport-level trust boundary with `auth.trustedProxies`: the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from. Identity headers are honored only from those peers, anything else gets `403 UNTRUSTED_PROXY_PEER`, and a Gateway configured for trusted-proxy mode without an enforceable boundary refuses to start. The peer is the transport peer (the last hop that opened the connection), never an `X-Forwarded-For` entry. Bind the listener so the proxy is the only thing that can reach it, and see [Gateway auth](/integrations/gateway) for the full failure-mode table.
+
 For multi-tenant deployments, see [Control Plane](/deployment/control-plane) for org, project, usage, and audit primitives.
 
 ## Execution Boundary
@@ -122,6 +124,7 @@ Before a production release:
 - CI is green on typecheck, dependency checks, and tests.
 - Database backups have been restored in a staging environment.
 - Gateway tokens are scoped and have bounded TTLs.
+- Trusted-proxy deployments declare `auth.trustedProxies`, and a direct request bypassing the proxy is refused with `403 UNTRUSTED_PROXY_PEER`.
 - Sandbox runtime enforcement has been tested against the intended threat model.
 - Approval paths have a named owner and a fallback owner (see [Approval](/components/approval)).
 - Logs are retained long enough to investigate delayed workflow failures.

--- a/docs/guides/custom-workflow-ui.mdx
+++ b/docs/guides/custom-workflow-ui.mdx
@@ -485,6 +485,8 @@ The Gateway auth mode determines which branch preserves per-user identity. In `m
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
 
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See [Gateway auth](/integrations/gateway).
+
 ## Local dev quick reference
 
 ```bash

--- a/docs/integrations/gateway.mdx
+++ b/docs/integrations/gateway.mdx
@@ -702,6 +702,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -709,7 +710,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -10527,6 +10527,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"
@@ -11342,6 +11343,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See [Gateway auth](/integrations/gateway). |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |
@@ -13591,6 +13593,8 @@ The proxy usually has two Gateway-auth branches:
 The Gateway auth mode determines which branch preserves per-user identity. In `mode: "trusted-proxy"`, the Gateway reads role, scopes, user id, and token id from the trusted headers the proxy set. In `mode: "token"` or `mode: "jwt"`, the Gateway reads the bearer credential and ignores trusted-proxy identity headers; use the service-token branch only when service identity is acceptable. The browser never sees a Gateway credential; the iframe's RPC calls and WebSocket upgrades flow through the proxy.
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
+
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See [Gateway auth](/integrations/gateway).
 
 ## Local dev quick reference
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10519,6 +10519,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"
@@ -11334,6 +11335,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See Gateway auth. |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |
@@ -13578,6 +13580,8 @@ The proxy usually has two Gateway-auth branches:
 The Gateway auth mode determines which branch preserves per-user identity. In `mode: "trusted-proxy"`, the Gateway reads role, scopes, user id, and token id from the trusted headers the proxy set. In `mode: "token"` or `mode: "jwt"`, the Gateway reads the bearer credential and ignores trusted-proxy identity headers; use the service-token branch only when service identity is acceptable. The browser never sees a Gateway credential; the iframe's RPC calls and WebSocket upgrades flow through the proxy.
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
+
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See Gateway auth.
 
 ## Local dev quick reference
 
@@ -17821,6 +17825,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -17828,7 +17833,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 

--- a/docs/llms-observability.txt
+++ b/docs/llms-observability.txt
@@ -1050,6 +1050,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -1057,7 +1058,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 

--- a/docs/reference/errors.mdx
+++ b/docs/reference/errors.mdx
@@ -289,6 +289,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See [Gateway auth](/integrations/gateway). |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |

--- a/docs/reference/types.mdx
+++ b/docs/reference/types.mdx
@@ -1828,6 +1828,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"

--- a/packages/server/src/GatewayAuthConfig.ts
+++ b/packages/server/src/GatewayAuthConfig.ts
@@ -33,6 +33,18 @@ export type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      /**
+       * Transport-level trust boundary. Required and non-empty: trusted-proxy
+       * mode authenticates from client-supplied identity headers, so the
+       * gateway only honors them when the immediate socket peer matches one of
+       * these entries. Each entry is an IP literal (`"10.0.0.7"`, `"::1"`), a
+       * CIDR block (`"10.0.0.0/24"`), or the literal `"unix"` for a
+       * Unix-domain listener. The peer is the transport peer — never
+       * `X-Forwarded-For` — so behind a proxy chain list only the last hop.
+       * Startup fails when this is missing, empty, malformed, or cannot apply
+       * to the socket the gateway binds.
+       */
+      trustedProxies: string[];
       trustedHeaders?: string[];
       allowedOrigins?: string[];
       defaultRole?: string;

--- a/packages/server/src/gateway.js
+++ b/packages/server/src/gateway.js
@@ -727,6 +727,189 @@ function isLoopbackHost(hostHeader) {
   );
 }
 /**
+ * Parse a dotted-quad IPv4 literal into its 4 raw bytes.
+ * @param {string} value
+ * @returns {Uint8Array | null}
+ */
+function parseIpv4Bytes(value) {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  const bytes = new Uint8Array(4);
+  for (let index = 0; index < 4; index += 1) {
+    const part = parts[index];
+    if (!/^\d{1,3}$/.test(part)) {
+      return null;
+    }
+    const octet = Number(part);
+    if (octet > 255) {
+      return null;
+    }
+    bytes[index] = octet;
+  }
+  return bytes;
+}
+/**
+ * Parse an IP literal into raw bytes: 4 for IPv4, 16 for IPv6. An IPv4-mapped
+ * IPv6 address (`::ffff:10.0.0.7`, what a dual-stack listener reports for an
+ * IPv4 peer) collapses to its 4-byte IPv4 form so one `10.0.0.7` entry matches
+ * both spellings. An RFC 4007 zone id (`fe80::1%eth0`) is stripped.
+ * @param {string} value
+ * @returns {Uint8Array | null}
+ */
+function parseIpBytes(value) {
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "") {
+    return null;
+  }
+  const zone = trimmed.indexOf("%");
+  const address = zone >= 0 ? trimmed.slice(0, zone) : trimmed;
+  if (!address.includes(":")) {
+    return parseIpv4Bytes(address);
+  }
+  // A trailing dotted quad ("::ffff:10.0.0.7") occupies the final two groups.
+  let text = address;
+  const lastColon = text.lastIndexOf(":");
+  if (text.slice(lastColon + 1).includes(".")) {
+    const embedded = parseIpv4Bytes(text.slice(lastColon + 1));
+    if (!embedded) {
+      return null;
+    }
+    const high = ((embedded[0] << 8) | embedded[1]).toString(16);
+    const low = ((embedded[2] << 8) | embedded[3]).toString(16);
+    text = `${text.slice(0, lastColon + 1)}${high}:${low}`;
+  }
+  const halves = text.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+  /**
+   * @param {string} part
+   * @returns {number[] | null}
+   */
+  const parseGroups = (part) => {
+    if (part === "") {
+      return [];
+    }
+    const parsed = [];
+    for (const group of part.split(":")) {
+      if (!/^[0-9a-f]{1,4}$/.test(group)) {
+        return null;
+      }
+      parsed.push(Number.parseInt(group, 16));
+    }
+    return parsed;
+  };
+  const head = parseGroups(halves[0]);
+  const tail = halves.length === 2 ? parseGroups(halves[1]) : [];
+  if (head === null || tail === null) {
+    return null;
+  }
+  const zeros = halves.length === 2 ? 8 - head.length - tail.length : 0;
+  if (zeros < 0 || (halves.length === 1 && head.length !== 8)) {
+    return null;
+  }
+  const words = [...head, ...new Array(zeros).fill(0), ...tail];
+  const bytes = new Uint8Array(16);
+  for (let index = 0; index < 8; index += 1) {
+    bytes[index * 2] = (words[index] >> 8) & 0xff;
+    bytes[index * 2 + 1] = words[index] & 0xff;
+  }
+  const mapped = bytes[10] === 0xff && bytes[11] === 0xff && bytes.slice(0, 10).every((byte) => byte === 0);
+  return mapped ? bytes.slice(12) : bytes;
+}
+/**
+ * @param {Uint8Array} peer
+ * @param {{ bytes: Uint8Array; prefix: number }} cidr
+ * @returns {boolean}
+ */
+function ipMatchesCidr(peer, cidr) {
+  // Address families never match across each other: a 4-byte IPv4 peer is only
+  // compared to IPv4 entries (mapped forms are normalized before we get here).
+  if (peer.length !== cidr.bytes.length) {
+    return false;
+  }
+  const wholeBytes = cidr.prefix >> 3;
+  for (let index = 0; index < wholeBytes; index += 1) {
+    if (peer[index] !== cidr.bytes[index]) {
+      return false;
+    }
+  }
+  const remainingBits = cidr.prefix & 7;
+  if (remainingBits === 0) {
+    return true;
+  }
+  const mask = (0xff << (8 - remainingBits)) & 0xff;
+  return (peer[wholeBytes] & mask) === (cidr.bytes[wholeBytes] & mask);
+}
+/**
+ * Compile one `auth.trustedProxies` entry: an IP literal, a CIDR block, or the
+ * literal `"unix"` (peers arriving over a Unix-domain socket, bounded by the
+ * socket file's filesystem permissions).
+ * @param {unknown} entry
+ * @returns {{ kind: "unix" } | { kind: "cidr"; bytes: Uint8Array; prefix: number }}
+ */
+function compileTrustedProxyEntry(entry) {
+  const value = typeof entry === "string" ? entry.trim().toLowerCase() : "";
+  if (value === "") {
+    throw new SmithersError("INVALID_INPUT", "auth.trustedProxies entries must be non-empty strings.");
+  }
+  if (value === "unix") {
+    return { kind: "unix" };
+  }
+  const slash = value.lastIndexOf("/");
+  const bytes = parseIpBytes(slash >= 0 ? value.slice(0, slash) : value);
+  if (!bytes) {
+    throw new SmithersError(
+      "INVALID_INPUT",
+      `auth.trustedProxies entry is not an IP address, a CIDR block, or "unix": ${String(entry)}`,
+    );
+  }
+  const maxPrefix = bytes.length * 8;
+  if (slash < 0) {
+    return { kind: "cidr", bytes, prefix: maxPrefix };
+  }
+  const suffix = value.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(suffix) || Number(suffix) > maxPrefix) {
+    throw new SmithersError(
+      "INVALID_INPUT",
+      `auth.trustedProxies entry has an out-of-range prefix length (max /${maxPrefix}): ${String(entry)}`,
+    );
+  }
+  return { kind: "cidr", bytes, prefix: Number(suffix) };
+}
+/**
+ * Compile the trusted-proxy transport trust boundary, failing startup when
+ * none is configured. trusted-proxy mode authenticates from client-supplied
+ * identity headers, so without a peer allow-list every client that can reach
+ * the listener could forge `x-user-role: operator` / `x-user-scopes: *`. A mode
+ * that cannot be enforced must not appear to work, so this throws rather than
+ * degrading to the old allow-everyone behavior (#785).
+ * @param {unknown} configured
+ * @returns {{ cidrs: { bytes: Uint8Array; prefix: number }[]; unix: boolean }}
+ */
+function compileTrustedProxies(configured) {
+  if (!Array.isArray(configured) || configured.length === 0) {
+    throw new SmithersError(
+      "INVALID_INPUT",
+      'auth.mode "trusted-proxy" requires a non-empty auth.trustedProxies list of peer IPs, CIDR blocks, or "unix". Without it the gateway cannot verify that identity headers arrived through your proxy, so any direct client could forge them.',
+    );
+  }
+  /** @type {{ bytes: Uint8Array; prefix: number }[]} */
+  const cidrs = [];
+  let unix = false;
+  for (const entry of configured) {
+    const compiled = compileTrustedProxyEntry(entry);
+    if (compiled.kind === "unix") {
+      unix = true;
+      continue;
+    }
+    cidrs.push({ bytes: compiled.bytes, prefix: compiled.prefix });
+  }
+  return { cidrs, unix };
+}
+/**
  * @param {unknown} value
  * @returns {number | undefined}
  */
@@ -1630,6 +1813,7 @@ export function statusForRpcError(code) {
       return 401;
     case "FORBIDDEN":
     case "Forbidden":
+    case "UNTRUSTED_PROXY_PEER":
       return 403;
     case "NOT_FOUND":
     case "METHOD_NOT_FOUND":
@@ -2808,6 +2992,14 @@ export class Gateway {
         ? DEFAULT_AUTH_DEADLINE_MS
         : Math.floor(assertPositiveFiniteInteger("authDeadlineMs", Number(options.authDeadlineMs)));
     this.auth = options.auth;
+    // #785: trusted-proxy mode authenticates from forgeable identity headers,
+    // so it only starts with an enforceable transport-level trust boundary.
+    // Compiling here (not on first request) makes a missing or malformed
+    // `trustedProxies` a startup failure instead of a silent open door.
+    this.trustedProxies = this.auth?.mode === "trusted-proxy" ? compileTrustedProxies(this.auth.trustedProxies) : null;
+    // Set by listen(): only a process that actually bound a Unix-domain socket
+    // may honor a "unix" trusted-proxy entry.
+    this.unixSocketListener = false;
     // A deliberate unauthenticated remote bind (`smithers gateway --insecure`)
     // trusts any Host, matching serve.js. Without this, --insecure passes the
     // CLI bind guard but isHostAllowed still 403s every non-loopback request.
@@ -5660,6 +5852,25 @@ a { color: var(--brand); }</style>
     if (this.server) {
       return this.server;
     }
+    // #785: the compiled trust boundary must be enforceable against the socket
+    // we are about to bind. A "unix"-only allow-list on a TCP listener (or an
+    // address-only allow-list on a Unix socket) would reject every request, so
+    // fail the bind instead of coming up in a mode that cannot work.
+    this.unixSocketListener = options.path !== undefined;
+    if (this.trustedProxies) {
+      if (this.unixSocketListener && !this.trustedProxies.unix) {
+        throw new SmithersError(
+          "INVALID_INPUT",
+          'auth.trustedProxies must include "unix" when the gateway listens on a Unix-domain socket; peer IPs and CIDR blocks never match a Unix peer.',
+        );
+      }
+      if (!this.unixSocketListener && this.trustedProxies.cidrs.length === 0) {
+        throw new SmithersError(
+          "INVALID_INPUT",
+          "auth.trustedProxies must include at least one peer IP or CIDR block when the gateway listens on a TCP port.",
+        );
+      }
+    }
     const wsServer = new WebSocketServer({
       noServer: true,
       maxPayload: this.maxPayload,
@@ -5793,6 +6004,39 @@ a { color: var(--brand); }</style>
         // end() (not write()+destroy()) so the response is flushed to the
         // peer before the socket closes — a bare destroy can RST away the
         // unsent bytes, leaving the client with no status.
+        socket.end(
+          "HTTP/1.1 403 Forbidden\r\n" +
+            "Connection: close\r\n" +
+            "Content-Type: text/plain; charset=utf-8\r\n" +
+            `X-Smithers-API-Version: ${SMITHERS_API_VERSION}\r\n` +
+            `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n` +
+            "\r\n" +
+            body,
+        );
+        return;
+      }
+      // #785: in trusted-proxy mode the only credential is a set of headers,
+      // so an upgrade from an untrusted peer can never authenticate. Refuse it
+      // at the handshake, as the Origin gate above does, instead of letting it
+      // hold a pre-auth slot until its `connect` is rejected.
+      if (this.auth?.mode === "trusted-proxy" && !this.isTrustedProxyPeer(req)) {
+        emitGatewayEffect(
+          incrementMetric(gatewayErrorsTotal, {
+            kind: "auth",
+            transport: "ws",
+          }),
+        );
+        emitGatewayLog(
+          "warning",
+          "Gateway WS upgrade rejected: peer is not a configured trusted proxy",
+          {
+            transport: "ws",
+            remoteAddress: req.socket.remoteAddress ?? null,
+            host: asString(req.headers.host) ?? null,
+          },
+          "gateway:connect",
+        );
+        const body = "Peer is not a configured trusted proxy\n";
         socket.end(
           "HTTP/1.1 403 Forbidden\r\n" +
             "Connection: close\r\n" +
@@ -7268,6 +7512,53 @@ a { color: var(--brand); }</style>
     }
   }
   /**
+   * The immediate transport peer of `req`: the address of the socket that is
+   * actually connected to this process.
+   *
+   * Deliberately NOT derived from `X-Forwarded-For` (or any other header):
+   * those are supplied by the very caller whose provenance is in question, so
+   * reading the peer from them would make the trust check circular. Behind a
+   * proxy chain (`client -> edge -> internal proxy -> gateway`) the peer is the
+   * LAST hop, the one that opened this connection — only that hop belongs in
+   * `trustedProxies`, and the earlier hops in `X-Forwarded-For` are just data
+   * the trusted proxy vouched for. A request whose socket reports no remote
+   * address arrived over a Unix-domain socket, whose peer set is bounded by the
+   * socket file's filesystem permissions rather than by an address.
+   * @param {IncomingMessage} req
+   * @returns {{ kind: "ip"; address: string } | { kind: "unix" }}
+   */
+  requestPeer(req) {
+    const remoteAddress = asString(req?.socket?.remoteAddress);
+    if (remoteAddress !== undefined && remoteAddress !== "") {
+      return { kind: "ip", address: remoteAddress };
+    }
+    return { kind: "unix" };
+  }
+  /**
+   * Whether `req`'s transport peer is a configured trusted proxy, the only
+   * condition under which trusted-proxy identity headers may be honored (#785).
+   * @param {IncomingMessage} req
+   * @returns {boolean}
+   */
+  isTrustedProxyPeer(req) {
+    const trusted = this.trustedProxies;
+    if (!trusted) {
+      return false;
+    }
+    const peer = this.requestPeer(req);
+    if (peer.kind === "unix") {
+      // Require an actual Unix-domain listener: a TCP socket that has lost its
+      // remote address (already destroyed, say) must never fall through into
+      // the unix branch and inherit the socket file's trust.
+      return trusted.unix && this.unixSocketListener;
+    }
+    const bytes = parseIpBytes(peer.address);
+    if (!bytes) {
+      return false;
+    }
+    return trusted.cidrs.some((cidr) => ipMatchesCidr(bytes, cidr));
+  }
+  /**
    * DNS-rebinding defense (spec decision 16a). An unauthenticated daemon grants
    * operator scope to every request, so a browser page at a name rebound to
    * 127.0.0.1 could drive `launchRun` (real compute/shell). Browsers send the
@@ -7422,6 +7713,30 @@ a { color: var(--brand); }</style>
       };
     }
     if (this.auth.mode === "trusted-proxy") {
+      // #785: every header read below is forgeable by anyone who can reach the
+      // listener, so they are honored ONLY when the immediate transport peer is
+      // a configured trusted proxy. Any other peer is REJECTED rather than
+      // downgraded to anonymous — a forged-credential attempt has to be visible
+      // — and returning here guarantees the headers never reach the
+      // authenticated context.
+      if (!this.isTrustedProxyPeer(req)) {
+        const peer = this.requestPeer(req);
+        emitGatewayLog(
+          "warning",
+          "Gateway rejected trusted-proxy identity headers from an untrusted peer",
+          {
+            peer: peer.kind === "ip" ? peer.address : "unix",
+            host: asString(req.headers.host) ?? null,
+            origin: asString(req.headers.origin) ?? null,
+          },
+          "gateway:auth",
+        );
+        return {
+          ok: false,
+          code: "UNTRUSTED_PROXY_PEER",
+          message: "trusted-proxy identity headers are only accepted from a configured trusted proxy peer",
+        };
+      }
       // Origin allow-list is enforced uniformly above (#446).
       const [userHeader = "x-user-id", scopesHeader = "x-user-scopes", roleHeader = "x-user-role"] = (
         this.auth.trustedHeaders ?? []

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -242,6 +242,18 @@ type GatewayAuthConfig$1 = {
     allowedOrigins?: string[];
 } | {
     mode: "trusted-proxy";
+    /**
+     * Transport-level trust boundary. Required and non-empty: trusted-proxy
+     * mode authenticates from client-supplied identity headers, so the
+     * gateway only honors them when the immediate socket peer matches one of
+     * these entries. Each entry is an IP literal (`"10.0.0.7"`, `"::1"`), a
+     * CIDR block (`"10.0.0.0/24"`), or the literal `"unix"` for a
+     * Unix-domain listener. The peer is the transport peer — never
+     * `X-Forwarded-For` — so behind a proxy chain list only the last hop.
+     * Startup fails when this is missing, empty, malformed, or cannot apply
+     * to the socket the gateway binds.
+     */
+    trustedProxies: string[];
     trustedHeaders?: string[];
     allowedOrigins?: string[];
     defaultRole?: string;

--- a/packages/server/src/index.d.ts
+++ b/packages/server/src/index.d.ts
@@ -1145,6 +1145,14 @@ declare class Gateway {
     hasActiveCrons: boolean;
     hasPendingTimers: boolean;
     cronSweepInFlight: boolean;
+    trustedProxies: {
+        cidrs: {
+            bytes: Uint8Array;
+            prefix: number;
+        }[];
+        unix: boolean;
+    } | null;
+    unixSocketListener: boolean;
     trustAnyHost: boolean;
     whatHappenedNarrator: any;
     /** @type {Map<string, { payload: Record<string, unknown> }>} */
@@ -1934,6 +1942,35 @@ declare class Gateway {
      * @returns {boolean}
      */
     isCookieOriginTrusted(req: IncomingMessage): boolean;
+    /**
+     * The immediate transport peer of `req`: the address of the socket that is
+     * actually connected to this process.
+     *
+     * Deliberately NOT derived from `X-Forwarded-For` (or any other header):
+     * those are supplied by the very caller whose provenance is in question, so
+     * reading the peer from them would make the trust check circular. Behind a
+     * proxy chain (`client -> edge -> internal proxy -> gateway`) the peer is the
+     * LAST hop, the one that opened this connection — only that hop belongs in
+     * `trustedProxies`, and the earlier hops in `X-Forwarded-For` are just data
+     * the trusted proxy vouched for. A request whose socket reports no remote
+     * address arrived over a Unix-domain socket, whose peer set is bounded by the
+     * socket file's filesystem permissions rather than by an address.
+     * @param {IncomingMessage} req
+     * @returns {{ kind: "ip"; address: string } | { kind: "unix" }}
+     */
+    requestPeer(req: IncomingMessage): {
+        kind: "ip";
+        address: string;
+    } | {
+        kind: "unix";
+    };
+    /**
+     * Whether `req`'s transport peer is a configured trusted proxy, the only
+     * condition under which trusted-proxy identity headers may be honored (#785).
+     * @param {IncomingMessage} req
+     * @returns {boolean}
+     */
+    isTrustedProxyPeer(req: IncomingMessage): boolean;
     /**
      * DNS-rebinding defense (spec decision 16a). An unauthenticated daemon grants
      * operator scope to every request, so a browser page at a name rebound to

--- a/packages/server/tests/gateway-domain-api.test.ts
+++ b/packages/server/tests/gateway-domain-api.test.ts
@@ -749,7 +749,7 @@ describe("Gateway REST domain API auth and SSE bounds", () => {
 
     const api = await createApi("sqlite");
     const trusted = new Gateway({
-      auth: { mode: "trusted-proxy", defaultScopes: [] },
+      auth: { mode: "trusted-proxy", trustedProxies: ["127.0.0.1", "::1"], defaultScopes: [] },
     });
     trusted.register("value", createValueWorkflow(api));
     const server = await trusted.listen({ port: 0, host: "127.0.0.1" });

--- a/packages/server/tests/gateway-host-defense.test.jsx
+++ b/packages/server/tests/gateway-host-defense.test.jsx
@@ -10,11 +10,11 @@ import { Gateway } from "../src/gateway.js";
  * reject a non-loopback Host — even though its Origin allow-list is permissive.
  */
 
-function req(host, origin) {
+function req(host, origin, remoteAddress = "127.0.0.1") {
   const headers = {};
   if (host !== undefined) headers.host = host;
   if (origin !== undefined) headers.origin = origin;
-  return { headers, socket: {} };
+  return { headers, socket: { remoteAddress } };
 }
 
 /** @type {Gateway[]} */
@@ -263,24 +263,128 @@ describe("gateway — JWT signature verification", () => {
  */
 describe("gateway — trusted-proxy scope fail-closed", () => {
   test("missing scopes header with no defaultScopes is rejected (no implicit '*')", async () => {
-    const gateway = makeGateway({ auth: { mode: "trusted-proxy" } });
+    const gateway = makeGateway({ auth: { mode: "trusted-proxy", trustedProxies: ["127.0.0.1"] } });
     const res = await gateway.authenticateRequest(req("127.0.0.1:7331"), null);
     expect(res.ok).toBe(false);
     expect(res.code).toBe("UNAUTHORIZED");
   });
 
   test("an explicitly-configured defaultScopes is honored when the header is absent", async () => {
-    const gateway = makeGateway({ auth: { mode: "trusted-proxy", defaultScopes: ["runs:read"] } });
+    const gateway = makeGateway({
+      auth: { mode: "trusted-proxy", trustedProxies: ["127.0.0.1"], defaultScopes: ["runs:read"] },
+    });
     const res = await gateway.authenticateRequest(req("127.0.0.1:7331"), null);
     expect(res.ok).toBe(true);
     expect(res.scopes).toEqual(["runs:read"]);
   });
 
   test("a present scopes header is parsed and used", async () => {
-    const gateway = makeGateway({ auth: { mode: "trusted-proxy" } });
+    const gateway = makeGateway({ auth: { mode: "trusted-proxy", trustedProxies: ["127.0.0.1"] } });
     const headers = { host: "127.0.0.1:7331", "x-user-scopes": "runs:read runs:write" };
-    const res = await gateway.authenticateRequest({ headers, socket: {} }, null);
+    const res = await gateway.authenticateRequest({ headers, socket: { remoteAddress: "127.0.0.1" } }, null);
     expect(res.ok).toBe(true);
     expect(res.scopes).toEqual(["runs:read", "runs:write"]);
+  });
+});
+
+/**
+ * #785: trusted-proxy identity headers are forgeable by anyone who can reach
+ * the listener, so the gateway honors them only when the IMMEDIATE TRANSPORT
+ * PEER (`req.socket.remoteAddress`, never `X-Forwarded-For`) is a configured
+ * trusted proxy. These unit cases pin the peer-matching rules; the real-server
+ * HTTP/WS coverage lives in gateway-trusted-proxy-peer.test.jsx.
+ */
+describe("gateway — trusted-proxy peer boundary (#785)", () => {
+  test("startup fails when trusted-proxy mode has no trust boundary", () => {
+    for (const auth of [
+      { mode: "trusted-proxy" },
+      { mode: "trusted-proxy", trustedProxies: [] },
+      { mode: "trusted-proxy", trustedProxies: ["not-an-ip"] },
+      { mode: "trusted-proxy", trustedProxies: ["10.0.0.0/33"] },
+      { mode: "trusted-proxy", trustedProxies: [""] },
+    ]) {
+      expect(() => new Gateway({ auth })).toThrow(/trustedProxies/);
+    }
+  });
+
+  test("a forged header set from an untrusted peer is rejected, not downgraded", async () => {
+    const gateway = makeGateway({
+      auth: { mode: "trusted-proxy", trustedProxies: ["10.4.0.0/24"], defaultScopes: ["runs:read"] },
+    });
+    const res = await gateway.authenticateRequest(
+      {
+        headers: {
+          host: "gateway.example.com",
+          "x-user-id": "attacker",
+          "x-user-role": "operator",
+          "x-user-scopes": "*",
+          "x-smithers-token-id": "forged",
+        },
+        socket: { remoteAddress: "203.0.113.9" },
+      },
+      null,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe("UNTRUSTED_PROXY_PEER");
+    // The forged identity must not leak into the result in any form.
+    expect(JSON.stringify(res)).not.toContain("operator");
+    expect(JSON.stringify(res)).not.toContain("attacker");
+  });
+
+  test("X-Forwarded-For cannot forge the peer: only the last hop counts", async () => {
+    const gateway = makeGateway({
+      auth: { mode: "trusted-proxy", trustedProxies: ["10.4.0.7"], defaultScopes: ["runs:read"] },
+    });
+    // An untrusted peer claiming a trusted address in XFF stays untrusted.
+    const spoofed = await gateway.authenticateRequest(
+      {
+        headers: { host: "gw", "x-forwarded-for": "10.4.0.7", "x-user-scopes": "*" },
+        socket: { remoteAddress: "203.0.113.9" },
+      },
+      null,
+    );
+    expect(spoofed.ok).toBe(false);
+    expect(spoofed.code).toBe("UNTRUSTED_PROXY_PEER");
+    // A trusted last hop is accepted even though earlier hops are untrusted.
+    const chained = await gateway.authenticateRequest(
+      {
+        headers: {
+          host: "gw",
+          "x-forwarded-for": "203.0.113.9, 198.51.100.4, 10.4.0.7",
+          "x-user-scopes": "run:read",
+        },
+        socket: { remoteAddress: "10.4.0.7" },
+      },
+      null,
+    );
+    expect(chained.ok).toBe(true);
+    expect(chained.scopes).toEqual(["run:read"]);
+  });
+
+  test("CIDR blocks, IPv6, and IPv4-mapped peers match as configured", async () => {
+    const gateway = makeGateway({
+      auth: { mode: "trusted-proxy", trustedProxies: ["10.4.0.0/24", "fd00::/8"], defaultScopes: ["run:read"] },
+    });
+    const allow = ["10.4.0.1", "10.4.0.254", "::ffff:10.4.0.9", "fd00::1", "fdaa:bb::5"];
+    for (const remoteAddress of allow) {
+      const res = await gateway.authenticateRequest({ headers: { host: "gw" }, socket: { remoteAddress } }, null);
+      expect(res.ok).toBe(true);
+    }
+    const deny = ["10.4.1.1", "10.5.0.1", "::1", "fe80::1", "203.0.113.9", ""];
+    for (const remoteAddress of deny) {
+      const res = await gateway.authenticateRequest({ headers: { host: "gw" }, socket: { remoteAddress } }, null);
+      expect(res.ok).toBe(false);
+      expect(res.code).toBe("UNTRUSTED_PROXY_PEER");
+    }
+  });
+
+  test('a "unix" entry never trusts a socket that merely lost its address', async () => {
+    const gateway = makeGateway({
+      auth: { mode: "trusted-proxy", trustedProxies: ["unix"], defaultScopes: ["run:read"] },
+    });
+    // No Unix listener was bound, so an address-less socket stays untrusted.
+    const res = await gateway.authenticateRequest({ headers: { host: "gw" }, socket: {} }, null);
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe("UNTRUSTED_PROXY_PEER");
   });
 });

--- a/packages/server/tests/gateway-trusted-proxy-peer.test.jsx
+++ b/packages/server/tests/gateway-trusted-proxy-peer.test.jsx
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { request as httpRequest } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WebSocket } from "ws";
+import { Gateway } from "../src/gateway.js";
+
+/**
+ * #785: in trusted-proxy mode the gateway authenticates from `x-user-id`,
+ * `x-user-scopes`, `x-user-role`, and `x-smithers-token-id` headers, all of
+ * which any client can set. It therefore honors them only when the IMMEDIATE
+ * TRANSPORT PEER — `req.socket.remoteAddress`, the far end of the socket that
+ * is connected to this process, never an `X-Forwarded-For` hop — matches the
+ * configured `trustedProxies` boundary.
+ *
+ * These suites drive the real listener over real sockets (no mocked auth),
+ * covering the HTTP RPC path and the WebSocket connect path, which
+ * authenticate through different code, plus a Unix-domain listener and the
+ * fail-closed startup behavior.
+ */
+
+/** @type {(() => unknown)[]} */
+const cleanups = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    try {
+      await cleanup();
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+const PROXY_HEADERS = {
+  "x-user-id": "user:proxy",
+  "x-user-scopes": "run:read",
+  "x-user-role": "operator",
+  "x-smithers-token-id": "proxy-token",
+};
+
+/**
+ * @param {string[]} trustedProxies
+ */
+async function listenTcp(trustedProxies) {
+  const gateway = new Gateway({
+    protocol: 1,
+    features: ["runs"],
+    heartbeatMs: 100,
+    auth: { mode: "trusted-proxy", trustedProxies },
+  });
+  const server = await gateway.listen({ port: 0, host: "127.0.0.1" });
+  cleanups.push(() => gateway.close());
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Gateway did not expose a port");
+  }
+  return { gateway, port: address.port };
+}
+
+/**
+ * @param {number} port
+ * @param {Record<string, string>} headers
+ */
+async function rpcOverTcp(port, headers) {
+  const response = await fetch(`http://127.0.0.1:${port}/rpc`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({ id: "rpc-1", method: "health", params: {} }),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+/**
+ * `fetch` cannot address a Unix-domain socket portably, so drive the same
+ * `POST /rpc` route through node:http with `socketPath`.
+ * @param {string} socketPath
+ * @param {Record<string, string>} headers
+ */
+function rpcOverUnix(socketPath, headers) {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ id: "rpc-1", method: "health", params: {} });
+    const req = httpRequest(
+      {
+        socketPath,
+        path: "/rpc",
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": Buffer.byteLength(body), ...headers },
+      },
+      (res) => {
+        let text = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          text += chunk;
+        });
+        res.on("end", () => resolve({ status: res.statusCode, body: JSON.parse(text) }));
+      },
+    );
+    req.on("error", reject);
+    req.end(body);
+  });
+}
+
+/**
+ * Open a WebSocket and run the `connect` handshake, reporting whether the
+ * socket even opened (a rejected upgrade never does) and the hello frame.
+ * @param {number} port
+ * @param {Record<string, string>} headers
+ */
+function wsConnect(port, headers) {
+  return new Promise((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers });
+    ws.on("error", () => {});
+    let settled = false;
+    /** @param {{ opened: boolean; hello?: unknown }} outcome */
+    const finish = (outcome) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        ws.close();
+      } catch {
+        /* already closing */
+      }
+      resolve(outcome);
+    };
+    ws.once("close", () => finish({ opened: false }));
+    ws.once("error", () => finish({ opened: false }));
+    ws.once("open", () => {
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "connect-1",
+          method: "connect",
+          params: {
+            minProtocol: 1,
+            maxProtocol: 1,
+            client: { id: "test-client", version: "1.0.0", platform: "bun-test" },
+          },
+        }),
+      );
+    });
+    ws.on("message", (raw) => {
+      const message = JSON.parse(String(raw));
+      if (message.type === "res" && message.id === "connect-1") {
+        finish({ opened: true, hello: message });
+      }
+    });
+    setTimeout(() => finish({ opened: false }), 5_000).unref?.();
+  });
+}
+
+describe("gateway — trusted-proxy peer boundary over the real listener (#785)", () => {
+  test("HTTP RPC: forged identity headers from an untrusted peer are rejected", async () => {
+    // The listener is on loopback but loopback is NOT a configured proxy, so a
+    // direct client is exactly the bypass path the issue describes.
+    const { port } = await listenTcp(["10.4.0.0/24"]);
+    const forged = await rpcOverTcp(port, { ...PROXY_HEADERS, "x-user-scopes": "*" });
+    expect(forged.status).toBe(403);
+    expect(forged.body.error?.code ?? forged.body.code).toBe("UNTRUSTED_PROXY_PEER");
+    // An X-Forwarded-For claiming the trusted address must not help: the peer
+    // is the transport peer, not a header-supplied address.
+    const spoofed = await rpcOverTcp(port, { ...PROXY_HEADERS, "x-forwarded-for": "10.4.0.7" });
+    expect(spoofed.status).toBe(403);
+    expect(spoofed.body.error?.code ?? spoofed.body.code).toBe("UNTRUSTED_PROXY_PEER");
+    // No credential at all is refused the same way; the mode has no anonymous
+    // fallback that a rejected header set could quietly become.
+    const anonymous = await rpcOverTcp(port, {});
+    expect(anonymous.status).toBe(403);
+  });
+
+  test("HTTP RPC: the same headers are honored from a configured trusted peer", async () => {
+    const { port } = await listenTcp(["127.0.0.1", "::1"]);
+    const accepted = await rpcOverTcp(port, PROXY_HEADERS);
+    expect(accepted.status).toBe(200);
+    expect(accepted.body.ok).toBe(true);
+  });
+
+  test("WebSocket connect: an untrusted peer is refused at the upgrade", async () => {
+    const { port } = await listenTcp(["10.4.0.0/24"]);
+    const outcome = await wsConnect(port, { ...PROXY_HEADERS, "x-user-scopes": "*" });
+    expect(outcome.opened).toBe(false);
+  });
+
+  test("WebSocket connect: a trusted peer authenticates with the proxied identity", async () => {
+    const { port } = await listenTcp(["127.0.0.1", "::1"]);
+    const outcome = await wsConnect(port, PROXY_HEADERS);
+    expect(outcome.opened).toBe(true);
+    expect(outcome.hello.ok).toBe(true);
+    expect(outcome.hello.payload.auth.userId).toBe("user:proxy");
+    expect(outcome.hello.payload.auth.role).toBe("operator");
+    expect(outcome.hello.payload.auth.scopes).toEqual(["run:read"]);
+    expect(outcome.hello.payload.auth.tokenId).toBe("proxy-token");
+  });
+
+  test("a Unix-domain listener trusts its peers only with an explicit 'unix' entry", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "smithers-gateway-unix-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const socketPath = join(dir, "gateway.sock");
+    const gateway = new Gateway({
+      protocol: 1,
+      features: ["runs"],
+      heartbeatMs: 100,
+      auth: { mode: "trusted-proxy", trustedProxies: ["unix"] },
+    });
+    await gateway.listen({ path: socketPath });
+    cleanups.push(() => gateway.close());
+    const accepted = await rpcOverUnix(socketPath, PROXY_HEADERS);
+    expect(accepted.status).toBe(200);
+    expect(accepted.body.ok).toBe(true);
+  });
+});
+
+describe("gateway — trusted-proxy startup is fail-closed (#785)", () => {
+  test("constructing trusted-proxy mode without a trust boundary throws", () => {
+    expect(() => new Gateway({ auth: { mode: "trusted-proxy" } })).toThrow(/trustedProxies/);
+    expect(() => new Gateway({ auth: { mode: "trusted-proxy", trustedProxies: [] } })).toThrow(/trustedProxies/);
+    expect(() => new Gateway({ auth: { mode: "trusted-proxy", trustedProxies: ["10.0.0"] } })).toThrow(
+      /trustedProxies/,
+    );
+  });
+
+  test("a boundary that cannot apply to the bound socket fails the listen", async () => {
+    const unixOnly = new Gateway({ auth: { mode: "trusted-proxy", trustedProxies: ["unix"] } });
+    cleanups.push(() => unixOnly.close());
+    await expect(unixOnly.listen({ port: 0, host: "127.0.0.1" })).rejects.toThrow(/peer IP or CIDR/);
+
+    const dir = mkdtempSync(join(tmpdir(), "smithers-gateway-unix-mismatch-"));
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+    const addressOnly = new Gateway({ auth: { mode: "trusted-proxy", trustedProxies: ["127.0.0.1"] } });
+    cleanups.push(() => addressOnly.close());
+    await expect(addressOnly.listen({ path: join(dir, "gateway.sock") })).rejects.toThrow(/must include "unix"/);
+  });
+});

--- a/packages/server/tests/gateway.test.jsx
+++ b/packages/server/tests/gateway.test.jsx
@@ -653,6 +653,7 @@ describe("Gateway", () => {
       heartbeatMs: 100,
       auth: {
         mode: "trusted-proxy",
+        trustedProxies: ["127.0.0.1", "::1"],
         allowedOrigins: ["https://app.example.com"],
         trustedHeaders: ["x-user-id", "x-user-scopes", "x-user-role"],
         defaultRole: "viewer",

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -10519,6 +10519,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"
@@ -11334,6 +11335,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See Gateway auth. |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |
@@ -13578,6 +13580,8 @@ The proxy usually has two Gateway-auth branches:
 The Gateway auth mode determines which branch preserves per-user identity. In `mode: "trusted-proxy"`, the Gateway reads role, scopes, user id, and token id from the trusted headers the proxy set. In `mode: "token"` or `mode: "jwt"`, the Gateway reads the bearer credential and ignores trusted-proxy identity headers; use the service-token branch only when service identity is acceptable. The browser never sees a Gateway credential; the iframe's RPC calls and WebSocket upgrades flow through the proxy.
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
+
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See Gateway auth.
 
 ## Local dev quick reference
 
@@ -17821,6 +17825,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -17828,7 +17833,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1108,6 +1108,13 @@ function checkGatewayAuthDocsMatchRuntimeDefaults() {
     ],
     [serverSource, "const allowedOrigins = this.auth?.allowedOrigins ?? [];"],
     [serverSource, "return !origin || allowedOrigins.includes(origin);"],
+    // #785: trusted-proxy identity headers are gated on the transport peer, and
+    // the mode refuses to start without an enforceable boundary.
+    [serverSource, "if (!this.isTrustedProxyPeer(req)) {"],
+    [serverSource, 'code: "UNTRUSTED_PROXY_PEER",'],
+    [GATEWAY_AUTH_CONFIG_SOURCE, "trustedProxies: string[];"],
+    [GATEWAY_INTEGRATION, 'trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"'],
+    [TYPES_REFERENCE, 'trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"'],
     [GATEWAY_INTEGRATION, 'scopesClaim?: string;          // default "scope"'],
     [GATEWAY_INTEGRATION, 'roleClaim?: string;            // default "role"'],
     [GATEWAY_INTEGRATION, 'userClaim?: string;            // default "sub"'],

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -10519,6 +10519,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       defaultRole?: string;          // default "operator"
@@ -11334,6 +11335,7 @@ JSON response codes, not `SmithersErrorInstance` objects.
 | `INVALID_JSON` | 400 | Body not valid JSON |
 | `SERVER_ERROR` | 500 | Unexpected server error |
 | `UNAUTHORIZED` | 401 | Missing or invalid auth token |
+| `UNTRUSTED_PROXY_PEER` | 403 | `mode: "trusted-proxy"` request or WebSocket upgrade whose transport peer is not in `auth.trustedProxies`. The identity headers are discarded, not honored. See Gateway auth. |
 | `WORKFLOW_PATH_OUTSIDE_ROOT` | 400 | Workflow path outside server root |
 | `RUN_ID_REQUIRED` | 400 | `runId` required when `resume: true` |
 | `RUN_ALREADY_EXISTS` | 409 | Run ID already exists |
@@ -13578,6 +13580,8 @@ The proxy usually has two Gateway-auth branches:
 The Gateway auth mode determines which branch preserves per-user identity. In `mode: "trusted-proxy"`, the Gateway reads role, scopes, user id, and token id from the trusted headers the proxy set. In `mode: "token"` or `mode: "jwt"`, the Gateway reads the bearer credential and ignores trusted-proxy identity headers; use the service-token branch only when service identity is acceptable. The browser never sees a Gateway credential; the iframe's RPC calls and WebSocket upgrades flow through the proxy.
 
 The same shape works behind any reverse proxy (Cloudflare, Cloudflare Access, Caddy, nginx, an internal API gateway): terminate session, strip identity headers off the request, set them from the validated session, forward to the Gateway. Trusted-proxy mode is **only safe behind something you control** that strips and rewrites identity headers; the Gateway docs call this out explicitly.
+
+Stripping headers at the proxy is necessary but not sufficient, because it does nothing about a client that skips the proxy entirely. Set `auth.trustedProxies` to the peer addresses, CIDR blocks, or `"unix"` socket the proxy connects from: the Gateway reads identity headers only from those peers, answers `403 UNTRUSTED_PROXY_PEER` to anything else, and refuses to start in trusted-proxy mode without the list. See Gateway auth.
 
 ## Local dev quick reference
 
@@ -17821,6 +17825,7 @@ type GatewayAuthConfig =
     }
   | {
       mode: "trusted-proxy";
+      trustedProxies: string[];      // REQUIRED: peer IPs / CIDR blocks, or "unix"
       allowedOrigins?: string[];     // default [] (no Origin allowlist)
       trustedHeaders?: string[];     // default ["x-user-id","x-user-scopes","x-user-role"]
       defaultRole?: string;          // default "operator"
@@ -17828,7 +17833,43 @@ type GatewayAuthConfig =
     };
 ```
 
-JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured.
+JWT auth reads scopes from `scope`, role from `role`, and user id from `sub` unless the `*Claim` options override those claim names. Missing JWT role falls back to `defaultRole` and then `operator`; missing JWT scopes fall back to `defaultScopes` and then `[]`. Trusted-proxy auth reads `trustedHeaders` as `[user, scopes, role]`; missing role falls back to `defaultRole` and then `operator`, and missing scopes fall back to `defaultScopes`, or the request is rejected when no `defaultScopes` is configured. Those headers are only read at all when the request's transport peer matches `trustedProxies` (see below).
+
+### Trusted-proxy trust boundary
+
+`trustedProxies` is **required** in `mode: "trusted-proxy"` and must be non-empty. The identity headers above are ordinary request headers, so any client that can reach the listener can set them. The Gateway therefore honors them only when the request's **immediate transport peer** is on the `trustedProxies` list.
+
+Each entry is one of:
+
+| Entry | Matches |
+|---|---|
+| `"10.4.0.7"` | that exact peer address (IPv4 or IPv6; `::ffff:10.4.0.7` matches `10.4.0.7`) |
+| `"10.4.0.0/24"` | any peer inside that CIDR block (IPv4 or IPv6 prefixes) |
+| `"unix"` | any peer of a Unix-domain listener, bounded by the socket file's filesystem permissions |
+
+The peer is `req.socket.remoteAddress`: the far end of the TCP (or Unix) connection actually attached to this process. It is never read from `X-Forwarded-For` or any other header, because those are supplied by the caller whose provenance is being checked, which would make the check circular. In a chain such as `client -> edge proxy -> internal proxy -> Gateway`, list **only the last hop**, the internal proxy that opens the connection to the Gateway. Earlier hops in `X-Forwarded-For` are data your trusted proxy vouched for, not identity the Gateway verifies.
+
+Failure modes, all fail-closed:
+
+| Condition | Result |
+|---|---|
+| `trustedProxies` missing, empty, or malformed | `new Gateway(...)` throws `INVALID_INPUT`; the process never starts |
+| Listening on a TCP port with only a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Listening on a Unix socket without a `"unix"` entry | `gateway.listen()` throws `INVALID_INPUT` |
+| Request or WebSocket upgrade from a peer not on the list | `403 UNTRUSTED_PROXY_PEER`, logged as `Gateway rejected trusted-proxy identity headers from an untrusted peer` |
+
+An untrusted peer is rejected rather than downgraded to an anonymous session, so a forged-credential attempt is visible in logs and metrics and the supplied headers never enter the authenticated context. WebSocket upgrades are refused at the handshake, before the socket opens. There is no configuration flag that restores the previous behavior of accepting identity headers from any peer.
+
+```ts
+const gateway = new Gateway({
+  auth: {
+    mode: "trusted-proxy",
+    trustedProxies: ["10.4.0.0/24"],   // the proxy subnet that fronts this Gateway
+    defaultScopes: ["run:read"],
+  },
+});
+await gateway.listen({ host: "10.4.0.20", port: 7331 });
+```
 
 `allowedOrigins` is available in every mode (token, jwt, trusted-proxy) as defense-in-depth. It defaults to `[]`, which enforces no Origin allowlist. When non-empty, the gateway rejects any HTTP RPC or WebSocket upgrade whose browser `Origin` header is not on the list; requests with no `Origin` header (server-to-server / CLI callers) are always allowed. Set it to your operator-UI origin(s) when exposing a token/jwt gateway to a browser.
 


### PR DESCRIPTION
Closes #785 (`severity:high`, from the 2026-07 full-codebase audit).

> **@fucory — this is a security fix with a deliberate breaking change. Please review before it lands.** It fails startup for trusted-proxy deployments that have not configured a trust boundary. That is the point — a mode that cannot be enforced must not appear to work — but it will break someone's config, so it is your call, not mine.

## The vulnerability

In trusted-proxy mode the gateway accepted `user`, `role`, `scope`, and token-id headers from **any** client that could reach the listener, without verifying the request came through a configured proxy.

- `gateway.js:4977-4980` — every Host allowed whenever auth is configured
- `gateway.js:5107-5135` — identity headers trusted directly

A direct request with `x-user-role: operator` and `x-user-scopes: *` authenticated with those forged grants. Any proxy-bypass path was a complete authorization bypass for run launch, cancellation, approvals, and administrative RPCs.

## The fix

Identity headers are honoured only when the **transport peer** is a configured trusted proxy — not a header-supplied address, which would be circular. A request from an untrusted peer carrying those headers is rejected outright rather than silently downgraded to anonymous, so a forged-credential attempt is visible and the headers never reach the authenticated context.

Startup **fails** when trusted-proxy mode is configured with no enforceable trust boundary.

Covered across the real deployment shapes: direct TCP, Unix socket, and a proxy chain with multiple `X-Forwarded-For` hops.

## Breaking change and migration

A trusted-proxy deployment with no configured trust boundary will now **fail to start** instead of running with a bypass. The operator must declare the trusted peer (address/CIDR, or the protected socket) in the gateway auth config. That is deliberate: the previous behavior was the vulnerability.

## Tests

Forged headers rejected from a direct/untrusted peer; equivalent headers accepted only from a configured trusted peer; both the HTTP RPC path and the WebSocket connect path (they authenticate through different code); and startup failing closed with no trust boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)