### PR TITLE
fix(server): assert webhook metric deltas, not process-global totals

### DIFF
--- a/packages/server/tests/gateway-webhooks.test.jsx
+++ b/packages/server/tests/gateway-webhooks.test.jsx
@@ -69,6 +69,40 @@ async function postGitHubWebhook(port, workflowKey, payload, secret, deliveryId)
   });
 }
 /**
+ * Current value of one Prometheus counter sample, or 0 when it is absent.
+ *
+ * Effect's metric registry is a process-global singleton and its counters are
+ * cumulative, so every `Gateway` built in this test process shares one
+ * `smithers_gateway_webhooks_received_total{workflow="github"}` — `/metrics`
+ * reports the whole process's total, not this gateway's. Any earlier test that
+ * posted a `github` webhook (`gateway-webhook-explicit-run-coverage.test.jsx`
+ * posts two) has therefore already advanced it, so asserting an absolute `1`
+ * passes only when this file happens to run first and otherwise burns the full
+ * poll deadline and fails with no SQLite error anywhere near it — the surviving
+ * shard-3 failure in #1577. Assert the DELTA across the request under test,
+ * matching `metricDelta` in serve.test.js and `metricValue` in
+ * streamDevTools.test.tsx.
+ *
+ * @param {string} metrics raw Prometheus exposition text
+ * @param {RegExp} pattern must capture the sample value in group 1
+ * @returns {number}
+ */
+function counterValue(metrics, pattern) {
+  const match = metrics.match(pattern);
+  return match ? Number(match[1]) : 0;
+}
+/**
+ * @param {number} port
+ * @returns {Promise<string>}
+ */
+async function fetchMetrics(port) {
+  return fetch(`http://127.0.0.1:${port}/metrics`).then((res) => res.text());
+}
+const WEBHOOKS_RECEIVED_GITHUB =
+  /smithers_gateway_webhooks_received_total\{[^}]*workflow="github"[^}]*\}\s+(\d+(?:\.\d+)?)/;
+const WEBHOOKS_REJECTED_BAD_SIGNATURE =
+  /smithers_gateway_webhooks_rejected_total\{[^}]*reason="invalid_signature"[^}]*workflow="github"[^}]*\}\s+(\d+(?:\.\d+)?)/;
+/**
  * @param {string} dbPath
  */
 function createWebhookWaitWorkflow(dbPath) {
@@ -156,6 +190,11 @@ describe("Gateway webhook ingestion", () => {
     });
     server = await gateway.listen({ port: 0, host: "127.0.0.1" });
     const port = getPort(server);
+    // Baseline BEFORE the request: the counters are process-global and may
+    // already be non-zero. See counterValue().
+    const metricsBefore = await fetchMetrics(port);
+    const receivedBefore = counterValue(metricsBefore, WEBHOOKS_RECEIVED_GITHUB);
+    const rejectedBefore = counterValue(metricsBefore, WEBHOOKS_REJECTED_BAD_SIGNATURE);
     const payload = JSON.stringify({
       issue: { id: 7 },
       comment: { body: "bad signature" },
@@ -177,20 +216,22 @@ describe("Gateway webhook ingestion", () => {
       },
     });
     // Metric updates run on forked fibers with no ordering guarantee, so poll
-    // until BOTH counters appear instead of sleeping once: a loaded runner can
+    // until BOTH counters advance instead of sleeping once: a loaded runner can
     // schedule the forks late and in either order.
-    const receivedPattern = /smithers_gateway_webhooks_received_total\{[^}]*workflow="github"[^}]*\}\s+1\b/;
-    const rejectedPattern =
-      /smithers_gateway_webhooks_rejected_total\{[^}]*reason="invalid_signature"[^}]*workflow="github"[^}]*\}\s+1\b/;
-    let metrics = "";
+    let received = receivedBefore;
+    let rejected = rejectedBefore;
     const deadline = Date.now() + 10_000;
     while (Date.now() < deadline) {
-      metrics = await fetch(`http://127.0.0.1:${port}/metrics`).then((res) => res.text());
-      if (receivedPattern.test(metrics) && rejectedPattern.test(metrics)) break;
+      const metrics = await fetchMetrics(port);
+      received = counterValue(metrics, WEBHOOKS_RECEIVED_GITHUB);
+      rejected = counterValue(metrics, WEBHOOKS_REJECTED_BAD_SIGNATURE);
+      if (received > receivedBefore && rejected > rejectedBefore) break;
       await sleep(50);
     }
-    expect(metrics).toMatch(receivedPattern);
-    expect(metrics).toMatch(rejectedPattern);
+    // Exactly one of each: this request is the only one either counter saw
+    // between the baseline and now, whatever the process-wide totals are.
+    expect(received).toBe(receivedBefore + 1);
+    expect(rejected).toBe(rejectedBefore + 1);
   }, 30_000);
   test("uses the GitHub decoder and durable delivery ledger for registry-backed launches", async () => {
     const dbPath = makeDbPath("github-source");

--- a/packages/smithers/src/create.js
+++ b/packages/smithers/src/create.js
@@ -520,6 +520,13 @@ export function createSmithers(schemas, opts) {
     if (dbClosed) return;
     dbClosed = true;
     openSqliteHandles.delete(closeDb);
+    // Evict the hot-reload cache entry too. Under SMITHERS_HOT the cache hands
+    // a re-import the previously opened database, and now that close() is
+    // reachable a caller can retire that database while the entry still points
+    // at it — the next import would then be handed a closed connection. The
+    // key is the same absDbPath the cold path caches under, and the hot path
+    // reuses this exact closure, so deleting it here covers both.
+    hotCache.delete(absDbPath);
     try {
       sqlite.close();
     } catch {}


### PR DESCRIPTION
Fixes the one test still failing on `test (ubuntu-latest, 3, 3)` after #1617's teardown sweep removed the `SQLITE_PROTOCOL` wedge.

## The bug

`smithers_gateway_webhooks_received_total` is an Effect `Metric.counter`. Effect's metric registry is a **process-global singleton** and its counters are cumulative. `bun test tests` runs every `packages/server` test file in one process, and CI shards by package — so every `Gateway` built in the shard shares one `{workflow="github"}` sample, and `/metrics` reports the whole process's running total, not the gateway under test.

`Gateway webhook ingestion > rejects invalid webhook signatures and records rejection metrics` asserted the **absolute** value `1`:

```js
const receivedPattern = /smithers_gateway_webhooks_received_total\{[^}]*workflow="github"[^}]*\}\s+1\b/;
```

That only holds when this file runs before every other file that posts a `github` webhook. `gateway-webhook-explicit-run-coverage.test.jsx` posts two. Bun walks the test directory in readdir order, which differs between local APFS and the runner's ext4 — locally `gateway-webhooks` happens to go first, on the runner it does not. When it doesn't, the counter is already at 2, the regex demanding `1` never matches, and the poll burns its full 10s deadline.

That is exactly the reported signature: a 10s timeout with **no SQLite error anywhere near it**, in a run where nothing stalled.

## Reproduced deterministically

Adding one test file that posts a single `github` webhook before `gateway-webhooks.test.jsx` fails it 100% of the time on the unfixed tree, and passes on the fixed one. Not a flake — a fixed order dependency.

## The fix

Baseline both counters before the request, then assert each advanced by exactly one. This matches the idiom already used elsewhere in the suite (`metricDelta` in `serve.test.js`, `metricValue` in `streamDevTools.test.tsx`) and makes the assertion independent of what else shares the process.

**No timeout was raised, no test skipped or retried, no shard rebalanced, and `jumpToFrame`'s `RewindFailed` → `Busy` rewrite is untouched.**

## Also here

`closeDb` now evicts its `SMITHERS_HOT` cache entry. #1617 made `close()` reachable, so a caller can retire a database while the hot-reload cache still points at it and hand the next import a closed connection.

## Independent confirmation of #1617's numbers

A/B on one identical tree, wrapping the `bun:sqlite` constructor, toggling only whether `closeTrackedSmithers` actually closes:

| | peak live handles | opens |
| --- | --- | --- |
| sweep disabled | **189** | 257 |
| sweep active | **53** | 257 |

Exactly the 189 → 53 over 257 opens reported on #1577.

## Gates

`packages/server` 778 pass / 0 fail · `packages/db` 837 pass · `packages/smithers` 351 pass · `pnpm lint` · `pnpm format:check` · `pnpm -r typecheck` — all clean.

(The branch was reset onto current `main` first: its previous contents were already merged as #1617, so committing on the stale tip would have reverted ~8.9k lines of `main`.)

Refs #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)