### PR TITLE
fix(engine): ignore resume pointers from unsuccessful attempts

### DIFF
--- a/packages/db/src/adapter.js
+++ b/packages/db/src/adapter.js
@@ -69,6 +69,7 @@ import { withSqliteWriteRetryEffect } from "./write-retry.js";
 import { camelToSnake } from "./utils/camelToSnake.js";
 import { capturePostgresTransactionTxid, recordCommittedTxid, shouldCapturePostgresTxid } from "./captureTxid.js";
 import { normalizeWaitForEventCorrelationId, parseWaitForEventAttemptSnapshot } from "./waitForEventAttempt.js";
+import { clearAttemptResumePointers, isNonSuccessTerminalAttemptState } from "./attempt-resume-pointers.js";
 /** @typedef {import("./adapter/AlertRow.ts").AlertRow} AlertRow */
 /** @typedef {import("./adapter/AlertStatus.ts").AlertStatus} AlertStatus */
 /** @typedef {import("./adapter/AttemptRow.ts").AttemptRow} AttemptRow */
@@ -2506,14 +2507,29 @@ export class SmithersDb {
    * @returns {RunnableEffect<void, SmithersError>}
    */
   updateAttempt(runId, nodeId, iteration, attempt, patch) {
-    return this.write(`update attempt ${nodeId}#${attempt}`, () =>
-      this.internalStorage.updateWhere(
-        "_smithers_attempts",
-        patch,
-        "run_id = ? AND node_id = ? AND iteration = ? AND attempt = ?",
-        [runId, nodeId, iteration, attempt],
-      ),
-    );
+    const where = "run_id = ? AND node_id = ? AND iteration = ? AND attempt = ?";
+    const whereParams = [runId, nodeId, iteration, attempt];
+    if (!isNonSuccessTerminalAttemptState(patch?.state)) {
+      return this.write(`update attempt ${nodeId}#${attempt}`, () =>
+        this.internalStorage.updateWhere("_smithers_attempts", patch, where, whereParams),
+      );
+    }
+    // The attempt is ending without success, so its resume pointers now name a
+    // conversation that is usually already gone (#1610). Drop them in the same
+    // statement that writes the terminal state, so the row stops advertising a
+    // session the next attempt would resume straight into AGENT_SESSION_LOST.
+    return this.write(`update attempt ${nodeId}#${attempt}`, async () => {
+      const patchedMetaJson = Object.hasOwn(patch, "metaJson")
+        ? patch.metaJson
+        : (
+            await this.internalStorage.queryOne(`SELECT meta_json FROM _smithers_attempts WHERE ${where} LIMIT 1`, [
+              ...whereParams,
+            ])
+          )?.metaJson;
+      const cleared = clearAttemptResumePointers(patchedMetaJson);
+      const effectivePatch = cleared === null ? patch : { ...patch, metaJson: cleared };
+      return this.internalStorage.updateWhere("_smithers_attempts", effectivePatch, where, whereParams);
+    });
   }
   /**
    * @param {string} runId
@@ -2553,8 +2569,8 @@ export class SmithersDb {
     );
   }
   claimAttemptTerminal(runId, nodeId, iteration, attempt, runtimeOwnerId, state, finishedAtMs, errorJson) {
-    return this.write(`claim attempt ${state} ${nodeId}#${attempt}`, () =>
-      this.internalStorage
+    return this.write(`claim attempt ${state} ${nodeId}#${attempt}`, async () => {
+      const claimed = await this.internalStorage
         .updateWhere(
           "_smithers_attempts",
           {
@@ -2571,8 +2587,26 @@ export class SmithersDb {
         `,
           [runId, nodeId, iteration, attempt, runtimeOwnerId, runtimeOwnerId],
         )
-        .then((count) => count > 0),
-    );
+        .then((count) => count > 0);
+      // Same hygiene as updateAttempt (#1610): an attempt that just ended
+      // failed or cancelled must not keep advertising its resume pointers. The
+      // claim already fenced this row, so the follow-up write is safe; resume
+      // resolution ignores pointers from non-successful attempts anyway, which
+      // is what keeps a crash between the two statements harmless.
+      if (claimed && isNonSuccessTerminalAttemptState(state)) {
+        const where = "run_id = ? AND node_id = ? AND iteration = ? AND attempt = ?";
+        const whereParams = [runId, nodeId, iteration, attempt];
+        const row = await this.internalStorage.queryOne(
+          `SELECT meta_json FROM _smithers_attempts WHERE ${where} LIMIT 1`,
+          [...whereParams],
+        );
+        const cleared = clearAttemptResumePointers(row?.metaJson);
+        if (cleared !== null) {
+          await this.internalStorage.updateWhere("_smithers_attempts", { metaJson: cleared }, where, whereParams);
+        }
+      }
+      return claimed;
+    });
   }
   /**
    * @param {string} runId

--- a/packages/db/src/attempt-resume-pointers.js
+++ b/packages/db/src/attempt-resume-pointers.js
@@ -1,0 +1,90 @@
+/**
+ * Resume pointers recorded on an attempt row (#1610).
+ *
+ * An agent attempt records where its conversation lives — the CLI session id
+ * (`agentResume`), the captured transcript (`agentConversation`), the last
+ * heartbeat payload carrying both (`lastHeartbeat`), and the sibling markers
+ * describing what the attempt itself resumed from. Those pointers are only
+ * meaningful while the conversation they name still exists. Once an attempt
+ * ends failed or cancelled the conversation is usually gone, so the next
+ * attempt of that node resumes a dead id and dies immediately with
+ * `AGENT_SESSION_LOST`, burning a retry without doing any work.
+ *
+ * Discarding a resume pointer costs conversation context, never work: the
+ * agent's real state lives in its worktree, not in the conversation. Do not
+ * "restore" a pointer here as an optimization.
+ */
+
+/**
+ * Attempt states that end an attempt without success. `in-progress` and the
+ * `waiting-*` states are deliberately absent: those attempts are still live and
+ * their pointers are the ones a legitimate resume uses.
+ * @type {ReadonlyArray<string>}
+ */
+export const NON_SUCCESS_TERMINAL_ATTEMPT_STATES = Object.freeze(["failed", "cancelled", "canceled"]);
+
+/**
+ * Meta keys that name a conversation rather than describe the attempt's work.
+ * @type {ReadonlyArray<string>}
+ */
+export const ATTEMPT_RESUME_POINTER_META_KEYS = Object.freeze([
+  "agentResume",
+  "agentConversation",
+  "lastHeartbeat",
+  "resumedFromConversation",
+  "resumedFromSession",
+]);
+
+const TERMINAL_STATE_SET = new Set(NON_SUCCESS_TERMINAL_ATTEMPT_STATES);
+
+/**
+ * @param {unknown} state
+ * @returns {boolean}
+ */
+export function isNonSuccessTerminalAttemptState(state) {
+  return typeof state === "string" && TERMINAL_STATE_SET.has(state);
+}
+
+/**
+ * Whether the resume pointers an attempt recorded may still be handed to a
+ * later attempt. Unknown/missing states stay usable: only a recorded
+ * non-success terminal transition is evidence the conversation is gone.
+ * @param {{ state?: unknown } | null | undefined} attempt
+ * @returns {boolean}
+ */
+export function attemptResumePointersUsable(attempt) {
+  return !isNonSuccessTerminalAttemptState(attempt?.state);
+}
+
+/**
+ * Strip resume pointers from a serialized attempt meta blob. Returns the
+ * rewritten JSON, or `null` when there was nothing to strip — callers use that
+ * to skip a pointless write. Unparseable meta is left untouched: it is not this
+ * function's job to discard a row it cannot read.
+ *
+ * An attempt carrying a `hijackHandoff` keeps every pointer. That attempt was
+ * cancelled *by* the hand-off: a human is sitting in the session it names, and
+ * both the resumed run and `smithers hijack` need the pointer to rejoin it.
+ *
+ * @param {unknown} metaJson
+ * @returns {string | null}
+ */
+export function clearAttemptResumePointers(metaJson) {
+  if (typeof metaJson !== "string" || metaJson.length === 0) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(metaJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  if (parsed.hijackHandoff && typeof parsed.hijackHandoff === "object") return null;
+  let changed = false;
+  for (const key of ATTEMPT_RESUME_POINTER_META_KEYS) {
+    if (!Object.hasOwn(parsed, key)) continue;
+    if (parsed[key] === null || parsed[key] === false) continue;
+    delete parsed[key];
+    changed = true;
+  }
+  return changed ? JSON.stringify(parsed) : null;
+}

--- a/packages/db/tests/attempt-resume-pointers.test.js
+++ b/packages/db/tests/attempt-resume-pointers.test.js
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { Effect } from "effect";
+import { SmithersDb } from "../src/adapter.js";
+import { ensureSmithersTables } from "../src/ensure.js";
+import {
+  attemptResumePointersUsable,
+  clearAttemptResumePointers,
+  isNonSuccessTerminalAttemptState,
+} from "../src/attempt-resume-pointers.js";
+
+/**
+ * #1610: an attempt that ends failed or cancelled keeps advertising the
+ * conversation it was talking to. That conversation is usually gone, so the
+ * next attempt of the node resumes a dead id and dies instantly with
+ * AGENT_SESSION_LOST, burning a retry without doing any work.
+ */
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  const db = drizzle(sqlite);
+  ensureSmithersTables(db);
+  return { adapter: new SmithersDb(db), sqlite };
+}
+
+const POINTERED_META = {
+  kind: "agent",
+  agentEngine: "claude-code",
+  agentResume: "session-uuid",
+  agentConversation: [{ role: "user", content: "hi" }],
+  lastHeartbeat: { agentResume: "session-uuid" },
+  resumedFromSession: "older-session-uuid",
+  resumedFromConversation: true,
+};
+
+/**
+ * @param {SmithersDb} adapter
+ * @param {string} runId
+ * @param {Record<string, unknown>} meta
+ */
+async function seedInProgressAttempt(adapter, runId, meta = POINTERED_META) {
+  await Effect.runPromise(
+    Effect.all([
+      adapter.insertRun({
+        runId,
+        workflowName: "resume-pointers",
+        status: "running",
+        createdAtMs: 1_000,
+        startedAtMs: 1_000,
+      }),
+      adapter.insertAttempt({
+        runId,
+        nodeId: "work",
+        iteration: 0,
+        attempt: 1,
+        state: "in-progress",
+        startedAtMs: 1_100,
+        metaJson: JSON.stringify(meta),
+      }),
+    ]),
+  );
+}
+
+/**
+ * @param {SmithersDb} adapter
+ * @param {string} runId
+ */
+async function readMeta(adapter, runId) {
+  const attempt = await Effect.runPromise(adapter.getAttempt(runId, "work", 0, 1));
+  return JSON.parse(attempt.metaJson);
+}
+
+describe("attempt resume pointers", () => {
+  test("classifies only the non-success terminal states", () => {
+    expect(isNonSuccessTerminalAttemptState("failed")).toBe(true);
+    expect(isNonSuccessTerminalAttemptState("cancelled")).toBe(true);
+    expect(isNonSuccessTerminalAttemptState("canceled")).toBe(true);
+    // Still live, or successful: these attempts own usable pointers.
+    expect(isNonSuccessTerminalAttemptState("in-progress")).toBe(false);
+    expect(isNonSuccessTerminalAttemptState("finished")).toBe(false);
+    expect(isNonSuccessTerminalAttemptState("waiting-approval")).toBe(false);
+    expect(isNonSuccessTerminalAttemptState(undefined)).toBe(false);
+    expect(attemptResumePointersUsable({ state: "failed" })).toBe(false);
+    expect(attemptResumePointersUsable({ state: "finished" })).toBe(true);
+    expect(attemptResumePointersUsable(undefined)).toBe(true);
+  });
+
+  test("clears pointers without touching what describes the work", () => {
+    const cleared = JSON.parse(clearAttemptResumePointers(JSON.stringify(POINTERED_META)));
+    expect(cleared).toEqual({ kind: "agent", agentEngine: "claude-code" });
+    // Nothing to strip reports no change, so callers can skip the write.
+    expect(clearAttemptResumePointers(JSON.stringify({ kind: "agent" }))).toBeNull();
+    expect(clearAttemptResumePointers(JSON.stringify({ agentResume: null }))).toBeNull();
+    expect(clearAttemptResumePointers("not json")).toBeNull();
+    expect(clearAttemptResumePointers(null)).toBeNull();
+    // A hand-off names a session a human is holding open.
+    expect(
+      clearAttemptResumePointers(JSON.stringify({ ...POINTERED_META, hijackHandoff: { engine: "claude-code" } })),
+    ).toBeNull();
+  });
+
+  test("updateAttempt clears the pointers when the attempt ends without success", async () => {
+    const { adapter, sqlite } = createTestDb();
+    try {
+      await seedInProgressAttempt(adapter, "run-cancel");
+      await Effect.runPromise(
+        adapter.updateAttempt("run-cancel", "work", 0, 1, { state: "cancelled", finishedAtMs: 1_200 }),
+      );
+      const meta = await readMeta(adapter, "run-cancel");
+      expect(meta).toEqual({ kind: "agent", agentEngine: "claude-code" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("updateAttempt clears pointers the same patch is trying to write", async () => {
+    const { adapter, sqlite } = createTestDb();
+    try {
+      await seedInProgressAttempt(adapter, "run-fail", { kind: "agent" });
+      await Effect.runPromise(
+        adapter.updateAttempt("run-fail", "work", 0, 1, {
+          state: "failed",
+          finishedAtMs: 1_200,
+          metaJson: JSON.stringify(POINTERED_META),
+        }),
+      );
+      const meta = await readMeta(adapter, "run-fail");
+      expect(meta).toEqual({ kind: "agent", agentEngine: "claude-code" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("updateAttempt leaves a successful attempt's pointers alone", async () => {
+    const { adapter, sqlite } = createTestDb();
+    try {
+      await seedInProgressAttempt(adapter, "run-finish");
+      await Effect.runPromise(
+        adapter.updateAttempt("run-finish", "work", 0, 1, { state: "finished", finishedAtMs: 1_200 }),
+      );
+      expect(await readMeta(adapter, "run-finish")).toEqual(POINTERED_META);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("claimAttemptTerminal clears the pointers it just made stale", async () => {
+    const { adapter, sqlite } = createTestDb();
+    try {
+      await seedInProgressAttempt(adapter, "run-claim");
+      const claimed = await Effect.runPromise(
+        adapter.claimAttemptTerminal("run-claim", "work", 0, 1, null, "failed", 1_200, null),
+      );
+      expect(claimed).toBe(true);
+      expect(await readMeta(adapter, "run-claim")).toEqual({ kind: "agent", agentEngine: "claude-code" });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  test("claimAttemptTerminal keeps a hand-off attempt resumable", async () => {
+    const { adapter, sqlite } = createTestDb();
+    try {
+      const handoffMeta = { ...POINTERED_META, hijackHandoff: { engine: "claude-code", resume: "session-uuid" } };
+      await seedInProgressAttempt(adapter, "run-handoff", handoffMeta);
+      const claimed = await Effect.runPromise(
+        adapter.claimAttemptTerminal("run-handoff", "work", 0, 1, null, "cancelled", 1_200, null),
+      );
+      expect(claimed).toBe(true);
+      // The hand-off cancelled this attempt precisely so a human could take
+      // the session over; both the resumed run and `smithers hijack` need it.
+      expect(await readMeta(adapter, "run-handoff")).toEqual(handoffMeta);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/packages/engine/src/engine.js
+++ b/packages/engine/src/engine.js
@@ -16,6 +16,7 @@ import {
 import { FRAME_KEYFRAME_INTERVAL } from "@smthrs/db/frame-codec";
 import { ensureSmithersTables } from "@smthrs/db/ensure";
 import { runCancellationSourceFromRow, SmithersDb } from "@smthrs/db/adapter";
+import { attemptResumePointersUsable, clearAttemptResumePointers } from "@smthrs/db/attempt-resume-pointers";
 import {
   selectOutputRow,
   validateOutput,
@@ -594,6 +595,22 @@ function shouldDiscardResumeSession(attempts) {
   return parseAttemptMetaJson(newestRelevantAttempt?.metaJson).discardResumeSession === true;
 }
 /**
+ * Serialize the attempt meta of an attempt that is ending without success.
+ *
+ * The row keeps everything that describes the work; it loses only the pointers
+ * that name a conversation (`agentResume`, `agentConversation`, the copied
+ * `lastHeartbeat`, and the resumedFrom* siblings), which are dead the moment
+ * the attempt is (#1610). This is hygiene — resume resolution ignores those
+ * pointers regardless, which is what repairs rows written before this existed.
+ *
+ * @param {Record<string, unknown>} attemptMeta
+ * @returns {string}
+ */
+function terminalAttemptMetaJson(attemptMeta) {
+  const metaJson = JSON.stringify(attemptMeta);
+  return clearAttemptResumePointers(metaJson) ?? metaJson;
+}
+/**
  * @param {unknown} value
  * @returns {unknown[] | undefined}
  */
@@ -960,14 +977,33 @@ function resolveCorrectionResumeSession(agent, meta) {
   return typeof meta.agentResume === "string" && meta.agentResume.length > 0 ? meta.agentResume : undefined;
 }
 /**
- * @param {Array<{ metaJson?: string | null }>} attempts
+ * Newest usable continuation across an attempt history.
+ *
+ * An attempt that ended failed or cancelled keeps recording where its
+ * conversation lived, but that conversation is usually already gone: resuming
+ * it kills the next attempt instantly with AGENT_SESSION_LOST and burns a retry
+ * doing no work (#1610). Ignoring those pointers at resolution time — rather
+ * than trusting the terminal transition to have scrubbed them — is what repairs
+ * histories that are already carrying one, and what survives a node reset.
+ *
+ * `hijackHandoff` is exempt: it is an explicit hand-off to a session a human is
+ * holding open, and the hand-off itself is what cancelled the attempt.
+ *
+ * Dropping a resume pointer costs conversation context, never work: the agent's
+ * real state lives in its worktree. Do not "restore" the pointer here as an
+ * optimization.
+ *
+ * @param {Array<{ state?: string | null, metaJson?: string | null }>} attempts
  * @param {string} engine
  * @returns {{ mode: "native-cli"; resume: string } | { mode: "conversation"; messages: unknown[] } | undefined}
  */
 function findHijackContinuation(attempts, engine) {
   for (const attempt of attempts) {
     const meta = parseAttemptMetaJson(attempt.metaJson);
-    const continuation = extractHijackContinuation(meta, engine);
+    const continuation = extractHijackContinuation(
+      attemptResumePointersUsable(attempt) ? meta : { hijackHandoff: meta.hijackHandoff },
+      engine,
+    );
     if (continuation) {
       return continuation;
     }
@@ -4992,13 +5028,22 @@ async function legacyExecuteTask(
   const resumeAttempts = resumeEligibleAttempts(attempts);
   const maxSchemaRetries =
     Number.isSafeInteger(desc.maxSchemaRetries) && desc.maxSchemaRetries >= 0 ? desc.maxSchemaRetries : 3;
-  const previousHeartbeat = (() => {
+  // The heartbeat payload is an application checkpoint that must survive a
+  // retry byte-for-byte, but it also mirrors the attempt's agentResume /
+  // agentConversation. Keep carrying the bytes forward; below, only the RESUME
+  // POINTERS inside them are ignored when the attempt that wrote them ended
+  // failed or cancelled (#1610).
+  // One pass: the payload and the attempt that wrote it must never disagree
+  // about which row they came from, so they are resolved together.
+  const previousHeartbeatSource = (() => {
     for (const attempt of resumeAttempts) {
       const parsed = parseAttemptHeartbeatData(attempt.heartbeatDataJson);
-      if (parsed !== null) return parsed;
+      if (parsed !== null) return { attempt, parsed };
     }
     return null;
   })();
+  const previousHeartbeat = previousHeartbeatSource?.parsed ?? null;
+  const heartbeatResumePointersUsable = attemptResumePointersUsable(previousHeartbeatSource?.attempt);
   const previousHeartbeatJson = (() => {
     for (const attempt of resumeAttempts) {
       if (typeof attempt.heartbeatDataJson === "string" && attempt.heartbeatDataJson.length > 0) {
@@ -6338,6 +6383,14 @@ async function legacyExecuteTask(
         const resetAttempts = new Set(
           attempts.filter(isResetCancelledAttempt).map((attempt) => `${attempt.iteration}:${attempt.attempt}`),
         );
+        // The engine mirrors every captured CLI session id into a
+        // `smithers.cli-session` checkpoint, so that row carries the same dead
+        // pointer as the attempt meta once the attempt ends without success
+        // (#1610). Agent-published checkpoints are untouched: they are durable
+        // state the agent asserted it can restore, not a session id.
+        const attemptsByKey = new Map(attempts.map((attempt) => [`${attempt.iteration}:${attempt.attempt}`, attempt]));
+        const checkpointResumePointerUsable = (candidate) =>
+          attemptResumePointersUsable(attemptsByKey.get(`${candidate.iteration}:${candidate.attempt}`));
         const checkpointDiscardAttempt = resumeAttempts.find(
           (attempt) =>
             !resetAttempts.has(`${attempt.iteration}:${attempt.attempt}`) &&
@@ -6375,9 +6428,10 @@ async function legacyExecuteTask(
             agentSupportsCheckpoint(effectiveAgent, candidate, "resume");
           if (!mayConsumeCheckpoint) continue;
           const loaded = await loadAgentCheckpoint(adapter, candidate, toolConfig.maxAgentCheckpointBytes);
-          const legacyResume = discardResumeSession
-            ? undefined
-            : resumeSessionFromCheckpoint(loaded, currentAgentEngine);
+          const legacyResume =
+            discardResumeSession || !checkpointResumePointerUsable(candidate)
+              ? undefined
+              : resumeSessionFromCheckpoint(loaded, currentAgentEngine);
           if (legacyResume) {
             resumeCheckpointRef = candidate;
             checkpointScanStopped = true;
@@ -6411,12 +6465,18 @@ async function legacyExecuteTask(
             );
           }
         }
+        // heartbeatResumePointersUsable is the #1610 gate: the heartbeat bytes
+        // still carry forward, but the session id and transcript inside them
+        // are ignored once the attempt that wrote them ended without success.
         const checkpointResumeSession =
-          !discardResumeSession && heartbeatCheckpointUsable && typeof heartbeatCheckpoint?.agentResume === "string"
+          !discardResumeSession &&
+          heartbeatCheckpointUsable &&
+          heartbeatResumePointersUsable &&
+          typeof heartbeatCheckpoint?.agentResume === "string"
             ? heartbeatCheckpoint.agentResume
             : undefined;
         const checkpointResumeMessages =
-          !discardResumeSession && heartbeatCheckpointUsable
+          !discardResumeSession && heartbeatCheckpointUsable && heartbeatResumePointersUsable
             ? asConversationMessages(heartbeatCheckpoint?.agentConversation)
             : undefined;
         const priorContinuation =
@@ -6431,7 +6491,12 @@ async function legacyExecuteTask(
           priorContinuation?.mode === "native-cli" && !discardResumeSession
             ? priorContinuation.resume
             : checkpointResumeSession;
-        if (!resumeSession && resumeCheckpointRef && !resumeCheckpoint) {
+        if (
+          !resumeSession &&
+          resumeCheckpointRef &&
+          !resumeCheckpoint &&
+          checkpointResumePointerUsable(resumeCheckpointRef)
+        ) {
           const stored = await loadAgentCheckpoint(adapter, resumeCheckpointRef, toolConfig.maxAgentCheckpointBytes);
           resumeSession = resumeSessionFromCheckpoint(stored, currentAgentEngine);
           resumeCheckpointRefConsumed = Boolean(resumeSession);
@@ -6442,11 +6507,15 @@ async function legacyExecuteTask(
         // params.options.continueSession; others ignore it. Caveat: if the
         // worktree is shared by concurrent tasks, --continue is cwd-scoped
         // and may attach the most recent session.
+        // --continue is the same pointer by another name: it re-attaches the
+        // newest session in this cwd, which is exactly the one the failed or
+        // cancelled attempt was using (#1610).
         const continueSession =
           !resumeSession &&
           !resumeCheckpoint &&
           !discardResumeSession &&
           heartbeatCheckpointUsable &&
+          heartbeatResumePointersUsable &&
           typeof heartbeatCheckpoint?.agentEngine === "string" &&
           resumeAttempts.length > 0;
         const resumeMessages =
@@ -8568,7 +8637,7 @@ async function legacyExecuteTask(
           );
           if (!claimed) return false;
           yield* adapter.updateAttempt(runId, desc.nodeId, desc.iteration, attemptNo, {
-            metaJson: JSON.stringify(attemptMeta),
+            metaJson: terminalAttemptMetaJson(attemptMeta),
             responseText,
           });
           for (const journalContext of activeToolJournalContexts) {
@@ -8719,7 +8788,7 @@ async function legacyExecuteTask(
         );
         if (!claimed) return false;
         yield* adapter.updateAttempt(runId, desc.nodeId, desc.iteration, attemptNo, {
-          metaJson: JSON.stringify(attemptMeta),
+          metaJson: terminalAttemptMetaJson(attemptMeta),
           responseText,
         });
         for (const journalContext of activeToolJournalContexts) {

--- a/packages/engine/tests/agent-checkpoints.e2e.test.jsx
+++ b/packages/engine/tests/agent-checkpoints.e2e.test.jsx
@@ -950,8 +950,12 @@ describe("durable agent checkpoints", () => {
     TIMEOUT_MS,
   );
 
+  // #1610: the retry used to resume the failed attempt's own native session.
+  // That pointer names a conversation the CLI has usually already dropped, so
+  // the retry died instantly with AGENT_SESSION_LOST. A fresh session reseeded
+  // from the fork source costs conversation context, never work.
   test(
-    "a forked hybrid retry resumes its own native session instead of reseeding the source checkpoint",
+    "a forked hybrid retry reseeds the source checkpoint instead of resuming the failed attempt's session",
     async () => {
       const { smithers, outputs, cleanup } = createTestSmithers(outputSchemas);
       const targetCalls = [];
@@ -1007,8 +1011,9 @@ describe("durable agent checkpoints", () => {
         expect(targetCalls[0].resumeCheckpoint).toEqual(checkpoint("source"));
         expect(targetCalls[0].checkpointMode).toBe("fork");
         expect(targetCalls[0].resumeSession).toBeUndefined();
-        expect(targetCalls[1].resumeCheckpoint).toBeUndefined();
-        expect(targetCalls[1].resumeSession).toBe("target-session");
+        expect(targetCalls[1].resumeSession).toBeUndefined();
+        expect(targetCalls[1].resumeCheckpoint).toEqual(checkpoint("source"));
+        expect(targetCalls[1].checkpointMode).toBe("fork");
       } finally {
         cleanup();
       }

--- a/packages/engine/tests/durability-snapshots.e2e.test.jsx
+++ b/packages/engine/tests/durability-snapshots.e2e.test.jsx
@@ -247,6 +247,7 @@ describeIfJj("durability snapshots wired into the engine", () => {
     const child = spawnCheckpointCrashRun({ dbPath, markerPath, rootDir: jjDir, runId });
     let resumedWorkspace;
     let resumedSession;
+    let resumedCheckpoint;
     const stable = {
       codec: "smithers.cli-session",
       version: 1,
@@ -259,6 +260,7 @@ describeIfJj("durability snapshots wired into the engine", () => {
       checkpointCapabilities: [{ codec: stable.codec, versions: [1], modes: ["resume"] }],
       async generate(args) {
         resumedSession = args.resumeSession;
+        resumedCheckpoint = args.resumeCheckpoint;
         const file = join(args.rootDir, "agent-output.txt");
         resumedWorkspace = existsSync(file) ? readFileSync(file, "utf8") : null;
         return { text: '{"value":47}' };
@@ -285,7 +287,13 @@ describeIfJj("durability snapshots wired into the engine", () => {
         runWorkflow(workflow, { input: {}, runId, rootDir: jjDir, resume: true, force: true }),
       );
       expect(resumed.status).toBe("finished");
-      expect(resumedSession).toBe("stable-session");
+      // #1610: resume cancels the crashed attempt, so the session id it
+      // recorded is no longer handed back — that id is exactly the class of
+      // pointer that used to kill the next attempt with AGENT_SESSION_LOST.
+      // The agent restores from the checkpoint instead, and the workspace (the
+      // agent's real state) is still rewound to it.
+      expect(resumedSession).toBeUndefined();
+      expect(resumedCheckpoint).toEqual(stable);
       expect(resumedWorkspace).toBe("after republish\n");
     } finally {
       if (child.child.exitCode === null && !child.child.killed) {

--- a/packages/engine/tests/engine-internals.test.js
+++ b/packages/engine/tests/engine-internals.test.js
@@ -787,9 +787,12 @@ describe("engine internals: durability, options and graph helpers", () => {
         agentResume: "stale-session",
       }),
     };
+    // Live, not failed: this case is about the reset boundary deciding which
+    // attempts are ELIGIBLE. Whether an eligible attempt's pointer is usable is
+    // a separate rule (#1610) covered by the next test.
     const fresh = {
       attempt: 1,
-      state: "failed",
+      state: "in-progress",
       startedAtMs: 1_100,
       heartbeatDataJson: JSON.stringify({ agentResume: "fresh-session" }),
       metaJson: JSON.stringify({ agentEngine: "cli", agentResume: "fresh-session" }),
@@ -799,6 +802,45 @@ describe("engine internals: durability, options and graph helpers", () => {
       mode: "native-cli",
       resume: "fresh-session",
     });
+  });
+
+  test("resume pointers from failed or cancelled attempts are never offered as a continuation", () => {
+    // #1610: the conversation an unsuccessful attempt named is usually already
+    // gone, so reusing the pointer kills the next attempt with
+    // AGENT_SESSION_LOST and burns a retry doing no work.
+    const attemptWith = (state, meta) => ({ attempt: 1, state, startedAtMs: 100, metaJson: JSON.stringify(meta) });
+    const nativeMeta = { agentEngine: "cli", agentResume: "dead-session" };
+    const conversationMeta = { agentEngine: "cli", agentConversation: [{ role: "user", content: "hi" }] };
+
+    expect(I.findHijackContinuation([attemptWith("failed", nativeMeta)], "cli")).toBeUndefined();
+    expect(I.findHijackContinuation([attemptWith("cancelled", nativeMeta)], "cli")).toBeUndefined();
+    expect(I.findHijackContinuation([attemptWith("failed", conversationMeta)], "cli")).toBeUndefined();
+    // A successful attempt's pointer stays usable, and so does a live one.
+    expect(I.findHijackContinuation([attemptWith("finished", nativeMeta)], "cli")).toEqual({
+      mode: "native-cli",
+      resume: "dead-session",
+    });
+    expect(I.findHijackContinuation([attemptWith("in-progress", nativeMeta)], "cli")).toEqual({
+      mode: "native-cli",
+      resume: "dead-session",
+    });
+    // A hand-off is exempt: that attempt was cancelled BY the hand-off and a
+    // human is sitting in the session it names.
+    expect(
+      I.findHijackContinuation(
+        [attemptWith("cancelled", { ...nativeMeta, hijackHandoff: { engine: "cli", resume: "handoff-session" } })],
+        "cli",
+      ),
+    ).toEqual({ mode: "native-cli", resume: "handoff-session" });
+    // An older successful attempt is not resurrected by a newer failed one:
+    // history is walked newest-first and the failed row simply contributes
+    // nothing, so the succeeded pointer behind it is still the newest usable.
+    expect(
+      I.findHijackContinuation(
+        [attemptWith("failed", nativeMeta), { ...attemptWith("finished", { agentEngine: "cli", agentResume: "ok" }) }],
+        "cli",
+      ),
+    ).toEqual({ mode: "native-cli", resume: "ok" });
   });
 
   test("retry hydration accepts current durable state and ignores stale or legacy deadlines", () => {

--- a/packages/engine/tests/stale-resume-pointers.e2e.test.jsx
+++ b/packages/engine/tests/stale-resume-pointers.e2e.test.jsx
@@ -1,0 +1,306 @@
+/** @jsxImportSource smthrs */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SmithersDb } from "@smthrs/db/adapter";
+import { Task, Workflow, runWorkflow } from "smthrs";
+import { createTestSmithers } from "../../smithers/tests/helpers.js";
+import { outputSchemas } from "../../smithers/tests/schema.js";
+import { Effect } from "effect";
+
+/**
+ * Stale resume pointers on unsuccessful attempts (#1610).
+ *
+ * Every agent attempt records where its conversation lives (`agentResume` in
+ * `_smithers_attempts.meta_json`, mirrored into the heartbeat payload). Once the
+ * attempt ends failed or cancelled that conversation is usually gone, so the
+ * next attempt of the node resumed a dead id and died immediately with
+ * `AGENT_SESSION_LOST` — burning one of the node's 2-3 retries without doing any
+ * work. A live fleet sweep found 64 rows in that state.
+ *
+ * Two halves, tested here:
+ *   1. Resolution ignores pointers recorded by attempts that did not succeed.
+ *      This is what repairs rows that are ALREADY poisoned, which is why the
+ *      seeded histories below write their rows raw instead of going through the
+ *      engine.
+ *   2. The terminal transition clears the pointers, so rows stop accumulating.
+ *
+ * A fresh session is always safe: the agent's real state lives in its worktree,
+ * not in the conversation.
+ */
+
+const TIMEOUT_MS = 30_000;
+
+/**
+ * Seed an attempt history exactly as a poisoned production row looks, bypassing
+ * the engine's terminal-transition hygiene. Returns the (VCS-free) root the
+ * resumed run must use, so the resume metadata check sees no drift.
+ *
+ * @param {SmithersDb} adapter
+ * @param {string} runId
+ * @param {Array<{ attempt: number; state: string; startedAtMs: number; meta?: Record<string, unknown>; heartbeat?: Record<string, unknown> }>} attempts
+ */
+async function seedPoisonedRun(adapter, runId, attempts) {
+  const rootDir = mkdtempSync(join(tmpdir(), "stale-resume-pointers-"));
+  await Effect.runPromise(
+    adapter.insertRun({
+      runId,
+      // The resume guard checks the workflow name; the fixtures name the
+      // workflow after the run.
+      workflowName: runId,
+      workflowPath: null,
+      status: "cancelled",
+      createdAtMs: 1_000,
+      startedAtMs: 1_000,
+      finishedAtMs: 2_000,
+    }),
+  );
+  for (const attempt of attempts) {
+    await Effect.runPromise(
+      adapter.insertAttempt({
+        runId,
+        nodeId: "work",
+        iteration: 0,
+        attempt: attempt.attempt,
+        state: attempt.state,
+        startedAtMs: attempt.startedAtMs,
+        finishedAtMs: attempt.startedAtMs + 10,
+        errorJson: null,
+        jjPointer: null,
+        cached: false,
+        heartbeatDataJson: attempt.heartbeat ? JSON.stringify(attempt.heartbeat) : null,
+        metaJson: JSON.stringify({ kind: "agent", ...attempt.meta }),
+        responseText: null,
+      }),
+    );
+  }
+  return rootDir;
+}
+
+/**
+ * @param {Array<Record<string, unknown>>} calls
+ */
+function recordingAgent(calls) {
+  return {
+    id: "stale-pointer-agent",
+    cliEngine: "fake-cli",
+    tools: {},
+    /** @param {any} args */
+    async generate(args) {
+      calls.push({ resumeSession: args.resumeSession, continueSession: args.continueSession });
+      return { text: '{"value":1}' };
+    },
+  };
+}
+
+describe("stale resume pointers on unsuccessful attempts", () => {
+  test(
+    "a failed attempt's resume pointer is not reused by the next attempt",
+    async () => {
+      const { smithers, outputs, db, cleanup } = createTestSmithers(outputSchemas);
+      try {
+        const calls = [];
+        const agent = {
+          id: "failing-then-working",
+          cliEngine: "fake-cli",
+          tools: {},
+          /** @param {any} args */
+          async generate(args) {
+            calls.push({ resumeSession: args.resumeSession, continueSession: args.continueSession });
+            if (calls.length === 1) {
+              // Capture a session id the way every CLI agent does, then fail
+              // for a reason that has nothing to do with the session.
+              args.onEvent?.({ type: "started", engine: "fake-cli", resume: "dead-session-uuid" });
+              throw new Error("transient tool failure");
+            }
+            return { text: '{"value":1}' };
+          },
+        };
+        const workflow = smithers(() => (
+          <Workflow name="stale-pointer-failed">
+            <Task id="work" output={outputs.outputA} agent={agent} retries={1}>
+              produce a value
+            </Task>
+          </Workflow>
+        ));
+        const result = await Effect.runPromise(runWorkflow(workflow, { input: {} }));
+        expect(result.status).toBe("finished");
+        expect(calls).toHaveLength(2);
+        expect(calls[0].resumeSession).toBeUndefined();
+        // The retry must start a fresh session instead of dying on a dead id,
+        // and must not fall back to the cwd-scoped --continue either.
+        expect(calls[1].resumeSession).toBeUndefined();
+        expect(calls[1].continueSession).toBeFalsy();
+
+        // Hygiene half: the failed row no longer advertises the session.
+        const adapter = new SmithersDb(db);
+        const attempts = await Effect.runPromise(adapter.listAttempts(result.runId, "work", 0));
+        const failed = attempts.find((attempt) => attempt.state === "failed");
+        expect(failed).toBeDefined();
+        const failedMeta = JSON.parse(failed.metaJson);
+        expect(failedMeta.agentResume).toBeUndefined();
+        expect(failedMeta.agentConversation).toBeFalsy();
+        expect(failedMeta.lastHeartbeat).toBeFalsy();
+        // Everything describing the work itself survives.
+        expect(failedMeta.agentEngine).toBe("fake-cli");
+      } finally {
+        await cleanup();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "a cancelled attempt's resume pointer is not reused by the next attempt",
+    async () => {
+      const { smithers, outputs, db, cleanup } = createTestSmithers(outputSchemas);
+      let rootDir;
+      try {
+        const adapter = new SmithersDb(db);
+        const runId = "stale-pointer-cancelled";
+        // An engine bounce (crash recovery, concurrency change, quota-park
+        // resume) cancels the in-flight attempt and leaves its pointer behind.
+        rootDir = await seedPoisonedRun(adapter, runId, [
+          {
+            attempt: 1,
+            state: "cancelled",
+            startedAtMs: 1_100,
+            meta: { agentEngine: "fake-cli", agentResume: "dead-session-uuid" },
+            heartbeat: { agentEngine: "fake-cli", agentResume: "dead-session-uuid" },
+          },
+        ]);
+        const calls = [];
+        const workflow = smithers(() => (
+          <Workflow name="stale-pointer-cancelled">
+            <Task id="work" output={outputs.outputA} agent={recordingAgent(calls)} retries={1}>
+              produce a value
+            </Task>
+          </Workflow>
+        ));
+        const result = await Effect.runPromise(
+          runWorkflow(workflow, { input: {}, runId, rootDir, resume: true, force: true }),
+        );
+        expect(result.status).toBe("finished");
+        expect(calls).toHaveLength(1);
+        expect(calls[0].resumeSession).toBeUndefined();
+        expect(calls[0].continueSession).toBeFalsy();
+      } finally {
+        if (rootDir) rmSync(rootDir, { recursive: true, force: true });
+        await cleanup();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "a succeeded attempt's resume pointer is still honored",
+    async () => {
+      const { smithers, outputs, db, cleanup } = createTestSmithers(outputSchemas);
+      let rootDir;
+      try {
+        const adapter = new SmithersDb(db);
+        const runId = "stale-pointer-succeeded";
+        rootDir = await seedPoisonedRun(adapter, runId, [
+          {
+            attempt: 1,
+            state: "finished",
+            startedAtMs: 1_100,
+            meta: { agentEngine: "fake-cli", agentResume: "live-session-uuid" },
+            heartbeat: { agentEngine: "fake-cli", agentResume: "live-session-uuid" },
+          },
+        ]);
+        const calls = [];
+        const workflow = smithers(() => (
+          <Workflow name="stale-pointer-succeeded">
+            <Task id="work" output={outputs.outputA} agent={recordingAgent(calls)} retries={1}>
+              produce a value
+            </Task>
+          </Workflow>
+        ));
+        const result = await Effect.runPromise(
+          runWorkflow(workflow, { input: {}, runId, rootDir, resume: true, force: true }),
+        );
+        expect(result.status).toBe("finished");
+        expect(calls).toHaveLength(1);
+        // The fix must not disable resume: a session recorded by an attempt
+        // that actually succeeded is still live and still worth continuing.
+        expect(calls[0].resumeSession).toBe("live-session-uuid");
+      } finally {
+        if (rootDir) rmSync(rootDir, { recursive: true, force: true });
+        await cleanup();
+      }
+    },
+    TIMEOUT_MS,
+  );
+
+  test(
+    "a pointer survives neither a node reset nor accumulated attempt history",
+    async () => {
+      const { smithers, outputs, db, cleanup } = createTestSmithers(outputSchemas);
+      let rootDir;
+      try {
+        const adapter = new SmithersDb(db);
+        const runId = "stale-pointer-reset-history";
+        // Reproduction path 1 — `smithers timetravel --no-vcs --no-deps
+        // --force`: the reset row carries the chronological boundary, and the
+        // post-reset failures below it are the ones whose pointers used to be
+        // picked up again once attempt numbering restarted.
+        //
+        // Reproduction path 2 — accumulated history: the newest failure never
+        // reached a `started` event, so resolution walked back to an older
+        // failed row and resurrected ITS pointer.
+        rootDir = await seedPoisonedRun(adapter, runId, [
+          {
+            attempt: 5,
+            state: "cancelled",
+            startedAtMs: 900,
+            meta: {
+              resetCancelled: true,
+              resetResumeBoundaryMs: 1_000,
+              agentEngine: "fake-cli",
+              agentResume: "pre-reset-session",
+            },
+          },
+          {
+            attempt: 1,
+            state: "failed",
+            startedAtMs: 1_100,
+            meta: { agentEngine: "fake-cli", agentResume: "post-reset-session-1" },
+            heartbeat: { agentEngine: "fake-cli", agentResume: "post-reset-session-1" },
+          },
+          {
+            attempt: 2,
+            state: "failed",
+            startedAtMs: 1_200,
+            meta: { agentEngine: "fake-cli", agentResume: "post-reset-session-2" },
+            heartbeat: { agentEngine: "fake-cli", agentResume: "post-reset-session-2" },
+          },
+          // Died before the CLI announced a session, so this row holds no
+          // pointer of its own to shadow the older ones.
+          { attempt: 3, state: "failed", startedAtMs: 1_300, meta: { agentEngine: "fake-cli" } },
+        ]);
+        const calls = [];
+        const workflow = smithers(() => (
+          <Workflow name="stale-pointer-reset-history">
+            {/* The seeded history already burned three attempts. */}
+            <Task id="work" output={outputs.outputA} agent={recordingAgent(calls)} retries={5}>
+              produce a value
+            </Task>
+          </Workflow>
+        ));
+        const result = await Effect.runPromise(
+          runWorkflow(workflow, { input: {}, runId, rootDir, resume: true, force: true }),
+        );
+        expect(result.status).toBe("finished");
+        expect(calls).toHaveLength(1);
+        expect(calls[0].resumeSession).toBeUndefined();
+        expect(calls[0].continueSession).toBeFalsy();
+      } finally {
+        if (rootDir) rmSync(rootDir, { recursive: true, force: true });
+        await cleanup();
+      }
+    },
+    TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
Closes #1610.

Split out of #1582. Resume pointers (`agentResume`, `agentConversation`, `lastHeartbeat`,
`resumedFromConversation`, `resumedFromSession`) persisted on attempts that ended **failed or
cancelled**. The next attempt picked one up, the conversation no longer existed, and it died
immediately with `AGENT_SESSION_LOST` — burning a retry without doing any work. A live fleet sweep
found **64 poisoned rows**, and the cycle was self-sustaining: every engine bounce manufactures more
cancelled attempts.

## Both halves, because either alone is insufficient

**1. Resolution-side filtering — the authoritative half.** New
`packages/db/src/attempt-resume-pointers.js` exports `attemptResumePointersUsable()`, applied in
`engine.js` on **every** channel that can carry a pointer:

- `findHijackContinuation()` (attempt-meta continuation, with `hijackHandoff` still honored via a
  narrowed `{hijackHandoff}` meta)
- the heartbeat checkpoint (`checkpointResumeSession` / `checkpointResumeMessages`)
- the engine-mirrored `smithers.cli-session` checkpoint refs, both in the scan loop and at the
  deferred load
- the cwd-scoped `--continue` fallback

This is what repairs the **already-poisoned** rows with no migration and no backfill.

**2. Clearing on terminal transition — hygiene.** `terminalAttemptMetaJson()` on the task-fail and
task-cancel writes, plus `updateAttempt()` and `claimAttemptTerminal()`. Verified to cover every
bounce path the issue names — `cancelInProgress`, `cancelStaleAttempts`, the resume-cancel-stale
sweep, `cancelPendingExternalWaits`, and the time-travel reset writers (whose
`resetResumeBoundaryMs` is preserved by the clear).

Implementing only (2) leaves existing rows poisoned; only (1) lets the store keep accumulating
misleading data.

**The watchdog SQL from the issue was deliberately not shipped.** A periodic `UPDATE` racing the
engine is a mitigation, not the repair.

## What was checked, not assumed

- A repo-wide grep for the five pointer keys found **no remaining unguarded resolution path**. The
  only other readers are `hijack.js` and `hijackCandidates.js` (hijack UX, not retry resolution) and
  `resolveCorrectionResumeSession` (reads the live attempt's own meta).
- **Success is preserved**: finished attempts keep their pointers, and `resolveForkAgentState` only
  reads finished attempts, so fork is untouched.
- `heartbeat_data_json` is still carried forward byte-for-byte; only the pointers inside it are
  ignored.
- The two new raw-SQL `?` placeholders are dialect-rewritten, so Postgres/PGlite is fine.

## Red before green, verified directly

Rather than asserting it: `engine.js` and `adapter.js` were reverted to pristine `origin/main` while
keeping the new tests. `attempt-resume-pointers.test.js` → **3 fail / 4 pass** (the three
adapter-behavior tests fail; the four pure-function tests pass because the module is a new file).
`stale-resume-pointers.e2e.test.jsx` → **3 fail / 1 pass**.

## The invariant that makes this safe

A fresh session is always safe here: the agent's real state lives in its **worktree**, not in the
conversation. Discarding a resume id costs conversation context, never work. That is stated in a
comment at the discard so nobody later "restores" the pointer as an optimization.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
