### PR TITLE
fix(review): stop reporting a failed review as findings: none

### DIFF
--- a/apps/review/src/cli/main.ts
+++ b/apps/review/src/cli/main.ts
@@ -68,6 +68,39 @@ function elapsedLabel(ms: number): string {
   return minutes > 0 ? `${minutes}m${String(secondsPart).padStart(2, "0")}s` : `${totalSeconds}s`;
 }
 
+/**
+ * Build the one-line run summary.
+ *
+ * A review whose file-review tasks all failed for an environmental reason
+ * (expired credentials, provider rate limit, network) yields zero findings for
+ * a reason that has nothing to do with the code under review. Reporting the
+ * usual `findings: none` there is indistinguishable from a clean review, so a
+ * failed or partial review says what actually happened instead.
+ *
+ * @param summary.filesChanged Files the walkthrough covered.
+ * @param summary.elapsed Preformatted elapsed-time label.
+ * @param summary.breakdown Severity breakdown, or `none` when there are no findings.
+ * @param summary.reviewFailed The review task itself reached a failed status.
+ * @param summary.failedFileReviews Per-file reviews that errored.
+ */
+export function buildRunSummaryLine(summary: {
+  filesChanged: number;
+  elapsed: string;
+  breakdown: string;
+  reviewFailed: boolean;
+  failedFileReviews: number;
+}): string {
+  const { filesChanged, elapsed, breakdown, reviewFailed, failedFileReviews } = summary;
+  const filesLabel = `${filesChanged} file${filesChanged === 1 ? "" : "s"}`;
+  const failedLabel = `${failedFileReviews} file review${failedFileReviews === 1 ? "" : "s"} failed`;
+  if (reviewFailed) {
+    const cause = failedFileReviews > 0 ? ` (${failedLabel})` : "";
+    return `reviewed ${filesLabel} in ${elapsed} — review did not complete${cause}; findings unavailable`;
+  }
+  const partial = failedFileReviews > 0 ? ` (incomplete: ${failedLabel})` : "";
+  return `reviewed ${filesLabel} in ${elapsed} — findings: ${breakdown}${partial}`;
+}
+
 function untrustedPullRequestBackground(pr: PullRequestTarget): string {
   const content = `PR #${pr.number}: ${pr.title}${pr.body.trim() ? `\n\n${pr.body.trim()}` : ""}`;
   const fence = fenceFor(content);
@@ -368,7 +401,13 @@ export async function runReviewCli(
   const filesChanged = Number(walkthrough.files ?? 0);
   const impactLevel = typeof walkthrough.impact === "string" ? walkthrough.impact : "";
   const questionCount = Number(walkthrough.questions ?? 0);
-  const summaryLine = `reviewed ${filesChanged} file${filesChanged === 1 ? "" : "s"} in ${elapsedLabel(Date.now() - startedAtMs)} — findings: ${severityBreakdown(findings)}`;
+  const summaryLine = buildRunSummaryLine({
+    filesChanged,
+    elapsed: elapsedLabel(Date.now() - startedAtMs),
+    breakdown: severityBreakdown(findings),
+    reviewFailed,
+    failedFileReviews,
+  });
   console.error(`[smithers-review] ${summaryLine}`);
   if (args.quiz !== "off" && impactLevel) {
     console.error(

--- a/apps/review/tests/cli/main.test.ts
+++ b/apps/review/tests/cli/main.test.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseQuizColumn, runReviewCli } from "../../src/cli/main";
+import { buildRunSummaryLine, parseQuizColumn, runReviewCli } from "../../src/cli/main";
 
 const MAIN_TS = fileURLToPath(new URL("../../src/cli/main.ts", import.meta.url));
 const PKG_ROOT = fileURLToPath(new URL("../../", import.meta.url));
@@ -149,6 +149,49 @@ describe("runReviewCli", () => {
     }
     expect(logs.join("\n")).toContain("Usage: smithers review [repo] [options]");
     expect(logs.join("\n")).toContain("smithers review --from main --to HEAD");
+  });
+});
+
+/**
+ * A review that produced no findings because every file review errored must not
+ * report "findings: none" — that is the exact wording of a clean review, so a
+ * CI credential expiry reads as a passing review to anyone scanning the log.
+ */
+describe("buildRunSummaryLine", () => {
+  const base = { filesChanged: 9, elapsed: "17s", breakdown: "none", reviewFailed: false, failedFileReviews: 0 };
+
+  test("a clean review reports findings: none", () => {
+    expect(buildRunSummaryLine(base)).toBe("reviewed 9 files in 17s — findings: none");
+  });
+
+  test("a review with findings reports the severity breakdown", () => {
+    expect(buildRunSummaryLine({ ...base, breakdown: "1 major, 2 minor" })).toBe(
+      "reviewed 9 files in 17s — findings: 1 major, 2 minor",
+    );
+  });
+
+  test("a failed review says so instead of claiming no findings", () => {
+    const line = buildRunSummaryLine({ ...base, reviewFailed: true, failedFileReviews: 5 });
+    expect(line).toBe(
+      "reviewed 9 files in 17s — review did not complete (5 file reviews failed); findings unavailable",
+    );
+    expect(line).not.toContain("findings: none");
+  });
+
+  test("a failed review with no per-file detail still refuses to claim no findings", () => {
+    const line = buildRunSummaryLine({ ...base, reviewFailed: true });
+    expect(line).toBe("reviewed 9 files in 17s — review did not complete; findings unavailable");
+    expect(line).not.toContain("findings: none");
+  });
+
+  test("a partial review reports the breakdown AND that coverage is incomplete", () => {
+    expect(buildRunSummaryLine({ ...base, failedFileReviews: 1 })).toBe(
+      "reviewed 9 files in 17s — findings: none (incomplete: 1 file review failed)",
+    );
+  });
+
+  test("singular file count reads naturally", () => {
+    expect(buildRunSummaryLine({ ...base, filesChanged: 1 })).toBe("reviewed 1 file in 17s — findings: none");
   });
 });
 


### PR DESCRIPTION
Not a filed issue. Found while triaging why the `review` CI job is red on every PR in this repo
right now.

## The defect

The stored Codex credential for CI has expired, so every file-review task fails with
`Failed to refresh token` / `401 Unauthorized`. The job then prints:

```
Review: All 5 file review(s) failed.
[smithers-review] reviewed 9 files in 17s — findings: none
```

`findings: none` is the exact wording of a clean review. Nothing in that line distinguishes "the
reviewer looked and found nothing" from "the reviewer never ran". Anyone scanning the log, or any
wrapper matching on it, reads a credential expiry as a passing review.

The job does exit 1, so this is not a silent pass. But the summary line is the part a human reads,
and it says the opposite of what happened.

## Who hits it

Anyone whose CI credential expires, whose provider rate-limits mid-run, or who has a network fault.
The failure mode is environmental, so it is not rare and it is not specific to this repo.

## The fix

`buildRunSummaryLine` is extracted as a pure function and reports what actually happened:

| Situation | Before | After |
| --- | --- | --- |
| Clean review | `findings: none` | `findings: none` (unchanged) |
| All file reviews failed | `findings: none` | `review did not complete (5 file reviews failed); findings unavailable` |
| Some file reviews failed | `findings: none` | `findings: none (incomplete: 1 file review failed)` |

The partial case matters as much as the failed one: a review that lost two of nine files to a rate
limit was reporting its findings as if they were complete.

## Note on the failing tests you will see

`apps/review/tests/cli/main.test.ts` has seven subprocess tests that fail on this machine under load
at bun's default 5s timeout. **They fail identically on pristine `origin/main`** — I verified by
alternating stashed and unstashed runs back to back: pristine 6 pass / 7 fail, this branch 12 pass /
7 fail, same seven. The six added are the new unit tests, all passing. Not addressed here, since
that is a separate pre-existing problem.

## Separately: the credential needs rotating

This PR makes the failure legible. It does not fix it. The `review` job stays red on every PR until
the Codex credential in repo secrets is re-authenticated, which only you can do.

## Gates

`pnpm -C apps/review test` (531 pass / 1 skip, plus the load flakes above); `lint`; `format:check`;
`pnpm -C apps/review typecheck`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
