### PR TITLE
fix(agents): discard a codex resume id whose rollout was never recorded

### DIFF
--- a/packages/agents/src/BaseCliAgent/BaseCliAgent.js
+++ b/packages/agents/src/BaseCliAgent/BaseCliAgent.js
@@ -183,6 +183,12 @@ function classifyNonRetryableAgentError(message, command, context = {}) {
  * - claude: `--resume <id>` of a killed/relocated conversation prints
  *   `No conversation found with session ID: <id>` (isolated jj worktrees can
  *   relocate the cwd its conversation store is keyed by).
+ * - codex: when the response stream drops before the rollout is recorded, the
+ *   thread id was captured but never persisted, so `exec resume <id>` fails
+ *   `thread/resume failed: no rollout found for thread id <id> (code -32600)`.
+ *   The disconnect is transient; without discarding the id the retry resumes
+ *   the same non-existent thread and the run burns its whole attempt budget
+ *   before failing over.
  *
  * `hadResumeSession` says whether THIS invocation actually resumed a prior
  * session. When it did not — the session that broke was already freshly
@@ -209,6 +215,26 @@ export function classifySessionLoss(command, errorText, rawStderr, hadResumeSess
         freshSessionFailure: !hadResumeSession,
         command: "kimi",
         kimiSessionId: kimiMatch[1],
+      },
+    );
+  }
+  const codexMatch =
+    command === "codex"
+      ? errorText.match(/no rollout found for thread id\s+([0-9a-z-]{8,})/i) ||
+        rawStderr.match(/no rollout found for thread id\s+([0-9a-z-]{8,})/i)
+      : null;
+  if (codexMatch) {
+    return new SmithersError(
+      "AGENT_SESSION_LOST",
+      hadResumeSession
+        ? `Codex thread ${codexMatch[1]} has no recorded rollout; the persisted resume id is dead. Retry will start a fresh session.`
+        : `Codex thread ${codexMatch[1]} has no recorded rollout even though this attempt started a FRESH session — the codex CLI is failing to record rollouts; retrying it will not help. Failing over to the next agent in the chain (if any).`,
+      {
+        failureRetryable: true,
+        discardResumeSession: true,
+        freshSessionFailure: !hadResumeSession,
+        command: "codex",
+        codexThreadId: codexMatch[1],
       },
     );
   }

--- a/packages/agents/tests/classifySessionLoss.test.js
+++ b/packages/agents/tests/classifySessionLoss.test.js
@@ -68,4 +68,52 @@ describe("classifySessionLoss", () => {
   test("an ordinary claude failure is NOT session loss", () => {
     expect(classifySessionLoss("claude", "CLI timed out after 4500000ms", "")).toBeNull();
   });
+
+  // A codex response stream that drops before the rollout is recorded leaves a
+  // captured thread id that was never persisted. Verbatim second-attempt error
+  // from five separate runs on 2026-08-17, each of which then burned all 19
+  // attempts resuming the same non-existent thread.
+  const CODEX_DEAD_THREAD =
+    "Error: thread/resume: thread/resume failed: no rollout found for thread id " +
+    "01a00cb3-1065-73b0-b422-366bc0585f4d (code -32600)";
+
+  test("codex 'no rollout found for thread id' on the error text is session loss", () => {
+    const err = classifySessionLoss("codex", CODEX_DEAD_THREAD, "");
+    expect(err).not.toBeNull();
+    expect(err.code).toBe("AGENT_SESSION_LOST");
+    expect(err.details.discardResumeSession).toBe(true);
+    expect(err.details.failureRetryable).toBe(true);
+    expect(err.details.command).toBe("codex");
+    expect(err.details.codexThreadId).toBe("01a00cb3-1065-73b0-b422-366bc0585f4d");
+    expect(err.message).toContain("Retry will start a fresh session");
+  });
+
+  test("codex dead rollout on stderr is session loss", () => {
+    const err = classifySessionLoss("codex", "", CODEX_DEAD_THREAD);
+    expect(err).not.toBeNull();
+    expect(err.details.discardResumeSession).toBe(true);
+  });
+
+  test("codex dead rollout on a FRESH session reports honestly and does not promise a retry", () => {
+    const err = classifySessionLoss("codex", CODEX_DEAD_THREAD, "", false);
+    expect(err).not.toBeNull();
+    expect(err.details.freshSessionFailure).toBe(true);
+    expect(err.details.discardResumeSession).toBe(true);
+    expect(err.message).toContain("FRESH session");
+    expect(err.message).not.toContain("Retry will start a fresh session");
+  });
+
+  test("the codex pattern on a different CLI is NOT session loss", () => {
+    expect(classifySessionLoss("claude", CODEX_DEAD_THREAD, "")).toBeNull();
+  });
+
+  test("an ordinary codex failure is NOT session loss", () => {
+    expect(
+      classifySessionLoss(
+        "codex",
+        "stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+        "",
+      ),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
## The dead loop

When a codex response stream drops before the rollout is recorded, the thread id has been captured but never persisted. The next attempt resumes it and gets, deterministically and instantly:

```
thread/resume: thread/resume failed: no rollout found for thread id <id> (code -32600)
```

Nothing discards the dead id, so **every** remaining attempt resumes the same non-existent thread. The original disconnect is transient; the dead-loop is not.

Observed on **five separate runs today**, each burning all 19 attempts before the chain failed over — the run then stalls with `failed 3 consecutive attempts with an identical error`. The attempt budget is spent on an id that can never resolve.

Concrete sequence from one of them:

```
attempt 1  stream disconnected before completion: error sending request for url
           (https://chatgpt.com/backend-api/codex/responses)
attempt 2  thread/resume failed: no rollout found for thread id 01a00cb3-…
attempt 3+ … chain falls through, 19 attempts, RunFailed
```

## The fix

`classifySessionLoss` already solves exactly this shape for **kimi** (`kimi -r <uuid>`) and **claude** (`No conversation found with session ID`). Codex simply had no branch. This adds the symmetric one: a typed `AGENT_SESSION_LOST` carrying `discardResumeSession: true`, so the engine drops the dead id and mints a fresh session on the next attempt.

It also carries the existing honest-reporting variant: when the session that broke was *already* fresh, the message says so and stops promising that a retry will help, so the run fails over instead of pretending.

## Tests

Five cases in `packages/agents/tests/classifySessionLoss.test.js`, using the **verbatim** error string from the failing runs: match on error text, match on stderr, the fresh-session variant, cross-CLI isolation (the codex pattern must not classify for claude), and that an ordinary codex stream disconnect is *not* session loss.

Verified red before the fix (3 fail) and green after (12 pass).

## Gates

`bun test packages/agents/tests/classifySessionLoss.test.js` 12 pass · `pnpm format:check` pass.

`pnpm -C packages/agents test` has 11 failures — **all pre-existing on pristine `origin/main`**, verified by stashing this change and re-running: NanocodexAgent auth/workspace-precedence (macOS `/var` vs `/private/var` symlink resolution), the engine cache-capability-fingerprint pair, the Nanocodex checkpoint codec, and a PiAgent JSON-mode case. None touch `classifySessionLoss`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)