### PR TITLE
fix(db): add bounded run history gc

### DIFF
--- a/apps/cli/docs/llms-full.txt
+++ b/apps/cli/docs/llms-full.txt
@@ -2718,7 +2718,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -2738,6 +2738,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -2752,6 +2754,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -2760,22 +2783,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -2811,13 +2834,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered

--- a/apps/cli/src/index.js
+++ b/apps/cli/src/index.js
@@ -13099,6 +13099,11 @@ const cli = Cli.create({
     options: z.object({
       olderThan: z.string().default("7d").describe("Only reclaim artifacts unused for at least this long, e.g. 24h"),
       dryRun: z.boolean().default(false).describe("Report what would be removed without removing anything"),
+      dbRetentionDays: z
+        .number()
+        .nonnegative()
+        .optional()
+        .describe("Opt in to deleting terminal database runs older than this many days"),
       includeUnmanaged: z
         .boolean()
         .default(false)
@@ -13115,6 +13120,7 @@ const cli = Cli.create({
           dryRun: c.options.dryRun,
           includeUnmanaged: c.options.includeUnmanaged,
           forceWorktrees: c.options.force,
+          dbRetentionDays: c.options.dbRetentionDays,
         });
         if (c.format !== "json") {
           const disk = result.disk.before;
@@ -13135,6 +13141,23 @@ const cli = Cli.create({
               `Keeping ${formatBytes(unmanagedBytes)} of unowned legacy scratch; inspect with --dry-run and opt in with --include-unmanaged.`,
             );
           }
+          const snapshots = result.database.snapshots;
+          console.log(
+            result.dryRun
+              ? `Would compact ${snapshots.remainingRows ?? 0} legacy snapshot row(s), removing ${formatBytes(snapshots.remainingInlineBytes ?? 0)} of inline payloads.`
+              : `Compacted ${snapshots.migratedRows} legacy snapshot row(s), clearing ${formatBytes(snapshots.clearedInlineBytes)} of inline payloads for content-addressed reuse.`,
+          );
+          const retention = result.database.retention;
+          if (retention.enabled) {
+            console.log(
+              `${result.dryRun ? "Would remove" : "Removed"} ${retention.removedRuns.length} terminal database run(s) older than ${retention.retentionDays} day(s).`,
+            );
+          } else {
+            console.log(
+              "Database run retention is disabled; opt in with --db-retention-days or SMITHERS_DB_RETENTION_DAYS.",
+            );
+          }
+          console.log("Database pages are reusable, but Smithers never VACUUMs an online database.");
         }
         return c.ok(result);
       } catch (err) {

--- a/apps/cli/src/workspaceGc.js
+++ b/apps/cli/src/workspaceGc.js
@@ -1,5 +1,6 @@
 import { findVcsRoot } from "@smthrs/vcs/find-root";
 import { reapWorktrees } from "@smthrs/engine/reapWorktrees";
+import { compactLegacySnapshots, retainRunHistory } from "@smthrs/db/run-history-gc";
 import { findSmithersAnchorDir } from "smthrs/findSmithersAnchorDir";
 import { join } from "node:path";
 import { cliWorkspace } from "./cliWorkspace.js";
@@ -19,7 +20,7 @@ const DAY_MS = 24 * 60 * 60 * 1_000;
  *
  * @param {{
  *   cwd?: string;
- *   adapter?: Pick<import("@smthrs/db/adapter").SmithersDb, "getRun"> | null;
+ *   adapter?: import("@smthrs/db/adapter").SmithersDb | null;
  *   olderThanMs?: number;
  *   dryRun?: boolean;
  *   includeUnmanaged?: boolean;
@@ -29,6 +30,10 @@ const DAY_MS = 24 * 60 * 60 * 1_000;
  *   tempRoots?: string[];
  *   liveCwds?: string[] | null;
  *   sizeOf?: (path: string) => Promise<number>;
+ *   env?: NodeJS.ProcessEnv;
+ *   dbRetentionDays?: number | null;
+ *   dbChunkSize?: number;
+ *   snapshotBatchSize?: number;
  * }} [options]
  */
 export async function runWorkspaceGc(options = {}) {
@@ -37,6 +42,15 @@ export async function runWorkspaceGc(options = {}) {
   const olderThanMs = options.olderThanMs ?? 7 * DAY_MS;
   const dryRun = options.dryRun ?? false;
   const nowMs = options.nowMs ?? Date.now();
+  const env = options.env ?? process.env;
+  const configuredRetention = options.dbRetentionDays ?? env.SMITHERS_DB_RETENTION_DAYS;
+  let dbRetentionDays = null;
+  if (configuredRetention !== undefined && configuredRetention !== null && configuredRetention !== "") {
+    dbRetentionDays = Number(configuredRetention);
+    if (!Number.isFinite(dbRetentionDays) || dbRetentionDays < 0) {
+      throw new Error("SMITHERS_DB_RETENTION_DAYS must be a nonnegative number");
+    }
+  }
   const before = filesystemUsage(workspaceRoot);
   const liveCwds =
     options.includeUnmanaged && options.liveCwds === undefined ? listLiveProcessCwds() : options.liveCwds;
@@ -60,6 +74,7 @@ export async function runWorkspaceGc(options = {}) {
       olderThanMs,
       dryRun,
       nowMs,
+      env,
       allowAbsentRuns: false,
       minimumAgeForSizeCap: true,
     });
@@ -70,6 +85,7 @@ export async function runWorkspaceGc(options = {}) {
       olderThanMs,
       dryRun,
       nowMs,
+      env,
       allowAbsentRuns: false,
       minimumAgeForSizeCap: true,
     });
@@ -113,6 +129,40 @@ export async function runWorkspaceGc(options = {}) {
       liveCwds,
       sizeOf: options.sizeOf,
     });
+    const retention =
+      adapter && dbRetentionDays !== null
+        ? await retainRunHistory(adapter, {
+            cutoffMs: nowMs - dbRetentionDays * DAY_MS,
+            dryRun,
+            chunkSize: options.dbChunkSize,
+          })
+        : {
+            enabled: false,
+            dryRun,
+            retentionDays: null,
+            removedRuns: [],
+            rowsByTable: {},
+            interrupted: false,
+            skipped: adapter ? "retention-not-configured" : "no-database",
+          };
+    if (retention.enabled) retention.retentionDays = dbRetentionDays;
+    // Delete explicitly retained history first so snapshot compaction never
+    // spends I/O deduplicating payloads that this invocation will remove.
+    const snapshots = adapter
+      ? await compactLegacySnapshots(adapter, {
+          dryRun,
+          batchSize: options.snapshotBatchSize,
+        })
+      : {
+          dryRun,
+          migratedRows: 0,
+          clearedInlineBytes: 0,
+          batches: 0,
+          remainingRows: 0,
+          remainingInlineBytes: 0,
+          interrupted: false,
+          skipped: "no-database",
+        };
     const bytesFreed =
       logs.bytesFreed +
       legacyLogs.bytesFreed +
@@ -132,8 +182,13 @@ export async function runWorkspaceGc(options = {}) {
       worktrees,
       unownedWorktrees,
       unmanagedScratch,
+      database: {
+        snapshots,
+        retention,
+        vacuumed: false,
+      },
     };
   } finally {
-    cleanup();
+    await cleanup();
   }
 }

--- a/apps/cli/tests/disk-gc.test.js
+++ b/apps/cli/tests/disk-gc.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, utimesSync } from "node:fs";
 import { join } from "node:path";
+import { Database } from "bun:sqlite";
 import { reapSandboxRoots } from "../src/reapSandboxRoots.js";
 import { reapUnmanagedScratch } from "../src/reapUnmanagedScratch.js";
 import {
@@ -159,6 +161,101 @@ test(
     expect(existsSync(logFile)).toBe(false);
     expect(existsSync(legacyLogFile)).toBe(false);
     expect(existsSync(sandboxRoot)).toBe(false);
+    const sqlite = new Database(repo.path("smithers.db"), { readonly: true });
+    expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_runs WHERE run_id = ?").get(runId).count).toBe(1);
+    sqlite.close();
+  },
+  CLI_COMMAND_TIMEOUT_MS,
+);
+
+test(
+  "smithers gc compacts legacy snapshots and requires explicit database retention",
+  () => {
+    const repo = createTempRepo();
+    pinSqliteBackend(repo.dir);
+    writeTestWorkflow(repo);
+    const initial = runSmithers(["up", "workflow.tsx", "--run-id", "schema-seed"], {
+      cwd: repo.dir,
+      format: "json",
+      timeoutMs: CLI_COMMAND_TIMEOUT_MS,
+    });
+    expect(initial.exitCode).toBe(0);
+
+    const sqlite = new Database(repo.path("smithers.db"));
+    const insertRun = sqlite.query(
+      `INSERT INTO _smithers_runs
+         (run_id, workflow_name, status, created_at_ms, finished_at_ms)
+       VALUES (?, 'workflow', ?, 1, ?)`,
+    );
+    insertRun.run("old-terminal", "finished", 2);
+    insertRun.run("live-running", "running", null);
+    insertRun.run("live-paused", "paused", null);
+    insertRun.run("live-waiting", "waiting-approval", null);
+    for (const runId of ["old-terminal", "live-running", "live-paused", "live-waiting"]) {
+      sqlite
+        .query(
+          "INSERT INTO _smithers_events (run_id, seq, timestamp_ms, type, payload_json) VALUES (?, 0, 1, 'test', '{}')",
+        )
+        .run(runId);
+    }
+    const nodesJson = "[]";
+    const outputsJson = '{"answer":42}';
+    const ralphJson = "[]";
+    const inputJson = '{"prompt":"legacy"}';
+    const hash = createHash("sha256")
+      .update(`{"nodes":${nodesJson},"outputs":${outputsJson},"ralph":${ralphJson},"input":${inputJson}}`)
+      .digest("hex");
+    sqlite
+      .query(
+        `INSERT INTO _smithers_snapshots
+           (run_id, frame_no, nodes_json, outputs_json, ralph_json, input_json, content_hash, created_at_ms)
+         VALUES ('live-paused', 0, ?, ?, ?, ?, ?, 1)`,
+      )
+      .run(nodesJson, outputsJson, ralphJson, inputJson, hash);
+    const refsBefore = sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count;
+    sqlite.close();
+
+    const dryRun = runSmithers(["gc", "--dry-run", "--db-retention-days", "0"], {
+      cwd: repo.dir,
+      format: "json",
+      timeoutMs: CLI_COMMAND_TIMEOUT_MS,
+    });
+    expect(dryRun.exitCode).toBe(0);
+    expect(dryRun.json?.database?.snapshots?.remainingRows).toBe(1);
+    expect(dryRun.json?.database?.retention?.removedRuns.map((run) => run.runId)).toContain("old-terminal");
+    const afterDryRun = new Database(repo.path("smithers.db"));
+    expect(afterDryRun.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count).toBe(
+      refsBefore,
+    );
+    expect(
+      afterDryRun.query("SELECT COUNT(*) AS count FROM _smithers_runs WHERE run_id = 'old-terminal'").get().count,
+    ).toBe(1);
+    afterDryRun.close();
+
+    const gc = runSmithers(["gc", "--db-retention-days", "0"], {
+      cwd: repo.dir,
+      format: "json",
+      timeoutMs: CLI_COMMAND_TIMEOUT_MS,
+    });
+    expect(gc.exitCode).toBe(0);
+    expect(gc.json?.database?.snapshots).toMatchObject({ migratedRows: 1, remainingRows: 0 });
+    expect(gc.json?.database?.retention?.removedRuns.map((run) => run.runId)).toContain("old-terminal");
+    const afterGc = new Database(repo.path("smithers.db"));
+    expect(
+      afterGc.query("SELECT COUNT(*) AS count FROM _smithers_runs WHERE run_id = 'old-terminal'").get().count,
+    ).toBe(0);
+    expect(
+      afterGc
+        .query("SELECT run_id FROM _smithers_runs WHERE run_id LIKE 'live-%' ORDER BY run_id")
+        .all()
+        .map((row) => row.run_id),
+    ).toEqual(["live-paused", "live-running", "live-waiting"]);
+    expect(
+      afterGc.query("SELECT content_hash FROM _smithers_snapshot_payload_refs WHERE content_hash = ?").get(hash)
+        .content_hash,
+    ).toBe(hash);
+    expect(afterGc.query("PRAGMA foreign_key_check").all()).toEqual([]);
+    afterGc.close();
   },
   CLI_COMMAND_TIMEOUT_MS,
 );

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -110,7 +110,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -130,6 +130,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -144,6 +146,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -152,22 +175,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -203,13 +226,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered

--- a/docs/llms-core.txt
+++ b/docs/llms-core.txt
@@ -2704,7 +2704,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -2724,6 +2724,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -2738,6 +2740,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -2746,22 +2769,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -2797,13 +2820,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2718,7 +2718,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -2738,6 +2738,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -2752,6 +2754,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -2760,22 +2783,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -2811,13 +2834,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered

--- a/docs/runtime/database-storage-audit.mdx
+++ b/docs/runtime/database-storage-audit.mdx
@@ -28,12 +28,12 @@ pruning keep their current eviction contracts.
 
 SQLite `dbstat` reported:
 
-| Table | Physical bytes |
-| --- | ---: |
+| Table                 | Physical bytes |
+| --------------------- | -------------: |
 | `_smithers_snapshots` | 41,281,441,792 |
-| `_smithers_events` | 2,140,786,688 |
-| `_smithers_frames` | 1,489,481,728 |
-| `_smithers_attempts` | 197,328,896 |
+| `_smithers_events`    |  2,140,786,688 |
+| `_smithers_frames`    |  1,489,481,728 |
+| `_smithers_attempts`  |    197,328,896 |
 
 The dominant sampled snapshot held about 6.45 MB of state, almost all in
 `outputs_json`; 40 consecutive rows shared the exact same content hash, making
@@ -41,8 +41,8 @@ snapshot representation the first storage target by a wide margin.
 
 ## Snapshot representation
 
-Migration `0025_snapshot_contents` leaves `_smithers_snapshots` physically
-unchanged and only adds:
+Migration `0025_snapshot_contents` left `_smithers_snapshots` physically
+unchanged and added:
 
 - `_smithers_snapshot_contents`, keyed by the snapshot content hash, holding the
   four raw JSON fields once;
@@ -75,6 +75,12 @@ External SQLite descriptors must provide an atomic `transaction()` callback;
 those that can't hold that boundary, including Cloudflare D1, fail before a
 transactional write begins rather than risk a partial frame or snapshot.
 
+`smithers gc` now migrates those pre-0025 inline rows in bounded transactions.
+Each transaction inserts and verifies content, compacts the snapshot metadata,
+and adds its reference atomically. Progress is the data shape itself: an
+interrupted invocation resumes from the remaining non-empty inline rows. The
+command's dry run reports row and byte totals without writing.
+
 The unreleased gzip prototype behind existing dogfood data stays under its old
 table name, readable with hash verification; the final migration doesn't
 rename, copy, index, or add a column to the roughly 41 GB snapshot table.
@@ -97,14 +103,20 @@ pnpm -C packages/time-travel exec bun test tests/snapshot.test.js
 pnpm -C packages/engine exec bun test tests/time-travel-postgres.test.js
 ```
 
-## What this does not reclaim
+## Retention and physical file size
 
-The change limits future growth without rewriting existing inline snapshots.
-SQLite has `auto_vacuum=0`, so deleting or clearing old payloads wouldn't return
-file space to the OS anyway; reclaiming existing space needs a separate offline
-workflow (verified backup, free-space check, batched materialization, integrity
-verification, `VACUUM INTO`, atomic replacement) that must never run
-automatically against the live 66 GB store.
+`smithers gc --db-retention-days DAYS` opts into incremental deletion of old
+terminal runs. There is no default database retention window and the existing
+filesystem `--older-than` setting does not enable it. The dry run inventories
+eligible runs and per-table rows. Active, paused, waiting, unfinished
+`continued` runs, and ancestors needed by retained descendants are never
+eligible.
+
+SQLite has `auto_vacuum=0`, so compaction and retention return pages to its
+freelist for reuse without returning file bytes to the OS. Smithers deliberately
+does not expose an online vacuum path. Physical shrinking remains an explicit
+offline operator workflow after every process holding the store is stopped and
+a backup is verified. PostgreSQL remains under operator-managed vacuum policy.
 
 Old binaries don't understand compact rows, so rollback after new writes means
 restoring a pre-upgrade backup: the migration doesn't claim an unavailable
@@ -120,7 +132,8 @@ The next candidates are representation changes rather than metrics deletion:
    metadata, preserving the existing bounded keyframe/delta codec.
 3. Deduplicate the same large error JSON currently present in both attempts and
    matching `NodeFailed` events.
-4. Offer explicit terminal-run archival with complete run-owned-table coverage.
+4. Add archive/export-before-retention for operators who want a cold history
+   tier instead of deletion.
 
 Each needs its own compatibility, concurrency, store-copy, and recovery design;
 none is folded into the snapshot migration.

--- a/packages/db/src/index.d.ts
+++ b/packages/db/src/index.d.ts
@@ -10244,6 +10244,62 @@ type RunDriverLiveness = {
     heartbeatFresh: boolean;
 };
 
+/**
+ * Incrementally move legacy inline snapshot payloads into content-addressed
+ * storage. Each page is its own transaction, so interruption leaves only
+ * complete compact rows and a later invocation resumes from inline rows.
+ *
+ * @param {import("./adapter.js").SmithersDb} adapter
+ * @param {{ batchSize?: number; dryRun?: boolean; maxBatches?: number; signal?: AbortSignal }} [options]
+ */
+declare function compactLegacySnapshots(adapter: SmithersDb, options?: {
+    batchSize?: number;
+    dryRun?: boolean;
+    maxBatches?: number;
+    signal?: AbortSignal;
+}): Promise<{
+    dryRun: boolean;
+    migratedRows: number;
+    clearedInlineBytes: number;
+    batches: number;
+    remainingRows: number | null;
+    remainingInlineBytes: number | null;
+    interrupted: boolean;
+}>;
+/**
+ * Remove terminal run history older than an explicit cutoff. There is no
+ * implicit retention default; callers must opt in by passing cutoffMs.
+ *
+ * @param {import("./adapter.js").SmithersDb} adapter
+ * @param {{ cutoffMs: number; dryRun?: boolean; chunkSize?: number; maxRuns?: number; signal?: AbortSignal }} options
+ * @returns {Promise<{
+ *   enabled: true;
+ *   dryRun: boolean;
+ *   cutoffMs: number;
+ *   removedRuns: Array<{ runId: string; status: unknown; finishedAtMs: number }>;
+ *   rowsByTable: Record<string, number>;
+ *   interrupted: boolean;
+ * }>}
+ */
+declare function retainRunHistory(adapter: SmithersDb, options: {
+    cutoffMs: number;
+    dryRun?: boolean;
+    chunkSize?: number;
+    maxRuns?: number;
+    signal?: AbortSignal;
+}): Promise<{
+    enabled: true;
+    dryRun: boolean;
+    cutoffMs: number;
+    removedRuns: Array<{
+        runId: string;
+        status: unknown;
+        finishedAtMs: number;
+    }>;
+    rowsByTable: Record<string, number>;
+    interrupted: boolean;
+}>;
+
 /** @typedef {import("drizzle-orm").Table} _Table */
 /**
  * @param {_Table} table
@@ -10631,4 +10687,4 @@ type AgentCheckpointContentRow = AgentCheckpointContentRow$2;
 type AgentCheckpointRefRow = AgentCheckpointRefRow$2;
 type SchemaRegistryEntry = SchemaRegistryEntry$1;
 
-export { type AgentCheckpointContentRow, type AgentCheckpointRefRow, type AlertRow, type AlertSeverity, type AlertStatus, type AnyColumn, type ApprovalRow, type AttemptRow, type CacheRow, type CacheRowLike, type CountRow, DB_ALERT_ALLOWED_SEVERITIES, DB_ALERT_ALLOWED_STATUSES, DB_ALERT_ID_MAX_LENGTH, DB_ALERT_MESSAGE_MAX_LENGTH, DB_ALERT_POLICY_NAME_MAX_LENGTH, DB_RUN_ALLOWED_STATUSES, DB_RUN_ID_MAX_LENGTH, DB_RUN_WORKFLOW_NAME_MAX_LENGTH, type Database, type Dialect, type DocRow, type EvalCaseResultRow, type EvalSuiteRow, type EventHistoryQuery, type ExternalSqliteDescriptor, FRAME_KEYFRAME_INTERVAL, type FrameDelta, type FrameDeltaOp, type FrameEncoding, type FrameRow, type HumanRequestRow, type IntegrationDeliveryClaim, type JsonBounds, type JsonPath, type JsonPathSegment, NODE_DIFF_MAX_BYTES, NodeDiffCache, type NodeDiffCacheResult, type NodeDiffCacheRow$1 as NodeDiffCacheRow, NodeDiffTooLargeError, type NodeRow, OUTPUT_PROVENANCE_SEQ, type OutputKey, type OutputSnapshot, POSTGRES, type PendingHumanRequestRow, RUN_DRIVER_HEARTBEAT_STALE_MS, type RalphRow, type RunAncestryRow, type RunDriverLiveness, type RunRow, type RunnableEffect, SQLITE, STEAL_OWNERSHIP_FLAG, type SchemaRegistryEntry, type SignalQuery, type SignalRow, SmithersDb, type SmithersError$1 as SmithersError, SqlMessageStorage, type SqlMessageStorageEventHistoryQuery, type SqliteParam, type SqliteTransactionState, type SqliteWriteRetryOptions, type StaleRunRecord, type SteerRow, type Table, type TxidCapture, type ZodError, type _BunSQLiteDatabase, type _NodeDiffCacheRow, type _OutputKey, type _SmithersDb, type _SmithersError, applyFrameDelta, applyFrameDeltaJson, assertJsonPayloadWithinBounds, assertMaxBytes, assertMaxJsonDepth, assertMaxStringLength, assertNoReservedColumns, assertOptionalArrayMaxLength, assertOptionalStringMaxLength, assertPositiveFiniteInteger, assertPositiveFiniteNumber, beginTransactionSql, buildKeyWhere, buildOutputRow, camelToSnake, capturePostgresTransactionTxid, captureTxid, classifyRunDriverLiveness, coerceOutputRowForSnapshot, columnType, createTxidCapture, describeLiveDriverRefusal, describeSchemaShape, encodeFrameDelta, ensureSmithersTables, ensureSmithersTablesEffect, ensureSqlMessageStorage, ensureSqlMessageStorageEffect, formatRuntimeOwnerId, getAgentOutputSchema, getJsonColumnKeys, getKeyColumns, getSmithersSchemaSignature, getSqlMessageStorage, hasActiveTxidCapture, isPidAlive, isPostgresDb, isRealPostgresAdapter, isRetryableSqliteWriteError, isRunDriverAlive, jsonExtractText, loadInput, loadInputEffect, loadOutputs, loadOutputsEffect, loadRunOutputRowsEffect, normalizeFrameEncoding, openDurableSqliteDatabase, parseFrameDelta, parseRuntimeOwnerIdentity, parseRuntimeOwnerPid, pgRowToDrizzle, quoteIdentifier, readProcessStartMs, recordCommittedTxid, runCancellationSourceFromRow, runWithTxidCapture, schemaSignature, selectOutputRow, selectOutputRowEffect, serializeFrameDelta, shouldCapturePostgresTxid, smithersAgentCheckpointContents, smithersAgentCheckpoints, smithersAlerts, smithersApprovals, smithersAttempts, smithersCache, smithersCron, smithersDocs, smithersEvalCases, smithersEvalSuites, smithersEvents, smithersFrames, smithersHumanRequests, smithersIntegrationCursors, smithersIntegrationDeliveries, smithersMemoryFacts, smithersMemoryMessages, smithersMemoryNoteSupersessions, smithersMemoryNotes, smithersMemoryThreads, smithersNodeDiffs, smithersNodes, smithersOutputProvenance, smithersRalph, smithersRuns, smithersSandboxes, smithersSchemaMigrations, smithersScorers, smithersSignals, smithersSteers, smithersTimeTravelAudit, smithersToolCallArchive, smithersToolCalls, smithersVectors, smithersWorkspaceCheckpoints, smithersWorkspaceStates, stripAutoColumns, syncZodTableSchema, syncZodTableSchemaPostgres, translateDdl, translatePlaceholders, unwrapZodType, upsertOutputRow, upsertOutputRowEffect, validateExistingOutput, validateInput, validateOutput, withSqliteWriteRetry, withSqliteWriteRetryEffect, zodSchemaColumns, zodToCreateTableSQL, zodToTable };
+export { type AgentCheckpointContentRow, type AgentCheckpointRefRow, type AlertRow, type AlertSeverity, type AlertStatus, type AnyColumn, type ApprovalRow, type AttemptRow, type CacheRow, type CacheRowLike, type CountRow, DB_ALERT_ALLOWED_SEVERITIES, DB_ALERT_ALLOWED_STATUSES, DB_ALERT_ID_MAX_LENGTH, DB_ALERT_MESSAGE_MAX_LENGTH, DB_ALERT_POLICY_NAME_MAX_LENGTH, DB_RUN_ALLOWED_STATUSES, DB_RUN_ID_MAX_LENGTH, DB_RUN_WORKFLOW_NAME_MAX_LENGTH, type Database, type Dialect, type DocRow, type EvalCaseResultRow, type EvalSuiteRow, type EventHistoryQuery, type ExternalSqliteDescriptor, FRAME_KEYFRAME_INTERVAL, type FrameDelta, type FrameDeltaOp, type FrameEncoding, type FrameRow, type HumanRequestRow, type IntegrationDeliveryClaim, type JsonBounds, type JsonPath, type JsonPathSegment, NODE_DIFF_MAX_BYTES, NodeDiffCache, type NodeDiffCacheResult, type NodeDiffCacheRow$1 as NodeDiffCacheRow, NodeDiffTooLargeError, type NodeRow, OUTPUT_PROVENANCE_SEQ, type OutputKey, type OutputSnapshot, POSTGRES, type PendingHumanRequestRow, RUN_DRIVER_HEARTBEAT_STALE_MS, type RalphRow, type RunAncestryRow, type RunDriverLiveness, type RunRow, type RunnableEffect, SQLITE, STEAL_OWNERSHIP_FLAG, type SchemaRegistryEntry, type SignalQuery, type SignalRow, SmithersDb, type SmithersError$1 as SmithersError, SqlMessageStorage, type SqlMessageStorageEventHistoryQuery, type SqliteParam, type SqliteTransactionState, type SqliteWriteRetryOptions, type StaleRunRecord, type SteerRow, type Table, type TxidCapture, type ZodError, type _BunSQLiteDatabase, type _NodeDiffCacheRow, type _OutputKey, type _SmithersDb, type _SmithersError, applyFrameDelta, applyFrameDeltaJson, assertJsonPayloadWithinBounds, assertMaxBytes, assertMaxJsonDepth, assertMaxStringLength, assertNoReservedColumns, assertOptionalArrayMaxLength, assertOptionalStringMaxLength, assertPositiveFiniteInteger, assertPositiveFiniteNumber, beginTransactionSql, buildKeyWhere, buildOutputRow, camelToSnake, capturePostgresTransactionTxid, captureTxid, classifyRunDriverLiveness, coerceOutputRowForSnapshot, columnType, compactLegacySnapshots, createTxidCapture, describeLiveDriverRefusal, describeSchemaShape, encodeFrameDelta, ensureSmithersTables, ensureSmithersTablesEffect, ensureSqlMessageStorage, ensureSqlMessageStorageEffect, formatRuntimeOwnerId, getAgentOutputSchema, getJsonColumnKeys, getKeyColumns, getSmithersSchemaSignature, getSqlMessageStorage, hasActiveTxidCapture, isPidAlive, isPostgresDb, isRealPostgresAdapter, isRetryableSqliteWriteError, isRunDriverAlive, jsonExtractText, loadInput, loadInputEffect, loadOutputs, loadOutputsEffect, loadRunOutputRowsEffect, normalizeFrameEncoding, openDurableSqliteDatabase, parseFrameDelta, parseRuntimeOwnerIdentity, parseRuntimeOwnerPid, pgRowToDrizzle, quoteIdentifier, readProcessStartMs, recordCommittedTxid, retainRunHistory, runCancellationSourceFromRow, runWithTxidCapture, schemaSignature, selectOutputRow, selectOutputRowEffect, serializeFrameDelta, shouldCapturePostgresTxid, smithersAgentCheckpointContents, smithersAgentCheckpoints, smithersAlerts, smithersApprovals, smithersAttempts, smithersCache, smithersCron, smithersDocs, smithersEvalCases, smithersEvalSuites, smithersEvents, smithersFrames, smithersHumanRequests, smithersIntegrationCursors, smithersIntegrationDeliveries, smithersMemoryFacts, smithersMemoryMessages, smithersMemoryNoteSupersessions, smithersMemoryNotes, smithersMemoryThreads, smithersNodeDiffs, smithersNodes, smithersOutputProvenance, smithersRalph, smithersRuns, smithersSandboxes, smithersSchemaMigrations, smithersScorers, smithersSignals, smithersSteers, smithersTimeTravelAudit, smithersToolCallArchive, smithersToolCalls, smithersVectors, smithersWorkspaceCheckpoints, smithersWorkspaceStates, stripAutoColumns, syncZodTableSchema, syncZodTableSchemaPostgres, translateDdl, translatePlaceholders, unwrapZodType, upsertOutputRow, upsertOutputRowEffect, validateExistingOutput, validateInput, validateOutput, withSqliteWriteRetry, withSqliteWriteRetryEffect, zodSchemaColumns, zodToCreateTableSQL, zodToTable };

--- a/packages/db/src/index.js
+++ b/packages/db/src/index.js
@@ -17,6 +17,7 @@ export * from "./output.js";
 export * from "./openDurableSqliteDatabase.js";
 export * from "./runtime-owner.js";
 export * from "./runDriverLiveness.js";
+export * from "./run-history-gc.js";
 export * from "./schema-signature.js";
 export * from "./snapshot.js";
 export * from "./sql-message-storage.js";

--- a/packages/db/src/run-history-gc.js
+++ b/packages/db/src/run-history-gc.js
@@ -1,0 +1,446 @@
+import { createHash } from "node:crypto";
+import { Buffer } from "node:buffer";
+import { Effect } from "effect";
+import { POSTGRES, quoteIdentifier } from "./dialect.js";
+
+const TERMINAL_RUN_STATUSES = new Set(["finished", "failed", "cancelled", "canceled", "continued"]);
+const TERMINAL_STATUS_SQL = "'finished', 'failed', 'cancelled', 'canceled', 'continued'";
+const DEFAULT_CHUNK_SIZE = 250;
+const DEFAULT_SNAPSHOT_BATCH_SIZE = 5;
+
+// These rows are owned by one run and have a literal run_id column. Keep this
+// list explicit: memory rows merely carry provenance and must outlive retention.
+const RUN_OWNED_TABLES = [
+  // Delete content references before their owning attempt/snapshot rows so
+  // ref-count triggers can reclaim unreferenced payloads deterministically.
+  "_smithers_agent_checkpoints",
+  "_smithers_agent_processes",
+  "_smithers_alerts",
+  "_smithers_approvals",
+  "_smithers_attempts",
+  "_smithers_branches",
+  "_smithers_events",
+  "_smithers_frames",
+  "_smithers_human_requests",
+  "_smithers_node_diffs",
+  "_smithers_output_provenance",
+  "_smithers_ralph",
+  "_smithers_rewind_leases",
+  "_smithers_run_usage",
+  "_smithers_sandboxes",
+  "_smithers_scorers",
+  "_smithers_signals",
+  "_smithers_snapshot_payload_refs",
+  "_smithers_snapshots",
+  "_smithers_steers",
+  "_smithers_time_travel_audit",
+  "_smithers_tool_call_archive",
+  "_smithers_tool_calls",
+  "_smithers_vcs_tags",
+  "_smithers_workspace_checkpoints",
+  "_smithers_workspace_states",
+  // Nodes are last because they identify user output tables.
+  "_smithers_nodes",
+];
+
+/** @param {number} value @param {string} label */
+function positiveInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`);
+  return value;
+}
+
+/** @param {unknown} value */
+function numeric(value) {
+  const number = Number(value ?? 0);
+  return Number.isFinite(number) ? number : 0;
+}
+
+/** @param {string} nodesJson @param {string} outputsJson @param {string} ralphJson @param {string} inputJson */
+function snapshotContentHash(nodesJson, outputsJson, ralphJson, inputJson) {
+  return createHash("sha256")
+    .update(`{"nodes":${nodesJson},"outputs":${outputsJson},"ralph":${ralphJson},"input":${inputJson}}`)
+    .digest("hex");
+}
+
+/** @param {import("./adapter.js").SmithersDb} adapter @param {string} label @param {() => Promise<any>} operation */
+function inTransaction(adapter, label, operation) {
+  return adapter.withTransaction(label, Effect.promise(operation));
+}
+
+/** @param {ReturnType<import("./sql-message-storage.js").getSqlMessageStorage>} storage */
+async function legacySnapshotInventory(storage) {
+  const byteLength =
+    storage.dialect === POSTGRES
+      ? "octet_length(nodes_json) + octet_length(outputs_json) + octet_length(ralph_json) + octet_length(input_json)"
+      : "length(CAST(nodes_json AS BLOB)) + length(CAST(outputs_json AS BLOB)) + length(CAST(ralph_json AS BLOB)) + length(CAST(input_json AS BLOB))";
+  const row = await storage.queryOne(
+    `SELECT COUNT(*) AS row_count, COALESCE(SUM(${byteLength}), 0) AS inline_bytes
+       FROM _smithers_snapshots
+      WHERE nodes_json <> '' OR outputs_json <> '' OR ralph_json <> '' OR input_json <> ''`,
+  );
+  return { rows: numeric(row?.rowCount), inlineBytes: numeric(row?.inlineBytes) };
+}
+
+/**
+ * Incrementally move legacy inline snapshot payloads into content-addressed
+ * storage. Each page is its own transaction, so interruption leaves only
+ * complete compact rows and a later invocation resumes from inline rows.
+ *
+ * @param {import("./adapter.js").SmithersDb} adapter
+ * @param {{ batchSize?: number; dryRun?: boolean; maxBatches?: number; signal?: AbortSignal }} [options]
+ */
+export async function compactLegacySnapshots(adapter, options = {}) {
+  const storage = adapter.internalStorage;
+  const batchSize = positiveInteger(options.batchSize ?? DEFAULT_SNAPSHOT_BATCH_SIZE, "snapshot batch size");
+  const maxBatches = options.maxBatches ?? Number.POSITIVE_INFINITY;
+  if (!(maxBatches === Number.POSITIVE_INFINITY || (Number.isSafeInteger(maxBatches) && maxBatches >= 0))) {
+    throw new Error("maxBatches must be a nonnegative integer");
+  }
+  if (options.dryRun) {
+    const inventory = await legacySnapshotInventory(storage);
+    return {
+      dryRun: true,
+      migratedRows: 0,
+      clearedInlineBytes: 0,
+      batches: 0,
+      remainingRows: inventory.rows,
+      remainingInlineBytes: inventory.inlineBytes,
+      interrupted: false,
+    };
+  }
+
+  let migratedRows = 0;
+  let clearedInlineBytes = 0;
+  let batches = 0;
+  /** @type {{ runId: string; frameNo: number } | null} */
+  let cursor = null;
+  let completed = false;
+  while (batches < maxBatches && !options.signal?.aborted) {
+    const result = await inTransaction(adapter, "compact legacy snapshots", async () => {
+      const afterCursor = cursor === null ? "" : " AND (run_id > ? OR (run_id = ? AND frame_no > ?))";
+      const params = cursor === null ? [batchSize] : [cursor.runId, cursor.runId, cursor.frameNo, batchSize];
+      const lock = storage.dialect === POSTGRES ? " FOR UPDATE" : "";
+      const rows = await storage.queryAll(
+        `SELECT run_id, frame_no, nodes_json, outputs_json, ralph_json, input_json, content_hash
+           FROM _smithers_snapshots
+          WHERE (nodes_json <> '' OR outputs_json <> '' OR ralph_json <> '' OR input_json <> '')
+          ${afterCursor}
+          ORDER BY run_id, frame_no
+          LIMIT ?${lock}`,
+        params,
+      );
+      let bytes = 0;
+      for (const row of rows) {
+        const nodesJson = String(row.nodesJson);
+        const outputsJson = String(row.outputsJson);
+        const ralphJson = String(row.ralphJson);
+        const inputJson = String(row.inputJson);
+        const contentHash = String(row.contentHash);
+        const computedHash = snapshotContentHash(nodesJson, outputsJson, ralphJson, inputJson);
+        if (computedHash !== contentHash) {
+          throw new Error(
+            `Legacy snapshot content hash mismatch for ${String(row.runId)} frame ${String(row.frameNo)}: expected ${contentHash}, computed ${computedHash}`,
+          );
+        }
+        await storage.execute(
+          `INSERT INTO _smithers_snapshot_contents
+             (content_hash, nodes_json, outputs_json, ralph_json, input_json, ref_count)
+           VALUES (?, ?, ?, ?, ?, 0)
+           ON CONFLICT (content_hash) DO NOTHING`,
+          [contentHash, nodesJson, outputsJson, ralphJson, inputJson],
+        );
+        const stored = await storage.queryOne(
+          `SELECT nodes_json, outputs_json, ralph_json, input_json
+             FROM _smithers_snapshot_contents WHERE content_hash = ? LIMIT 1`,
+          [contentHash],
+        );
+        if (
+          !stored ||
+          stored.nodesJson !== nodesJson ||
+          stored.outputsJson !== outputsJson ||
+          stored.ralphJson !== ralphJson ||
+          stored.inputJson !== inputJson
+        ) {
+          throw new Error(`Snapshot content hash collision or corruption: ${contentHash}`);
+        }
+        // The reference trigger requires a compact parent. Both writes are in
+        // this transaction, so readers see either the old inline row or the
+        // complete content-addressed row, never the state between them.
+        await storage.execute(
+          `UPDATE _smithers_snapshots
+              SET nodes_json = '', outputs_json = '', ralph_json = '', input_json = ''
+            WHERE run_id = ? AND frame_no = ?`,
+          [row.runId, row.frameNo],
+        );
+        await storage.execute(
+          `INSERT INTO _smithers_snapshot_payload_refs (run_id, frame_no, content_hash)
+           VALUES (?, ?, ?)
+           ON CONFLICT (run_id, frame_no) DO NOTHING`,
+          [row.runId, row.frameNo, contentHash],
+        );
+        const reference = await storage.queryOne(
+          `SELECT content_hash FROM _smithers_snapshot_payload_refs WHERE run_id = ? AND frame_no = ? LIMIT 1`,
+          [row.runId, row.frameNo],
+        );
+        if (reference?.contentHash !== contentHash) {
+          throw new Error(`Snapshot content reference mismatch for ${String(row.runId)} frame ${String(row.frameNo)}`);
+        }
+        bytes +=
+          Buffer.byteLength(nodesJson) +
+          Buffer.byteLength(outputsJson) +
+          Buffer.byteLength(ralphJson) +
+          Buffer.byteLength(inputJson);
+      }
+      const last = rows.at(-1);
+      return {
+        rows: rows.length,
+        bytes,
+        cursor: last ? { runId: String(last.runId), frameNo: numeric(last.frameNo) } : null,
+      };
+    });
+    if (result.rows === 0) {
+      completed = true;
+      break;
+    }
+    migratedRows += result.rows;
+    clearedInlineBytes += result.bytes;
+    batches++;
+    cursor = result.cursor;
+    // Give the control plane and signal handlers a scheduling point between
+    // write transactions instead of immediately reacquiring SQLite's lock.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return {
+    dryRun: false,
+    migratedRows,
+    clearedInlineBytes,
+    batches,
+    remainingRows: completed ? 0 : null,
+    remainingInlineBytes: completed ? 0 : null,
+    interrupted: !completed,
+  };
+}
+
+/** @param {ReturnType<import("./sql-message-storage.js").getSqlMessageStorage>} storage @param {string} table */
+async function tableHasRunId(storage, table) {
+  if (storage.dialect === POSTGRES) {
+    const row = await storage.queryOne(
+      `SELECT 1 AS found FROM information_schema.columns
+        WHERE table_schema = current_schema() AND table_name = ? AND column_name = 'run_id' LIMIT 1`,
+      [table],
+    );
+    return Boolean(row);
+  }
+  const row = await storage.queryOne(`SELECT 1 AS found FROM pragma_table_info(?) WHERE name = 'run_id' LIMIT 1`, [
+    table,
+  ]);
+  return Boolean(row);
+}
+
+/** @param {ReturnType<import("./sql-message-storage.js").getSqlMessageStorage>} storage @param {string} runId */
+async function outputTablesForRun(storage, runId) {
+  const rows = await storage.queryAll(
+    "SELECT DISTINCT output_table FROM _smithers_nodes WHERE run_id = ? AND output_table IS NOT NULL ORDER BY output_table",
+    [runId],
+  );
+  const tables = [];
+  for (const row of rows) {
+    const table = String(row.outputTable);
+    if (!table.startsWith("_smithers_") && (await tableHasRunId(storage, table))) tables.push(table);
+  }
+  return tables;
+}
+
+/** @param {unknown} status @param {unknown} finishedAtMs @param {number} cutoffMs */
+function isEligible(status, finishedAtMs, cutoffMs) {
+  return (
+    TERMINAL_RUN_STATUSES.has(String(status).toLowerCase()) &&
+    numeric(finishedAtMs) > 0 &&
+    numeric(finishedAtMs) < cutoffMs
+  );
+}
+
+/** @param {ReturnType<import("./sql-message-storage.js").getSqlMessageStorage>} storage @param {number} cutoffMs */
+async function dryRunCandidates(storage, cutoffMs) {
+  const rows = await storage.queryAll(
+    "SELECT run_id, parent_run_id, status, finished_at_ms FROM _smithers_runs ORDER BY finished_at_ms, run_id",
+  );
+  const byParent = new Map();
+  for (const row of rows) {
+    if (row.parentRunId == null) continue;
+    const children = byParent.get(String(row.parentRunId)) ?? [];
+    children.push(row);
+    byParent.set(String(row.parentRunId), children);
+  }
+  const memo = new Map();
+  const removable = (row, visiting = new Set()) => {
+    const runId = String(row.runId);
+    if (memo.has(runId)) return memo.get(runId);
+    if (visiting.has(runId) || !isEligible(row.status, row.finishedAtMs, cutoffMs)) return false;
+    const next = new Set(visiting).add(runId);
+    const result = (byParent.get(runId) ?? []).every((child) => removable(child, next));
+    memo.set(runId, result);
+    return result;
+  };
+  return rows.filter((row) => removable(row));
+}
+
+/** @param {Record<string, number>} target @param {string} table @param {number} count */
+function addCount(target, table, count) {
+  if (count > 0) target[table] = (target[table] ?? 0) + count;
+}
+
+/**
+ * Count or delete one bounded page while rechecking terminal status and age in
+ * the same statement. SQLite uses rowid and PostgreSQL uses ctid.
+ * @param {import("./adapter.js").SmithersDb} adapter
+ * @param {string} table
+ * @param {string} runColumn
+ * @param {string} runId
+ * @param {number} cutoffMs
+ * @param {number} chunkSize
+ */
+async function deleteChunk(adapter, table, runColumn, runId, cutoffMs, chunkSize) {
+  const storage = adapter.internalStorage;
+  const locator = storage.dialect === POSTGRES ? "ctid" : "rowid";
+  const quotedTable = quoteIdentifier(table);
+  const quotedColumn = quoteIdentifier(runColumn);
+  return inTransaction(adapter, `retain run history ${runId}`, async () => {
+    const rows = await storage.queryAll(
+      `DELETE FROM ${quotedTable}
+        WHERE ${locator} IN (
+          SELECT ${locator} FROM ${quotedTable} WHERE ${quotedColumn} = ? LIMIT ?
+        )
+          AND EXISTS (
+            SELECT 1 FROM _smithers_runs r
+             WHERE r.run_id = ?
+               AND r.status IN (${TERMINAL_STATUS_SQL})
+               AND r.finished_at_ms IS NOT NULL
+               AND r.finished_at_ms > 0
+               AND r.finished_at_ms < ?
+          )
+        RETURNING 1 AS removed`,
+      [runId, chunkSize, runId, cutoffMs],
+    );
+    return rows.length;
+  });
+}
+
+/** @param {ReturnType<import("./sql-message-storage.js").getSqlMessageStorage>} storage @param {string} table @param {string} column @param {string} runId */
+async function countRows(storage, table, column, runId) {
+  const row = await storage.queryOne(
+    `SELECT COUNT(*) AS row_count FROM ${quoteIdentifier(table)} WHERE ${quoteIdentifier(column)} = ?`,
+    [runId],
+  );
+  return numeric(row?.rowCount);
+}
+
+/**
+ * Remove terminal run history older than an explicit cutoff. There is no
+ * implicit retention default; callers must opt in by passing cutoffMs.
+ *
+ * @param {import("./adapter.js").SmithersDb} adapter
+ * @param {{ cutoffMs: number; dryRun?: boolean; chunkSize?: number; maxRuns?: number; signal?: AbortSignal }} options
+ * @returns {Promise<{
+ *   enabled: true;
+ *   dryRun: boolean;
+ *   cutoffMs: number;
+ *   removedRuns: Array<{ runId: string; status: unknown; finishedAtMs: number }>;
+ *   rowsByTable: Record<string, number>;
+ *   interrupted: boolean;
+ * }>}
+ */
+export async function retainRunHistory(adapter, options) {
+  if (!Number.isFinite(options?.cutoffMs)) throw new Error("cutoffMs is required for database retention");
+  const cutoffMs = options.cutoffMs;
+  const chunkSize = positiveInteger(options.chunkSize ?? DEFAULT_CHUNK_SIZE, "retention chunk size");
+  const maxRuns = options.maxRuns ?? Number.POSITIVE_INFINITY;
+  if (!(maxRuns === Number.POSITIVE_INFINITY || (Number.isSafeInteger(maxRuns) && maxRuns >= 0))) {
+    throw new Error("maxRuns must be a nonnegative integer");
+  }
+  const storage = adapter.internalStorage;
+  const rowsByTable = {};
+  const removedRuns = [];
+
+  if (options.dryRun) {
+    const candidates = await dryRunCandidates(storage, cutoffMs);
+    for (const run of candidates.slice(0, maxRuns)) {
+      const runId = String(run.runId);
+      for (const table of await outputTablesForRun(storage, runId)) {
+        addCount(rowsByTable, table, await countRows(storage, table, "run_id", runId));
+      }
+      for (const table of RUN_OWNED_TABLES) {
+        addCount(rowsByTable, table, await countRows(storage, table, "run_id", runId));
+      }
+      addCount(
+        rowsByTable,
+        "_smithers_eval_cases",
+        await countRows(storage, "_smithers_eval_cases", "eval_run_id", runId),
+      );
+      addCount(rowsByTable, "_smithers_runs", 1);
+      removedRuns.push({ runId, status: run.status, finishedAtMs: numeric(run.finishedAtMs) });
+    }
+    return { enabled: true, dryRun: true, cutoffMs, removedRuns, rowsByTable, interrupted: false };
+  }
+
+  while (removedRuns.length < maxRuns && !options.signal?.aborted) {
+    // Absolute leaves only: deleting a parent would break a retained child's
+    // ancestry. Once an eligible leaf is removed, its parent can become the
+    // next candidate in this same invocation.
+    const candidate = await storage.queryOne(
+      `SELECT r.run_id, r.status, r.finished_at_ms
+         FROM _smithers_runs r
+        WHERE r.status IN (${TERMINAL_STATUS_SQL})
+          AND r.finished_at_ms IS NOT NULL
+          AND r.finished_at_ms > 0
+          AND r.finished_at_ms < ?
+          AND NOT EXISTS (SELECT 1 FROM _smithers_runs child WHERE child.parent_run_id = r.run_id)
+        ORDER BY r.finished_at_ms, r.run_id
+        LIMIT 1`,
+      [cutoffMs],
+    );
+    if (!candidate) break;
+    const runId = String(candidate.runId);
+    const tables = [
+      ...(await outputTablesForRun(storage, runId)).map((table) => [table, "run_id"]),
+      ...RUN_OWNED_TABLES.map((table) => [table, "run_id"]),
+      ["_smithers_eval_cases", "eval_run_id"],
+    ];
+    for (const [table, column] of tables) {
+      while (!options.signal?.aborted) {
+        const count = await deleteChunk(adapter, table, column, runId, cutoffMs, chunkSize);
+        addCount(rowsByTable, table, count);
+        if (count < chunkSize) break;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      if (options.signal?.aborted) break;
+    }
+    if (options.signal?.aborted) break;
+    const deleted = await inTransaction(adapter, `delete retained run ${runId}`, async () =>
+      storage.queryAll(
+        `DELETE FROM _smithers_runs
+          WHERE run_id = ?
+            AND status IN (${TERMINAL_STATUS_SQL})
+            AND finished_at_ms IS NOT NULL
+            AND finished_at_ms > 0
+            AND finished_at_ms < ?
+            AND NOT EXISTS (SELECT 1 FROM _smithers_runs child WHERE child.parent_run_id = ?)
+          RETURNING run_id`,
+        [runId, cutoffMs, runId],
+      ),
+    );
+    if (deleted.length === 0) break;
+    addCount(rowsByTable, "_smithers_runs", 1);
+    removedRuns.push({ runId, status: candidate.status, finishedAtMs: numeric(candidate.finishedAtMs) });
+    adapter.clearFrameCacheForRun(runId);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return {
+    enabled: true,
+    dryRun: false,
+    cutoffMs,
+    removedRuns,
+    rowsByTable,
+    interrupted: Boolean(options.signal?.aborted || removedRuns.length >= maxRuns),
+  };
+}

--- a/packages/db/tests/run-history-gc.test.js
+++ b/packages/db/tests/run-history-gc.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { SmithersDb } from "../src/adapter.js";
+import { ensureSmithersTables } from "../src/ensure.js";
+import { compactLegacySnapshots, retainRunHistory } from "../src/run-history-gc.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  ensureSmithersTables(db);
+  return { adapter: new SmithersDb(db), sqlite };
+}
+
+function contentHash(nodesJson, outputsJson, ralphJson, inputJson) {
+  return createHash("sha256")
+    .update(`{"nodes":${nodesJson},"outputs":${outputsJson},"ralph":${ralphJson},"input":${inputJson}}`)
+    .digest("hex");
+}
+
+function insertLegacySnapshot(sqlite, runId, frameNo, payload) {
+  const nodesJson = JSON.stringify([{ nodeId: "task", state: "finished" }]);
+  const outputsJson = JSON.stringify({ result: payload });
+  const ralphJson = "[]";
+  const inputJson = JSON.stringify({ prompt: "restore me" });
+  const hash = contentHash(nodesJson, outputsJson, ralphJson, inputJson);
+  sqlite
+    .query(
+      `INSERT INTO _smithers_snapshots
+         (run_id, frame_no, nodes_json, outputs_json, ralph_json, input_json, vcs_pointer, workflow_hash, content_hash, created_at_ms)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, 'workflow', ?, 1)`,
+    )
+    .run(runId, frameNo, nodesJson, outputsJson, ralphJson, inputJson, hash);
+  return { nodesJson, outputsJson, ralphJson, inputJson, hash };
+}
+
+describe("legacy snapshot compaction", () => {
+  test("resumes after one batch and leaves every committed snapshot restorable", async () => {
+    const { adapter, sqlite } = createTestDb();
+    const expected = insertLegacySnapshot(sqlite, "run-a", 0, "shared payload");
+    insertLegacySnapshot(sqlite, "run-b", 0, "shared payload");
+
+    const interrupted = await compactLegacySnapshots(adapter, { batchSize: 1, maxBatches: 1 });
+    expect(interrupted).toMatchObject({ migratedRows: 1, remainingRows: null, interrupted: true });
+    expect(sqlite.query("PRAGMA foreign_key_check").all()).toEqual([]);
+    expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count).toBe(1);
+    expect(sqlite.query("SELECT ref_count FROM _smithers_snapshot_contents").get().ref_count).toBe(1);
+
+    const completed = await compactLegacySnapshots(adapter, { batchSize: 1 });
+    expect(completed).toMatchObject({ migratedRows: 1, remainingRows: 0, interrupted: false });
+    expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_contents").get().count).toBe(1);
+    expect(sqlite.query("SELECT ref_count FROM _smithers_snapshot_contents").get().ref_count).toBe(2);
+    expect(sqlite.query("PRAGMA foreign_key_check").all()).toEqual([]);
+
+    const restored = sqlite
+      .query(
+        `SELECT c.nodes_json, c.outputs_json, c.ralph_json, c.input_json
+           FROM _smithers_snapshots s
+           JOIN _smithers_snapshot_payload_refs r USING (run_id, frame_no)
+           JOIN _smithers_snapshot_contents c ON c.content_hash = r.content_hash
+          WHERE s.run_id = 'run-a' AND s.frame_no = 0`,
+      )
+      .get();
+    expect(restored).toEqual({
+      nodes_json: expected.nodesJson,
+      outputs_json: expected.outputsJson,
+      ralph_json: expected.ralphJson,
+      input_json: expected.inputJson,
+    });
+    const compact = sqlite
+      .query("SELECT nodes_json, outputs_json, ralph_json, input_json FROM _smithers_snapshots")
+      .all();
+    expect(compact.every((row) => Object.values(row).every((value) => value === ""))).toBe(true);
+  });
+
+  test("dry run reports duplicate inline bytes and changes no rows", async () => {
+    const { adapter, sqlite } = createTestDb();
+    insertLegacySnapshot(sqlite, "run-a", 0, "payload");
+    const before = sqlite.serialize();
+    const result = await compactLegacySnapshots(adapter, { dryRun: true });
+    expect(result.remainingRows).toBe(1);
+    expect(result.remainingInlineBytes).toBeGreaterThan(0);
+    expect(result.migratedRows).toBe(0);
+    expect(sqlite.serialize()).toEqual(before);
+  });
+});
+
+describe("terminal run retention", () => {
+  test("removes only old terminal leaves and all run-owned history in bounded chunks", async () => {
+    const { adapter, sqlite } = createTestDb();
+    const nowMs = Date.UTC(2026, 7, 16);
+    const cutoffMs = nowMs - 30 * 24 * 60 * 60 * 1_000;
+    const oldMs = cutoffMs - 1;
+    const recentMs = cutoffMs + 1;
+    const runs = [
+      ["finished", "finished", oldMs],
+      ["failed", "failed", oldMs],
+      ["cancelled", "cancelled", oldMs],
+      ["continued", "continued", oldMs],
+      ["running", "running", null],
+      ["paused", "paused", null],
+      ["waiting-human", "waiting-approval", null],
+      ["waiting-event", "waiting-event", null],
+      ["waiting-timer", "waiting-timer", null],
+      ["recent", "finished", recentMs],
+      ["continued-live", "continued", null],
+    ];
+    const insertRun = sqlite.query(
+      `INSERT INTO _smithers_runs
+         (run_id, workflow_name, status, created_at_ms, finished_at_ms)
+       VALUES (?, 'workflow', ?, 1, ?)`,
+    );
+    const insertEvent = sqlite.query(
+      "INSERT INTO _smithers_events (run_id, seq, timestamp_ms, type, payload_json) VALUES (?, ?, 1, 'test', '{}')",
+    );
+    for (const [runId, status, finishedAtMs] of runs) {
+      insertRun.run(runId, status, finishedAtMs);
+      for (let seq = 0; seq < 3; seq++) insertEvent.run(runId, seq);
+    }
+    sqlite.exec(
+      `CREATE TABLE results (
+         run_id TEXT NOT NULL,
+         node_id TEXT NOT NULL,
+         iteration INTEGER NOT NULL,
+         value TEXT NOT NULL
+       )`,
+    );
+    for (const runId of ["finished", "running"]) {
+      sqlite
+        .query(
+          "INSERT INTO _smithers_nodes (run_id, node_id, iteration, state, updated_at_ms, output_table) VALUES (?, 'task', 0, 'finished', 1, 'results')",
+        )
+        .run(runId);
+      sqlite.query("INSERT INTO results VALUES (?, 'task', 0, 'value')").run(runId);
+    }
+    const snapshot = insertLegacySnapshot(sqlite, "finished", 0, "retained content");
+    await compactLegacySnapshots(adapter);
+    expect(sqlite.query("SELECT content_hash FROM _smithers_snapshot_contents").get().content_hash).toBe(snapshot.hash);
+
+    const result = await retainRunHistory(adapter, { cutoffMs, chunkSize: 2 });
+    expect(result.removedRuns.map((run) => run.runId).sort()).toEqual(["cancelled", "continued", "failed", "finished"]);
+    expect(result.rowsByTable._smithers_events).toBe(12);
+    expect(result.rowsByTable.results).toBe(1);
+    expect(
+      sqlite
+        .query("SELECT run_id FROM _smithers_runs ORDER BY run_id")
+        .all()
+        .map((row) => row.run_id),
+    ).toEqual(["continued-live", "paused", "recent", "running", "waiting-event", "waiting-human", "waiting-timer"]);
+    expect(sqlite.query("SELECT run_id FROM results").all()).toEqual([{ run_id: "running" }]);
+    expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_contents").get().count).toBe(0);
+    expect(sqlite.query("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  test("dry run removes nothing and a live descendant protects its terminal ancestry", async () => {
+    const { adapter, sqlite } = createTestDb();
+    sqlite.exec(`
+      INSERT INTO _smithers_runs
+        (run_id, workflow_name, status, created_at_ms, finished_at_ms)
+      VALUES ('terminal-leaf', 'workflow', 'finished', 1, 2),
+             ('terminal-parent', 'workflow', 'finished', 1, 2),
+             ('live-child', 'workflow', 'paused', 1, NULL);
+      UPDATE _smithers_runs SET parent_run_id = 'terminal-parent' WHERE run_id = 'live-child';
+      INSERT INTO _smithers_events (run_id, seq, timestamp_ms, type, payload_json)
+      VALUES ('terminal-leaf', 0, 1, 'test', '{}'),
+             ('terminal-parent', 0, 1, 'test', '{}'),
+             ('live-child', 0, 1, 'test', '{}');
+    `);
+    const before = sqlite.serialize();
+    const result = await retainRunHistory(adapter, { cutoffMs: 10, dryRun: true, chunkSize: 1 });
+    expect(result.removedRuns.map((run) => run.runId)).toEqual(["terminal-leaf"]);
+    expect(result.rowsByTable).toMatchObject({ _smithers_events: 1, _smithers_runs: 1 });
+    expect(sqlite.serialize()).toEqual(before);
+  });
+});

--- a/packages/smithers/docs/llms-full.txt
+++ b/packages/smithers/docs/llms-full.txt
@@ -2718,7 +2718,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -2738,6 +2738,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -2752,6 +2754,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -2760,22 +2783,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -2811,13 +2834,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered

--- a/packages/time-travel/tests/snapshot.test.js
+++ b/packages/time-travel/tests/snapshot.test.js
@@ -8,6 +8,7 @@ import { gzipSync } from "node:zlib";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { ensureSmithersTables } from "@smthrs/db/ensure";
 import { SmithersDb } from "@smthrs/db/adapter";
+import { compactLegacySnapshots } from "@smthrs/db/run-history-gc";
 import {
   captureSnapshot,
   loadSnapshot,
@@ -445,7 +446,10 @@ describe("captureSnapshot", () => {
     );
     const loadMs = performance.now() - loadStart;
     const baseline = new Database(join(dir, "baseline.db"));
-    ensureSmithersTables(drizzle(baseline));
+    const baselineDb = drizzle(baseline);
+    ensureSmithersTables(baselineDb);
+    const baselineAdapter = new SmithersDb(baselineDb);
+    const legacyContentHash = createHash("sha256").update(uncompressed).digest("hex");
     const insert = baseline.query(
       "INSERT INTO _smithers_snapshots (run_id, frame_no, nodes_json, outputs_json, ralph_json, input_json, vcs_pointer, workflow_hash, content_hash, created_at_ms) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)",
     );
@@ -457,17 +461,27 @@ describe("captureSnapshot", () => {
         JSON.stringify(data.outputs),
         JSON.stringify(data.ralph),
         JSON.stringify(data.input),
-        `baseline-${frameNo}`,
+        legacyContentHash,
         frameNo,
       );
     const baselineBytes =
       baseline.query("PRAGMA page_count").get().page_count * baseline.query("PRAGMA page_size").get().page_size;
     const addressedBytes =
       sqlite.query("PRAGMA page_count").get().page_count * sqlite.query("PRAGMA page_size").get().page_size;
+    const migrated = await compactLegacySnapshots(baselineAdapter);
+    baseline.query("PRAGMA wal_checkpoint(TRUNCATE)").get();
+    const migratedReusableBytes =
+      baseline.query("PRAGMA freelist_count").get().freelist_count * baseline.query("PRAGMA page_size").get().page_size;
+    const migratedAllocatedBytes =
+      baseline.query("PRAGMA page_count").get().page_count * baseline.query("PRAGMA page_size").get().page_size;
+    const migratedNetReclaimedBytes = baselineBytes - (migratedAllocatedBytes - migratedReusableBytes);
     console.info(
-      `snapshot benchmark: frames=${frameCount} logicalPayload=${Buffer.byteLength(uncompressed) * frameCount} uniquePayload=${payloads.bytes} baselineSqlite=${baselineBytes} addressedSqlite=${addressedBytes} captureMs=${captureMs.toFixed(2)} loadMs=${loadMs.toFixed(2)}`,
+      `snapshot benchmark: frames=${frameCount} logicalPayload=${Buffer.byteLength(uncompressed) * frameCount} uniquePayload=${payloads.bytes} baselineSqlite=${baselineBytes} addressedSqlite=${addressedBytes} migratedInline=${migrated.clearedInlineBytes} migratedReusable=${migratedReusableBytes} migratedNetReclaimed=${migratedNetReclaimedBytes} captureMs=${captureMs.toFixed(2)} loadMs=${loadMs.toFixed(2)}`,
     );
     expect(addressedBytes).toBeLessThan(baselineBytes * 0.2);
+    expect(migrated).toMatchObject({ migratedRows: frameCount, remainingRows: 0 });
+    expect(migratedReusableBytes).toBeGreaterThan(baselineBytes * 0.75);
+    expect(migratedNetReclaimedBytes).toBeGreaterThan(baselineBytes * 0.8);
     await adapter.deleteSnapshotsAfter("bench", 10);
     expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_contents").get().count).toBe(1);
     await adapter.deleteSnapshotsAfter("bench", -1);
@@ -524,9 +538,11 @@ describe("captureSnapshot", () => {
       )
       .digest("hex");
     sqlite
-      .query(`UPDATE _smithers_snapshots
+      .query(
+        `UPDATE _smithers_snapshots
             SET nodes_json = ?, outputs_json = ?, ralph_json = ?, input_json = ?, content_hash = ?
-            WHERE run_id = 'inline-replace' AND frame_no = 0`)
+            WHERE run_id = 'inline-replace' AND frame_no = 0`,
+      )
       .run(nodesJson, outputsJson, ralphJson, inputJson, contentHash);
     expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count).toBe(0);
     expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_contents").get().count).toBe(0);
@@ -582,7 +598,7 @@ describe("captureSnapshot", () => {
     expect(list[0].frameNo).toBe(0);
     expect(list[1].frameNo).toBe(1);
   });
-  test("loads legacy inline snapshots without creating payload references", async () => {
+  test("loads legacy inline snapshots before and after resumable content-addressed compaction", async () => {
     const { sqlite, adapter } = createTestDb();
     const data = sampleData({ input: { prompt: "legacy-inline" } });
     const raw = JSON.stringify({ nodes: data.nodes, outputs: data.outputs, ralph: data.ralph, input: data.input });
@@ -602,6 +618,11 @@ describe("captureSnapshot", () => {
     const loaded = await loadSnapshot(adapter, "legacy", 0);
     expect(JSON.parse(loaded.inputJson)).toEqual({ prompt: "legacy-inline" });
     expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count).toBe(0);
+    expect(await compactLegacySnapshots(adapter)).toMatchObject({ migratedRows: 1, remainingRows: 0 });
+    const restored = await loadSnapshot(adapter, "legacy", 0);
+    expect(restored).toEqual(loaded);
+    expect(JSON.parse(restored.inputJson)).toEqual(data.input);
+    expect(sqlite.query("SELECT COUNT(*) AS count FROM _smithers_snapshot_payload_refs").get().count).toBe(1);
     sqlite.close();
   });
   test("hydrates the preserved compressed prototype without rewriting it", async () => {

--- a/skills/smithers/llms-full.txt
+++ b/skills/smithers/llms-full.txt
@@ -2718,7 +2718,7 @@ MCP tools). It also subsumes the weaker heartbeat-freshness check, so it never
 needs to be combined with `--force`. The gateway's `resumeRun` RPC deliberately
 has no equivalent: a remote caller can never steal a live run.
 
-A *stale* run (dead driver, expired claim) still resumes with no extra flag,
+A _stale_ run (dead driver, expired claim) still resumes with no extra flag,
 so ordinary crash recovery and `bunx smthrs supervise` are unaffected.
 
 If resume fails with `RESUME_METADATA_MISMATCH`, the workflow file changed after the run started. Resume validates the original workflow metadata and source hash; it is not a hot-reload mechanism for stopped runs. Start a fresh run instead, for example with a new `--run-id`, or overwrite an existing planned id with `--force` when that command supports it. When iterating on a workflow definition, expect each edit to require a fresh run rather than `--resume`.
@@ -2738,6 +2738,8 @@ Use the unified collector to inspect filesystem capacity and stale artifacts:
 ```sh
 bunx smthrs gc --dry-run
 bunx smthrs gc --older-than 24h
+bunx smthrs gc --dry-run --db-retention-days 30
+bunx smthrs gc --db-retention-days 30
 ```
 
 `gc` reclaims logs, `.smithers/sandboxes/<runId>` roots, and Smithers-owned
@@ -2752,6 +2754,27 @@ protects every candidate, and an unowned worktree must be clean with its HEAD
 already merged or pushed. `--force` applies only to owned worktrees and allows
 their uncommitted or unpushed contents to be removed.
 
+The same explicit `gc` invocation reports legacy inline snapshot payloads and,
+without `--dry-run`, moves them into the content-addressed snapshot store in
+small resumable transactions. This representation-only compaction preserves
+run history and is independent of retention.
+
+Database run retention has **no destructive default**. Opt in per invocation
+with `--db-retention-days DAYS`, or set `SMITHERS_DB_RETENTION_DAYS`; zero is
+allowed. Only runs in a terminal state with a recorded finish time older than
+the cutoff are eligible. Running, paused, waiting, unfinished `continued`
+runs, and terminal ancestors of retained descendants are protected. Deletion
+uses small committed chunks and removes the run record last. `--dry-run`
+reports eligible runs and row counts without changing either snapshots or run
+history.
+
+Cleared and deleted SQLite pages become reusable inside `smithers.db`, but the
+file does not shrink automatically. Smithers never runs `VACUUM` against an
+online store. To return those pages to the filesystem, stop every engine,
+gateway, and other process using the database, verify a backup, and run the
+SQLite `VACUUM` command offline. PostgreSQL installations should use their
+normal operator-managed vacuum policy.
+
 ## Interactive mode and the full-screen TUI monitor
 
 `bunx smthrs up --interactive` (or just `bunx smthrs up` / `bunx smthrs workflow run` from an interactive TTY without a positional argument) opens a terminal UI that guides you through three steps:
@@ -2760,22 +2783,22 @@ their uncommitted or unpushed contents to be removed.
 2. **Input prompts** - fill required fields for the chosen workflow.
 3. **Full-screen monitor** - the run starts in a detached background process and the terminal switches into a full-screen view that tracks it live.
 
-The monitor connects to a local Gateway on port 7331, starting one automatically if none is running.  It exits when you press `q`.
+The monitor connects to a local Gateway on port 7331, starting one automatically if none is running. It exits when you press `q`.
 
 **Agents: hand humans interactive commands.** When you (an AI agent) give a human a command to run themselves, include the `--interactive` flag whenever the command supports it (`bunx smthrs up --interactive`, `bunx smthrs workflow run WORKFLOW_ID --interactive`), so the human lands in this full-screen monitor instead of a detached log tail. Reserve the non-interactive forms for CI, scripts, and the commands you execute yourself with your shell tool. Never pass `--interactive` to a command you run programmatically, since it opens a full-screen TUI your harness cannot drive.
 
 ### Monitor modes and keybindings
 
-The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any *non-Tree* mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
+The monitor opens in **Tree** mode. Switch modes with the letter aliases below. From any _non-Tree_ mode the number keys `1`–`5` also jump straight to a mode (and `1` returns to Tree).
 
-| Mode | Reach it with | What you see |
-|------|---------------|--------------|
-| **Tree** | `1` (from another mode) | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting |
-| **Graph** | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree |
-| **Logs** | `l`, or `3` | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow |
-| **Timeline** | `t`, or `4` | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
-| **Hijack** | `h`, or `5` | Hand off to `bunx smthrs hijack` for an active node |
-| **Quit** | `q` (or Ctrl-C) | (quit) |
+| Mode         | Reach it with                      | What you see                                                                                                                                               |
+| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tree**     | `1` (from another mode)            | Node tree with per-node output, logs, diffs, and props; inline approval banner when waiting                                                                |
+| **Graph**    | `g` (toggles Tree ↔ Graph), or `2` | Directed dependency graph; `j`/`k` navigate, `⏎` inspects a node in Tree                                                                                   |
+| **Logs**     | `l`, or `3`                        | Filtered event stream (up to 2 000 events); `[`/`]` filter by attempt, `f` toggles follow                                                                  |
+| **Timeline** | `t`, or `4`                        | Horizontal tick strip you scrub with `j`/`k` to inspect node state at past frames; `L` jumps back to live (inspect-only; rewind with `bunx smthrs rewind`) |
+| **Hijack**   | `h`, or `5`                        | Hand off to `bunx smthrs hijack` for an active node                                                                                                        |
+| **Quit**     | `q` (or Ctrl-C)                    | (quit)                                                                                                                                                     |
 
 Inside **Tree** mode the number keys are **inspector tabs, not mode switches**: `1` output, `2` logs, `3` diff, `4` props (`←`/`→` also walk the tabs). Use the `g`/`l`/`t`/`h` aliases to leave Tree.
 
@@ -2811,13 +2834,13 @@ bunx smthrs ui RUN_ID
 
 Five commands cross historical boundaries. Pick by what each acts on:
 
-| Command | Acts on | Behavior |
-| --- | --- | --- |
-| `rewind` | a run | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`. |
-| `replay` | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow. |
-| `fork` | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
-| `timetravel` | a past task state | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow. |
-| `revert` | the workspace | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow. |
+| Command      | Acts on               | Behavior                                                                                                                                                                          |
+| ------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind`     | a run                 | Rewinds a run to a previous frame. Args: `RUN_ID FRAME_NO`.                                                                                                                       |
+| `replay`     | a snapshot checkpoint | Forks from a checkpoint and resumes execution (time-travel fork). Takes a workflow.                                                                                               |
+| `fork`       | a snapshot checkpoint | Creates a child run. `--run` also resumes it. `--reset-node` resets exactly the nodes you name; downstream dependents keep the parent's finished output unless you name them too. |
+| `timetravel` | a past task state     | Reverts filesystem plus DB state to a previous task state, then optionally resumes. Takes a workflow.                                                                             |
+| `revert`     | the workspace         | Reverts the workspace to a previous task attempt's filesystem state only, no DB reset. Takes a workflow.                                                                          |
 
 Every command prints an effect-boundary report, including a clean report when
 no effects are crossed. `revert`, `timetravel`, and `rewind` run registered


### PR DESCRIPTION
Closes #1349.

## The problem

The control-plane `smithers.db` grew without bound. A 100GB file was observed in the wild. There was
no retention and no GC, and legacy inline snapshot rows were never migrated, so every run's snapshots
accumulated forever at full size.

## What this adds

`smithers gc` gains two independent capabilities:

**Snapshot compaction** deduplicates repeated snapshot rows. It is resumable, works in five-row
batches so a large database can be processed without a long write lock, and it preserves behavior:
nothing observable changes, the bytes just stop being stored repeatedly. On a realistic fixture of 12
repeated 6.61 MB snapshots it reclaimed **72,765,440 bytes, 91.1% of the 79,888,384-byte baseline**.

**Terminal-run retention** deletes history for runs that have reached a terminal state and are older
than a window. It is incremental, and it protects lineage and live runs: a run that another run
descends from, or that is still active, is never collected.

`--dry-run` reports what each would reclaim without touching anything.

## Two decisions I made, both worth your confirmation

**1. Retention is disabled by default.** It only runs when you pass `--db-retention-days` or set
`SMITHERS_DB_RETENTION_DAYS`. An upgrade must never silently delete a user's run history. Snapshot
compaction, being behavior-preserving, is the part that is safe to have on.

The cost of that choice: someone with a 100GB database gets no relief from upgrading alone. They have
to find and set the flag. I think that is the right trade against silently destroying history, but it
is your call, and if you want a default window instead, say which.

**2. No online VACUUM.** Compaction and retention free pages for reuse inside the file; they do not
shrink it on disk. Smithers never VACUUMs a live database. Shrinking the file requires stopping every
database user, verifying a backup, then running VACUUM offline, and the docs say exactly that rather
than implying `gc` reclaims disk. (A VACUUM against a database another process holds open is how you
corrupt it.)

**Also worth deciding:** whether the docs should recommend a concrete opt-in window, e.g. 30 days.
I did not invent one, since the right number depends on how you expect people to use time travel.

## Gates

db 824 pass / 5 skip; smithers; engine 1271 pass / 3 skip; CLI 269/269 batches; `lint`;
`format:check`; full workspace typecheck; `docs:llms`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
